### PR TITLE
feat: Support JDK 21+

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,9 @@ jobs:
       fail-fast: false
       matrix:
         java:
+          - 21
           - 25
+          - 26
     runs-on: ubuntu-latest
     timeout-minutes: 7
 
@@ -67,7 +69,7 @@ jobs:
       fail-fast: false
       matrix:
         java:
-          - 25
+          - 21
         example:
           - weather
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,9 @@ on:
 permissions:
   contents: write
 
+env:
+  JAVA_VERSION: 21
+
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -51,11 +54,11 @@ jobs:
           -DnewVersion=${{ steps.release.outputs.release_version }}
           -DgenerateBackupPoms=false
 
-      - name: Set up JDK 25
+      - name: Set up JDK ${{ env.JAVA_VERSION }}
         uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: '25'
+          java-version: ${{ env.JAVA_VERSION }}
           cache: maven
           server-id: central
           server-username: MAVEN_CENTRAL_USERNAME

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 .PHONY: build test package conformance e2e clean format all inspector example
 
-all: clean format build
+all: clean format build example
 
 build:
-	@echo "🏗️  Building..."
+	@echo "🏗️ Building..."
 	@mvn -version
 	@mvn verify -q
 
@@ -40,4 +40,4 @@ format:
 .PHONY: inspector
 inspector:
 	@echo "🧐 MCP Inspector"
-	@npx -y @modelcontextprotocol/inspector
+	@npx -y @modelcontextprotocol/inspector --config mcp-inspector.json

--- a/README.md
+++ b/README.md
@@ -3,9 +3,10 @@
 [![Maven Central](https://img.shields.io/maven-central/v/dev.tachyonmcp/tachyon-server)](https://repo1.maven.org/maven2/dev/tachyonmcp/tachyon-server/)
 [![Build](https://github.com/kpavlov/tachyon/actions/workflows/build.yml/badge.svg?branch=main)](https://github.com/kpavlov/tachyon/actions/workflows/build.yml)
 [![Conformance 46 of 46](https://img.shields.io/badge/Conformance-Server:%2046%20%2F%2046%0A-green?logo=modelcontextprotocol)](https://github.com/modelcontextprotocol/conformance)
+[![JVM](https://img.shields.io/badge/JVM-21+-orange.svg?logo=jvm)](http://java.com)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/kpavlov/tachyon)
 
-**Tachyon MCP** — A Java 25 [Model Context Protocol](https://modelcontextprotocol.io) (MCP) server built on [Netty 4.2](https://netty.io).
+**Tachyon MCP** — A Java 21 [Model Context Protocol](https://modelcontextprotocol.io) (MCP) server built on [Netty 4.2](https://netty.io).
 Fully implements MCP spec **2025-11-25** Streamable HTTP transport, session lifecycle, native I/O transports, and a stateless mode for serverless deployments.
 
 **TL;DR**

--- a/conformance/src/test/java/dev/tachyonmcp/conformance/AbstractServerConformanceIT.java
+++ b/conformance/src/test/java/dev/tachyonmcp/conformance/AbstractServerConformanceIT.java
@@ -93,29 +93,29 @@ abstract class AbstractServerConformanceIT {
                 "test_simple_text",
                 "Returns simple text",
                 INPUT_SCHEMA_NO_ARGS,
-                (_, _) -> ToolResult.text("This is a simple text response for testing.")));
+                (ctx, args) -> ToolResult.text("This is a simple text response for testing.")));
 
         server.registerTool(SyncToolHandler.of(
                 "test_image_content",
                 "Returns image content",
                 INPUT_SCHEMA_NO_ARGS,
-                (_, _) -> ToolResult.of(List.of(ImageContent.of(MINI_PNG_BASE64, "image/png")))));
+                (ctx, args) -> ToolResult.of(List.of(ImageContent.of(MINI_PNG_BASE64, "image/png")))));
 
         server.registerTool(SyncToolHandler.of(
                 "test_audio_content",
                 "Returns audio content",
                 INPUT_SCHEMA_NO_ARGS,
-                (_, _) -> ToolResult.of(List.of(AudioContent.of(MINI_WAV_BASE64, "audio/wav")))));
+                (ctx, args) -> ToolResult.of(List.of(AudioContent.of(MINI_WAV_BASE64, "audio/wav")))));
 
         server.registerTool(SyncToolHandler.of(
-                "test_embedded_resource", "Returns embedded resource", INPUT_SCHEMA_NO_ARGS, (_, _) -> {
+                "test_embedded_resource", "Returns embedded resource", INPUT_SCHEMA_NO_ARGS, (ctx, args) -> {
                     var res = TextResourceContents.of(
                             "test://embedded-resource", "text/plain", "This is an embedded resource content.");
                     return ToolResult.of(List.of(EmbeddedResource.of(res)));
                 }));
 
         server.registerTool(SyncToolHandler.of(
-                "test_multiple_content_types", "Returns multiple content types", INPUT_SCHEMA_NO_ARGS, (_, _) -> {
+                "test_multiple_content_types", "Returns multiple content types", INPUT_SCHEMA_NO_ARGS, (ctx, args) -> {
                     var mixed = TextResourceContents.of(
                             "test://mixed-content-resource", "application/json", "{\"test\":\"data\",\"value\":123}");
                     return ToolResult.of(
@@ -128,7 +128,7 @@ abstract class AbstractServerConformanceIT {
                 "test_error_handling",
                 "Always returns error",
                 INPUT_SCHEMA_NO_ARGS,
-                (_, _) -> ToolResult.error("This tool intentionally returns an error for testing")));
+                (ctx, args) -> ToolResult.error("This tool intentionally returns an error for testing")));
 
         server.registerTool(new ToolHandler() {
             @Override
@@ -236,7 +236,7 @@ abstract class AbstractServerConformanceIT {
                 }));
 
         server.registerTool(SyncToolHandler.of(
-                "test_elicitation_sep1034_defaults", "Elicitation with defaults", INPUT_SCHEMA_NO_ARGS, (ctx, _) -> {
+                "test_elicitation_sep1034_defaults", "Elicitation with defaults", INPUT_SCHEMA_NO_ARGS, (ctx, args) -> {
                     try {
                         var paramsMap = Map.of(
                                 "mode", "form",
@@ -274,7 +274,7 @@ abstract class AbstractServerConformanceIT {
                 }));
 
         server.registerTool(SyncToolHandler.of(
-                "test_elicitation_sep1330_enums", "Elicitation with enums", INPUT_SCHEMA_NO_ARGS, (ctx, _) -> {
+                "test_elicitation_sep1330_enums", "Elicitation with enums", INPUT_SCHEMA_NO_ARGS, (ctx, args) -> {
                     try {
                         var props = new LinkedHashMap<String, Object>();
                         props.put(
@@ -352,7 +352,7 @@ abstract class AbstractServerConformanceIT {
                 "test_reconnection",
                 "A tool that triggers SSE stream closure to test client reconnection behavior",
                 INPUT_SCHEMA_NO_ARGS,
-                (_, _) -> {
+                (ctx, args) -> {
                     var stream = OutboundSseStreamMessageRouter.currentOutboundSseStream();
                     if (stream != null) {
                         stream.start();
@@ -422,20 +422,20 @@ abstract class AbstractServerConformanceIT {
         server.resources()
                 .add(
                         ResourceDescriptor.of("hello", "hello://world", "Hello resource", "text/plain"),
-                        (_, _) -> TextResourceContents.of("hello://world", "text/plain", "Hello, World!"));
+                        (ctx, req) -> TextResourceContents.of("hello://world", "text/plain", "Hello, World!"));
 
         server.resources()
                 .add(
                         ResourceDescriptor.of(
                                 "static-text", "test://static-text", "Static text resource", "text/plain"),
-                        (_, _) -> TextResourceContents.of(
+                        (ctx, req) -> TextResourceContents.of(
                                 "test://static-text", "text/plain", "This is static text content for testing."));
 
         server.resources()
                 .add(
                         ResourceDescriptor.of(
                                 "static-binary", "test://static-binary", "Static binary resource", "image/png"),
-                        (_, _) -> BlobResourceContents.of("test://static-binary", "image/png", MINI_PNG_BASE64));
+                        (ctx, req) -> BlobResourceContents.of("test://static-binary", "image/png", MINI_PNG_BASE64));
 
         server.resources()
                 .addTemplate(ResourceTemplateEntry.of(

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/ResourceCapabilitiesE2eTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/ResourceCapabilitiesE2eTest.java
@@ -28,10 +28,11 @@ class ResourceCapabilitiesE2eTest extends AbstractMcpE2eTest {
         server.resources()
                 .add(
                         ResourceDescriptor.of("doc", "resource://doc", "A document", "text/plain"),
-                        (_, _) -> TextResourceContents.of("resource://doc", "text/plain", "Hello"))
+                        (ctx, req) -> TextResourceContents.of("resource://doc", "text/plain", "Hello"))
                 .add(
                         ResourceDescriptor.of("code", "resource://code", "Source code", "text/x-java"),
-                        (_, _) -> TextResourceContents.of("resource://code", "text/x-java", "package com.example;"));
+                        (ctx, req) ->
+                                TextResourceContents.of("resource://code", "text/x-java", "package com.example;"));
 
         try (var client = createTestClient()) {
             var sessionId = client.initialize();

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/TasksExtensionE2eTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/TasksExtensionE2eTest.java
@@ -159,7 +159,7 @@ class TasksExtensionE2eTest extends AbstractMcpE2eTest {
     @Test
     void shouldNotifyTaskStatusOnCreate() throws Exception {
         // The extension's create_task tool is async, so notifications don't route
-        // through POST-SSE (ScopedValue not inherited by ForkJoin threads).
+        // through POST-SSE (ThreadLocal not inherited by ForkJoin threads).
         // This test uses a synchronous tool to verify notification delivery.
         startServer(TachyonMcpServer.builder()
                 .tool(new ToolHandler() {

--- a/examples/weather/pom.xml
+++ b/examples/weather/pom.xml
@@ -14,10 +14,10 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.release>25</maven.compiler.release>
+        <maven.compiler.release>21</maven.compiler.release>
         <jackson.version>3.2.0</jackson.version>
         <junit.version>6.1.0</junit.version>
-        <tachyon-server.version>1.0.0-alpha.1</tachyon-server.version>
+        <tachyon-server.version>1.0.0-alpha.2</tachyon-server.version>
 <!--        <tachyon-server.version>1-SNAPSHOT</tachyon-server.version>-->
         <assertj.version>3.27.7</assertj.version>
     </properties>
@@ -94,7 +94,7 @@
     <!-- Resolves the plugin from the parent project's local staging repo (populated by make ci / make build). -->
     <repositories>
         <repository>
-            <id>ksp-maven-plugin-local</id>
+            <id>project-local</id>
             <url>file://${project.basedir}/../../target/local-repo</url>
         </repository>
     </repositories>

--- a/mcp-inspector.json
+++ b/mcp-inspector.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "default-server": {
+      "type": "streamable-http",
+      "url": "http://127.0.0.1:8080/mcp",
+      "note": "For Streamable HTTP connections, add this URL directly in your MCP Client"
+    }
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -56,11 +56,10 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- Java -->
-        <java.version>25</java.version>
+        <java.version>21</java.version>
 
         <!-- Dependencies -->
         <assertj.version>3.27.7</assertj.version>
-        <jackson-annotations.version>2.22</jackson-annotations.version>
         <jackson.version>3.2.0</jackson.version>
         <json-schema-validator.version>3.0.5</json-schema-validator.version>
         <java-mcp-sdk.version>2.0.0</java-mcp-sdk.version>

--- a/tachyon-server/src/main/java/dev/tachyonmcp/runtime/InteractionContext.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/runtime/InteractionContext.java
@@ -30,7 +30,7 @@ public interface InteractionContext<S extends Session> {
     @Nullable
     S session();
 
-    void setSession(S session);
+    void setSession(@Nullable S session);
 
     void enableExtension(String extensionId);
 

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/HandlerWatchdog.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/HandlerWatchdog.java
@@ -54,16 +54,11 @@ public final class HandlerWatchdog {
         var frames = thread.getStackTrace();
         var sb = new StringBuilder();
         for (var f : frames) sb.append("\n    at ").append(f);
-        switch (state) {
-            case BLOCKED ->
-                logger.warn(
-                        MSG, method, id, elapsedMs, state, thread.getName(), thread.threadId(), thread.isVirtual(), sb);
-            case RUNNABLE ->
-                logger.debug(
-                        MSG, method, id, elapsedMs, state, thread.getName(), thread.threadId(), thread.isVirtual(), sb);
-            default ->
-                logger.debug(
-                        MSG, method, id, elapsedMs, state, thread.getName(), thread.threadId(), thread.isVirtual(), sb);
+        if (state == Thread.State.BLOCKED) {
+            logger.warn(MSG, method, id, elapsedMs, state, thread.getName(), thread.threadId(), thread.isVirtual(), sb);
+        } else {
+            logger.debug(
+                    MSG, method, id, elapsedMs, state, thread.getName(), thread.threadId(), thread.isVirtual(), sb);
         }
     }
 }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/McpDispatcher.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/McpDispatcher.java
@@ -312,7 +312,7 @@ public class McpDispatcher {
         var finalReason = rawReason;
         server.getSession(sessionId)
                 .ifPresentOrElse(
-                        _ -> {
+                        session -> {
                             var reasonMsg = finalReason != null ? ": " + finalReason : "";
                             var cancelled = server.failPendingRequest(finalRequestId, "Cancelled" + reasonMsg);
                             if (cancelled) {

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/McpServer.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/McpServer.java
@@ -347,7 +347,7 @@ public class McpServer implements Closeable {
     public void registerPendingRequest(Object requestId, CompletableFuture<String> future) {
         pendingRequests.put(requestId, future);
         future.orTimeout(PENDING_REQUEST_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
-        future.whenComplete((_, ex) -> {
+        future.whenComplete((res, ex) -> {
             if (ex instanceof TimeoutException) {
                 var removed = pendingRequests.remove(requestId);
                 if (removed != null) {

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/OutboundSseStreamMessageRouter.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/OutboundSseStreamMessageRouter.java
@@ -6,49 +6,49 @@ package dev.tachyonmcp.server;
 
 import dev.tachyonmcp.server.session.McpSession;
 import dev.tachyonmcp.server.session.SseEvent;
+import java.util.concurrent.Callable;
 import org.jspecify.annotations.Nullable;
 
 /**
  * Default {@link MessageRouter} that diverts events through an {@link OutboundSseStream} bound in
- * the current dispatch context when the dispatch session matches the target session. Otherwise lets
+ * the current dispatch context when the dispatch session matches the target session. Otherwise, lets
  * the caller fall through to the normal GET-SSE path.
  */
 public final class OutboundSseStreamMessageRouter implements MessageRouter {
 
-    private static final ScopedValue<OutboundSseStream> OUTBOUND_SSE_STREAM = ScopedValue.newInstance();
-    private static final ScopedValue<String> DISPATCH_SESSION_ID = ScopedValue.newInstance();
+    private static final ThreadLocal<@Nullable OutboundSseStream> OUTBOUND_SSE_STREAM = new ThreadLocal<>();
+    private static final ThreadLocal<@Nullable String> DISPATCH_SESSION_ID = new ThreadLocal<>();
 
-    public static <T, X extends Exception> T withDispatchContext(
-            String sessionId, @Nullable OutboundSseStream outboundSseStream, ScopedValue.CallableOp<T, X> action)
-            throws X {
-        if (outboundSseStream == null) {
-            return ScopedValue.where(DISPATCH_SESSION_ID, sessionId).call(action);
+    public static <T> T withDispatchContext(
+            @Nullable String sessionId, @Nullable OutboundSseStream outboundSseStream, Callable<T> action)
+            throws Exception {
+        var prevSessionId = DISPATCH_SESSION_ID.get();
+        var prevStream = OUTBOUND_SSE_STREAM.get();
+        DISPATCH_SESSION_ID.set(sessionId);
+        OUTBOUND_SSE_STREAM.set(outboundSseStream);
+        try {
+            return action.call();
+        } finally {
+            if (prevSessionId == null) DISPATCH_SESSION_ID.remove();
+            else DISPATCH_SESSION_ID.set(prevSessionId);
+            if (prevStream == null) OUTBOUND_SSE_STREAM.remove();
+            else OUTBOUND_SSE_STREAM.set(prevStream);
         }
-        return ScopedValue.where(DISPATCH_SESSION_ID, sessionId)
-                .where(OUTBOUND_SSE_STREAM, outboundSseStream)
-                .call(action);
-    }
-
-    static void runWithDispatchContext(
-            String sessionId, @Nullable OutboundSseStream outboundSseStream, Runnable action) {
-        if (outboundSseStream == null) {
-            ScopedValue.where(DISPATCH_SESSION_ID, sessionId).run(action);
-            return;
-        }
-        ScopedValue.where(DISPATCH_SESSION_ID, sessionId)
-                .where(OUTBOUND_SSE_STREAM, outboundSseStream)
-                .run(action);
     }
 
     public static @Nullable OutboundSseStream currentOutboundSseStream() {
-        return OUTBOUND_SSE_STREAM.isBound() ? OUTBOUND_SSE_STREAM.get() : null;
+        return OUTBOUND_SSE_STREAM.get();
+    }
+
+    public static @Nullable String currentSessionId() {
+        return DISPATCH_SESSION_ID.get();
     }
 
     @Override
     public boolean tryRoute(McpSession session, SseEvent event) {
-        var outboundStream = OUTBOUND_SSE_STREAM.isBound() ? OUTBOUND_SSE_STREAM.get() : null;
+        var outboundStream = OUTBOUND_SSE_STREAM.get();
         if (outboundStream == null) return false;
-        var currentSessionId = DISPATCH_SESSION_ID.isBound() ? DISPATCH_SESSION_ID.get() : null;
+        var currentSessionId = DISPATCH_SESSION_ID.get();
         if (currentSessionId == null || !currentSessionId.equals(session.id())) return false;
         outboundStream.start();
         outboundStream.writeEvent(event);

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/builder/BuilderState.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/builder/BuilderState.java
@@ -130,7 +130,7 @@ final class BuilderState {
                             d,
                             r.handler() != null
                                     ? r.handler()
-                                    : (_, _) -> TextResourceContents.of(d.uri(), d.mimeType(), "", null));
+                                    : (ctx, req) -> TextResourceContents.of(d.uri(), d.mimeType(), "", null));
         });
         prompts.forEach(p -> server.prompts().add(p.descriptor(), p.handler()));
         tasks.forEach(t -> server.tasks().add(t));

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/builder/CapabilitiesStep.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/builder/CapabilitiesStep.java
@@ -82,7 +82,7 @@ public final class CapabilitiesStep {
     }
 
     public FeatureStep prompt(PromptDescriptor descriptor, List<PromptMessage> messages) {
-        state.prompts.add(new BuilderState.PromptRegistration(descriptor, _ -> messages));
+        state.prompts.add(new BuilderState.PromptRegistration(descriptor, args -> messages));
         return new FeatureStep(state);
     }
 

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/builder/FeatureStep.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/builder/FeatureStep.java
@@ -66,7 +66,7 @@ public final class FeatureStep {
     }
 
     public FeatureStep prompt(PromptDescriptor descriptor, List<PromptMessage> messages) {
-        state.prompts.add(new BuilderState.PromptRegistration(descriptor, _ -> messages));
+        state.prompts.add(new BuilderState.PromptRegistration(descriptor, args -> messages));
         return this;
     }
 

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/builder/IdentityStep.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/builder/IdentityStep.java
@@ -109,7 +109,7 @@ public final class IdentityStep {
     }
 
     public FeatureStep prompt(PromptDescriptor descriptor, List<PromptMessage> messages) {
-        state.prompts.add(new BuilderState.PromptRegistration(descriptor, _ -> messages));
+        state.prompts.add(new BuilderState.PromptRegistration(descriptor, args -> messages));
         return new FeatureStep(state);
     }
 

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/features/prompts/PromptRegistry.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/features/prompts/PromptRegistry.java
@@ -31,7 +31,7 @@ public class PromptRegistry extends Registry<PromptEntry> {
     }
 
     public void add(PromptDescriptor descriptor, List<PromptMessage> messages) {
-        super.add(new PromptEntry(descriptor, _ -> messages));
+        super.add(new PromptEntry(descriptor, args -> messages));
     }
 
     public void add(PromptDescriptor descriptor, PromptHandler handler) {

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/features/resources/ResourceRegistry.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/features/resources/ResourceRegistry.java
@@ -88,7 +88,7 @@ public class ResourceRegistry {
     }
 
     public PaginatedResult<ResourceDescriptor> list(int limit, @Nullable String cursor) {
-        return list(limit, cursor, DEFAULT_PAGE_SIZE, _ -> true);
+        return list(limit, cursor, DEFAULT_PAGE_SIZE, descriptor -> true);
     }
 
     public PaginatedResult<ResourceDescriptor> list(
@@ -97,7 +97,7 @@ public class ResourceRegistry {
     }
 
     public PaginatedResult<ResourceDescriptor> list(int limit, @Nullable String cursor, int defaultLimit) {
-        return list(limit, cursor, defaultLimit, _ -> true);
+        return list(limit, cursor, defaultLimit, descriptor -> true);
     }
 
     public PaginatedResult<ResourceDescriptor> list(
@@ -135,6 +135,7 @@ public class ResourceRegistry {
         return PaginatedResult.of(result, nextCursor);
     }
 
+    @Nullable
     ResourceEntry getByUri(String uri) {
         return byUri.get(uri);
     }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tasks/TasksExtension.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tasks/TasksExtension.java
@@ -5,6 +5,7 @@
 package dev.tachyonmcp.server.features.tasks;
 
 import dev.tachyonmcp.server.McpServer;
+import dev.tachyonmcp.server.OutboundSseStreamMessageRouter;
 import dev.tachyonmcp.server.domain.TextResourceContents;
 import dev.tachyonmcp.server.extensions.McpExtension;
 import dev.tachyonmcp.server.features.resources.ResourceTemplateEntry;
@@ -14,6 +15,7 @@ import dev.tachyonmcp.server.features.tools.ToolResult;
 import dev.tachyonmcp.server.session.McpContext;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
 import tools.jackson.databind.JsonNode;
@@ -72,16 +74,24 @@ public final class TasksExtension implements McpExtension {
 
         @Override
         public CompletionStage<Object> handleAsync(McpContext context, Object arguments) {
+            var sessionId = OutboundSseStreamMessageRouter.currentSessionId();
+            var outboundStream = OutboundSseStreamMessageRouter.currentOutboundSseStream();
             return CompletableFuture.supplyAsync(
                     () -> {
-                        String name = "unnamed";
-                        String description = null;
-                        if (arguments instanceof Map<?, ?> map) {
-                            if (map.get("name") instanceof String s) name = s;
-                            if (map.get("description") instanceof String s) description = s;
+                        try {
+                            return OutboundSseStreamMessageRouter.withDispatchContext(sessionId, outboundStream, () -> {
+                                String name = "unnamed";
+                                String description = null;
+                                if (arguments instanceof Map<?, ?> map) {
+                                    if (map.get("name") instanceof String s) name = s;
+                                    if (map.get("description") instanceof String s) description = s;
+                                }
+                                return ToolResult.text(
+                                        tasks.createTask(name, description).id());
+                            });
+                        } catch (Exception e) {
+                            throw new CompletionException(e);
                         }
-                        return ToolResult.text(
-                                tasks.createTask(name, description).id());
                     },
                     executor);
         }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tools/ToolRegistry.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tools/ToolRegistry.java
@@ -8,7 +8,9 @@ import static dev.tachyonmcp.transport.jsonrpc.JsonRpcErrors.invalidRequest;
 import static dev.tachyonmcp.transport.jsonrpc.JsonRpcErrors.methodNotFound;
 
 import dev.tachyonmcp.protocol.mcp.v2025_11_25.codecs.McpToolMapper;
-import dev.tachyonmcp.protocol.mcp.v2025_11_25.models.*;
+import dev.tachyonmcp.protocol.mcp.v2025_11_25.models.CallToolRequestParams;
+import dev.tachyonmcp.protocol.mcp.v2025_11_25.models.CallToolResult;
+import dev.tachyonmcp.protocol.mcp.v2025_11_25.models.ListToolsResult;
 import dev.tachyonmcp.server.JsonSchemaValidator;
 import dev.tachyonmcp.server.McpMethodHandler;
 import dev.tachyonmcp.server.features.PaginatedResult;
@@ -77,7 +79,7 @@ public class ToolRegistry {
     }
 
     public PaginatedResult<ToolDescriptor> list(int limit, @Nullable String cursor) {
-        return list(limit, cursor, DEFAULT_PAGE_SIZE, _ -> true);
+        return list(limit, cursor, DEFAULT_PAGE_SIZE, descriptor -> true);
     }
 
     public PaginatedResult<ToolDescriptor> list(int limit, @Nullable String cursor, Predicate<ToolDescriptor> filter) {
@@ -85,7 +87,7 @@ public class ToolRegistry {
     }
 
     public PaginatedResult<ToolDescriptor> list(int limit, @Nullable String cursor, int defaultLimit) {
-        return list(limit, cursor, defaultLimit, _ -> true);
+        return list(limit, cursor, defaultLimit, descriptor -> true);
     }
 
     public PaginatedResult<ToolDescriptor> list(

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/session/DefaultMcpContext.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/session/DefaultMcpContext.java
@@ -9,6 +9,7 @@ import dev.tachyonmcp.runtime.InteractionContext;
 import dev.tachyonmcp.server.McpServer;
 import dev.tachyonmcp.server.Notifications;
 import dev.tachyonmcp.server.ServerContext;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import org.jspecify.annotations.Nullable;
@@ -126,7 +127,7 @@ public class DefaultMcpContext implements McpContext {
     @SuppressWarnings("unchecked")
     public <T> @Nullable T getAttribute(String name) {
         if (interactionContext != null) {
-            return (T) interactionContext.getAttribute(name);
+            return interactionContext.getAttribute(name);
         }
         return null;
     }
@@ -176,15 +177,7 @@ public class DefaultMcpContext implements McpContext {
         }
     }
 
-    private class NotificationsImpl implements Notifications {
-
-        private final McpSession session;
-        private final McpServer server;
-
-        NotificationsImpl(McpSession session, McpServer server) {
-            this.session = session;
-            this.server = server;
-        }
+    private record NotificationsImpl(McpSession session, McpServer server) implements Notifications {
 
         @Override
         public void send(String method, Object params) {
@@ -194,7 +187,7 @@ public class DefaultMcpContext implements McpContext {
         @Override
         public void progress(@Nullable Object progressToken, double progress, double total, String message) {
             if (progressToken == null) return;
-            var paramsMap = new java.util.LinkedHashMap<String, Object>();
+            var paramsMap = new LinkedHashMap<String, Object>();
             paramsMap.put("progressToken", progressToken);
             paramsMap.put("progress", progress);
             paramsMap.put("total", total);

--- a/tachyon-server/src/main/java/dev/tachyonmcp/transport/jsonrpc/JsonRpcCodec.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/transport/jsonrpc/JsonRpcCodec.java
@@ -301,7 +301,7 @@ public final class JsonRpcCodec {
 
     public static <T> T decodeWithCodec(String json, Class<T> targetType) {
         try {
-            var codec = CodecRegistry.<T>codecFor(targetType);
+            var codec = CodecRegistry.codecFor(targetType);
             try (var p = Codec.FACTORY.createParser(TREE_READ_CONTEXT, json.getBytes(StandardCharsets.UTF_8))) {
                 if (p.nextToken() != JsonToken.START_OBJECT) {
                     throw new IOException("Expected JSON object");

--- a/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/ChannelHandlerUtils.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/ChannelHandlerUtils.java
@@ -20,7 +20,7 @@ public final class ChannelHandlerUtils {
 
     private ChannelHandlerUtils() {}
 
-    public static InteractionContext interactionContext(ChannelHandlerContext ctx) {
+    public static InteractionContext<?> interactionContext(ChannelHandlerContext ctx) {
         return Objects.requireNonNull(
                 ctx.channel().attr(INTERACTION_CONTEXT_KEY).get(),
                 "InteractionContext is null. Check if InteractionHandler is configured correctly.");
@@ -33,10 +33,6 @@ public final class ChannelHandlerUtils {
             response.headers().set(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN, origin);
         }
         ctx.writeAndFlush(response);
-    }
-
-    public static ChannelFuture sendPlainText(ChannelHandlerContext ctx, HttpResponseStatus status, String message) {
-        return sendPlainText(ctx, status, message, null);
     }
 
     /**
@@ -69,32 +65,13 @@ public final class ChannelHandlerUtils {
         return sendResponse(ctx, status, contentType, body, true, origin);
     }
 
-    public static ChannelFuture sendPlainText(
-            ChannelHandlerContext ctx, HttpResponseStatus status, String message, @Nullable String origin) {
-        return sendResponse(ctx, status, "text/plain", ByteBufUtil.writeUtf8(ctx.alloc(), message), false, origin);
-    }
-
-    public static ChannelFuture sendPlainText(
+    public static void sendPlainText(
             ChannelHandlerContext ctx,
             HttpResponseStatus status,
             String message,
             boolean close,
             @Nullable String origin) {
-        return sendResponse(ctx, status, "text/plain", ByteBufUtil.writeUtf8(ctx.alloc(), message), close, origin);
-    }
-
-    public static ChannelFuture sendResponse(
-            ChannelHandlerContext ctx, HttpResponseStatus status, String contentType, ByteBuf body) {
-        return sendResponse(ctx, status, contentType, body, null);
-    }
-
-    public static ChannelFuture sendResponse(
-            ChannelHandlerContext ctx,
-            HttpResponseStatus status,
-            String contentType,
-            ByteBuf body,
-            @Nullable String origin) {
-        return sendResponse(ctx, status, contentType, body, false, origin);
+        sendResponse(ctx, status, "text/plain", ByteBufUtil.writeUtf8(ctx.alloc(), message), close, origin);
     }
 
     public static ChannelFuture sendResponse(

--- a/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/InteractionHandler.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/InteractionHandler.java
@@ -8,11 +8,11 @@ import dev.tachyonmcp.runtime.DefaultInteractionContext;
 import dev.tachyonmcp.runtime.InteractionContext;
 import dev.tachyonmcp.runtime.InteractionContext.Lifecycle;
 import dev.tachyonmcp.runtime.InteractionEvent;
+import dev.tachyonmcp.runtime.Session;
 import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
-import io.netty.util.Attribute;
 import io.netty.util.AttributeKey;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
@@ -27,7 +27,7 @@ import org.slf4j.LoggerFactory;
 public class InteractionHandler extends ChannelDuplexHandler {
 
     private static final Logger logger = LoggerFactory.getLogger(InteractionHandler.class);
-    public static final AttributeKey<@Nullable InteractionContext> INTERACTION_CONTEXT_KEY =
+    public static final AttributeKey<@Nullable InteractionContext<Session>> INTERACTION_CONTEXT_KEY =
             AttributeKey.valueOf("interactionContext");
 
     private final String protocol;
@@ -37,9 +37,8 @@ public class InteractionHandler extends ChannelDuplexHandler {
     }
 
     @Override
-    @SuppressWarnings("NullableProblems")
     public void channelActive(ChannelHandlerContext ctx) {
-        Attribute<InteractionContext> attr = ctx.channel().attr(INTERACTION_CONTEXT_KEY);
+        final var attr = ctx.channel().attr(INTERACTION_CONTEXT_KEY);
         if (attr.compareAndSet(null, new DefaultInteractionContext<>(protocol))) {
             logger.debug("Interaction started: protocol={}", protocol);
         }
@@ -58,15 +57,14 @@ public class InteractionHandler extends ChannelDuplexHandler {
                 ic.setLifecycle(Lifecycle.OPERATION);
                 logger.debug("Interaction: INITIALIZATION → OPERATION");
             }
-            case InteractionEvent.ShutdownStarted ss -> {
+            case InteractionEvent.ShutdownStarted ignored -> {
                 var ic = ctx.channel().attr(INTERACTION_CONTEXT_KEY).get();
                 if (ic == null) break;
                 ic.setLifecycle(Lifecycle.SHUTDOWN);
                 logger.debug("Interaction: OPERATION → SHUTDOWN");
             }
-            case InteractionEvent.ShutdownComplete() -> {
+            case InteractionEvent.ShutdownComplete() ->
                 ctx.channel().attr(INTERACTION_CONTEXT_KEY).set(null);
-            }
             default -> {}
         }
         ctx.fireUserEventTriggered(evt);
@@ -79,7 +77,7 @@ public class InteractionHandler extends ChannelDuplexHandler {
 
     @Override
     public void close(ChannelHandlerContext ctx, ChannelPromise promise) {
-        ctx.fireUserEventTriggered(new InteractionEvent.ShutdownComplete());
+        ctx.fireUserEventTriggered(InteractionEvent.ShutdownComplete.INSTANCE);
         ctx.close(promise);
     }
 }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/McpInitializationHandler.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/McpInitializationHandler.java
@@ -58,10 +58,6 @@ public class McpInitializationHandler extends ChannelInboundHandlerAdapter {
     private final McpDispatcher dispatcher;
     private final Executor executor;
 
-    public McpInitializationHandler(McpServer server, McpDispatcher dispatcher) {
-        this(server, dispatcher, server.executor());
-    }
-
     public McpInitializationHandler(McpServer server, McpDispatcher dispatcher, Executor executor) {
         this.server = server;
         this.dispatcher = dispatcher;

--- a/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/McpOperationHandler.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/McpOperationHandler.java
@@ -11,7 +11,6 @@ import dev.tachyonmcp.runtime.InteractionEvent;
 import dev.tachyonmcp.runtime.McpHeaderNames;
 import dev.tachyonmcp.server.McpDispatcher;
 import dev.tachyonmcp.server.McpServer;
-import dev.tachyonmcp.server.session.DefaultMcpContext;
 import dev.tachyonmcp.server.session.McpSession;
 import dev.tachyonmcp.server.session.SessionEvent;
 import dev.tachyonmcp.transport.jsonrpc.JsonRpcMessage;
@@ -139,10 +138,10 @@ public class McpOperationHandler extends ChannelInboundHandlerAdapter {
             return;
         }
         switch (message) {
-            case JsonRpcMessage.Request reqMsg -> handlePostRequest(ctx, sessionId, reqMsg, origin);
+            case JsonRpcMessage.Request<?> reqMsg -> handlePostRequest(ctx, sessionId, reqMsg, origin);
             case JsonRpcMessage.Response resp -> handlePostResponse(ctx, resp, origin);
             case JsonRpcMessage.Error err -> handlePostError(ctx, err, origin);
-            case JsonRpcMessage.Notification not -> {
+            case JsonRpcMessage.Notification<?> not -> {
                 if (McpDispatcher.NOTIFICATIONS_INITIALIZED.equals(not.method())) {
                     // Activate the session synchronously before acking so a client that waits
                     // for this 202 observes an ACTIVE session on its next request, closing the
@@ -306,19 +305,6 @@ public class McpOperationHandler extends ChannelInboundHandlerAdapter {
 
     @Override
     public void channelInactive(ChannelHandlerContext ctx) {
-        var ic = ctx.channel().attr(InteractionHandler.INTERACTION_CONTEXT_KEY).get();
-        if (ic != null && ic.session() instanceof McpSession mcpSession) {
-            var mcpContext = new DefaultMcpContext(mcpSession, server, ic);
-            for (var ext : server.extensions()) {
-                if (ic.isExtensionEnabled(ext.extensionId())) {
-                    try {
-                        ext.onConnectionClose(mcpContext);
-                    } catch (Exception e) {
-                        logger.warn("Extension onConnectionClose error: {}", ext.extensionId(), e);
-                    }
-                }
-            }
-        }
         ctx.fireChannelInactive();
     }
 

--- a/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/sse/NettySseConnection.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/sse/NettySseConnection.java
@@ -25,7 +25,7 @@ public final class NettySseConnection implements SseConnection {
 
     public NettySseConnection(Channel channel, final Runnable onCloseAction) {
         this.channel = Objects.requireNonNull(channel, "channel");
-        channel.closeFuture().addListener(_ -> onCloseAction.run());
+        channel.closeFuture().addListener(ignored -> onCloseAction.run());
     }
 
     public Channel channel() {

--- a/tachyon-server/src/test/java/dev/tachyonmcp/server/ServerTest.java
+++ b/tachyon-server/src/test/java/dev/tachyonmcp/server/ServerTest.java
@@ -258,7 +258,7 @@ class ServerTest {
             server.resources()
                     .add(
                             ResourceDescriptor.of("dyn", "test://dyn", "Dyn resource", "text/plain"),
-                            (_, _) -> TextResourceContents.of("test://dyn", "text/plain", ""));
+                            (ctx, req) -> TextResourceContents.of("test://dyn", "text/plain", ""));
 
             var listChanged = conn.sent.stream()
                     .filter(e -> e.data().contains("notifications/resources/list_changed"))

--- a/tachyon-server/src/test/java/dev/tachyonmcp/server/features/resources/ResourceRegistryTest.java
+++ b/tachyon-server/src/test/java/dev/tachyonmcp/server/features/resources/ResourceRegistryTest.java
@@ -10,8 +10,6 @@ import dev.tachyonmcp.protocol.mcp.v2025_11_25.models.EmptyResult;
 import dev.tachyonmcp.protocol.mcp.v2025_11_25.models.ListResourceTemplatesResult;
 import dev.tachyonmcp.protocol.mcp.v2025_11_25.models.ListResourcesResult;
 import dev.tachyonmcp.protocol.mcp.v2025_11_25.models.ReadResourceResult;
-import dev.tachyonmcp.protocol.mcp.v2025_11_25.models.Resource;
-import dev.tachyonmcp.protocol.mcp.v2025_11_25.models.ResourceTemplate;
 import dev.tachyonmcp.server.McpMethodHandler;
 import dev.tachyonmcp.server.McpServer;
 import dev.tachyonmcp.server.TachyonMcpServer;
@@ -248,7 +246,7 @@ class ResourceRegistryTest {
         var result = (ListResourcesResult) handlers.get("resources/list").handle(DefaultMcpContext.noop(), null);
 
         assertThat(result.resources()).hasSize(1);
-        var resource = (Resource) result.resources().getFirst();
+        var resource = result.resources().getFirst();
         assertThat(resource.name()).isEqualTo("full-resource");
         assertThat(resource.uri()).isEqualTo("test://full");
         assertThat(resource.description()).isEqualTo("Full description");
@@ -283,7 +281,7 @@ class ResourceRegistryTest {
                 handlers.get("resources/templates/list").handle(DefaultMcpContext.noop(), null);
 
         assertThat(result.resourceTemplates()).hasSize(1);
-        var tmpl = (ResourceTemplate) result.resourceTemplates().getFirst();
+        var tmpl = result.resourceTemplates().getFirst();
         assertThat(tmpl.name()).isEqualTo("tmpl");
         assertThat(tmpl.uriTemplate()).isEqualTo("test://tmpl/{id}");
         assertThat(tmpl.description()).isEqualTo("Template desc");
@@ -308,7 +306,7 @@ class ResourceRegistryTest {
 
         // resources/list returns size WITHOUT loading content
         var listResult = (ListResourcesResult) handlers.get("resources/list").handle(DefaultMcpContext.noop(), null);
-        assertThat(((Resource) listResult.resources().getFirst()).size()).isEqualTo(4096.0);
+        assertThat(listResult.resources().getFirst().size()).isEqualTo(4096.0);
         assertThat(contentLoaded).isFalse();
 
         // resources/read triggers lazy content load
@@ -318,7 +316,7 @@ class ResourceRegistryTest {
 
     private static class CollectingConnection implements SseConnection {
         final java.util.ArrayList<SseEvent> sent = new java.util.ArrayList<>();
-        volatile boolean writable = true;
+        final boolean writable = true;
 
         @Override
         public boolean isWritable() {

--- a/tachyon-server/src/test/java/dev/tachyonmcp/transport/netty/NotificationDeliveryTest.java
+++ b/tachyon-server/src/test/java/dev/tachyonmcp/transport/netty/NotificationDeliveryTest.java
@@ -225,7 +225,7 @@ class NotificationDeliveryTest {
     private static class CollectingConnection implements SseConnection {
 
         final ArrayList<SseEvent> sent = new ArrayList<>();
-        volatile boolean writable = true;
+        final boolean writable = true;
 
         @Override
         public boolean isWritable() {


### PR DESCRIPTION
Downgrade to JDK 21+

Migrate the project from Java 25 to Java 21 by updating all build configs, CI workflows, and Maven POMs. Rename underscore lambda parameters to named parameters for Java 21 compatibility, migrate OutboundSseStreamMessageRouter from ScopedValue to ThreadLocal, and clean up Netty transport type safety and handler lifecycle code.

