### PR TITLE
fix: race: send accepted only after session is activated

### DIFF
--- a/e2e/src/test/java/dev/tachyonmcp/e2e/TasksExtensionE2eTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/TasksExtensionE2eTest.java
@@ -85,6 +85,31 @@ class TasksExtensionE2eTest extends AbstractMcpE2eTest {
     }
 
     @Test
+    void rejectsToolCallWhileSessionNotYetActive() throws Exception {
+        // Deterministic counterpart to the createTaskViaTool flake: initialize a session but
+        // deliberately skip notifications/initialized, so it stays INITIALIZING and the
+        // activation gate (McpDispatcher) rejects the tools/call with a JSON-RPC error.
+        // This is the exact response shape the flake produced when activation had not yet
+        // completed — and it falsifies the diagnosis if initialize secretly activates.
+        try (var client = createTestClient()) {
+            var initBody = """
+                    {"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{"extensions":{"io.modelcontextprotocol/tasks":{}}},"clientInfo":{"name":"test","version":"1.0"}}}
+                    """;
+            var initResponse = client.post(null, initBody);
+            var sessionId = initResponse.headers().firstValue("MCP-Session-Id").orElseThrow();
+
+            var response = client.post(sessionId, """
+                    {"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"create_task","arguments":{"name":"my-task"}}}
+                    """);
+
+            assertThat(response.statusCode()).isEqualTo(200);
+            assertThat(response.headers().firstValue("content-type").orElse("")).startsWith("application/json");
+            assertThat(response.body()).contains("not yet active");
+            assertThatJson(response.body()).inPath("$.error").isObject();
+        }
+    }
+
+    @Test
     void createCompletePollAndGetResult() throws Exception {
         try (var client = createTestClient()) {
             var sessionId = initializeWithExtension(client);

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/McpDispatcher.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/McpDispatcher.java
@@ -45,7 +45,7 @@ public class McpDispatcher {
 
     private static final String METHOD_INITIALIZE = "initialize";
     private static final String METHOD_PING = "ping";
-    private static final String NOTIFICATIONS_INITIALIZED = "notifications/initialized";
+    public static final String NOTIFICATIONS_INITIALIZED = "notifications/initialized";
     private static final String NOTIFICATIONS_CANCELLED = "notifications/cancelled";
     private static final String NOTIFICATIONS_TASKS_STATUS = "notifications/tasks/status";
 

--- a/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/McpOperationHandler.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/McpOperationHandler.java
@@ -143,9 +143,21 @@ public class McpOperationHandler extends ChannelInboundHandlerAdapter {
             case JsonRpcMessage.Response resp -> handlePostResponse(ctx, resp, origin);
             case JsonRpcMessage.Error err -> handlePostError(ctx, err, origin);
             case JsonRpcMessage.Notification not -> {
-                sendAccepted(ctx, origin);
-                CompletableFuture.runAsync(
-                        () -> dispatcher.dispatchNotification(not.method(), not.params(), sessionId), executor);
+                if (McpDispatcher.NOTIFICATIONS_INITIALIZED.equals(not.method())) {
+                    // Activate the session synchronously before acking so a client that waits
+                    // for this 202 observes an ACTIVE session on its next request, closing the
+                    // INITIALIZING race. Guarded so a handler failure still produces the ack.
+                    try {
+                        dispatcher.dispatchNotification(not.method(), not.params(), sessionId);
+                    } catch (RuntimeException e) {
+                        logger.warn("Failed to process {} notification", not.method(), e);
+                    }
+                    sendAccepted(ctx, origin);
+                } else {
+                    sendAccepted(ctx, origin);
+                    CompletableFuture.runAsync(
+                            () -> dispatcher.dispatchNotification(not.method(), not.params(), sessionId), executor);
+                }
             }
             default -> {
                 logger.warn("Unexpected message type: {}", message);


### PR DESCRIPTION
## Bug Fixes

Improved session initialization handling to properly reject tool calls when the session is not yet fully active.

## Tests

Added end-to-end test coverage for validating tool call rejection during incomplete session initialization.

## Walkthrough

McpDispatcher.NOTIFICATIONS_INITIALIZED is made public so McpOperationHandler can reference it directly. dispatchPostMessage is updated to dispatch the notifications/initialized notification synchronously before sending the 202 Accepted response, while all other notifications remain asynchronous. A new E2E test verifies that tool calls are rejected when the initialized notification has not yet been sent.