### PR TITLE
feat: json schema validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,99 +44,101 @@ void main() {
 
 ## Features
 
-### ✅ Core Protocol (46/46 conformance tests passing)
+### Core Protocol (46/46 conformance tests passing)
 
-- [x] JSON-RPC 2.0 — request/response/error/notification
-- [x] Streamable HTTP — POST, GET (SSE), DELETE, OPTIONS
-- [x] Lifecycle — initialize → initialized → ACTIVE
-- [x] Pagination — cursor-based across all list methods
-- [x] Session state machine — INITIALIZING → ACTIVE → CLOSED
-- [x] CORS & origin validation
-- [x] DNS rebinding protection
-- [x] Accept header strict validation (406)
-- [x] Pending request timeout (60s)
-- [x] SSE resumability via Last-Event-ID
+- JSON-RPC 2.0 — request/response/error/notification
+- Streamable HTTP — POST, GET (SSE), DELETE, OPTIONS
+- Lifecycle — initialize → initialized → ACTIVE
+- Pagination — cursor-based across all list methods
+- Session state machine — INITIALIZING → ACTIVE → CLOSED
+- CORS & origin validation
+- DNS rebinding protection
+- Accept header strict validation (406)
+- Pending request timeout (60s)
+- SSE resumability via Last-Event-ID
 
-### ✅ Tools
+### Tools
 
-- [x] `tools/list` — paginated with `nextCursor`
-- [x] `tools/call` — returns `CallToolResult` with `isError`
-- [x] `outputSchema` in listing
-- [x] `annotations` field
-- [x] `execution.taskSupport` (forbidden/optional/required)
-- [x] Synchronous & asynchronous handler interfaces
-- [x] Name validation (1–128 chars)
-- [x] `notifications/tools/list_changed` on add/remove
-- [x] Inline notifications + logging during tool call
+- `tools/list` — paginated with `nextCursor`
+- `tools/call` — returns `CallToolResult` with `isError`
+- `outputSchema` in listing
+- `annotations` field
+- `execution.taskSupport` (forbidden/optional/required)
+- Synchronous & asynchronous handler interfaces
+- Name validation (1–128 chars)
+- `notifications/tools/list_changed` on add/remove
+- Inline notifications + logging during tool call
+- Input schema validation
 
-### ✅ Resources
+### Resources
 
-- [x] `resources/list` — paginated
-- [x] `resources/read` — text & blob content
-- [x] `resources/templates/list` — URI templates
-- [x] `resources/subscribe` / `unsubscribe`
-- [x] `notifications/resources/list_changed`
-- [x] `notifications/resources/updated` to subscribers
-- [x] Dynamic content via `ResourceHandler` interface
+- `resources/list` — paginated
+- `resources/read` — text & blob content
+- `resources/templates/list` — URI templates
+- `resources/subscribe` / `unsubscribe`
+- `notifications/resources/list_changed`
+- `notifications/resources/updated` to subscribers
+- Dynamic content via `ResourceHandler` interface
 
-### ✅ Prompts
+### Prompts
 
-- [x] `prompts/list` — paginated with `nextCursor`
-- [x] `prompts/get` — invokes prompt resolver
-- [x] `notifications/prompts/list_changed`
+- `prompts/list` — paginated with `nextCursor`
+- `prompts/get` — invokes prompt resolver
+- `notifications/prompts/list_changed`
 
-### ✅ Tasks
+### Tasks
 
-- [x] `tasks/list`, `tasks/get`, `tasks/cancel`, `tasks/result`
-- [x] State machine enforcement — SUBMITTED → WORKING → COMPLETED/FAILED/CANCELLED
-- [x] `notifications/tasks/status` broadcast on every transition
-- [x] Task Janitor for stale tasks
-- [x] `execution.taskSupport` per tool (forbidden/optional/required)
-- [x] `TasksExtension` — negotiable extension exposing `create_task` tool + `task://{id}` resource template
-- [x] Extension-gated tool visibility (hidden from un-negotiated clients)
+- `tasks/list`, `tasks/get`, `tasks/cancel`, `tasks/result`
+- State machine enforcement — SUBMITTED → WORKING → COMPLETED/FAILED/CANCELLED
+- `notifications/tasks/status` broadcast on every transition
+- Task Janitor for stale tasks
+- `execution.taskSupport` per tool (forbidden/optional/required)
+- `TasksExtension` ([SEP-1686](https://modelcontextprotocol.io/seps/1686-tasks)) — negotiable extension exposing `create_task` tool + `task://{id}` resource template
+- Extension-gated tool visibility (hidden from un-negotiated clients)
 
-### ✅ Logging & Observability
+### Logging & Observability
 
-- [x] `logging/setLevel` per session
-- [x] `notifications/message` emitted above threshold
-- [x] Progress notifications
+- `logging/setLevel` per session
+- `notifications/message` emitted above threshold
+- Progress notifications
 
-### ✅ Client Communication
+### Client Communication
 
-- [x] `sampling/createMessage` — server → client request
-- [x] Elicitation — form mode
-- [x] `notifications/cancelled` — bidirectional
-- [x] `notifications/tasks/status` from client
+- `sampling/createMessage` — server → client request
+- Elicitation — ✅ form mode; ❌ url mode
+- `notifications/cancelled` — bidirectional
+- `notifications/tasks/status` from client
 
-### ✅ Transport & I/O
+### Transport & I/O
 
-- [x] Netty 4.2
-- [x] io_uring / epoll / kqueue / nio auto-detection
-- [x] Platform-thread event loops + virtual-thread handlers
-- [x] TCP_NODELAY, SO_KEEPALIVE
-- [x] Channel writability backpressure (`setAutoRead`)
-- [x] Configurable idle timeouts (reader/writer)
+- Netty 4.2
+- io_uring / epoll / kqueue / nio auto-detection
+- Platform-thread event loops + virtual-thread handlers
+- TCP_NODELAY, SO_KEEPALIVE
+- Channel writability backpressure (`setAutoRead`)
+- Configurable idle timeouts (reader/writer)
 
-### ✅ Session Management
+### Session Management
 
-- [x] **Stateless mode** — skip sessions for serverless
-- [x] IN_MEMORY session store (ConcurrentHashMap)
-- [x] Session Janitor — 5s sweep, 30s TTL
-- [x] SSE disconnect ≠ session removal (supports reconnect)
-- [x] Event log replay on reconnection
+- **Stateless mode** — skip sessions for serverless
+- IN_MEMORY session store (ConcurrentHashMap)
+- Session Janitor — 5s sweep, 30s TTL
+- SSE disconnect ≠ session removal (supports reconnect)
+- Event log replay on reconnection
 
 ---
 
 ## Installation
 
-**Requirements**: JDK 25+
+**Requirements**: JDK 21+
 
 ### Maven
+
 ```xml
 <dependency>
     <groupId>dev.tachyonmcp</groupId>
     <artifactId>tachyon-server</artifactId>
-    <version>1.0.0-alpha.1</version>
+    <version>1.0.0-alpha.2</version>
 </dependency>
 ```
 
@@ -150,6 +152,7 @@ mvn install -pl tachyon-mcp-server -DskipTests
 ## Quick Start
 
 ### Minimal server with tool
+
 ```java
 import dev.tachyonmcp.server.TachyonMcpServer;
 import dev.tachyonmcp.server.features.tools.AbstractSyncToolHandler;
@@ -181,7 +184,8 @@ void main() {
 }
 ```
 
-### With TasksExtension (negotiable)
+### With TasksExtension (negotiable) - [SEP-1686](https://modelcontextprotocol.io/seps/1686-tasks)
+
 ```java
 var handle = TachyonMcpServer.builder()
     .extension(new TasksExtension())   // exposes create_task tool + task://{id} resource
@@ -210,10 +214,10 @@ handler implementations are unaffected. Domain types track the 2026-07-28 spec s
 
 ## Gaps & Limitations
 
-- [ ] **Rate limiting** (Medium) — Not yet implemented
-- [ ] **URL elicitation mode / -32042 error** (Medium) — Form mode works, URL mode missing
-- [ ] **2026-07-28 draft protocol version** (Low) — Not negotiable; version-gated features ready
-- [ ] **Stale session on re-initialize** (Low) — 30s TTL lingering, affects reconnect only
+- [ ] **Rate limiting** — Not yet implemented
+- [ ] **URL elicitation mode / -32042 error**  — Form mode works, URL mode missing
+- [ ] **2026-07-28 draft protocol version** — Not negotiable; version-gated features ready
+- [ ] **Stale session on re-initialize** — 30s TTL lingering, affects reconnect only
 
 ---
 

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/DnsRebindingTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/DnsRebindingTest.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.TestInstance.Lifecycle;
  * Signalling {@code Connection: close} stops the client from reusing the socket.
  */
 @TestInstance(Lifecycle.PER_CLASS)
-class DnsRebindingE2eTest extends AbstractMcpE2eTest {
+class DnsRebindingTest extends AbstractMcpE2eTest {
 
     // language=JSON
     private static final String INIT_BODY = """

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/ExtensionsTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/ExtensionsTest.java
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.Test;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.node.JsonNodeFactory;
 
-class ExtensionsE2eTest extends AbstractMcpE2eTest {
+class ExtensionsTest extends AbstractMcpE2eTest {
 
     private static final String TEST_EXT_ID = "com.example/test";
 

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/LoggingTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/LoggingTest.java
@@ -9,7 +9,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
 
-class LoggingE2eTest extends AbstractMcpE2eTest {
+class LoggingTest extends AbstractMcpE2eTest {
 
     @Test
     void shouldReceiveLoggingNotificationAfterToolCall() throws Exception {

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/McpNegativeScenariosTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/McpNegativeScenariosTest.java
@@ -18,7 +18,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 @TestInstance(Lifecycle.PER_CLASS)
-class McpNegativeScenariosE2eTest extends AbstractMcpE2eTest {
+class McpNegativeScenariosTest extends AbstractMcpE2eTest {
 
     @Test
     void shouldRejectUnknownTool() {

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/McpSdkTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/McpSdkTest.java
@@ -18,7 +18,7 @@ import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 
-class McpSdkE2eTest extends AbstractMcpE2eTest {
+class McpSdkTest extends AbstractMcpE2eTest {
 
     @Test
     void shouldConnectInitializeAndPing() {

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/PromptCapabilitiesTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/PromptCapabilitiesTest.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.params.provider.CsvSource;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 
-class PromptCapabilitiesE2eTest extends AbstractMcpE2eTest {
+class PromptCapabilitiesTest extends AbstractMcpE2eTest {
 
     @Override
     protected void startDefaultServer() {

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/ResourceCapabilitiesTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/ResourceCapabilitiesTest.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import tools.jackson.databind.ObjectMapper;
 
-class ResourceCapabilitiesE2eTest extends AbstractMcpE2eTest {
+class ResourceCapabilitiesTest extends AbstractMcpE2eTest {
 
     @Test
     void shouldListRegisteredResources() throws Exception {

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/SchemaValidationTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/SchemaValidationTest.java
@@ -1,0 +1,299 @@
+/*
+ * Copyright (c) 2026 Konstantin Pavlov.
+ */
+
+package dev.tachyonmcp.e2e;
+
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.tachyonmcp.server.JsonSchemaValidator;
+import dev.tachyonmcp.server.NetworkntJsonSchemaValidator;
+import dev.tachyonmcp.server.TachyonMcpServer;
+import dev.tachyonmcp.server.domain.PromptArgument;
+import dev.tachyonmcp.server.domain.Role;
+import dev.tachyonmcp.server.domain.TextContent;
+import dev.tachyonmcp.server.features.prompts.PromptDescriptor;
+import dev.tachyonmcp.server.features.tools.SyncToolHandler;
+import dev.tachyonmcp.server.features.tools.ToolResult;
+import dev.tachyonmcp.server.session.McpContext;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.JsonNodeFactory;
+
+class SchemaValidationTest extends AbstractMcpE2eTest {
+
+    private static final JsonSchemaValidator VALIDATOR = new NetworkntJsonSchemaValidator();
+
+    private static final JsonNode TOOL_SCHEMA = buildToolSchema();
+    private static final JsonNode PROMPT_SCHEMA = buildPromptSchema();
+
+    // region: Tool input schema validation
+
+    @Test
+    void shouldValidateMultipleToolsWithDistinctSchemas() throws Exception {
+        startServer(TachyonMcpServer.builder()
+                .jsonSchemaValidator(VALIDATOR)
+                .tool(new ValidatedToolHandler())
+                .tool(new ValidatedToolHandler2())
+                .build());
+
+        try (var client = createTestClient()) {
+            var sessionId = client.initialize();
+
+            var r1 = client.sendRequest(sessionId, """
+                {"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"validated","arguments":{"name":"John","age":30}}}
+                """);
+            assertThat(r1.statusCode()).isEqualTo(200);
+            assertThatJson(r1.body()).isEqualTo("""
+                {"jsonrpc":"2.0","id":2,"result":{"content":[{"type":"text","text":"ok"}]}}
+                """);
+
+            var r2 = client.sendRequest(sessionId, """
+                {"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"validated2","arguments":{"email":"john@example.com","age":25}}}
+                """);
+            assertThat(r2.statusCode()).isEqualTo(200);
+            assertThatJson(r2.body()).isEqualTo("""
+                {"jsonrpc":"2.0","id":3,"result":{"content":[{"type":"text","text":"ok"}]}}
+                """);
+
+            var r3 = client.sendRequest(sessionId, """
+                {"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"validated2","arguments":{"email":"john@example.com"}}}
+                """);
+            assertThat(r3.statusCode()).isEqualTo(200);
+            assertThatJson(r3.body()).isEqualTo("""
+                {"jsonrpc":"2.0","id":4,"result":{"content":[{"type":"text","text":"ok"}]}}
+                """);
+        }
+    }
+
+    @Test
+    void shouldAcceptValidToolArguments() throws Exception {
+        startServer(TachyonMcpServer.builder()
+                .jsonSchemaValidator(VALIDATOR)
+                .tool(new ValidatedToolHandler())
+                .build());
+
+        try (var client = createTestClient()) {
+            var sessionId = client.initialize();
+            var response = client.sendRequest(sessionId, """
+                {"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"validated","arguments":{"name":"John","age":30}}}
+                """);
+
+            assertThat(response.statusCode()).isEqualTo(200);
+            // language=JSON
+            var expected = """
+                {"jsonrpc":"2.0","id":2,"result":{"content":[{"type":"text","text":"ok"}]}}
+                """;
+            assertThatJson(response.body()).isEqualTo(expected);
+        }
+    }
+
+    @Test
+    void shouldRejectToolCallWithMissingRequiredField() throws Exception {
+        startServer(TachyonMcpServer.builder()
+                .jsonSchemaValidator(VALIDATOR)
+                .tool(new ValidatedToolHandler())
+                .build());
+
+        try (var client = createTestClient()) {
+            var sessionId = client.initialize();
+            var response = client.sendRequest(sessionId, """
+                {"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"validated","arguments":{"age":30}}}
+                """);
+
+            assertThat(response.statusCode()).isEqualTo(200);
+            // language=JSON
+            var expected = """
+                {"jsonrpc":"2.0","id":2,"error":{"code":-32600,"message":"required property 'name' not found"}}
+                """;
+            assertThatJson(response.body()).isEqualTo(expected);
+        }
+    }
+
+    @Test
+    void shouldRejectToolCallWithWrongType() throws Exception {
+        startServer(TachyonMcpServer.builder()
+                .jsonSchemaValidator(VALIDATOR)
+                .tool(new ValidatedToolHandler())
+                .build());
+
+        try (var client = createTestClient()) {
+            var sessionId = client.initialize();
+            var response = client.sendRequest(sessionId, """
+                {"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"validated","arguments":{"name":123}}}
+                """);
+
+            assertThat(response.statusCode()).isEqualTo(200);
+
+            // language=JSON
+            var expected = """
+                {"jsonrpc":"2.0","id":2,"error":{"code":-32600,"message":"integer found, string expected"}}
+                """;
+            assertThatJson(response.body()).isEqualTo(expected);
+        }
+    }
+
+    // endregion
+
+    // region: Prompt input schema validation
+
+    @Test
+    void shouldAcceptValidPromptArguments() throws Exception {
+        startServer(TachyonMcpServer.builder().jsonSchemaValidator(VALIDATOR).build());
+
+        server.prompts()
+                .add(
+                        PromptDescriptor.of(
+                                "validated-prompt",
+                                "A validated prompt",
+                                null,
+                                List.of(PromptArgument.of("name", null, "Your name", true)),
+                                PROMPT_SCHEMA),
+                        List.of(dev.tachyonmcp.server.domain.PromptMessage.of(
+                                Role.USER, TextContent.of("Hello {name}"))));
+
+        try (var client = createTestClient()) {
+            var sessionId = client.initialize();
+            var response = client.sendRequest(sessionId, """
+                {"jsonrpc":"2.0","id":2,"method":"prompts/get","params":{"name":"validated-prompt","arguments":{"name":"John"}}}
+                """);
+
+            assertThat(response.statusCode()).isEqualTo(200);
+            // language=JSON
+            var expected = """
+                {"jsonrpc":"2.0","id":2,
+                "result":{"description":"A validated prompt","messages":[
+                    {"role":"user","content":{"type":"text","text":"Hello {name}"}}
+                  ]
+                }}
+                """;
+            assertThatJson(response.body()).isEqualTo(expected);
+            assertThatJson(response.body()).inPath("$.result").isObject().containsKey("messages");
+        }
+    }
+
+    @Test
+    void shouldRejectPromptWithMissingRequiredField() throws Exception {
+        startServer(TachyonMcpServer.builder().jsonSchemaValidator(VALIDATOR).build());
+
+        server.prompts()
+                .add(
+                        PromptDescriptor.of(
+                                "validated-prompt",
+                                "A validated prompt",
+                                null,
+                                List.of(PromptArgument.of("name", null, "Your name", true)),
+                                PROMPT_SCHEMA),
+                        List.of(dev.tachyonmcp.server.domain.PromptMessage.of(
+                                Role.USER, TextContent.of("Hello {name}"))));
+
+        try (var client = createTestClient()) {
+            var sessionId = client.initialize();
+            var response = client.sendRequest(sessionId, """
+                {"jsonrpc":"2.0","id":2,"method":"prompts/get","params":{"name":"validated-prompt","arguments":{}}}
+                """);
+
+            assertThat(response.statusCode()).isEqualTo(200);
+            // language=JSON
+            var expected = """
+                {"jsonrpc":"2.0","id":2,"error":{"code":-32602,"message":"required property 'name' not found"}}
+                """;
+            assertThatJson(response.body()).isEqualTo(expected);
+        }
+    }
+
+    // endregion
+
+    // region: Tool handler
+
+    private static class ValidatedToolHandler implements SyncToolHandler<Object, ToolResult> {
+
+        @Override
+        public String name() {
+            return "validated";
+        }
+
+        @Override
+        public String description() {
+            return "A tool with input schema validation";
+        }
+
+        @Override
+        public JsonNode inputSchema() {
+            return TOOL_SCHEMA;
+        }
+
+        @Override
+        public ToolResult handle(McpContext context, Object arguments) {
+            return ToolResult.text("ok");
+        }
+    }
+
+    // endregion
+
+    // region: Schema builders
+
+    private static class ValidatedToolHandler2 implements SyncToolHandler<Object, ToolResult> {
+
+        @Override
+        public String name() {
+            return "validated2";
+        }
+
+        @Override
+        public String description() {
+            return "Another tool with a distinct input schema";
+        }
+
+        @Override
+        public JsonNode inputSchema() {
+            return buildToolSchema2();
+        }
+
+        @Override
+        public ToolResult handle(McpContext context, Object arguments) {
+            return ToolResult.text("ok");
+        }
+    }
+
+    private static JsonNode buildToolSchema() {
+        var schema = JsonNodeFactory.instance.objectNode();
+        schema.put("type", "object");
+        var props = schema.putObject("properties");
+        var nameProp = props.putObject("name");
+        nameProp.put("type", "string");
+        var ageProp = props.putObject("age");
+        ageProp.put("type", "integer");
+        var req = schema.putArray("required");
+        req.add("name");
+        return schema;
+    }
+
+    private static JsonNode buildToolSchema2() {
+        var schema = JsonNodeFactory.instance.objectNode();
+        schema.put("type", "object");
+        var props = schema.putObject("properties");
+        var emailProp = props.putObject("email");
+        emailProp.put("type", "string");
+        var ageProp = props.putObject("age");
+        ageProp.put("type", "integer");
+        var req = schema.putArray("required");
+        req.add("email");
+        return schema;
+    }
+
+    private static JsonNode buildPromptSchema() {
+        var schema = JsonNodeFactory.instance.objectNode();
+        schema.put("type", "object");
+        var props = schema.putObject("properties");
+        var nameProp = props.putObject("name");
+        nameProp.put("type", "string");
+        var req = schema.putArray("required");
+        req.add("name");
+        return schema;
+    }
+
+    // endregion
+}

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/SessionLifecycleTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/SessionLifecycleTest.java
@@ -11,7 +11,7 @@ import dev.tachyonmcp.server.session.McpSession;
 import java.net.http.HttpResponse;
 import org.junit.jupiter.api.Test;
 
-class SessionLifecycleE2eTest extends AbstractMcpE2eTest {
+class SessionLifecycleTest extends AbstractMcpE2eTest {
 
     @Test
     void disconnectOneClientDoesNotAffectOther() throws Exception {

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/SseRetryTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/SseRetryTest.java
@@ -17,7 +17,7 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 @TestInstance(Lifecycle.PER_CLASS)
-class SseRetryE2eTest extends AbstractMcpE2eTest {
+class SseRetryTest extends AbstractMcpE2eTest {
 
     @Test
     void sseResponseIncludesRetryField() throws Exception {

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/StatelessServerTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/StatelessServerTest.java
@@ -23,7 +23,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class StatelessServerE2eTest {
+class StatelessServerTest {
 
     private McpServerHandle serverHandle;
     private int port;

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/TaskLifecycleTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/TaskLifecycleTest.java
@@ -18,7 +18,7 @@ import java.util.concurrent.CompletionStage;
 import org.junit.jupiter.api.Test;
 import tools.jackson.databind.JsonNode;
 
-class TaskLifecycleE2eTest extends AbstractMcpE2eTest {
+class TaskLifecycleTest extends AbstractMcpE2eTest {
 
     @Override
     protected void startDefaultServer() {

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/TasksBridgeTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/TasksBridgeTest.java
@@ -18,7 +18,7 @@ import java.util.Map;
 import org.junit.jupiter.api.Test;
 import tools.jackson.databind.node.JsonNodeFactory;
 
-class TasksBridgeE2eTest extends AbstractMcpE2eTest {
+class TasksBridgeTest extends AbstractMcpE2eTest {
 
     @Override
     protected void startDefaultServer() {

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/TasksExtensionTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/TasksExtensionTest.java
@@ -19,7 +19,11 @@ import java.util.concurrent.CompletionStage;
 import org.junit.jupiter.api.Test;
 import tools.jackson.databind.ObjectMapper;
 
-class TasksExtensionE2eTest extends AbstractMcpE2eTest {
+/**
+ * <a href="https://modelcontextprotocol.io/seps/1686-tasks">SEP-1686 Tasks</a> —
+ * negotiable extension exposed only when client opts in via {@code initialize} capabilities.
+ */
+class TasksExtensionTest extends AbstractMcpE2eTest {
 
     @Override
     protected void startDefaultServer() {

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/ToolCapabilitiesTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/ToolCapabilitiesTest.java
@@ -24,7 +24,7 @@ import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.node.JsonNodeFactory;
 
-class ToolCapabilitiesE2eTest extends AbstractMcpE2eTest {
+class ToolCapabilitiesTest extends AbstractMcpE2eTest {
 
     // region: Output Schema Tests
 

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/ToolErrorTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/ToolErrorTest.java
@@ -15,7 +15,7 @@ import org.junit.jupiter.api.Test;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.node.JsonNodeFactory;
 
-class ToolErrorE2eTest extends AbstractMcpE2eTest {
+class ToolErrorTest extends AbstractMcpE2eTest {
 
     @Override
     protected void startDefaultServer() {

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/ToolNotificationsTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/ToolNotificationsTest.java
@@ -18,7 +18,7 @@ import java.util.Map;
 import org.junit.jupiter.api.Test;
 import tools.jackson.databind.JsonNode;
 
-class ToolNotificationsE2eTest extends AbstractMcpE2eTest {
+class ToolNotificationsTest extends AbstractMcpE2eTest {
 
     @Override
     protected void startDefaultServer() {

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
     <groupId>dev.tachyonmcp</groupId>
     <artifactId>tachyon-root</artifactId>
-    <version>1.0.-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Tachyon MCP Root</name>

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/JsonSchemaValidator.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/JsonSchemaValidator.java
@@ -4,14 +4,15 @@
 
 package dev.tachyonmcp.server;
 
+import java.util.List;
 import tools.jackson.databind.JsonNode;
 
 @FunctionalInterface
 public interface JsonSchemaValidator {
 
-    void validate(JsonNode schema, JsonNode arguments) throws RuntimeException;
+    List<SchemaValidationError> validate(JsonNode schema, JsonNode arguments);
 
     static JsonSchemaValidator noop() {
-        return (schema, arguments) -> {};
+        return (schema, arguments) -> List.of();
     }
 }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/McpServer.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/McpServer.java
@@ -157,7 +157,7 @@ public class McpServer implements Closeable {
         this.serverInfo = buildServerInfo(config.identity());
         this.extensions = extensions != null ? extensions : List.of();
         this.sessionManager = new SessionManager(sessionStore);
-        this.validator = validator != null ? validator : JsonSchemaValidator.noop();
+        this.validator = validator != null ? validator : new NetworkntJsonSchemaValidator();
         this.toolRegistry = new ToolRegistry(this.validator);
         this.resourceRegistry = new ResourceRegistry(this);
         this.taskRegistry = new TaskRegistry(this);

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/NetworkntJsonSchemaValidator.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/NetworkntJsonSchemaValidator.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2026 Konstantin Pavlov.
+ */
+
+package dev.tachyonmcp.server;
+
+import com.networknt.schema.Schema;
+import com.networknt.schema.SchemaLocation;
+import com.networknt.schema.SchemaRegistry;
+import com.networknt.schema.SpecificationVersion;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import tools.jackson.databind.JsonNode;
+
+public class NetworkntJsonSchemaValidator implements JsonSchemaValidator {
+
+    private final SchemaRegistry registry;
+
+    // Tool/prompt schemas are static and reused across calls; networknt does not cache
+    // schemas compiled via getSchema(SchemaLocation, JsonNode), so we cache them ourselves
+    // keyed by schema content (JsonNode equals/hashCode are structural in Jackson).
+    private final ConcurrentMap<JsonNode, Schema> compiledSchemas = new ConcurrentHashMap<>();
+
+    public NetworkntJsonSchemaValidator() {
+        this.registry = SchemaRegistry.withDefaultDialect(SpecificationVersion.DRAFT_2020_12);
+    }
+
+    @Override
+    public List<SchemaValidationError> validate(JsonNode schema, JsonNode arguments) {
+        var compiledSchema = compiledSchemas.computeIfAbsent(schema, this::compile);
+        var errors = compiledSchema.validate(arguments);
+        if (errors.isEmpty()) {
+            return List.of();
+        }
+        return errors.stream()
+                .map(error -> new SchemaValidationError(
+                        error.getInstanceLocation().toString(), error.getKeyword(), error.getMessage()))
+                .toList();
+    }
+
+    private Schema compile(JsonNode schema) {
+        var location = SchemaLocation.of(
+                "urn:tachyon:schema:" + Integer.toHexString(schema.toString().hashCode()));
+        return registry.getSchema(location, schema);
+    }
+}

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/SchemaValidationError.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/SchemaValidationError.java
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2026 Konstantin Pavlov.
+ */
+
+package dev.tachyonmcp.server;
+
+public record SchemaValidationError(String path, String keyword, String message) {}

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/ServerBuilder.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/ServerBuilder.java
@@ -86,6 +86,10 @@ public final class ServerBuilder {
         return this;
     }
 
+    /**
+     * @deprecated Use {@link #info(Consumer)} builder
+     */
+    @Deprecated(forRemoval = true)
     public ServerBuilder websiteUrl(String websiteUrl) {
         identityBuilder.websiteUrl(websiteUrl);
         return this;
@@ -312,7 +316,7 @@ public final class ServerBuilder {
         final List<McpExtension> extensions = new ArrayList<>();
         final List<TaskEntry> tasks = new ArrayList<>();
 
-        JsonSchemaValidator jsonSchemaValidator = JsonSchemaValidator.noop();
+        JsonSchemaValidator jsonSchemaValidator = new NetworkntJsonSchemaValidator();
 
         record PromptRegistration(PromptDescriptor descriptor, PromptHandler handler) {}
 

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/TachyonMcpServer.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/TachyonMcpServer.java
@@ -26,8 +26,7 @@ public final class TachyonMcpServer {
         var store = config.session().sessionStore() != null
                 ? config.session().sessionStore()
                 : new dev.tachyonmcp.server.session.InMemorySessionStore();
-        var server = new McpServer(
-                router, store, config, dev.tachyonmcp.server.JsonSchemaValidator.noop(), java.util.List.of());
+        var server = new McpServer(router, store, config, new NetworkntJsonSchemaValidator(), java.util.List.of());
         var nettyConfig = new NettyServerConfig(
                 config.network().host(),
                 config.network().port(),

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/config/CapabilitiesConfig.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/config/CapabilitiesConfig.java
@@ -74,7 +74,6 @@ public abstract class CapabilitiesConfig {
         return ImmutableCapabilitiesConfig.builder();
     }
 
-    @Value.Builder
     public interface Builder {
 
         Builder toolsMode(Mode mode);

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/domain/DefaultReadResourceRequest.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/domain/DefaultReadResourceRequest.java
@@ -6,5 +6,6 @@ package dev.tachyonmcp.server.domain;
 
 import java.util.Map;
 import org.jspecify.annotations.Nullable;
+import tools.jackson.databind.JsonNode;
 
-record DefaultReadResourceRequest(String uri, @Nullable Map<String, Object> meta) implements ReadResourceRequest {}
+record DefaultReadResourceRequest(String uri, @Nullable Map<String, JsonNode> meta) implements ReadResourceRequest {}

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/domain/ReadResourceRequest.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/domain/ReadResourceRequest.java
@@ -6,6 +6,7 @@ package dev.tachyonmcp.server.domain;
 
 import java.util.Map;
 import org.jspecify.annotations.Nullable;
+import tools.jackson.databind.JsonNode;
 
 /**
  * A request from the dispatcher to read a resource by URI.
@@ -18,9 +19,9 @@ public interface ReadResourceRequest {
     String uri();
 
     @Nullable
-    Map<String, Object> meta();
+    Map<String, JsonNode> meta();
 
-    static ReadResourceRequest of(String uri, @Nullable Map<String, Object> meta) {
+    static ReadResourceRequest of(String uri, @Nullable Map<String, JsonNode> meta) {
         return new DefaultReadResourceRequest(uri, meta);
     }
 }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/features/prompts/PromptRegistry.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/features/prompts/PromptRegistry.java
@@ -10,14 +10,17 @@ import dev.tachyonmcp.protocol.mcp.v2025_11_25.models.GetPromptResult;
 import dev.tachyonmcp.protocol.mcp.v2025_11_25.models.ListPromptsResult;
 import dev.tachyonmcp.server.JsonSchemaValidator;
 import dev.tachyonmcp.server.McpMethodHandler;
+import dev.tachyonmcp.server.SchemaValidationError;
 import dev.tachyonmcp.server.domain.PromptMessage;
 import dev.tachyonmcp.server.features.Registry;
 import dev.tachyonmcp.server.features.tools.ToolRegistry;
 import dev.tachyonmcp.server.session.McpContext;
+import dev.tachyonmcp.transport.jsonrpc.JsonRpcCodec;
 import dev.tachyonmcp.transport.jsonrpc.JsonRpcErrors;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import org.jspecify.annotations.Nullable;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.node.JsonNodeFactory;
@@ -91,14 +94,19 @@ public class PromptRegistry extends Registry<PromptEntry> {
             var inputSchema = entry.descriptor().inputSchema();
             if (inputSchema != null) {
                 var argsNode = JsonNodeFactory.instance.objectNode();
-                var argsMap = extractArgumentsMap(params);
+                Map<String, JsonNode> argsMap;
+                try {
+                    argsMap = extractArgumentsMap(params);
+                } catch (RuntimeException e) {
+                    return JsonRpcErrors.invalidParams("Invalid arguments");
+                }
                 if (argsMap != null) {
                     argsMap.forEach(argsNode::set);
                 }
-                try {
-                    validator.validate(inputSchema, argsNode);
-                } catch (RuntimeException e) {
-                    return JsonRpcErrors.invalidParams(e.getMessage());
+                var errors = validator.validate(inputSchema, argsNode);
+                if (!errors.isEmpty()) {
+                    return JsonRpcErrors.invalidParams(
+                            errors.stream().map(SchemaValidationError::message).collect(Collectors.joining("; ")));
                 }
             }
             java.util.List<PromptMessage> domainMessages;
@@ -118,21 +126,22 @@ public class PromptRegistry extends Registry<PromptEntry> {
 
         private static String extractArguments(Object params) {
             if (params instanceof GetPromptRequestParams p && p.arguments() != null) {
-                return p.arguments().toString();
+                return JsonRpcCodec.writeValueAsString(p.arguments());
             }
             if (params instanceof Map<?, ?> map && map.get("arguments") instanceof Map<?, ?> args) {
-                return args.toString();
+                return JsonRpcCodec.writeValueAsString(args);
             }
             return "";
         }
 
-        @SuppressWarnings("unchecked")
         private static @Nullable Map<String, JsonNode> extractArgumentsMap(Object params) {
             if (params instanceof GetPromptRequestParams p && p.arguments() != null) {
                 return p.arguments();
             }
-            if (params instanceof Map<?, ?> map && map.get("arguments") instanceof Map<?, ?> args) {
-                return (Map<String, JsonNode>) args;
+            if (params instanceof Map<?, ?> map) {
+                var json = JsonRpcCodec.writeValueAsString(map);
+                var typed = JsonRpcCodec.decodeWithCodec(json, GetPromptRequestParams.class);
+                return typed.arguments();
             }
             return null;
         }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tools/ToolRegistry.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tools/ToolRegistry.java
@@ -13,21 +13,28 @@ import dev.tachyonmcp.protocol.mcp.v2025_11_25.models.CallToolResult;
 import dev.tachyonmcp.protocol.mcp.v2025_11_25.models.ListToolsResult;
 import dev.tachyonmcp.server.JsonSchemaValidator;
 import dev.tachyonmcp.server.McpMethodHandler;
+import dev.tachyonmcp.server.SchemaValidationError;
 import dev.tachyonmcp.server.features.PaginatedResult;
 import dev.tachyonmcp.server.session.McpContext;
 import dev.tachyonmcp.transport.jsonrpc.JsonRpcCodec;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.node.JsonNodeFactory;
 
 public class ToolRegistry {
+
+    private static final Logger logger = LoggerFactory.getLogger(ToolRegistry.class);
 
     private final ConcurrentHashMap<String, ToolHandler> handlers = new ConcurrentHashMap<>();
     private final JsonSchemaValidator validator;
@@ -250,23 +257,23 @@ public class ToolRegistry {
             if (args != null) {
                 argumentsNode.setAll(args);
             }
-            try {
-                validator.validate(schema, argumentsNode);
-                return null;
-            } catch (RuntimeException e) {
-                return e.getMessage();
-            }
+            var errors = validator.validate(schema, argumentsNode);
+            if (errors.isEmpty()) return null;
+            return joinMessages(errors);
         }
 
         private void validateOutput(@Nullable JsonNode schema, CallToolResult result) {
             if (schema == null || result.structuredContent() == null) return;
             var contentNode = JsonNodeFactory.instance.objectNode();
             contentNode.setAll(result.structuredContent());
-            try {
-                validator.validate(schema, contentNode);
-            } catch (RuntimeException ignored) {
-                // advisory only
+            var errors = validator.validate(schema, contentNode);
+            if (!errors.isEmpty()) {
+                logger.debug("Tool output failed schema validation (advisory only): {}", joinMessages(errors));
             }
+        }
+
+        private static String joinMessages(List<SchemaValidationError> errors) {
+            return errors.stream().map(SchemaValidationError::message).collect(Collectors.joining("; "));
         }
 
         private void sendLoggingIfEnabled(McpContext context, String toolName, String status) {

--- a/tachyon-server/src/test/java/dev/tachyonmcp/server/NetworkntJsonSchemaValidatorTest.java
+++ b/tachyon-server/src/test/java/dev/tachyonmcp/server/NetworkntJsonSchemaValidatorTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2026 Konstantin Pavlov.
+ */
+
+package dev.tachyonmcp.server;
+
+import static dev.tachyonmcp.test.TestUtils.parseJson;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class NetworkntJsonSchemaValidatorTest {
+
+    private final NetworkntJsonSchemaValidator validator = new NetworkntJsonSchemaValidator();
+
+    @Test
+    void shouldReturnNoErrorsForValidArguments() {
+        var schema = parseJson("""
+            {"type":"object","properties":{"name":{"type":"string"}},"required":["name"]}
+            """);
+        var arguments = parseJson("""
+            {"name":"John"}
+            """);
+
+        assertThat(validator.validate(schema, arguments)).isEmpty();
+    }
+
+    @Test
+    void shouldReturnErrorWithPathAndKeywordForMissingRequiredProperty() {
+        var schema = parseJson("""
+            {"type":"object","properties":{"name":{"type":"string"}},"required":["name"]}
+            """);
+        var arguments = parseJson("{}");
+
+        var errors = validator.validate(schema, arguments);
+
+        assertThat(errors).hasSize(1);
+        assertThat(errors.getFirst().keyword()).isEqualTo("required");
+        assertThat(errors.getFirst().message()).contains("name");
+    }
+
+    @Test
+    void shouldReturnErrorForWrongType() {
+        var schema = parseJson("""
+            {"type":"object","properties":{"age":{"type":"integer"}}}
+            """);
+        var arguments = parseJson("""
+            {"age":"not a number"}
+            """);
+
+        var errors = validator.validate(schema, arguments);
+
+        assertThat(errors).hasSize(1);
+        assertThat(errors.getFirst().keyword()).isEqualTo("type");
+    }
+
+    @Test
+    void shouldValidateDistinctSchemasIndependently() {
+        var nameSchema = parseJson("""
+            {"type":"object","properties":{"name":{"type":"string"}},"required":["name"]}
+            """);
+        var emailSchema = parseJson("""
+            {"type":"object","properties":{"email":{"type":"string"}},"required":["email"]}
+            """);
+
+        // Same validator instance compiles and caches both schemas; calls must not cross-contaminate.
+        assertThat(validator.validate(nameSchema, parseJson("""
+            {"name":"John"}
+            """))).isEmpty();
+        assertThat(validator.validate(emailSchema, parseJson("""
+            {"email":"john@example.com"}
+            """))).isEmpty();
+        assertThat(validator.validate(nameSchema, parseJson("""
+            {"email":"john@example.com"}
+            """))).hasSize(1);
+        assertThat(validator.validate(emailSchema, parseJson("""
+            {"name":"John"}
+            """))).hasSize(1);
+    }
+
+    @Test
+    void shouldReuseCompiledSchemaForRepeatedCallsWithEquivalentSchemaContent() {
+        var schema1 = parseJson("""
+            {"type":"object","properties":{"name":{"type":"string"}},"required":["name"]}
+            """);
+        var schema2 = parseJson("""
+            {"type":"object","properties":{"name":{"type":"string"}},"required":["name"]}
+            """);
+
+        assertThat(validator.validate(schema1, parseJson("{}"))).hasSize(1);
+        assertThat(validator.validate(schema2, parseJson("{}"))).hasSize(1);
+    }
+}


### PR DESCRIPTION
Add NetworkNT-backed JSON schema validation to server setup, update prompt and resource request typing, add end-to-end schema validation tests, and refresh README, build, and test naming text.

## New Features

- Added JSON Schema validation support for tools and prompts, improving request checks and error feedback.
- Default server setup now enables schema validation out of the box.
- Updated end-to-end coverage for validation, sessions, logging, extensions, and task-related flows.

## Bug Fixes

- Corrected request metadata handling for resource reads.
- Improved prompt argument serialization for more reliable processing.
- Fixed the project version value in the build configuration.

## Documentation

- Refreshed the README formatting and updated installation/version examples.