### PR TITLE
feat: SSE heartbeat

### DIFF
--- a/.agents/skills/tachyon-tesing/SKILL.md
+++ b/.agents/skills/tachyon-tesing/SKILL.md
@@ -14,3 +14,4 @@ description: Apply project specific rules when designing and writing tests
 - Prefer Java MCP SDK client. Raw http for edge cases.
 - `JsonUnit` + AssertJ for JSON asserts. Assert full JSON. Ignore dynamic fields with `.whenIgnoringPaths(...)`. Use `IGNORING_ARRAY_ORDER`, `IGNORING_EXTRA_FIELDS`, `TREATING_NULL_AS_ABSENT`.
 - `// language=JSON` before JSON strings.
+- Awaitility for e2e tests and polling

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,6 +69,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload results to Codecov
+        if: ${{ !cancelled() }}
         uses: codecov/codecov-action@v7
         with:
           name: codecov-jdk${{ matrix.java }}
@@ -76,9 +77,15 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: kpavlov/tachyon
 
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+
       - name: Upload reports as artifacts
         uses: actions/upload-artifact@v7
-        if: always()
+        if: ${{ !cancelled() }}
         with:
           name: reports-jdk-${{ matrix.java }}
           path: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@ mvn spotless:apply  # auto-fix
 ## Rules
 
 - TDD + SOLID. TachyonServer is SUT in unit tests.
-- **Tests**: JUnit 5 + AssertJ. `@TempDir` for unit, port 0 for E2E. Prefer E2E for long scenarios. No tautologies. Many asserts per test.
+- **Tests**: JUnit 6 + AssertJ + Awaitlilty. `@TempDir` for unit, port 0 for E2E. Prefer E2E for long scenarios. No tautologies. Many asserts per test.
 - **Nullability**: JSpecify `@Nullable`/`@NonNull`.
 - **Copyright**: `/* Copyright (c) 2026 Konstantin Pavlov. */` everywhere.
 - **No comments** unless spec needs explain.

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/ServerInfoTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/ServerInfoTest.java
@@ -6,19 +6,28 @@ package dev.tachyonmcp.e2e;
 
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 
+import dev.tachyonmcp.server.domain.Icon;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
-class ServerInfoTestTest extends AbstractMcpE2eTest {
+class ServerInfoTest extends AbstractMcpE2eTest {
 
     @Test
     void allCapabilitiesEnabled() throws Exception {
-        startServer(it -> it.capabilities(c -> c.completions()
-                .logging()
-                .prompts(true)
-                .tools(true)
-                .resources(true, true)
-                .prompts(true)
-                .tasks(true, true, true)));
+        startServer(it -> it.info(b -> b.name("test-server")
+                        .version("2.0")
+                        .description("Test server")
+                        .title("Test Server")
+                        .websiteUrl("https://example.com/mcp")
+                        .instructions("Test instructions")
+                        .addIcons(Icon.of("https://example.com/icon.png", "image/png", List.of("32x32"), "light")))
+                .capabilities(c -> c.completions()
+                        .logging()
+                        .prompts(true)
+                        .tools(true)
+                        .resources(true, true)
+                        .prompts(true)
+                        .tasks(true, true, true)));
 
         try (var client = createTestClient()) {
             // language=json
@@ -32,8 +41,21 @@ class ServerInfoTestTest extends AbstractMcpE2eTest {
                   "jsonrpc": "2.0",
                   "id": 1,
                   "result": {
-                    "protocolVersion":"2025-11-25",
-                    "serverInfo":{"name":"tachyon-mcp","version":"0.1"},
+                    "protocolVersion": "2025-11-25",
+                    "serverInfo": {
+                      "name": "test-server",
+                      "version": "2.0",
+                      "description": "Test server",
+                      "title": "Test Server",
+                      "websiteUrl": "https://example.com/mcp",
+                      "icons": [{
+                        "src": "https://example.com/icon.png",
+                        "mimeType": "image/png",
+                        "sizes": ["32x32"],
+                        "theme": "light"
+                      }]
+                    },
+                    "instructions": "Test instructions",
                     "capabilities": {
                       "logging": {},
                       "completions": {},

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/SseHeartbeatE2eTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/SseHeartbeatE2eTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2026 Konstantin Pavlov.
+ */
+
+package dev.tachyonmcp.e2e;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.tachyonmcp.server.McpServer;
+import dev.tachyonmcp.server.TachyonServer;
+import dev.tachyonmcp.transport.netty.McpChannelInitializer;
+import dev.tachyonmcp.transport.netty.NettyServer;
+import dev.tachyonmcp.transport.netty.NettyServerConfig;
+import java.net.Socket;
+import java.net.SocketTimeoutException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+/**
+ * Verifies that a silent SSE stream is kept alive by periodic comment heartbeats rather than being
+ * reaped on idle. Uses a short reader-idle timeout so the real {@link io.netty.handler.timeout.IdleStateHandler}
+ * fires repeatedly within the test window — proving both the heartbeat write and the timer rescheduling.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class SseHeartbeatE2eTest {
+
+    private static final Duration READER_IDLE = Duration.ofMillis(150);
+
+    private McpServer server;
+    private NettyServer nettyServer;
+    private int port;
+
+    @BeforeAll
+    void startServer() {
+        server = TachyonServer.builder().build();
+        var config = new NettyServerConfig(
+                "127.0.0.1",
+                0,
+                "/mcp",
+                READER_IDLE,
+                Duration.ofMinutes(5),
+                McpChannelInitializer.DEFAULT_MAX_CONTENT_LENGTH,
+                NettyServerConfig.buildCorsConfig(null, false, false, null),
+                null);
+        nettyServer = new NettyServer(server, config);
+        port = nettyServer.port();
+    }
+
+    @AfterAll
+    void stopServer() {
+        nettyServer.close();
+        server.close();
+    }
+
+    @Test
+    void idleSseStreamReceivesRepeatedHeartbeats() throws Exception {
+        var sessionId = initializeSession();
+
+        // Read for ~5 reader-idle intervals; a 150ms idle should yield several ":\r\n" comments.
+        var raw = readRawSse(sessionId, READER_IDLE.toMillis() * 5);
+
+        assertThat(raw).as("stream must open as text/event-stream").contains("text/event-stream");
+        assertThat(countOccurrences(raw, ":\r\n"))
+                .as("reader-idle must drive repeated SSE comment heartbeats (proves timer rescheduling)")
+                .isGreaterThanOrEqualTo(2);
+    }
+
+    private String initializeSession() throws Exception {
+        try (var client = HttpClient.newHttpClient()) {
+            // language=JSON
+            var body = """
+                    {"jsonrpc":"2.0","id":0,"method":"initialize",
+                     "params":{"protocolVersion":"2025-11-25","capabilities":{},
+                               "clientInfo":{"name":"test","version":"1.0"}}}
+                    """;
+            var response = client.send(
+                    HttpRequest.newBuilder()
+                            .uri(URI.create("http://localhost:" + port + "/mcp"))
+                            .header("Content-Type", "application/json")
+                            .header("Accept", "application/json, text/event-stream")
+                            .header("MCP-Protocol-Version", "2025-11-25")
+                            .POST(HttpRequest.BodyPublishers.ofString(body))
+                            .build(),
+                    HttpResponse.BodyHandlers.ofString());
+            var sessionId = response.headers().firstValue("MCP-Session-Id").orElseThrow();
+            client.send(
+                    HttpRequest.newBuilder()
+                            .uri(URI.create("http://localhost:" + port + "/mcp"))
+                            .header("Content-Type", "application/json")
+                            .header("Accept", "application/json, text/event-stream")
+                            .header("MCP-Protocol-Version", "2025-11-25")
+                            .header("MCP-Session-Id", sessionId)
+                            // language=JSON
+                            .POST(HttpRequest.BodyPublishers.ofString(
+                                    "{\"jsonrpc\":\"2.0\",\"method\":\"notifications/initialized\"}"))
+                            .build(),
+                    HttpResponse.BodyHandlers.ofString());
+            return sessionId;
+        }
+    }
+
+    /** Opens a raw SSE GET and accumulates everything received over {@code durationMs}. */
+    private String readRawSse(String sessionId, long durationMs) throws Exception {
+        try (var socket = new Socket("localhost", port)) {
+            var req = ("GET /mcp HTTP/1.1\r\n"
+                            + "Host: localhost:" + port + "\r\n"
+                            + "MCP-Session-Id: " + sessionId + "\r\n"
+                            + "Accept: text/event-stream\r\n"
+                            + "\r\n")
+                    .getBytes(StandardCharsets.UTF_8);
+            socket.getOutputStream().write(req);
+            socket.getOutputStream().flush();
+            socket.setSoTimeout(50);
+
+            var sb = new StringBuilder();
+            var buf = new byte[4096];
+            var deadline = System.currentTimeMillis() + durationMs;
+            while (System.currentTimeMillis() < deadline) {
+                try {
+                    var n = socket.getInputStream().read(buf);
+                    if (n < 0) break;
+                    if (n > 0) sb.append(new String(buf, 0, n, StandardCharsets.UTF_8));
+                } catch (SocketTimeoutException e) {
+                    // No data this poll; keep reading until the deadline.
+                }
+            }
+            return sb.toString();
+        }
+    }
+
+    private static int countOccurrences(String haystack, String needle) {
+        var count = 0;
+        for (var i = haystack.indexOf(needle); i >= 0; i = haystack.indexOf(needle, i + needle.length())) {
+            count++;
+        }
+        return count;
+    }
+}

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/McpServer.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/McpServer.java
@@ -46,8 +46,7 @@ public class McpServer implements Closeable {
     private final Map<String, McpMethodHandler> methodHandlers = new ConcurrentHashMap<>();
     final Map<String, LoggingLevel> loggingLevels = new ConcurrentHashMap<>();
     final ConcurrentHashMap<Object, CompletableFuture<String>> pendingRequests = new ConcurrentHashMap<>();
-    private final ExecutorService virtualThreadExecutor = Executors.newThreadPerTaskExecutor(
-            Thread.ofVirtual().name("mcp-handler-vt-", 0).factory());
+    private final ExecutorService virtualThreadExecutor = Executors.newVirtualThreadPerTaskExecutor();
     private final List<McpExtension> extensions;
     private final Map<String, String> extensionMethodOwners = new ConcurrentHashMap<>();
     private final Map<String, McpExtension> extensionsById = new ConcurrentHashMap<>();

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/features/prompts/PromptDescriptor.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/features/prompts/PromptDescriptor.java
@@ -13,7 +13,6 @@ import org.jspecify.annotations.Nullable;
 import tools.jackson.databind.JsonNode;
 
 @Value.Immutable
-@Value.Builder
 @Value.Style(
         allParameters = true,
         visibility = Value.Style.ImplementationVisibility.PACKAGE,

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/features/resources/ResourceDescriptor.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/features/resources/ResourceDescriptor.java
@@ -16,7 +16,6 @@ import org.jspecify.annotations.Nullable;
         allParameters = true,
         visibility = Value.Style.ImplementationVisibility.PACKAGE,
         typeImmutable = "Default*")
-@Value.Builder
 public interface ResourceDescriptor extends McpResourceType {
 
     String name();

--- a/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/McpChannelInitializer.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/McpChannelInitializer.java
@@ -14,6 +14,7 @@ import dev.tachyonmcp.transport.netty.http.StatelessValidatorHandler;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelPipeline;
+import io.netty.channel.group.ChannelGroup;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.handler.codec.http.HttpObjectAggregator;
 import io.netty.handler.codec.http.HttpServerCodec;
@@ -72,6 +73,8 @@ public class McpChannelInitializer extends ChannelInitializer<SocketChannel> {
     @Nullable
     private final Consumer<ChannelPipeline> pipelineCustomizer;
 
+    private final ChannelGroup childChannels;
+
     public McpChannelInitializer(
             String endpointPath,
             boolean stateless,
@@ -79,6 +82,7 @@ public class McpChannelInitializer extends ChannelInitializer<SocketChannel> {
             Duration readerIdleTimeout,
             Duration writerIdleTimeout,
             int maxContentLength,
+            ChannelGroup childChannels,
             @Nullable CorsConfig corsConfig,
             @Nullable Consumer<ChannelPipeline> pipelineCustomizer) {
         this.stateless = stateless;
@@ -88,6 +92,7 @@ public class McpChannelInitializer extends ChannelInitializer<SocketChannel> {
         this.maxContentLength = maxContentLength;
         this.corsConfig = corsConfig;
         this.pipelineCustomizer = pipelineCustomizer;
+        this.childChannels = childChannels;
         this.dispatcher = new McpDispatcher(server, server.executor());
         ContextProvider provider = new ContextProvider() {
             @Override
@@ -105,6 +110,7 @@ public class McpChannelInitializer extends ChannelInitializer<SocketChannel> {
 
     @Override
     protected void initChannel(SocketChannel ch) {
+        childChannels.add(ch);
         final var p = ch.pipeline();
         p.addFirst("flush", new FlushConsolidationHandler(FLUSH_AFTER, true));
         if (CHANNEL_LOGGING_ENABLED) {

--- a/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/McpChannelInitializer.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/McpChannelInitializer.java
@@ -134,6 +134,11 @@ public class McpChannelInitializer extends ChannelInitializer<SocketChannel> {
         // transferred. A separate HttpServerExpectContinueHandler would defeat that by
         // always acking 100 Continue upstream of the aggregator.
         p.addLast("http-aggregator", new HttpObjectAggregator(maxContentLength));
+        // On a plain HTTP keep-alive socket an idle tick closes the connection. On a channel carrying
+        // an open SSE stream (marked via SseHeartbeat) McpOperationHandler instead emits a comment
+        // heartbeat, so the idle interval doubles as the SSE keep-alive cadence: an SSE client only
+        // reads, so reader-idle keeps firing and drives the heartbeat. Lower readerIdleTimeout below
+        // any intermediary proxy's idle timeout (commonly 60s) to keep streams from being reaped.
         if (!readerIdleTimeout.isZero() || !writerIdleTimeout.isZero()) {
             p.addLast(
                     "idle",

--- a/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/McpOperationHandler.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/McpOperationHandler.java
@@ -16,6 +16,7 @@ import dev.tachyonmcp.server.session.McpSession;
 import dev.tachyonmcp.server.session.SessionEvent;
 import dev.tachyonmcp.transport.jsonrpc.JsonRpcMessage;
 import dev.tachyonmcp.transport.netty.sse.PostSseStream;
+import dev.tachyonmcp.transport.netty.sse.SseHeartbeat;
 import dev.tachyonmcp.transport.netty.sse.SseManager;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
@@ -316,8 +317,15 @@ public class McpOperationHandler extends ChannelInboundHandlerAdapter {
     @Override
     public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
         if (evt instanceof IdleStateEvent) {
-            logger.debug("Idle timeout, closing channel: {}", ctx.channel().remoteAddress());
-            ctx.close();
+            if (SseHeartbeat.isEnabled(ctx.channel())) {
+                // Long-lived SSE stream: a silent client is normal (it only reads), so an idle tick
+                // means "keep alive", not "dead". Emit a comment heartbeat instead of closing; a
+                // failed heartbeat write reaps a genuinely dead client.
+                SseHeartbeat.send(ctx.channel());
+            } else {
+                logger.debug("Idle timeout, closing channel: {}", ctx.channel().remoteAddress());
+                ctx.close();
+            }
         } else {
             ctx.fireUserEventTriggered(evt);
         }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/NettyServer.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/NettyServer.java
@@ -11,6 +11,7 @@ import io.netty.channel.*;
 import io.netty.channel.epoll.Epoll;
 import io.netty.channel.epoll.EpollIoHandler;
 import io.netty.channel.epoll.EpollServerSocketChannel;
+import io.netty.channel.group.DefaultChannelGroup;
 import io.netty.channel.kqueue.KQueue;
 import io.netty.channel.kqueue.KQueueIoHandler;
 import io.netty.channel.kqueue.KQueueServerSocketChannel;
@@ -21,6 +22,7 @@ import io.netty.channel.uring.IoUring;
 import io.netty.channel.uring.IoUringIoHandler;
 import io.netty.channel.uring.IoUringServerSocketChannel;
 import io.netty.util.concurrent.DefaultThreadFactory;
+import io.netty.util.concurrent.GlobalEventExecutor;
 import java.io.Closeable;
 import java.net.InetSocketAddress;
 import org.slf4j.Logger;
@@ -38,6 +40,7 @@ public final class NettyServer implements Closeable {
 
     final MultiThreadIoEventLoopGroup eventLoopGroup;
     private final Channel serverChannel;
+    private final DefaultChannelGroup childChannels = new DefaultChannelGroup(GlobalEventExecutor.INSTANCE);
 
     public int port() {
         return ((InetSocketAddress) serverChannel.localAddress()).getPort();
@@ -79,6 +82,7 @@ public final class NettyServer implements Closeable {
                         config.readerIdleTimeout(),
                         config.writerIdleTimeout(),
                         config.maxContentLength(),
+                        childChannels,
                         config.corsConfig(),
                         config.pipelineCustomizer()));
 
@@ -120,7 +124,10 @@ public final class NettyServer implements Closeable {
         logger.debug("Shutting down NettyServer");
         try {
             serverChannel.close().sync();
-            eventLoopGroup.shutdownGracefully().sync();
+            childChannels.close().sync();
+            eventLoopGroup
+                    .shutdownGracefully(0, 3, java.util.concurrent.TimeUnit.SECONDS)
+                    .sync();
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
         }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/sse/PostSseStream.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/sse/PostSseStream.java
@@ -99,6 +99,7 @@ public final class PostSseStream implements OutboundSseStream {
         channel.write(response);
         channel.write(
                 new DefaultHttpContent(ByteBufUtil.writeUtf8(channel.alloc(), "retry: " + SSE_RETRY_DELAY_MS + "\n")));
+        SseHeartbeat.enable(channel);
         // Priming event: gives the client a Last-Event-ID baseline for reconnection (SEP-1699).
         var primingId = eventIdSupplier.getAsLong();
         var priming = new SseEvent(String.valueOf(primingId), "message", "");

--- a/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/sse/SseHeartbeat.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/sse/SseHeartbeat.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2026 Konstantin Pavlov.
+ */
+
+package dev.tachyonmcp.transport.netty.sse;
+
+import io.netty.buffer.ByteBufUtil;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.handler.codec.http.DefaultHttpContent;
+import io.netty.util.AttributeKey;
+
+/**
+ * Keeps long-lived SSE streams alive across idle periods. A channel carrying an open SSE response is
+ * marked via {@link #enable(Channel)}; the idle handler then emits an SSE comment heartbeat
+ * ({@code :\r\n}) on each idle tick instead of closing the channel, so neither the client's read
+ * timeout nor an intermediary proxy reaps the otherwise silent connection.
+ *
+ * <p>A heartbeat is itself a chunk write, so a failed write (dead client, RST) closes the channel —
+ * idle-close is no longer the dead-client detector once SSE channels stop closing on idle.
+ */
+public final class SseHeartbeat {
+
+    private static final AttributeKey<Boolean> ACTIVE = AttributeKey.valueOf("sseHeartbeatActive");
+
+    private SseHeartbeat() {}
+
+    /** Marks {@code channel} as carrying an open SSE stream. Call after the SSE response headers are written. */
+    public static void enable(Channel channel) {
+        channel.attr(ACTIVE).set(Boolean.TRUE);
+    }
+
+    /** @return {@code true} if {@code channel} carries an open SSE stream and should be kept alive across idle. */
+    public static boolean isEnabled(Channel channel) {
+        return Boolean.TRUE.equals(channel.attr(ACTIVE).get());
+    }
+
+    /**
+     * Writes an SSE comment heartbeat ({@code :\r\n}) on the channel's event loop, closing the channel
+     * if the write fails. Skipped when the channel is inactive or already backpressured (bytes are
+     * pending, so the stream is not actually idle).
+     */
+    public static void send(Channel channel) {
+        if (!channel.isActive() || !channel.isWritable()) {
+            return;
+        }
+        var buf = ByteBufUtil.writeAscii(channel.alloc(), ":\r\n");
+        channel.writeAndFlush(new DefaultHttpContent(buf)).addListener((ChannelFutureListener) f -> {
+            if (!f.isSuccess()) channel.close();
+        });
+    }
+}

--- a/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/sse/SseManager.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/sse/SseManager.java
@@ -74,6 +74,7 @@ public class SseManager {
         ctx.write(response);
         ctx.writeAndFlush(
                 new DefaultHttpContent(ByteBufUtil.writeUtf8(ctx.alloc(), "retry: " + SSE_RETRY_DELAY_MS + "\n")));
+        SseHeartbeat.enable(ctx.channel());
         var primeSse = new SseEvent(String.valueOf(server.nextEventId()), "message", "");
         connection.send(primeSse);
     }

--- a/tachyon-server/src/test/java/dev/tachyonmcp/transport/netty/McpOperationHandlerRequestTest.java
+++ b/tachyon-server/src/test/java/dev/tachyonmcp/transport/netty/McpOperationHandlerRequestTest.java
@@ -26,6 +26,10 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -156,7 +160,7 @@ class McpOperationHandlerRequestTest {
     // Once a tool upgrades the POST response to SSE, the stream is long-lived: an idle tick must
     // emit a comment heartbeat (":\r\n") to keep it alive instead of closing the channel.
     @Test
-    void idleOnUpgradedPostSseStreamSendsHeartbeat() {
+    void idleOnUpgradedPostSseStreamSendsHeartbeat() throws InterruptedException {
         var descriptor = ToolDescriptor.builder("stalled_tool")
                 .description("upgrades to SSE then never completes")
                 .inputSchema(JsonNodeFactory.instance
@@ -164,8 +168,8 @@ class McpOperationHandlerRequestTest {
                         .put("type", "object")
                         .putObject("properties"))
                 .build();
-        // Emits one progress notification (upgrading POST → SSE) then returns a future that never
-        // completes, so the stream stays open and idle when the idle event fires.
+        var upgraded = new CountDownLatch(1);
+        var neverComplete = new CompletableFuture<ToolResult>();
         ToolHandler<ToolResult> stalledTool = new ToolHandler<>() {
             @Override
             public ToolDescriptor descriptor() {
@@ -175,13 +179,15 @@ class McpOperationHandlerRequestTest {
             @Override
             public CompletionStage<ToolResult> handle(ToolRequest request, McpContext ctx) {
                 ctx.notifications().progress(request.progressToken(), 0, 100, "working");
-                return new CompletableFuture<>();
+                upgraded.countDown();
+                return neverComplete;
             }
         };
         var srv = TachyonServer.builder().tool(stalledTool).build();
+        ExecutorService pool = Executors.newSingleThreadExecutor();
         var ch = new EmbeddedChannel(
                 new InteractionHandler(provider(srv)),
-                new McpOperationHandler(srv, new McpDispatcher(srv, Runnable::run), Runnable::run));
+                new McpOperationHandler(srv, new McpDispatcher(srv, pool::execute), Runnable::run));
         srv.createSession("sess-stall").activate();
         try {
             var request = new DefaultFullHttpRequest(
@@ -197,7 +203,10 @@ class McpOperationHandlerRequestTest {
                     .set("MCP-Session-Id", "sess-stall")
                     .set(HttpHeaderNames.ACCEPT, "application/json, text/event-stream");
             ch.writeInbound(request);
-            drain(ch).forEach(ReferenceCountUtil::release); // consume the SSE upgrade frames
+            assertThat(upgraded.await(5, TimeUnit.SECONDS))
+                    .as("tool must emit progress within 5 s")
+                    .isTrue();
+            drain(ch).forEach(ReferenceCountUtil::release);
 
             ch.pipeline().fireUserEventTriggered(IdleStateEvent.FIRST_READER_IDLE_STATE_EVENT);
             ch.runPendingTasks();
@@ -214,8 +223,10 @@ class McpOperationHandlerRequestTest {
                 content.release();
             }
         } finally {
+            neverComplete.cancel(true);
             ch.close();
             srv.close();
+            pool.shutdownNow();
         }
     }
 

--- a/tachyon-server/src/test/java/dev/tachyonmcp/transport/netty/McpOperationHandlerRequestTest.java
+++ b/tachyon-server/src/test/java/dev/tachyonmcp/transport/netty/McpOperationHandlerRequestTest.java
@@ -153,6 +153,72 @@ class McpOperationHandlerRequestTest {
         }
     }
 
+    // Once a tool upgrades the POST response to SSE, the stream is long-lived: an idle tick must
+    // emit a comment heartbeat (":\r\n") to keep it alive instead of closing the channel.
+    @Test
+    void idleOnUpgradedPostSseStreamSendsHeartbeat() {
+        var descriptor = ToolDescriptor.builder("stalled_tool")
+                .description("upgrades to SSE then never completes")
+                .inputSchema(JsonNodeFactory.instance
+                        .objectNode()
+                        .put("type", "object")
+                        .putObject("properties"))
+                .build();
+        // Emits one progress notification (upgrading POST → SSE) then returns a future that never
+        // completes, so the stream stays open and idle when the idle event fires.
+        ToolHandler<ToolResult> stalledTool = new ToolHandler<>() {
+            @Override
+            public ToolDescriptor descriptor() {
+                return descriptor;
+            }
+
+            @Override
+            public CompletionStage<ToolResult> handle(ToolRequest request, McpContext ctx) {
+                ctx.notifications().progress(request.progressToken(), 0, 100, "working");
+                return new CompletableFuture<>();
+            }
+        };
+        var srv = TachyonServer.builder().tool(stalledTool).build();
+        var ch = new EmbeddedChannel(
+                new InteractionHandler(provider(srv)),
+                new McpOperationHandler(srv, new McpDispatcher(srv, Runnable::run), Runnable::run));
+        srv.createSession("sess-stall").activate();
+        try {
+            var request = new DefaultFullHttpRequest(
+                    HttpVersion.HTTP_1_1,
+                    HttpMethod.POST,
+                    "/mcp",
+                    Unpooled.copiedBuffer(
+                            "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/call\",\"params\":{"
+                                    + "\"name\":\"stalled_tool\",\"arguments\":{},\"_meta\":{\"progressToken\":7}}}",
+                            StandardCharsets.UTF_8));
+            request.headers()
+                    .set(HttpHeaderNames.ORIGIN, "http://localhost:3000")
+                    .set("MCP-Session-Id", "sess-stall")
+                    .set(HttpHeaderNames.ACCEPT, "application/json, text/event-stream");
+            ch.writeInbound(request);
+            drain(ch).forEach(ReferenceCountUtil::release); // consume the SSE upgrade frames
+
+            ch.pipeline().fireUserEventTriggered(IdleStateEvent.FIRST_READER_IDLE_STATE_EVENT);
+            ch.runPendingTasks();
+
+            assertThat(ch.isOpen())
+                    .as("upgraded POST-SSE stream must survive an idle tick")
+                    .isTrue();
+            var heartbeat = ch.readOutbound();
+            assertThat(heartbeat).isInstanceOf(HttpContent.class);
+            var content = (HttpContent) heartbeat;
+            try {
+                assertThat(content.content().toString(StandardCharsets.UTF_8)).isEqualTo(":\r\n");
+            } finally {
+                content.release();
+            }
+        } finally {
+            ch.close();
+            srv.close();
+        }
+    }
+
     // GET with a session id that does not exist is rejected with 400.
     @Test
     void getUnknownSessionReturnsBadRequest() {

--- a/tachyon-server/src/test/java/dev/tachyonmcp/transport/netty/McpOperationHandlerTest.java
+++ b/tachyon-server/src/test/java/dev/tachyonmcp/transport/netty/McpOperationHandlerTest.java
@@ -12,6 +12,7 @@ import dev.tachyonmcp.server.TachyonServer;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.http.*;
+import io.netty.handler.timeout.IdleStateEvent;
 import java.nio.charset.StandardCharsets;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.AfterEach;
@@ -104,6 +105,44 @@ class McpOperationHandlerTest {
     }
 
     @Test
+    void idleOnSseStreamSendsHeartbeatAndKeepsChannelOpen() {
+        server.createSession("sess-hb").activate();
+
+        var request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/mcp");
+        request.headers()
+                .set(HttpHeaderNames.ORIGIN, "http://localhost:3000")
+                .set(HttpHeaderNames.ACCEPT, "text/event-stream")
+                .set("MCP-Session-Id", "sess-hb");
+        channel.writeInbound(request);
+        channel.runPendingTasks();
+        drainOutbound();
+
+        channel.pipeline().fireUserEventTriggered(IdleStateEvent.FIRST_READER_IDLE_STATE_EVENT);
+        channel.runPendingTasks();
+
+        assertThat(channel.isOpen()).as("SSE stream must survive an idle tick").isTrue();
+        assertThat(readComment())
+                .as("idle tick must emit an SSE comment heartbeat")
+                .isEqualTo(":\r\n");
+
+        // Reader-idle is not reset by our writes, so a second tick fires again and reschedules.
+        channel.pipeline().fireUserEventTriggered(IdleStateEvent.READER_IDLE_STATE_EVENT);
+        channel.runPendingTasks();
+        assertThat(channel.isOpen()).isTrue();
+        assertThat(readComment()).isEqualTo(":\r\n");
+    }
+
+    @Test
+    void idleOnNonSseChannelClosesChannel() {
+        channel.pipeline().fireUserEventTriggered(IdleStateEvent.FIRST_READER_IDLE_STATE_EVENT);
+        channel.runPendingTasks();
+
+        assertThat(channel.isOpen())
+                .as("plain idle keep-alive socket must close on idle")
+                .isFalse();
+    }
+
+    @Test
     void deleteWithoutSessionReturnsError() {
         var request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.DELETE, "/mcp");
         request.headers().set(HttpHeaderNames.ORIGIN, "http://localhost:3000");
@@ -169,5 +208,23 @@ class McpOperationHandlerTest {
         var msg = channel.readOutbound();
         assertThat(msg).isInstanceOf(FullHttpResponse.class);
         return (FullHttpResponse) msg;
+    }
+
+    private void drainOutbound() {
+        Object msg;
+        while ((msg = channel.readOutbound()) != null) {
+            io.netty.util.ReferenceCountUtil.release(msg);
+        }
+    }
+
+    private String readComment() {
+        var msg = channel.readOutbound();
+        assertThat(msg).isInstanceOf(HttpContent.class);
+        var content = (HttpContent) msg;
+        try {
+            return content.content().toString(StandardCharsets.UTF_8);
+        } finally {
+            content.release();
+        }
     }
 }

--- a/tachyon-server/src/test/java/dev/tachyonmcp/transport/netty/McpOperationHandlerTest.java
+++ b/tachyon-server/src/test/java/dev/tachyonmcp/transport/netty/McpOperationHandlerTest.java
@@ -125,7 +125,8 @@ class McpOperationHandlerTest {
                 .as("idle tick must emit an SSE comment heartbeat")
                 .isEqualTo(":\r\n");
 
-        // Reader-idle is not reset by our writes, so a second tick fires again and reschedules.
+        // A second idle event produces another heartbeat (the handler is stateless across ticks).
+        // Real-timer rescheduling is proven by SseHeartbeatE2eTest, not here.
         channel.pipeline().fireUserEventTriggered(IdleStateEvent.READER_IDLE_STATE_EVENT);
         channel.runPendingTasks();
         assertThat(channel.isOpen()).isTrue();


### PR DESCRIPTION
Problem: The pipeline closed channels on any IdleStateEvent. A GET SSE stream's client only reads (never sends), so reader-idle (60s) was killing live streams, and a quiet server killed them at writer-idle (5min).

An idle tick now keeps SSE streams alive with a comment heartbeat instead of closing — reusing the standard IdleStateHandler, no new pipeline handler.