### PR TITLE
fix: Netty pipeline handlers

### DIFF
--- a/.agents/skills/tachyon-tesing/SKILL.md
+++ b/.agents/skills/tachyon-tesing/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: testing
-description: Apply when designing and writing tests
+name: tachyon-testing
+description: Apply project specific rules when designing and writing tests
 ---
 
 # Test Rules

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,13 +114,12 @@ jobs:
         env:
           NEXT_VERSION: ${{ steps.next-version.outputs.next_version }}
         run: |
-          if git diff --quiet -- pom.xml; then
+          if git diff --quiet -- 'pom.xml' '**/pom.xml'; then
             echo "main is already set to ${NEXT_VERSION}"
             exit 0
           fi
-
           git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add pom.xml
+          git config user.email "41898282+github-actions[bot]`@users.noreply.github.com`"
+          git add -- 'pom.xml' '**/pom.xml'
           git commit -m "chore: prepare for next development iteration ${NEXT_VERSION}"
           git push origin HEAD:main

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/AcceptHeaderValidationTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/AcceptHeaderValidationTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2026 Konstantin Pavlov.
+ */
+
+package dev.tachyonmcp.e2e;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Guards the MCP {@code Accept}-header rules enforced by {@code AcceptValidationHandler}: POST must
+ * accept {@code application/json} and {@code text/event-stream}; GET must accept
+ * {@code text/event-stream}. Regression test for the handler having been positioned before the
+ * aggregator, where its {@code FullHttpRequest} match never fired and validation was silently
+ * skipped.
+ */
+class AcceptHeaderValidationTest extends AbstractMcpE2eTest {
+
+    // language=JSON
+    private static final String INIT_BODY =
+            "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":\"2025-11-25\",\"capabilities\":{},\"clientInfo\":{\"name\":\"t\",\"version\":\"1\"}}}";
+
+    private HttpResponse<String> post(String accept) throws Exception {
+        var builder = HttpRequest.newBuilder()
+                .uri(URI.create("http://localhost:" + port + "/mcp"))
+                .header("Content-Type", "application/json")
+                .header("MCP-Protocol-Version", "2025-11-25")
+                .POST(HttpRequest.BodyPublishers.ofString(INIT_BODY));
+        if (accept != null) builder.header("Accept", accept);
+        return HttpClient.newHttpClient().send(builder.build(), HttpResponse.BodyHandlers.ofString());
+    }
+
+    private HttpResponse<String> get(String accept) throws Exception {
+        var builder = HttpRequest.newBuilder()
+                .uri(URI.create("http://localhost:" + port + "/mcp"))
+                .header("MCP-Protocol-Version", "2025-11-25")
+                .GET();
+        if (accept != null) builder.header("Accept", accept);
+        return HttpClient.newHttpClient().send(builder.build(), HttpResponse.BodyHandlers.ofString());
+    }
+
+    @Test
+    void shouldRejectPostMissingEventStreamAccept() throws Exception {
+        var response = post("application/json");
+        assertThat(response.statusCode()).isEqualTo(406);
+        assertThat(response.body()).contains("text/event-stream");
+    }
+
+    @Test
+    void shouldRejectPostWithNoAcceptHeader() throws Exception {
+        assertThat(post(null).statusCode()).isEqualTo(406);
+    }
+
+    @Test
+    void shouldRejectGetMissingEventStreamAccept() throws Exception {
+        var response = get("application/json");
+        assertThat(response.statusCode()).isEqualTo(406);
+        assertThat(response.body()).contains("text/event-stream");
+    }
+
+    @Test
+    void shouldAcceptPostWithBothMediaTypes() throws Exception {
+        var response = post("application/json, text/event-stream");
+        assertThat(response.statusCode()).isNotEqualTo(406);
+    }
+}

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/AcceptHeaderValidationTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/AcceptHeaderValidationTest.java
@@ -66,6 +66,25 @@ class AcceptHeaderValidationTest extends AbstractMcpE2eTest {
     @Test
     void shouldAcceptPostWithBothMediaTypes() throws Exception {
         var response = post("application/json, text/event-stream");
+        assertThat(response.statusCode()).isEqualTo(200);
+        assertThat(response.body()).contains("result");
+    }
+
+    @Test
+    void shouldAcceptPostWithWildcardSubtypes() throws Exception {
+        var response = post("application/*, text/*");
         assertThat(response.statusCode()).isNotEqualTo(406);
+    }
+
+    @Test
+    void shouldRejectPostWithQZeroOnRequiredType() throws Exception {
+        var response = post("application/json;q=0, text/event-stream");
+        assertThat(response.statusCode()).isEqualTo(406);
+    }
+
+    @Test
+    void shouldRejectPostWithPartialMediaTypeMatch() throws Exception {
+        var response = post("application/json-seq, text/event-stream");
+        assertThat(response.statusCode()).isEqualTo(406);
     }
 }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/ChannelHandlerUtils.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/ChannelHandlerUtils.java
@@ -5,7 +5,6 @@
 package dev.tachyonmcp.transport.netty;
 
 import static dev.tachyonmcp.transport.netty.InteractionHandler.INTERACTION_CONTEXT_KEY;
-import static io.netty.channel.ChannelFutureListener.CLOSE;
 
 import dev.tachyonmcp.runtime.InteractionContext;
 import io.netty.buffer.ByteBuf;
@@ -77,18 +76,12 @@ public final class ChannelHandlerUtils {
         var response = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, status, body);
         response.headers().set(HttpHeaderNames.CONTENT_TYPE, contentType);
         response.headers().set(HttpHeaderNames.CONTENT_LENGTH, body.readableBytes());
-        if (close) {
-            response.headers().set(HttpHeaderNames.CONNECTION, HttpHeaderValues.CLOSE);
-        }
         if (origin != null) {
             response.headers().set(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN, origin);
         }
-
-        ChannelFuture channelFuture = ctx.writeAndFlush(response);
-        if (close) {
-            return channelFuture.addListener(CLOSE);
-        } else {
-            return channelFuture;
-        }
+        // Mark the keep-alive intent; HttpServerKeepAliveHandler adds `Connection: close`
+        // and closes the channel after this response when keep-alive is disabled.
+        HttpUtil.setKeepAlive(response, !close);
+        return ctx.writeAndFlush(response);
     }
 }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/LifecyclePipelineCoordinator.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/LifecyclePipelineCoordinator.java
@@ -5,13 +5,11 @@
 package dev.tachyonmcp.transport.netty;
 
 import dev.tachyonmcp.runtime.InteractionEvent;
-import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@ChannelHandler.Sharable
 public class LifecyclePipelineCoordinator extends ChannelInboundHandlerAdapter {
 
     private static final Logger logger = LoggerFactory.getLogger(LifecyclePipelineCoordinator.class);

--- a/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/McpChannelInitializer.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/McpChannelInitializer.java
@@ -17,7 +17,6 @@ import io.netty.channel.ChannelPipeline;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.handler.codec.http.HttpObjectAggregator;
 import io.netty.handler.codec.http.HttpServerCodec;
-import io.netty.handler.codec.http.HttpServerExpectContinueHandler;
 import io.netty.handler.codec.http.HttpServerKeepAliveHandler;
 import io.netty.handler.codec.http.cors.CorsConfig;
 import io.netty.handler.codec.http.cors.CorsHandler;
@@ -26,6 +25,7 @@ import io.netty.handler.logging.LogLevel;
 import io.netty.handler.logging.LoggingHandler;
 import io.netty.handler.timeout.IdleStateHandler;
 import java.time.Duration;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import org.jspecify.annotations.Nullable;
 
@@ -45,9 +45,11 @@ public class McpChannelInitializer extends ChannelInitializer<SocketChannel> {
     /** Default max aggregated request body. 64 KB was too small for schemas + tool results. */
     public static final int DEFAULT_MAX_CONTENT_LENGTH = 1024 * 1024; // 1 MB
 
-    private static final LoggingHandler CHANNEL_LOGGER =
-            new LoggingHandler("me.kpavlov.tachyon.transport.netty.channel", LogLevel.DEBUG);
-    public static final int flushAfter = FlushConsolidationHandler.DEFAULT_EXPLICIT_FLUSH_AFTER_FLUSHES;
+    private static final String CHANNEL_LOGGER_NAME = "me.kpavlov.tachyon.transport.netty.channel";
+    private static final LoggingHandler CHANNEL_LOGGER = new LoggingHandler(CHANNEL_LOGGER_NAME, LogLevel.DEBUG);
+    private static final boolean CHANNEL_LOGGING_ENABLED =
+            org.slf4j.LoggerFactory.getLogger(CHANNEL_LOGGER_NAME).isDebugEnabled();
+    private static final int FLUSH_AFTER = FlushConsolidationHandler.DEFAULT_EXPLICIT_FLUSH_AFTER_FLUSHES;
 
     private final Duration readerIdleTimeout;
     private final Duration writerIdleTimeout;
@@ -104,9 +106,12 @@ public class McpChannelInitializer extends ChannelInitializer<SocketChannel> {
     @Override
     protected void initChannel(SocketChannel ch) {
         final var p = ch.pipeline();
-        p.addFirst("flush", new FlushConsolidationHandler(flushAfter, true));
-        p.addLast("logger", CHANNEL_LOGGER);
+        p.addFirst("flush", new FlushConsolidationHandler(FLUSH_AFTER, true));
+        if (CHANNEL_LOGGING_ENABLED) {
+            p.addLast("logger", CHANNEL_LOGGER);
+        }
         p.addLast("http", new HttpServerCodec());
+
         // Idiomatic keep-alive management: inspects each request's Connection intent and either
         // keeps the socket alive or appends `Connection: close` and closes after the final content.
         // Placed right after the codec so it governs responses from ALL downstream handlers
@@ -124,14 +129,16 @@ public class McpChannelInitializer extends ChannelInitializer<SocketChannel> {
         }
         p.addLast("interaction", interactionHandler);
 
-        // Reject oversized bodies announced via `Expect: 100-continue` before they are
-        // transferred, instead of buffering and then failing in the aggregator.
-        p.addLast("expect-continue", new HttpServerExpectContinueHandler());
+        // HttpObjectAggregator owns `Expect: 100-continue`: it answers 100 Continue for
+        // acceptable requests and rejects oversized ones (413/417) before the body is
+        // transferred. A separate HttpServerExpectContinueHandler would defeat that by
+        // always acking 100 Continue upstream of the aggregator.
         p.addLast("http-aggregator", new HttpObjectAggregator(maxContentLength));
         if (!readerIdleTimeout.isZero() || !writerIdleTimeout.isZero()) {
             p.addLast(
                     "idle",
-                    new IdleStateHandler((int) readerIdleTimeout.toSeconds(), (int) writerIdleTimeout.toSeconds(), 0));
+                    new IdleStateHandler(
+                            readerIdleTimeout.toMillis(), writerIdleTimeout.toMillis(), 0, TimeUnit.MILLISECONDS));
         }
 
         // Both stateless and stateful modes go through the initialization phase handler.

--- a/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/McpChannelInitializer.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/McpChannelInitializer.java
@@ -18,6 +18,7 @@ import io.netty.channel.socket.SocketChannel;
 import io.netty.handler.codec.http.HttpObjectAggregator;
 import io.netty.handler.codec.http.HttpServerCodec;
 import io.netty.handler.codec.http.HttpServerExpectContinueHandler;
+import io.netty.handler.codec.http.HttpServerKeepAliveHandler;
 import io.netty.handler.codec.http.cors.CorsConfig;
 import io.netty.handler.codec.http.cors.CorsHandler;
 import io.netty.handler.flush.FlushConsolidationHandler;
@@ -106,6 +107,11 @@ public class McpChannelInitializer extends ChannelInitializer<SocketChannel> {
         p.addFirst("flush", new FlushConsolidationHandler(flushAfter, true));
         p.addLast("logger", CHANNEL_LOGGER);
         p.addLast("http", new HttpServerCodec());
+        // Idiomatic keep-alive management: inspects each request's Connection intent and either
+        // keeps the socket alive or appends `Connection: close` and closes after the final content.
+        // Placed right after the codec so it governs responses from ALL downstream handlers
+        // (validation handlers write before the aggregator; protocol handlers write after it).
+        p.addLast("http-keep-alive", new HttpServerKeepAliveHandler());
         p.addLast("dns-rebinding", DNS_REBINDING_HANDLER);
         if (corsConfig != null) {
             p.addLast("cors", new CorsHandler(corsConfig));

--- a/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/McpInitializationHandler.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/McpInitializationHandler.java
@@ -152,6 +152,9 @@ public class McpInitializationHandler extends ChannelInboundHandlerAdapter {
         dispatcher
                 .dispatchRequestAsync(id, method, params, null, postStream, null)
                 .whenComplete((result, ex) -> ctx.executor().execute(() -> {
+                    // Neutralize the unused stream so a late server→client message cannot open a
+                    // second response on this (potentially keep-alive) channel.
+                    postStream.close();
                     if (ex != null) {
                         logger.error("Dispatch failed for pre-session request: method={}", method, ex);
                         sendResponseAndClose(
@@ -186,6 +189,9 @@ public class McpInitializationHandler extends ChannelInboundHandlerAdapter {
                         ChannelHandlerUtils.requireInteractionContext(ctx))
                 .whenComplete((result, ex) -> ctx.executor().execute(() -> {
                     var elapsedMs = (System.nanoTime() - startNs) / 1_000_000;
+                    // initialize never emits server→client messages, but neutralize defensively so
+                    // the keep-alive JSON response below can never be preceded by an SSE upgrade.
+                    postStream.close();
                     if (ex != null) {
                         logger.error("Initialize dispatch failed: id={}, elapsed={}ms", id, elapsedMs, ex);
                         sendResponseAndClose(

--- a/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/McpOperationHandler.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/McpOperationHandler.java
@@ -17,7 +17,6 @@ import dev.tachyonmcp.server.session.SessionEvent;
 import dev.tachyonmcp.transport.jsonrpc.JsonRpcMessage;
 import dev.tachyonmcp.transport.netty.sse.PostSseStream;
 import dev.tachyonmcp.transport.netty.sse.SseManager;
-import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.handler.codec.http.FullHttpRequest;
@@ -38,10 +37,9 @@ import org.slf4j.LoggerFactory;
  * directly (stateless mode) or dynamically by {@link McpInitializationHandler}
  * after a successful initialize.
  *
- * <p>{@code @Sharable} — this handler is stateless. Per-connection state lives in
- * {@link InteractionHandler}'s channel attribute.
+ * <p>Instantiated per channel (see {@link McpHandlerManager#createOperationHandler()});
+ * per-connection state lives in {@link InteractionHandler}'s channel attribute.
  */
-@ChannelHandler.Sharable
 public class McpOperationHandler extends ChannelInboundHandlerAdapter {
 
     private static final Logger logger = LoggerFactory.getLogger(McpOperationHandler.class);

--- a/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/McpOperationHandler.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/McpOperationHandler.java
@@ -203,6 +203,9 @@ public class McpOperationHandler extends ChannelInboundHandlerAdapter {
                         if (postStream.started()) {
                             postStream.close();
                         } else {
+                            // Neutralize the stream so a late server→client message cannot start a
+                            // second HTTP response on this channel, then send the JSON error.
+                            postStream.close();
                             sendInternalError(ctx, requestId, origin);
                         }
                         return;
@@ -221,6 +224,11 @@ public class McpOperationHandler extends ChannelInboundHandlerAdapter {
                         }
                         return;
                     }
+                    // A keep-alive JSON/202 response is about to be written; neutralize the unused
+                    // stream so a server→client message that arrives after this check (e.g. an async
+                    // tool's status notification) cannot open a second response on the pooled socket
+                    // and corrupt the next request's reuse of it.
+                    postStream.close();
                     if (result instanceof McpDispatcher.DispatchResult.Accepted) {
                         sendAccepted(ctx, origin);
                         return;

--- a/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/McpResponseWriter.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/McpResponseWriter.java
@@ -9,7 +9,6 @@ import dev.tachyonmcp.transport.jsonrpc.JsonRpcCodec;
 import dev.tachyonmcp.transport.jsonrpc.JsonRpcErrors;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelFuture;
-import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.*;
 import org.jspecify.annotations.Nullable;
@@ -37,9 +36,10 @@ public final class McpResponseWriter {
                                 HttpHeaderNames.CONTENT_TYPE.toString(),
                                 HttpHeaderNames.ORIGIN.toString()))
                 .set(HttpHeaderNames.ACCESS_CONTROL_MAX_AGE, "86400");
-        // Signal close so the client does not pool this socket; we close it right after the write.
+        // Signal close so the client does not pool this socket; HttpServerKeepAliveHandler
+        // appends `Connection: close` and closes the channel after this response.
         HttpUtil.setKeepAlive(response, false);
-        ctx.writeAndFlush(response).addListener(ChannelFutureListener.CLOSE);
+        ctx.writeAndFlush(response);
     }
 
     public static ChannelFuture sendJsonResponse(
@@ -56,21 +56,16 @@ public final class McpResponseWriter {
         var response = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK, body);
         response.headers().set(HttpHeaderNames.CONTENT_TYPE, "application/json");
         response.headers().set(HttpHeaderNames.CONTENT_LENGTH, body.readableBytes());
-        if (close) {
-            response.headers().set(HttpHeaderNames.CONNECTION, HttpHeaderValues.CLOSE);
-        }
         if (sessionId != null) {
             response.headers().set(McpHeaderNames.MCP_SESSION_ID, sessionId);
         }
         if (origin != null) {
             response.headers().set(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN, origin);
         }
-        final ChannelFuture channelFuture = ctx.writeAndFlush(response);
-        if (close) {
-            return channelFuture.addListener(ChannelFutureListener.CLOSE);
-        } else {
-            return channelFuture;
-        }
+        // HttpServerKeepAliveHandler appends `Connection: close` and closes the channel after
+        // this response when keep-alive is disabled.
+        HttpUtil.setKeepAlive(response, !close);
+        return ctx.writeAndFlush(response);
     }
 
     public static ChannelFuture sendInternalError(ChannelHandlerContext ctx, Object id, @Nullable String origin) {

--- a/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/NettyServer.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/NettyServer.java
@@ -53,6 +53,7 @@ public final class NettyServer implements Closeable {
 
     public NettyServer(McpServer server, NettyServerConfig config) {
         var transport = Transport.detect();
+        logger.info("Netty transport: {}", transport.channel.getSimpleName());
 
         // Event loops run on PLATFORM threads. Netty I/O loops never voluntarily
         // yield (they spin in epoll_wait / io_uring_enter / Selector.select), and
@@ -67,7 +68,6 @@ public final class NettyServer implements Closeable {
                 .channel(transport.channel)
                 .option(ChannelOption.SO_BACKLOG, 1024)
                 .option(ChannelOption.SO_REUSEADDR, true)
-                .option(ChannelOption.ALLOCATOR, PooledByteBufAllocator.DEFAULT)
                 .childOption(ChannelOption.ALLOCATOR, PooledByteBufAllocator.DEFAULT)
                 .childOption(ChannelOption.TCP_NODELAY, true)
                 .childOption(ChannelOption.SO_KEEPALIVE, true)

--- a/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/http/AcceptValidationHandler.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/http/AcceptValidationHandler.java
@@ -10,9 +10,10 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandler.Sharable;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
-import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpHeaderValues;
 import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import java.nio.charset.StandardCharsets;
 import org.slf4j.Logger;
@@ -33,12 +34,16 @@ public final class AcceptValidationHandler extends ChannelInboundHandlerAdapter 
         this.mcpEndpoint = mcpEndpoint;
     }
 
-    static final String[] POST_ACCEPT_TYPES = {"application/json", "text/event-stream"};
-    static final String[] GET_ACCEPT_TYPES = {"text/event-stream"};
+    private static final String APPLICATION_JSON = HttpHeaderValues.APPLICATION_JSON.toString();
+    private static final String TEXT_EVENT_STREAM = HttpHeaderValues.TEXT_EVENT_STREAM.toString();
+    private static final String TEXT_PLAIN = HttpHeaderValues.TEXT_PLAIN.toString();
+
+    static final String[] POST_ACCEPT_TYPES = {APPLICATION_JSON, TEXT_EVENT_STREAM};
+    static final String[] GET_ACCEPT_TYPES = {TEXT_EVENT_STREAM};
 
     @Override
     public void channelRead(ChannelHandlerContext ctx, Object msg) {
-        if (msg instanceof FullHttpRequest req && req.uri().startsWith(mcpEndpoint)) {
+        if (msg instanceof HttpRequest req && req.uri().startsWith(mcpEndpoint)) {
             var method = req.method();
             if (method == HttpMethod.POST) {
                 if (!isAcceptable(req, POST_ACCEPT_TYPES)) {
@@ -55,18 +60,52 @@ public final class AcceptValidationHandler extends ChannelInboundHandlerAdapter 
         ctx.fireChannelRead(msg);
     }
 
-    private static boolean isAcceptable(FullHttpRequest req, String[] requiredTypes) {
+    private static boolean isAcceptable(HttpRequest req, String[] requiredTypes) {
         var accept = req.headers().get(HttpHeaderNames.ACCEPT);
         if (accept == null || accept.isBlank()) return false;
-        if (accept.contains("*/*")) return true;
+        // Spec requires ALL listed types (POST must accept both application/json and
+        // text/event-stream, since the server chooses either for the response).
         for (var required : requiredTypes) {
-            if (accept.contains(required)) return true;
+            if (!accepts(accept, required)) return false;
+        }
+        return true;
+    }
+
+    /** Returns true if any media range in {@code accept} matches {@code requiredType} with q != 0. */
+    private static boolean accepts(String accept, String requiredType) {
+        var requiredMainType = requiredType.substring(0, requiredType.indexOf('/'));
+        for (var range : accept.split(",")) {
+            if (matches(range.trim(), requiredType, requiredMainType)) return true;
         }
         return false;
     }
 
-    private static void reject(ChannelHandlerContext ctx, FullHttpRequest req, String method, String[] requiredTypes) {
-        logger.warn(
+    private static boolean matches(String range, String requiredType, String requiredMainType) {
+        if (range.isEmpty()) return false;
+        var params = range.split(";");
+        var mediaRange = params[0].trim();
+        // A q=0 entry explicitly rejects the media range, even a wildcard one.
+        for (int i = 1; i < params.length; i++) {
+            var param = params[i].trim();
+            if (param.regionMatches(true, 0, "q=", 0, 2)) {
+                try {
+                    if (Double.parseDouble(param.substring(2).trim()) == 0.0) return false;
+                } catch (NumberFormatException ignored) {
+                    // Malformed q-value: treat as present (q defaults to 1).
+                }
+            }
+        }
+        if (mediaRange.equals("*/*") || mediaRange.equalsIgnoreCase(requiredType)) return true;
+        var slash = mediaRange.indexOf('/');
+        if (slash < 0) return false;
+        var rangeSub = mediaRange.substring(slash + 1);
+        return rangeSub.equals("*")
+                && slash == requiredMainType.length()
+                && mediaRange.regionMatches(true, 0, requiredMainType, 0, slash);
+    }
+
+    private static void reject(ChannelHandlerContext ctx, HttpRequest req, String method, String[] requiredTypes) {
+        logger.debug(
                 "MCP client {} Accept header on {}; required '{}'",
                 req.headers().get(HttpHeaderNames.ACCEPT) == null ? "missing" : "incompatible",
                 method,
@@ -74,7 +113,6 @@ public final class AcceptValidationHandler extends ChannelInboundHandlerAdapter 
         var msg = "Accept header must include " + String.join(" or ", requiredTypes) + " on " + method;
         var body = Unpooled.copiedBuffer(msg, StandardCharsets.UTF_8);
         var origin = req.headers().get(HttpHeaderNames.ORIGIN);
-        req.release();
-        sendResponseAndClose(ctx, HttpResponseStatus.NOT_ACCEPTABLE, "text/plain", body, origin);
+        sendResponseAndClose(ctx, HttpResponseStatus.NOT_ACCEPTABLE, TEXT_PLAIN, body, origin);
     }
 }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/sse/PostSseStream.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/sse/PostSseStream.java
@@ -92,7 +92,7 @@ public final class PostSseStream implements OutboundSseStream {
                 .set(HttpHeaderNames.CONTENT_TYPE, "text/event-stream")
                 .set(HttpHeaderNames.TRANSFER_ENCODING, HttpHeaderValues.CHUNKED)
                 .set(HttpHeaderNames.CACHE_CONTROL, "no-cache")
-                .set(HttpHeaderNames.CONNECTION, "keep-alive");
+                .set(HttpHeaderNames.CONNECTION, HttpHeaderValues.CLOSE);
         if (origin != null) {
             response.headers().set(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN, origin);
         }

--- a/tachyon-server/src/test/java/dev/tachyonmcp/transport/netty/McpOperationHandlerRequestTest.java
+++ b/tachyon-server/src/test/java/dev/tachyonmcp/transport/netty/McpOperationHandlerRequestTest.java
@@ -1,0 +1,283 @@
+/*
+ * Copyright (c) 2026 Konstantin Pavlov.
+ */
+
+package dev.tachyonmcp.transport.netty;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.tachyonmcp.protocol.ContextProvider;
+import dev.tachyonmcp.server.McpDispatcher;
+import dev.tachyonmcp.server.McpServer;
+import dev.tachyonmcp.server.TachyonServer;
+import dev.tachyonmcp.server.features.tools.ToolDescriptor;
+import dev.tachyonmcp.server.features.tools.ToolHandler;
+import dev.tachyonmcp.server.features.tools.ToolRequest;
+import dev.tachyonmcp.server.features.tools.ToolResult;
+import dev.tachyonmcp.server.session.McpContext;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.http.*;
+import io.netty.handler.timeout.IdleStateEvent;
+import io.netty.util.ReferenceCountUtil;
+import java.net.SocketException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.node.JsonNodeFactory;
+
+/**
+ * Covers {@link McpOperationHandler}'s POST request-dispatch paths and connection-lifecycle
+ * callbacks that the basic handler test does not exercise: JSON-RPC request dispatch, the
+ * client→server response/error paths, the POST→SSE upgrade, idle/exception handling, and the
+ * stateless GET branch. {@link InteractionHandler} sits in front so {@code handlePostRequest} can
+ * resolve the per-channel interaction context, mirroring the production pipeline.
+ */
+class McpOperationHandlerRequestTest {
+
+    private static final ToolDescriptor PROGRESS_DESCRIPTOR = ToolDescriptor.builder("progress_tool")
+            .description("emits progress notifications")
+            .inputSchema(
+                    JsonNodeFactory.instance.objectNode().put("type", "object").putObject("properties"))
+            .build();
+
+    /** Emits two progress notifications (which upgrade the POST response to SSE), then returns a result. */
+    private static final ToolHandler<ToolResult> PROGRESS_TOOL = new ToolHandler<>() {
+        @Override
+        public ToolDescriptor descriptor() {
+            return PROGRESS_DESCRIPTOR;
+        }
+
+        @Override
+        public CompletionStage<ToolResult> handle(ToolRequest request, McpContext ctx) {
+            var pt = request.progressToken();
+            ctx.notifications().progress(pt, 0, 100, "Starting");
+            ctx.notifications().progress(pt, 100, 100, "Complete");
+            return CompletableFuture.completedFuture(ToolResult.text("ok"));
+        }
+    };
+
+    private McpServer server;
+    private EmbeddedChannel channel;
+
+    @BeforeEach
+    void setUp() {
+        server = TachyonServer.builder().tool(PROGRESS_TOOL).build();
+        var dispatcher = new McpDispatcher(server, Runnable::run);
+        channel = new EmbeddedChannel(
+                new InteractionHandler(provider(server)), new McpOperationHandler(server, dispatcher, Runnable::run));
+        server.createSession("sess-op").activate();
+    }
+
+    @AfterEach
+    void tearDown() {
+        channel.close();
+        server.close();
+    }
+
+    // A successful JSON-RPC request returns its result as a single JSON response (keep-alive path).
+    @Test
+    void postRequestReturnsJsonResult() {
+        var response = post("{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"ping\"}");
+        assertThat(response.status()).isEqualTo(HttpResponseStatus.OK);
+        assertThat(response.headers().get(HttpHeaderNames.CONTENT_TYPE)).contains("application/json");
+        assertThat(response.content().toString(StandardCharsets.UTF_8)).contains("result");
+        response.release();
+    }
+
+    // An unknown method dispatches to a JSON-RPC error envelope, still over a 200 JSON response.
+    @Test
+    void postUnknownMethodReturnsJsonRpcError() {
+        var response = post("{\"jsonrpc\":\"2.0\",\"id\":7,\"method\":\"does/notExist\"}");
+        assertThat(response.status()).isEqualTo(HttpResponseStatus.OK);
+        var body = response.content().toString(StandardCharsets.UTF_8);
+        assertThat(body).contains("error").contains("Method not found");
+        response.release();
+    }
+
+    // A client→server JSON-RPC response (no pending request) is acknowledged with 202.
+    @Test
+    void postResponseMessageReturnsAccepted() {
+        var response = post("{\"jsonrpc\":\"2.0\",\"id\":\"42\",\"result\":{}}");
+        assertThat(response.status()).isEqualTo(HttpResponseStatus.ACCEPTED);
+        response.release();
+    }
+
+    // A client→server JSON-RPC error (no pending request) is acknowledged with 202.
+    @Test
+    void postErrorMessageReturnsAccepted() {
+        var response = post("{\"jsonrpc\":\"2.0\",\"id\":\"42\",\"error\":{\"code\":-1,\"message\":\"boom\"}}");
+        assertThat(response.status()).isEqualTo(HttpResponseStatus.ACCEPTED);
+        response.release();
+    }
+
+    // A non-"initialized" notification is acknowledged with 202 and dispatched asynchronously.
+    @Test
+    void postCancelledNotificationReturnsAccepted() {
+        var response = post("{\"jsonrpc\":\"2.0\",\"method\":\"notifications/cancelled\","
+                + "\"params\":{\"requestId\":\"1\",\"reason\":\"user\"}}");
+        assertThat(response.status()).isEqualTo(HttpResponseStatus.ACCEPTED);
+        response.release();
+    }
+
+    // A tool that emits progress upgrades the POST response to an SSE stream; the final result is
+    // delivered as the last SSE event (SEP-1699 POST-SSE streaming).
+    @Test
+    void toolProgressUpgradesPostResponseToSseStream() {
+        writeInbound("{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/call\",\"params\":{"
+                + "\"name\":\"progress_tool\",\"arguments\":{},\"_meta\":{\"progressToken\":42}}}");
+
+        var outbound = drainOutbound();
+        try {
+            var head = outbound.getFirst();
+            assertThat(head).isInstanceOf(HttpResponse.class).isNotInstanceOf(FullHttpResponse.class);
+            var sseResponse = (HttpResponse) head;
+            assertThat(sseResponse.status()).isEqualTo(HttpResponseStatus.OK);
+            assertThat(sseResponse.headers().get(HttpHeaderNames.CONTENT_TYPE)).isEqualTo("text/event-stream");
+
+            var streamBody = contentText(outbound);
+            assertThat(streamBody)
+                    .contains("notifications/progress")
+                    .contains("\"progress\":0.0")
+                    .contains("\"progress\":100.0")
+                    .contains("result")
+                    .contains("ok");
+        } finally {
+            outbound.forEach(ReferenceCountUtil::release);
+        }
+    }
+
+    // GET with a session id that does not exist is rejected with 400.
+    @Test
+    void getUnknownSessionReturnsBadRequest() {
+        var request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/mcp");
+        request.headers()
+                .set(HttpHeaderNames.ORIGIN, "http://localhost:3000")
+                .set(HttpHeaderNames.ACCEPT, "text/event-stream")
+                .set("MCP-Session-Id", "ghost");
+        channel.writeInbound(request);
+
+        var response = readResponse();
+        assertThat(response.status()).isEqualTo(HttpResponseStatus.BAD_REQUEST);
+        assertThat(response.content().toString(StandardCharsets.UTF_8)).contains("Unknown session");
+        response.release();
+    }
+
+    // An idle-timeout event closes the channel.
+    @Test
+    void idleTimeoutClosesChannel() {
+        channel.pipeline().fireUserEventTriggered(IdleStateEvent.FIRST_READER_IDLE_STATE_EVENT);
+        channel.runPendingTasks();
+        assertThat(channel.isOpen()).isFalse();
+    }
+
+    // A connection reset (SocketException) closes the channel quietly.
+    @Test
+    void socketExceptionClosesChannel() {
+        channel.pipeline().fireExceptionCaught(new SocketException("connection reset"));
+        channel.runPendingTasks();
+        assertThat(channel.isOpen()).isFalse();
+    }
+
+    // Any other exception closes the channel.
+    @Test
+    void genericExceptionClosesChannel() {
+        channel.pipeline().fireExceptionCaught(new RuntimeException("boom"));
+        channel.runPendingTasks();
+        assertThat(channel.isOpen()).isFalse();
+    }
+
+    // In stateless mode a GET opens an SSE stream without requiring a session.
+    @Test
+    void statelessGetOpensSseStream() {
+        var statelessServer =
+                TachyonServer.builder().session(s -> s.stateless(true)).build();
+        var ch = new EmbeddedChannel(
+                new InteractionHandler(provider(statelessServer)),
+                new McpOperationHandler(
+                        statelessServer, new McpDispatcher(statelessServer, Runnable::run), Runnable::run));
+        try {
+            var request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/mcp");
+            request.headers()
+                    .set(HttpHeaderNames.ORIGIN, "http://localhost:3000")
+                    .set(HttpHeaderNames.ACCEPT, "text/event-stream");
+            ch.writeInbound(request);
+
+            var outbound = drain(ch);
+            try {
+                assertThat(outbound.getFirst()).isInstanceOf(HttpResponse.class);
+                var response = (HttpResponse) outbound.getFirst();
+                assertThat(response.status()).isEqualTo(HttpResponseStatus.OK);
+                assertThat(response.headers().get(HttpHeaderNames.CONTENT_TYPE)).isEqualTo("text/event-stream");
+            } finally {
+                outbound.forEach(ReferenceCountUtil::release);
+            }
+        } finally {
+            ch.close();
+            statelessServer.close();
+        }
+    }
+
+    private FullHttpResponse post(String body) {
+        writeInbound(body);
+        return readResponse();
+    }
+
+    private void writeInbound(String body) {
+        var request = new DefaultFullHttpRequest(
+                HttpVersion.HTTP_1_1, HttpMethod.POST, "/mcp", Unpooled.copiedBuffer(body, StandardCharsets.UTF_8));
+        request.headers()
+                .set(HttpHeaderNames.ORIGIN, "http://localhost:3000")
+                .set("MCP-Session-Id", "sess-op")
+                .set(HttpHeaderNames.ACCEPT, "application/json, text/event-stream");
+        channel.writeInbound(request);
+    }
+
+    private FullHttpResponse readResponse() {
+        channel.runPendingTasks();
+        var msg = channel.readOutbound();
+        assertThat(msg).isInstanceOf(FullHttpResponse.class);
+        return (FullHttpResponse) msg;
+    }
+
+    private List<Object> drainOutbound() {
+        return drain(channel);
+    }
+
+    private static List<Object> drain(EmbeddedChannel ch) {
+        ch.runPendingTasks();
+        var messages = new ArrayList<>();
+        Object msg;
+        while ((msg = ch.readOutbound()) != null) {
+            messages.add(msg);
+        }
+        assertThat(messages).as("expected at least one outbound message").isNotEmpty();
+        return messages;
+    }
+
+    private static String contentText(List<Object> messages) {
+        var sb = new StringBuilder();
+        for (var msg : messages) {
+            if (msg instanceof HttpContent content) {
+                sb.append(content.content().toString(StandardCharsets.UTF_8));
+            }
+        }
+        return sb.toString();
+    }
+
+    private static ContextProvider provider(McpServer server) {
+        return new ContextProvider() {
+            @Override
+            @SuppressWarnings("unchecked")
+            public <T> @Nullable T provide(Class<T> type) {
+                return type.isInstance(server) ? (T) server : null;
+            }
+        };
+    }
+}

--- a/tachyon-server/src/test/java/dev/tachyonmcp/transport/netty/NettyServerThreadingTest.java
+++ b/tachyon-server/src/test/java/dev/tachyonmcp/transport/netty/NettyServerThreadingTest.java
@@ -18,8 +18,11 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import tools.jackson.databind.JsonNode;
 
+@Execution(ExecutionMode.SAME_THREAD)
 class NettyServerThreadingTest {
 
     @Test

--- a/tachyon-server/src/test/resources/junit-platform.properties
+++ b/tachyon-server/src/test/resources/junit-platform.properties
@@ -2,5 +2,5 @@ junit.jupiter.execution.parallel.config.executor-service=WORKER_THREAD_POOL
 junit.jupiter.execution.parallel.enabled = true
 junit.jupiter.execution.parallel.mode.classes.default = concurrent
 junit.jupiter.execution.parallel.mode.default = concurrent
-junit.jupiter.execution.timeout.default = 5 s
+junit.jupiter.execution.timeout.default = 15 s
 


### PR DESCRIPTION
Refactors Netty HTTP connection management to use HttpUtil.setKeepAlive instead of explicit Connection: close headers and ChannelFutureListener.CLOSE. Adds HttpServerKeepAliveHandler to the pipeline, defensively closes PostSseStream in all request handler paths, tightens AcceptValidationHandler to require all media types, and adds e2e tests for Accept header validation. The release workflow is updated to stage all pom.xml files.