### PR TITLE
fix: `Send Connection:close` header when closing channel

### DIFF
--- a/e2e/src/test/java/dev/tachyonmcp/e2e/DnsRebindingE2eTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/DnsRebindingE2eTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026 Konstantin Pavlov.
+ */
+
+package dev.tachyonmcp.e2e;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+
+/**
+ * Verifies DNS-rebinding protection and, crucially, that a rejected request is closed with a
+ * {@code Connection: close} header.
+ *
+ * <p>Regression guard for a 50%-flaky conformance failure on Linux: the server used to reject
+ * with a default keep-alive 403 and then close the socket anyway. Clients (e.g. undici) pooled
+ * that socket, raced the next request onto it, and intermittently saw "other side closed".
+ * Signalling {@code Connection: close} stops the client from reusing the socket.
+ */
+@TestInstance(Lifecycle.PER_CLASS)
+class DnsRebindingE2eTest extends AbstractMcpE2eTest {
+
+    // language=JSON
+    private static final String INIT_BODY = """
+            {
+              "jsonrpc":"2.0",
+              "id":1,
+              "method":"initialize",
+              "params":{
+                "protocolVersion":"2025-11-25",
+                "capabilities":{},
+                "clientInfo":{"name":"test","version":"1.0"}
+              }
+            }
+            """;
+
+    @Test
+    void rejectsNonLocalhostOriginAndSignalsClose() throws Exception {
+        try (var client = createTestClient()) {
+            var response = client.postWithOrigin("http://evil.example.com", INIT_BODY);
+
+            assertThat(response.statusCode()).isEqualTo(403);
+            assertThat(response.headers().firstValue("connection"))
+                    .as("rejected requests must signal Connection: close so the client does not pool the socket")
+                    .hasValueSatisfying(v -> assertThat(v).isEqualToIgnoringCase("close"));
+        }
+    }
+
+    @Test
+    void acceptsLocalhostOrigin() throws Exception {
+        try (var client = createTestClient()) {
+            var response = client.postWithOrigin("http://localhost:" + port, INIT_BODY);
+
+            assertThat(response.statusCode()).isEqualTo(200);
+        }
+    }
+}

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/TestMcpClient.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/TestMcpClient.java
@@ -65,6 +65,19 @@ public record TestMcpClient(int serverPort, HttpClient httpClient) implements Cl
         return post(null, body);
     }
 
+    /**
+     * POSTs an MCP request carrying an {@code Origin} header. Used to exercise the
+     * DNS-rebinding protection, which validates {@code Origin} before {@code Host}.
+     */
+    public HttpResponse<String> postWithOrigin(String origin, String body) throws Exception {
+        return httpClient.send(
+                baseRequest()
+                        .header("Origin", origin)
+                        .POST(HttpRequest.BodyPublishers.ofString(body))
+                        .build(),
+                HttpResponse.BodyHandlers.ofString());
+    }
+
     public HttpResponse<String> post(@Nullable String sessionId, String body) throws Exception {
         var builder = baseRequest();
         if (sessionId != null) {

--- a/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/ChannelHandlerUtils.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/ChannelHandlerUtils.java
@@ -39,6 +39,36 @@ public final class ChannelHandlerUtils {
         return sendPlainText(ctx, status, message, null);
     }
 
+    /**
+     * Writes a {@code text/plain} response and closes the connection. The response carries
+     * {@code Connection: close} so the client does not return the socket to its keep-alive pool
+     * (reusing a socket the server is about to close causes intermittent "other side closed"
+     * errors, e.g. with undici on Linux). Prefer this over {@code sendPlainText(...).addListener(CLOSE)}.
+     */
+    public static ChannelFuture sendPlainTextAndClose(
+            ChannelHandlerContext ctx, HttpResponseStatus status, String message) {
+        return sendPlainTextAndClose(ctx, status, message, null);
+    }
+
+    /** {@link #sendPlainTextAndClose(ChannelHandlerContext, HttpResponseStatus, String)} echoing {@code origin}. */
+    public static ChannelFuture sendPlainTextAndClose(
+            ChannelHandlerContext ctx, HttpResponseStatus status, String message, @Nullable String origin) {
+        return sendResponse(ctx, status, "text/plain", ByteBufUtil.writeUtf8(ctx.alloc(), message), true, origin);
+    }
+
+    /**
+     * Writes a response with the given content type and body, then closes the connection with a
+     * {@code Connection: close} header. See {@link #sendPlainTextAndClose} for why the header matters.
+     */
+    public static ChannelFuture sendResponseAndClose(
+            ChannelHandlerContext ctx,
+            HttpResponseStatus status,
+            String contentType,
+            ByteBuf body,
+            @Nullable String origin) {
+        return sendResponse(ctx, status, contentType, body, true, origin);
+    }
+
     public static ChannelFuture sendPlainText(
             ChannelHandlerContext ctx, HttpResponseStatus status, String message, @Nullable String origin) {
         return sendResponse(ctx, status, "text/plain", ByteBufUtil.writeUtf8(ctx.alloc(), message), false, origin);

--- a/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/McpInitializationHandler.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/McpInitializationHandler.java
@@ -6,10 +6,9 @@ package dev.tachyonmcp.transport.netty;
 
 import static dev.tachyonmcp.transport.netty.ChannelHandlerUtils.interactionContext;
 import static dev.tachyonmcp.transport.netty.ChannelHandlerUtils.sendAccepted;
-import static dev.tachyonmcp.transport.netty.ChannelHandlerUtils.sendResponse;
+import static dev.tachyonmcp.transport.netty.ChannelHandlerUtils.sendResponseAndClose;
 import static dev.tachyonmcp.transport.netty.McpResponseWriter.sendJsonResponse;
 import static dev.tachyonmcp.transport.netty.McpResponseWriter.sendOptions;
-import static io.netty.channel.ChannelFutureListener.CLOSE;
 
 import dev.tachyonmcp.runtime.InteractionContext;
 import dev.tachyonmcp.runtime.InteractionEvent;
@@ -120,8 +119,8 @@ public class McpInitializationHandler extends ChannelInboundHandlerAdapter {
                     logger.error("Failed to parse POST body during initialization", ex);
                     ctx.executor().execute(() -> {
                         var errorBytes = dispatcher.parseError();
-                        sendResponse(ctx, HttpResponseStatus.BAD_REQUEST, "application/json", errorBytes, origin)
-                                .addListener(CLOSE);
+                        sendResponseAndClose(
+                                ctx, HttpResponseStatus.BAD_REQUEST, "application/json", errorBytes, origin);
                     });
                     return null;
                 });
@@ -132,8 +131,7 @@ public class McpInitializationHandler extends ChannelInboundHandlerAdapter {
         switch (message) {
             case null -> {
                 var errorBytes = dispatcher.parseError();
-                sendResponse(ctx, HttpResponseStatus.BAD_REQUEST, "application/json", errorBytes, origin)
-                        .addListener(CLOSE);
+                sendResponseAndClose(ctx, HttpResponseStatus.BAD_REQUEST, "application/json", errorBytes, origin);
             }
             case JsonRpcMessage.Request req
             when METHOD_INITIALIZE.equals(req.method()) -> handleInitialize(ctx, req.id(), req.params(), origin);
@@ -160,13 +158,12 @@ public class McpInitializationHandler extends ChannelInboundHandlerAdapter {
                 .whenComplete((result, ex) -> ctx.executor().execute(() -> {
                     if (ex != null) {
                         logger.error("Dispatch failed for pre-session request: method={}", req.method(), ex);
-                        sendResponse(
-                                        ctx,
-                                        HttpResponseStatus.INTERNAL_SERVER_ERROR,
-                                        "application/json",
-                                        dispatcher.parseError(),
-                                        origin)
-                                .addListener(CLOSE);
+                        sendResponseAndClose(
+                                ctx,
+                                HttpResponseStatus.INTERNAL_SERVER_ERROR,
+                                "application/json",
+                                dispatcher.parseError(),
+                                origin);
                         return;
                     }
                     if (result instanceof McpDispatcher.DispatchResult.Accepted) {
@@ -189,13 +186,12 @@ public class McpInitializationHandler extends ChannelInboundHandlerAdapter {
                     var elapsedMs = (System.nanoTime() - startNs) / 1_000_000;
                     if (ex != null) {
                         logger.error("Initialize dispatch failed: id={}, elapsed={}ms", id, elapsedMs, ex);
-                        sendResponse(
-                                        ctx,
-                                        HttpResponseStatus.INTERNAL_SERVER_ERROR,
-                                        "application/json",
-                                        dispatcher.parseError(),
-                                        origin)
-                                .addListener(CLOSE);
+                        sendResponseAndClose(
+                                ctx,
+                                HttpResponseStatus.INTERNAL_SERVER_ERROR,
+                                "application/json",
+                                dispatcher.parseError(),
+                                origin);
                         return;
                     }
                     logger.debug("Initialize response: id={}, elapsed={}ms", id, elapsedMs);

--- a/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/McpResponseWriter.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/McpResponseWriter.java
@@ -8,7 +8,6 @@ import dev.tachyonmcp.runtime.McpHeaderNames;
 import dev.tachyonmcp.transport.jsonrpc.JsonRpcCodec;
 import dev.tachyonmcp.transport.jsonrpc.JsonRpcErrors;
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufUtil;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
@@ -21,8 +20,7 @@ public final class McpResponseWriter {
 
     public static void sendOptions(ChannelHandlerContext ctx, @Nullable String origin) {
         if (origin == null || origin.isEmpty()) {
-            sendPlainText(ctx, HttpResponseStatus.FORBIDDEN, "Origin Required")
-                    .addListener(ChannelFutureListener.CLOSE);
+            ChannelHandlerUtils.sendPlainTextAndClose(ctx, HttpResponseStatus.FORBIDDEN, "Origin Required");
             return;
         }
         var response = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.NO_CONTENT);
@@ -39,6 +37,8 @@ public final class McpResponseWriter {
                                 HttpHeaderNames.CONTENT_TYPE.toString(),
                                 HttpHeaderNames.ORIGIN.toString()))
                 .set(HttpHeaderNames.ACCESS_CONTROL_MAX_AGE, "86400");
+        // Signal close so the client does not pool this socket; we close it right after the write.
+        HttpUtil.setKeepAlive(response, false);
         ctx.writeAndFlush(response).addListener(ChannelFutureListener.CLOSE);
     }
 
@@ -76,14 +76,5 @@ public final class McpResponseWriter {
     public static ChannelFuture sendInternalError(ChannelHandlerContext ctx, Object id, @Nullable String origin) {
         var body = JsonRpcCodec.serializeError(id, JsonRpcErrors.INTERNAL_ERROR, "Internal error", null);
         return sendJsonResponse(ctx, body, true, null, origin);
-    }
-
-    private static ChannelFuture sendPlainText(ChannelHandlerContext ctx, HttpResponseStatus status, String message) {
-        var response =
-                new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, status, ByteBufUtil.writeUtf8(ctx.alloc(), message));
-        response.headers().set(HttpHeaderNames.CONTENT_TYPE, "text/plain");
-        response.headers()
-                .set(HttpHeaderNames.CONTENT_LENGTH, response.content().readableBytes());
-        return ctx.writeAndFlush(response);
     }
 }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/ProtocolVersionHandler.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/ProtocolVersionHandler.java
@@ -4,10 +4,11 @@
 
 package dev.tachyonmcp.transport.netty;
 
+import static dev.tachyonmcp.transport.netty.ChannelHandlerUtils.sendResponseAndClose;
+
 import dev.tachyonmcp.runtime.McpHeaderNames;
 import dev.tachyonmcp.transport.jsonrpc.JsonRpcCodec;
 import dev.tachyonmcp.transport.jsonrpc.JsonRpcErrors;
-import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandler.Sharable;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
@@ -39,13 +40,8 @@ public class ProtocolVersionHandler extends ChannelInboundHandlerAdapter {
             if (protoVersion != null && !SUPPORTED_VERSIONS.contains(protoVersion)) {
                 var err = JsonRpcErrors.invalidRequest("Unsupported protocol version");
                 var body = JsonRpcCodec.serializeError(-1, err.code(), err.message(), null);
-                var response = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.BAD_REQUEST, body);
-                response.headers().set(HttpHeaderNames.CONTENT_TYPE, "application/json");
                 var origin = req.headers().get(HttpHeaderNames.ORIGIN);
-                if (origin != null) {
-                    response.headers().set(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN, origin);
-                }
-                ctx.writeAndFlush(response).addListener(ChannelFutureListener.CLOSE);
+                sendResponseAndClose(ctx, HttpResponseStatus.BAD_REQUEST, "application/json", body, origin);
                 return;
             }
         }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/http/AcceptValidationHandler.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/http/AcceptValidationHandler.java
@@ -4,17 +4,16 @@
 
 package dev.tachyonmcp.transport.netty.http;
 
+import static dev.tachyonmcp.transport.netty.ChannelHandlerUtils.sendResponseAndClose;
+
 import io.netty.buffer.Unpooled;
-import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandler.Sharable;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
-import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpResponseStatus;
-import io.netty.handler.codec.http.HttpVersion;
 import java.nio.charset.StandardCharsets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -74,13 +73,8 @@ public final class AcceptValidationHandler extends ChannelInboundHandlerAdapter 
                 String.join(", ", requiredTypes));
         var msg = "Accept header must include " + String.join(" or ", requiredTypes) + " on " + method;
         var body = Unpooled.copiedBuffer(msg, StandardCharsets.UTF_8);
-        var response = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.NOT_ACCEPTABLE, body);
-        response.headers().set(HttpHeaderNames.CONTENT_TYPE, "text/plain");
         var origin = req.headers().get(HttpHeaderNames.ORIGIN);
-        if (origin != null) {
-            response.headers().set(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN, origin);
-        }
         req.release();
-        ctx.writeAndFlush(response).addListener(ChannelFutureListener.CLOSE);
+        sendResponseAndClose(ctx, HttpResponseStatus.NOT_ACCEPTABLE, "text/plain", body, origin);
     }
 }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/http/DnsRebindingProtectionHandler.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/http/DnsRebindingProtectionHandler.java
@@ -4,8 +4,7 @@
 
 package dev.tachyonmcp.transport.netty.http;
 
-import static dev.tachyonmcp.transport.netty.ChannelHandlerUtils.sendPlainText;
-import static io.netty.channel.ChannelFutureListener.CLOSE;
+import static dev.tachyonmcp.transport.netty.ChannelHandlerUtils.sendPlainTextAndClose;
 
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
@@ -29,12 +28,12 @@ public class DnsRebindingProtectionHandler extends ChannelInboundHandlerAdapter 
         if (msg instanceof HttpRequest req) {
             var origin = req.headers().getAsString(HttpHeaderNames.ORIGIN);
             if (origin != null && !origin.isEmpty() && !isLocalhostOrigin(origin)) {
-                sendPlainText(ctx, HttpResponseStatus.FORBIDDEN, "Forbidden").addListener(CLOSE);
+                sendPlainTextAndClose(ctx, HttpResponseStatus.FORBIDDEN, "Forbidden");
                 return;
             }
             var host = req.headers().getAsString(HttpHeaderNames.HOST);
             if (host != null && !host.isEmpty() && !isLocalhostAuthority(host)) {
-                sendPlainText(ctx, HttpResponseStatus.FORBIDDEN, "Forbidden").addListener(CLOSE);
+                sendPlainTextAndClose(ctx, HttpResponseStatus.FORBIDDEN, "Forbidden");
                 return;
             }
         }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/http/EndpointValidatorHandler.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/http/EndpointValidatorHandler.java
@@ -4,8 +4,7 @@
 
 package dev.tachyonmcp.transport.netty.http;
 
-import static dev.tachyonmcp.transport.netty.ChannelHandlerUtils.sendPlainText;
-import static io.netty.channel.ChannelFutureListener.CLOSE;
+import static dev.tachyonmcp.transport.netty.ChannelHandlerUtils.sendPlainTextAndClose;
 
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
@@ -37,7 +36,7 @@ public class EndpointValidatorHandler extends ChannelInboundHandlerAdapter {
 
             if (!uri.startsWith(mcpEndpoint)) {
                 LOGGER.warn("Unknown endpoint: {}", uri);
-                sendPlainText(ctx, HttpResponseStatus.NOT_FOUND, "Not Found").addListener(CLOSE);
+                sendPlainTextAndClose(ctx, HttpResponseStatus.NOT_FOUND, "Not Found");
                 return;
             }
         }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/http/StatelessValidatorHandler.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/http/StatelessValidatorHandler.java
@@ -4,8 +4,7 @@
 
 package dev.tachyonmcp.transport.netty.http;
 
-import static dev.tachyonmcp.transport.netty.ChannelHandlerUtils.sendPlainText;
-import static io.netty.channel.ChannelFutureListener.CLOSE;
+import static dev.tachyonmcp.transport.netty.ChannelHandlerUtils.sendPlainTextAndClose;
 
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
@@ -27,17 +26,15 @@ public class StatelessValidatorHandler extends ChannelInboundHandlerAdapter {
             var sessionId = req.headers().get("MCP-Session-Id");
             var lastEventId = req.headers().get("Last-Event-ID");
             if (sessionId != null || lastEventId != null) {
-                sendPlainText(ctx, HttpResponseStatus.NOT_FOUND, "Stateless server does not support sessions")
-                        .addListener(CLOSE);
+                sendPlainTextAndClose(ctx, HttpResponseStatus.NOT_FOUND, "Stateless server does not support sessions");
                 return;
             }
 
             if (req.method() == HttpMethod.DELETE) {
-                sendPlainText(
-                                ctx,
-                                HttpResponseStatus.METHOD_NOT_ALLOWED,
-                                "Session management not available in stateless mode")
-                        .addListener(CLOSE);
+                sendPlainTextAndClose(
+                        ctx,
+                        HttpResponseStatus.METHOD_NOT_ALLOWED,
+                        "Session management not available in stateless mode");
                 return;
             }
         }


### PR DESCRIPTION
## Issue

The valid request is not being wrongly 403'd (that would show statusCode 403), and the reject path is not losing its 403 to an RST. Instead the valid request's socket is torn down before any response. "other side closed" is undici's error for reusing a pooled  keep-alive socket that the server had already closed.

 Mechanism: the preceding evil request gets a 403 with no Connection: close header (HTTP/1.1 default = keep-alive), then the handler closes the socket anyway via an async `.addListener(CLOSE)`
. undici reads the complete 403, returns the socket to its per-origin
 pool as reusable, then races the next (valid initialize) request onto that socket while the server's FIN is in flight. On Linux that race is lost ~50% of the time; macOS's timing happens to win. Setting Connection: close makes undici discard the socket and
 open a fresh one, eliminating the race.

 Every early reject-and-close handler has this same latent defect.

## The Change

Introduces sendPlainTextAndClose and sendResponseAndClose helper methods in ChannelHandlerUtils that send HTTP responses with `Connection: close` and optionally set `Access-Control-Allow-Origin`. All Netty pipeline handlers are refactored to use these helpers, replacing the prior `sendPlainText/sendResponse(...).addListener(CLOSE)` pattern. Two E2E tests verify that non-localhost origins receive 403 with Connection: close and localhost origins receive 200.