### PR TITLE
feat!: refactor handlers api

### DIFF
--- a/.agents/skills/tachyon-mcp/resources/java/ToolHandlerExample.java
+++ b/.agents/skills/tachyon-mcp/resources/java/ToolHandlerExample.java
@@ -2,16 +2,13 @@
  * Copyright (c) 2026 Konstantin Pavlov.
  */
 
-import dev.tachyonmcp.server.features.tools.AbstractSyncToolHandler;
-import dev.tachyonmcp.server.features.tools.SyncToolHandler;
-import dev.tachyonmcp.server.features.tools.ToolDescriptor;
-import dev.tachyonmcp.server.features.tools.ToolResult;
+import dev.tachyonmcp.server.features.tools.*;
 import dev.tachyonmcp.server.session.McpContext;
-import java.util.Map;
 import org.jspecify.annotations.NonNull;
-import org.jspecify.annotations.Nullable;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
+
+import java.util.Map;
 
 /**
  * Demonstrates the two tool-handler patterns:
@@ -36,20 +33,20 @@ final class ToolHandlerExample {
     /**
      * Lambda-style: use SyncToolHandler.of() inside a builder chain.
      */
-    static SyncToolHandler<ToolResult> lambdaHello() {
+    static SyncToolHandler lambdaHello() {
         return SyncToolHandler.of("hello", "Say hello", null, (ctx, args) -> ToolResult.text("Hello, world!"));
     }
 
     /**
      * Lambda with input schema and arguments.
      */
-    static SyncToolHandler<ToolResult> lambdaGreet() {
+    static SyncToolHandler lambdaGreet() {
         return SyncToolHandler.of(
                 "greeting",
                 "Generates a personalized greeting",
                 GREET_SCHEMA,
-                (@NonNull McpContext ctx, @Nullable Map<String, JsonNode> args) -> {
-                    String name = args.get("name").asString();
+                (@NonNull McpContext ctx, ToolArgs args) -> {
+                    String name = args.string("name");
                     return ToolResult.text("Hello, " + name + "!");
                 });
     }
@@ -57,7 +54,7 @@ final class ToolHandlerExample {
     /**
      * Class-based: extend AbstractSyncToolHandler.
      */
-    static final class GreetingTool extends AbstractSyncToolHandler<ToolResult> {
+    static final class GreetingTool extends AbstractSyncToolHandler {
         GreetingTool() {
             super(ToolDescriptor.builder("greeting")
                     .title("Greeting")
@@ -68,8 +65,8 @@ final class ToolHandlerExample {
 
         @Override
         @NonNull
-        public ToolResult handle(McpContext ctx, @NonNull Map<String, JsonNode> args) {
-            var name = args.get("name").asString();
+        public ToolResult<String> handle(McpContext ctx, ToolArgs args) {
+            var name = args.string("name");
             return ToolResult.text("Hello, " + name + "!");
         }
     }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,9 +23,10 @@ mvn spotless:apply  # auto-fix
 
 ## Rules
 
+- Talk concisely like smart Caveman
 - TDD + SOLID. TachyonServer is SUT in unit tests.
-- **Tests**: JUnit 6 + AssertJ + Awaitlilty. `@TempDir` for unit, port 0 for E2E. Prefer E2E for long scenarios. No tautologies. Many asserts per test.
-- **Nullability**: JSpecify `@Nullable`/`@NonNull`.
+- **Tests**: JUnit 6 + AssertJ + Awaitility. `@TempDir` for unit, port 0 for E2E. Prefer E2E for long scenarios. No tautologies. Many asserts per test.
+- **Nullability**: JSpecify `@Nullable`/`@NonNull`. `@NullMarked` at package level.
 - **Copyright**: `/* Copyright (c) 2026 Konstantin Pavlov. */` everywhere.
 - **No comments** unless spec needs explain.
 - Unit tests only when E2E can't. Drop unit if E2E covers.

--- a/conformance/src/test/java/dev/tachyonmcp/conformance/AbstractConformanceServer.java
+++ b/conformance/src/test/java/dev/tachyonmcp/conformance/AbstractConformanceServer.java
@@ -14,14 +14,16 @@ import dev.tachyonmcp.server.features.resources.ResourceTemplateEntry;
 import dev.tachyonmcp.server.features.tools.*;
 import dev.tachyonmcp.server.session.McpContext;
 import dev.tachyonmcp.transport.jsonrpc.JsonRpcCodec;
-import java.util.*;
+import java.util.Base64;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 import org.awaitility.Awaitility;
-import org.jspecify.annotations.Nullable;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.node.JsonNodeFactory;
@@ -177,26 +179,26 @@ abstract class AbstractConformanceServer {
                 "test_image_content",
                 "Returns image content",
                 INPUT_SCHEMA_NO_ARGS,
-                (ctx, args) -> ToolResult.of(List.of(ImageContent.of(MINI_PNG_BASE64, "image/png")))));
+                (ctx, args) -> ToolResult.blocks(ImageContent.of(MINI_PNG_BASE64, "image/png"))));
 
         server.registerTool(SyncToolHandler.of(
                 "test_audio_content",
                 "Returns audio content",
                 INPUT_SCHEMA_NO_ARGS,
-                (ctx, args) -> ToolResult.of(List.of(AudioContent.of(MINI_WAV_BASE64, "audio/wav")))));
+                (ctx, args) -> ToolResult.blocks(AudioContent.of(MINI_WAV_BASE64, "audio/wav"))));
 
         server.registerTool(SyncToolHandler.of(
                 "test_embedded_resource", "Returns embedded resource", INPUT_SCHEMA_NO_ARGS, (ctx, args) -> {
                     var res = TextResourceContents.of(
                             "test://embedded-resource", "text/plain", "This is an embedded resource content.");
-                    return ToolResult.of(List.of(EmbeddedResource.of(res)));
+                    return ToolResult.blocks(EmbeddedResource.of(res));
                 }));
 
         server.registerTool(SyncToolHandler.of(
                 "test_multiple_content_types", "Returns multiple content types", INPUT_SCHEMA_NO_ARGS, (ctx, args) -> {
                     var mixed = TextResourceContents.of(
                             "test://mixed-content-resource", "application/json", "{\"test\":\"data\",\"value\":123}");
-                    return ToolResult.of(
+                    return ToolResult.blocks(
                             TextContent.of("Multiple content types test:"),
                             ImageContent.of(MINI_PNG_BASE64, "image/png"),
                             EmbeddedResource.of(mixed));
@@ -208,7 +210,7 @@ abstract class AbstractConformanceServer {
                 INPUT_SCHEMA_NO_ARGS,
                 (ctx, args) -> ToolResult.error("This tool intentionally returns an error for testing")));
 
-        server.registerTool(new ToolHandler<>() {
+        server.registerTool(new ToolHandler() {
             @Override
             public ToolDescriptor descriptor() {
                 return ToolDescriptor.builder("test_tool_with_progress")
@@ -218,7 +220,7 @@ abstract class AbstractConformanceServer {
             }
 
             @Override
-            public CompletionStage<ToolResult> handle(ToolRequest request, McpContext ctx) {
+            public CompletionStage<? extends ToolResult<?>> handle(ToolRequest request, McpContext ctx) {
                 var pt = request.progressToken();
                 if (pt != null) {
                     ctx.notifications().progress(pt, 0, 100, "Starting");
@@ -231,7 +233,7 @@ abstract class AbstractConformanceServer {
             }
         });
 
-        server.registerTool(new ToolHandler<>() {
+        server.registerTool(new ToolHandler() {
             @Override
             public ToolDescriptor descriptor() {
                 return ToolDescriptor.builder("test_tool_with_logging")
@@ -241,7 +243,7 @@ abstract class AbstractConformanceServer {
             }
 
             @Override
-            public CompletionStage<ToolResult> handle(ToolRequest request, McpContext ctx) {
+            public CompletionStage<? extends ToolResult<?>> handle(ToolRequest request, McpContext ctx) {
                 ctx.notifications().info("tachyon.tools", Map.of("message", "Tool execution started"));
                 delay(50);
                 ctx.notifications().info("tachyon.tools", Map.of("message", "Tool processing data"));
@@ -253,8 +255,9 @@ abstract class AbstractConformanceServer {
 
         server.registerTool(SyncToolHandler.of(
                 "test_sampling", "Tool that requests sampling", INPUT_SCHEMA_WITH_PROMPT, (ctx, args) -> {
-                    if (args instanceof Map<?, ?> map && map.get("prompt") != null) {
-                        var prompt = map.get("prompt");
+                    var promptOpt = args.stringOpt("prompt");
+                    if (promptOpt.isPresent()) {
+                        var prompt = promptOpt.get();
                         try {
                             var paramsMap = Map.of(
                                     "messages",
@@ -283,20 +286,23 @@ abstract class AbstractConformanceServer {
 
         server.registerTool(SyncToolHandler.of(
                 "test_elicitation", "Tool that requests elicitation", INPUT_SCHEMA_WITH_MESSAGE, (ctx, args) -> {
-                    if (args instanceof Map<?, ?> map && map.get("message") != null) {
-                        var message = map.get("message");
+                    var messageOpt = args.stringOpt("message");
+                    if (messageOpt.isPresent()) {
+                        var message = messageOpt.get();
                         try {
                             var paramsMap = Map.of(
-                                    "mode", "form",
-                                    "message", message.toString(),
+                                    "mode",
+                                    "form",
+                                    "message",
+                                    message,
                                     "requestedSchema",
-                                            Map.of(
-                                                    "type", "object",
-                                                    "properties",
-                                                            Map.of(
-                                                                    "username", Map.of("type", "string"),
-                                                                    "email", Map.of("type", "string")),
-                                                    "required", List.of("username", "email")));
+                                    Map.of(
+                                            "type", "object",
+                                            "properties",
+                                                    Map.of(
+                                                            "username", Map.of("type", "string"),
+                                                            "email", Map.of("type", "string")),
+                                            "required", List.of("username", "email")));
                             var responseJson = ctx.server()
                                     .sendRequest("elicitation/create", JsonRpcCodec.writeValueAsString(paramsMap))
                                     .get(2, TimeUnit.SECONDS);
@@ -416,12 +422,13 @@ abstract class AbstractConformanceServer {
 
         var inputSchema = buildJsonSchema();
         server.registerTool(
-                new AbstractSyncToolHandler<>(ToolDescriptor.builder("json_schema_2020_12_tool")
+                new AbstractSyncToolHandler(ToolDescriptor.builder("json_schema_2020_12_tool")
                         .description("Tool with JSON Schema 2020-12 features")
                         .inputSchema(inputSchema)
                         .build()) {
+
                     @Override
-                    public ToolResult handle(McpContext context, @Nullable Map<String, JsonNode> arguments) {
+                    public ToolResult<String> handle(McpContext context, ToolArgs arguments) {
                         return ToolResult.text("JSON Schema 2020-12 tool called");
                     }
                 });
@@ -443,7 +450,7 @@ abstract class AbstractConformanceServer {
     }
 
     private void registerInputRequiredTools(McpServer server) {
-        server.registerTool(new ToolHandler<>() {
+        server.registerTool(new ToolHandler() {
             @Override
             public ToolDescriptor descriptor() {
                 return ToolDescriptor.builder("test_input_required_result_elicitation")
@@ -453,7 +460,7 @@ abstract class AbstractConformanceServer {
             }
 
             @Override
-            public CompletionStage<ToolResult> handle(ToolRequest request, McpContext ctx) {
+            public CompletionStage<ToolResult<?>> handle(ToolRequest request, McpContext ctx) {
                 var inputResponses = request.inputResponses();
                 if (inputResponses != null && inputResponses.containsKey("user_name")) {
                     var resp = inputResponses.get("user_name");
@@ -468,7 +475,7 @@ abstract class AbstractConformanceServer {
             }
         });
 
-        server.registerTool(new ToolHandler<>() {
+        server.registerTool(new ToolHandler() {
             @Override
             public ToolDescriptor descriptor() {
                 return ToolDescriptor.builder("test_input_required_result_sampling")
@@ -478,7 +485,7 @@ abstract class AbstractConformanceServer {
             }
 
             @Override
-            public CompletionStage<ToolResult> handle(ToolRequest request, McpContext ctx) {
+            public CompletionStage<ToolResult<?>> handle(ToolRequest request, McpContext ctx) {
                 var inputResponses = request.inputResponses();
                 if (inputResponses != null && inputResponses.containsKey("capital_question")) {
                     var resp = inputResponses.get("capital_question");
@@ -492,7 +499,7 @@ abstract class AbstractConformanceServer {
             }
         });
 
-        server.registerTool(new ToolHandler<>() {
+        server.registerTool(new ToolHandler() {
             @Override
             public ToolDescriptor descriptor() {
                 return ToolDescriptor.builder("test_input_required_result_list_roots")
@@ -502,7 +509,7 @@ abstract class AbstractConformanceServer {
             }
 
             @Override
-            public CompletionStage<ToolResult> handle(ToolRequest request, McpContext ctx) {
+            public CompletionStage<ToolResult<?>> handle(ToolRequest request, McpContext ctx) {
                 var inputResponses = request.inputResponses();
                 if (inputResponses != null && inputResponses.containsKey("client_roots")) {
                     return CompletableFuture.completedFuture(ToolResult.text("Roots received"));
@@ -512,7 +519,7 @@ abstract class AbstractConformanceServer {
             }
         });
 
-        server.registerTool(new ToolHandler<>() {
+        server.registerTool(new ToolHandler() {
             @Override
             public ToolDescriptor descriptor() {
                 return ToolDescriptor.builder("test_input_required_result_request_state")
@@ -522,7 +529,7 @@ abstract class AbstractConformanceServer {
             }
 
             @Override
-            public CompletionStage<ToolResult> handle(ToolRequest request, McpContext ctx) {
+            public CompletionStage<ToolResult<?>> handle(ToolRequest request, McpContext ctx) {
                 var inputResponses = request.inputResponses();
                 var requestState = request.requestState();
                 if (inputResponses != null && inputResponses.containsKey("confirm") && requestState != null) {
@@ -534,7 +541,7 @@ abstract class AbstractConformanceServer {
             }
         });
 
-        server.registerTool(new ToolHandler<>() {
+        server.registerTool(new ToolHandler() {
             @Override
             public ToolDescriptor descriptor() {
                 return ToolDescriptor.builder("test_input_required_result_multiple_inputs")
@@ -544,7 +551,7 @@ abstract class AbstractConformanceServer {
             }
 
             @Override
-            public CompletionStage<ToolResult> handle(ToolRequest request, McpContext ctx) {
+            public CompletionStage<ToolResult<?>> handle(ToolRequest request, McpContext ctx) {
                 var inputResponses = request.inputResponses();
                 if (inputResponses != null
                         && inputResponses.containsKey("user_name")
@@ -560,7 +567,7 @@ abstract class AbstractConformanceServer {
             }
         });
 
-        server.registerTool(new ToolHandler<>() {
+        server.registerTool(new ToolHandler() {
             @Override
             public ToolDescriptor descriptor() {
                 return ToolDescriptor.builder("test_input_required_result_multi_round")
@@ -570,7 +577,7 @@ abstract class AbstractConformanceServer {
             }
 
             @Override
-            public CompletionStage<ToolResult> handle(ToolRequest request, McpContext ctx) {
+            public CompletionStage<ToolResult<?>> handle(ToolRequest request, McpContext ctx) {
                 var inputResponses = request.inputResponses();
                 var requestState = request.requestState();
                 if (inputResponses != null && inputResponses.containsKey("step2")) {
@@ -596,7 +603,7 @@ abstract class AbstractConformanceServer {
             }
         });
 
-        server.registerTool(new ToolHandler<>() {
+        server.registerTool(new ToolHandler() {
             @Override
             public ToolDescriptor descriptor() {
                 return ToolDescriptor.builder("test_input_required_result_tampered_state")
@@ -606,7 +613,7 @@ abstract class AbstractConformanceServer {
             }
 
             @Override
-            public CompletionStage<ToolResult> handle(ToolRequest request, McpContext ctx) {
+            public CompletionStage<ToolResult<?>> handle(ToolRequest request, McpContext ctx) {
                 var inputResponses = request.inputResponses();
                 var requestState = request.requestState();
                 if (inputResponses != null && inputResponses.containsKey("confirm")) {
@@ -621,7 +628,7 @@ abstract class AbstractConformanceServer {
             }
         });
 
-        server.registerTool(new ToolHandler<>() {
+        server.registerTool(new ToolHandler() {
             @Override
             public ToolDescriptor descriptor() {
                 return ToolDescriptor.builder("test_input_required_result_capabilities")
@@ -631,7 +638,7 @@ abstract class AbstractConformanceServer {
             }
 
             @Override
-            public CompletionStage<ToolResult> handle(ToolRequest request, McpContext ctx) {
+            public CompletionStage<ToolResult<?>> handle(ToolRequest request, McpContext ctx) {
                 var meta = request.meta();
                 var capabilities = meta != null ? meta.get("io.modelcontextprotocol/clientCapabilities") : null;
                 var hasSampling =
@@ -726,7 +733,7 @@ abstract class AbstractConformanceServer {
                         });
     }
 
-    private static class EchoToolHandler extends AbstractSyncToolHandler<ToolResult> {
+    private static class EchoToolHandler extends AbstractSyncToolHandler {
 
         // language=json
         private static final JsonNode INPUT_SCHEMA = parseJson("""
@@ -745,9 +752,9 @@ abstract class AbstractConformanceServer {
         }
 
         @Override
-        public ToolResult handle(McpContext context, @Nullable Map<String, JsonNode> arguments) {
-            var message = Objects.requireNonNull(arguments).get("message");
-            return ToolResult.text(message != null ? message.asString() : "");
+        public ToolResult<String> handle(McpContext context, ToolArgs arguments) {
+            var message = arguments.stringOr("message", "");
+            return ToolResult.text(message);
         }
     }
 }

--- a/e2e/pom.xml
+++ b/e2e/pom.xml
@@ -14,7 +14,7 @@
 
     <artifactId>e2e</artifactId>
 
-    <name>Tachyon MCP :: E2E</name>
+    <name>Tachyon MCP E2E</name>
     <description>End-to-end tests</description>
 
     <properties>

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/EchoToolHandler.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/EchoToolHandler.java
@@ -1,22 +1,18 @@
-/*
- * Copyright (c) 2026 Konstantin Pavlov.
- */
+/* Copyright (c) 2026 Konstantin Pavlov. */
 
 package dev.tachyonmcp.e2e;
 
 import dev.tachyonmcp.server.features.tools.AbstractAsyncToolHandler;
+import dev.tachyonmcp.server.features.tools.ToolArgs;
 import dev.tachyonmcp.server.features.tools.ToolDescriptor;
 import dev.tachyonmcp.server.features.tools.ToolResult;
 import dev.tachyonmcp.server.session.McpContext;
-import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
-import org.jspecify.annotations.Nullable;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.node.JsonNodeFactory;
-import tools.jackson.databind.node.StringNode;
 
-class EchoToolHandler extends AbstractAsyncToolHandler<ToolResult> {
+class EchoToolHandler extends AbstractAsyncToolHandler {
 
     static final JsonNode ECHO_INPUT_SCHEMA = buildEchoSchema();
 
@@ -40,13 +36,7 @@ class EchoToolHandler extends AbstractAsyncToolHandler<ToolResult> {
     }
 
     @Override
-    public CompletionStage<ToolResult> handleAsync(McpContext context, @Nullable Map<String, JsonNode> arguments) {
-        return CompletableFuture.supplyAsync(() -> {
-            if (arguments == null) {
-                return ToolResult.text("");
-            }
-            var text = (StringNode) arguments.get("message");
-            return ToolResult.text(text != null ? text.stringValue() : "");
-        });
+    public CompletionStage<? extends ToolResult<?>> handleAsync(McpContext context, ToolArgs args) {
+        return CompletableFuture.supplyAsync(() -> ToolResult.text(args.stringOr("message", "")));
     }
 }

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/ExtensionsTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/ExtensionsTest.java
@@ -211,7 +211,7 @@ class ExtensionsTest extends AbstractMcpE2eTest {
                 }
 
                 @Override
-                public CompletionStage<ToolResult> handle(ToolRequest request, McpContext context) {
+                public CompletionStage<ToolResult<?>> handle(ToolRequest request, McpContext context) {
                     return CompletableFuture.completedFuture(ToolResult.text("ext-tool-result"));
                 }
             });

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/InputRequiredResultTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/InputRequiredResultTest.java
@@ -100,6 +100,22 @@ class InputRequiredResultTest extends AbstractMcpE2eTest {
     }
 
     @Test
+    void inputRequiredPreservesMeta() throws Exception {
+        startServer(it -> it.tool(new MetaInputRequiredTestHandler()));
+
+        try (var client = createTestClient()) {
+            var sessionId = client.initialize();
+
+            var response = client.sendRequest(sessionId, """
+                {"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"test_meta_elicitation","arguments":{}}}
+                """);
+
+            assertThatJson(response.body()).inPath("$.result.resultType").isEqualTo("input_required");
+            assertThatJson(response.body()).inPath("$.result._meta.trace-id").isEqualTo("abc-123");
+        }
+    }
+
+    @Test
     void missingInputResponsesReRequests() throws Exception {
         startServer(it -> it.tool(new InputRequiredTestHandler()));
 
@@ -179,7 +195,7 @@ class InputRequiredResultTest extends AbstractMcpE2eTest {
         }
 
         @Override
-        public CompletionStage<ToolResult> handle(ToolRequest request, McpContext context) {
+        public CompletionStage<ToolResult<?>> handle(ToolRequest request, McpContext context) {
             var inputResponses = request.inputResponses();
             if (inputResponses != null && inputResponses.containsKey("user_name")) {
                 var resp = inputResponses.get("user_name");
@@ -214,7 +230,7 @@ class InputRequiredResultTest extends AbstractMcpE2eTest {
         }
 
         @Override
-        public CompletionStage<ToolResult> handle(ToolRequest request, McpContext context) {
+        public CompletionStage<ToolResult<?>> handle(ToolRequest request, McpContext context) {
             var inputResponses = request.inputResponses();
             var requestState = request.requestState();
 
@@ -242,6 +258,22 @@ class InputRequiredResultTest extends AbstractMcpE2eTest {
         }
     }
 
+    private static class MetaInputRequiredTestHandler extends AbstractToolHandler implements ToolHandler {
+
+        MetaInputRequiredTestHandler() {
+            super(ToolDescriptor.builder("test_meta_elicitation")
+                    .description("Tests InputRequiredResult meta propagation")
+                    .build());
+        }
+
+        @Override
+        public CompletionStage<ToolResult<?>> handle(ToolRequest request, McpContext context) {
+            var inputRequests = Map.of("user_name", buildFormElicitation("What is your name?", "name", "string"));
+            return CompletableFuture.completedFuture(
+                    ToolResult.inputRequired(inputRequests, null).withMeta("trace-id", FACTORY.stringNode("abc-123")));
+        }
+    }
+
     private static class UrlElicitationTestHandler extends AbstractToolHandler implements ToolHandler {
 
         UrlElicitationTestHandler() {
@@ -251,7 +283,7 @@ class InputRequiredResultTest extends AbstractMcpE2eTest {
         }
 
         @Override
-        public CompletionStage<ToolResult> handle(ToolRequest request, McpContext context) {
+        public CompletionStage<ToolResult<?>> handle(ToolRequest request, McpContext context) {
             var inputResponses = request.inputResponses();
             if (inputResponses != null && inputResponses.containsKey("auth")) {
                 var resp = inputResponses.get("auth");

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/ResourceTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/ResourceTest.java
@@ -11,14 +11,12 @@ import dev.tachyonmcp.server.domain.TextContent;
 import dev.tachyonmcp.server.domain.TextResourceContents;
 import dev.tachyonmcp.server.features.resources.ResourceDescriptor;
 import dev.tachyonmcp.server.features.tools.SyncToolHandler;
+import dev.tachyonmcp.server.features.tools.ToolArgs;
 import dev.tachyonmcp.server.features.tools.ToolResult;
 import dev.tachyonmcp.server.session.McpContext;
-import java.util.List;
-import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
-import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 
 class ResourceTest extends AbstractMcpE2eTest {
@@ -198,7 +196,7 @@ class ResourceTest extends AbstractMcpE2eTest {
 
     // ---- Tool handler implementations ----
 
-    private record NotifyListChangedToolHandler(String action) implements SyncToolHandler<ToolResult> {
+    private record NotifyListChangedToolHandler(String action) implements SyncToolHandler {
 
         @Override
         public String name() {
@@ -211,7 +209,7 @@ class ResourceTest extends AbstractMcpE2eTest {
         }
 
         @Override
-        public ToolResult handle(McpContext context, Map<String, JsonNode> arguments) {
+        public ToolResult<?> handle(McpContext context, ToolArgs arguments) {
             var resources = context.server().mcpServer().resources();
             if ("add".equals(action)) {
                 resources.add(
@@ -220,11 +218,11 @@ class ResourceTest extends AbstractMcpE2eTest {
             } else {
                 resources.remove("doc");
             }
-            return ToolResult.of(List.of(TextContent.of("done")));
+            return ToolResult.blocks(TextContent.of("done"));
         }
     }
 
-    private static class NotifyUpdatedToolHandler implements SyncToolHandler<ToolResult> {
+    private static class NotifyUpdatedToolHandler implements SyncToolHandler {
         @Override
         public String name() {
             return "notify-update";
@@ -236,9 +234,9 @@ class ResourceTest extends AbstractMcpE2eTest {
         }
 
         @Override
-        public ToolResult handle(McpContext context, Map<String, JsonNode> arguments) {
+        public ToolResult<?> handle(McpContext context, ToolArgs arguments) {
             context.server().mcpServer().resources().notifyResourceUpdated("resource://doc");
-            return ToolResult.of(List.of(TextContent.of("notified")));
+            return ToolResult.blocks(TextContent.of("notified"));
         }
     }
 }

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/SchemaValidationTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/SchemaValidationTest.java
@@ -14,11 +14,10 @@ import dev.tachyonmcp.server.domain.Role;
 import dev.tachyonmcp.server.domain.TextContent;
 import dev.tachyonmcp.server.features.prompts.PromptDescriptor;
 import dev.tachyonmcp.server.features.tools.SyncToolHandler;
+import dev.tachyonmcp.server.features.tools.ToolArgs;
 import dev.tachyonmcp.server.features.tools.ToolResult;
 import dev.tachyonmcp.server.session.McpContext;
 import java.util.List;
-import java.util.Map;
-import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.node.JsonNodeFactory;
@@ -198,7 +197,7 @@ class SchemaValidationTest extends AbstractMcpE2eTest {
 
     // region: Tool handler
 
-    private static class ValidatedToolHandler implements SyncToolHandler<ToolResult> {
+    private static class ValidatedToolHandler implements SyncToolHandler {
 
         @Override
         public String name() {
@@ -216,7 +215,7 @@ class SchemaValidationTest extends AbstractMcpE2eTest {
         }
 
         @Override
-        public ToolResult handle(McpContext context, @Nullable Map<String, JsonNode> arguments) {
+        public ToolResult<?> handle(McpContext context, ToolArgs arguments) {
             return ToolResult.text("ok");
         }
     }
@@ -225,7 +224,7 @@ class SchemaValidationTest extends AbstractMcpE2eTest {
 
     // region: Schema builders
 
-    private static class ValidatedToolHandler2 implements SyncToolHandler<ToolResult> {
+    private static class ValidatedToolHandler2 implements SyncToolHandler {
 
         @Override
         public String name() {
@@ -243,7 +242,7 @@ class SchemaValidationTest extends AbstractMcpE2eTest {
         }
 
         @Override
-        public ToolResult handle(McpContext context, @Nullable Map<String, JsonNode> arguments) {
+        public ToolResult<?> handle(McpContext context, ToolArgs arguments) {
             return ToolResult.text("ok");
         }
     }

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/TaskLifecycleTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/TaskLifecycleTest.java
@@ -7,6 +7,7 @@ package dev.tachyonmcp.e2e;
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import dev.tachyonmcp.server.features.tools.ToolArgs;
 import dev.tachyonmcp.server.features.tools.ToolDescriptor;
 import dev.tachyonmcp.server.features.tools.ToolHandler;
 import dev.tachyonmcp.server.features.tools.ToolRequest;
@@ -15,7 +16,6 @@ import dev.tachyonmcp.server.session.McpContext;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import org.junit.jupiter.api.Test;
-import tools.jackson.databind.JsonNode;
 
 class TaskLifecycleTest extends AbstractMcpE2eTest {
 
@@ -152,9 +152,9 @@ class TaskLifecycleTest extends AbstractMcpE2eTest {
         }
 
         @Override
-        public CompletionStage<ToolResult> handle(ToolRequest request, McpContext context) {
-            var args = request.arguments();
-            var name = args != null && args.get("name") instanceof JsonNode n ? n.asString() : "unnamed";
+        public CompletionStage<? extends ToolResult<?>> handle(ToolRequest request, McpContext context) {
+            var args = ToolArgs.of(request.arguments());
+            var name = args.stringOr("name", "unnamed");
             context.server().mcpServer().tasks().createTask(name, null);
             return CompletableFuture.completedFuture(ToolResult.text("created"));
         }

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/TasksExtensionTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/TasksExtensionTest.java
@@ -179,7 +179,7 @@ class TasksExtensionTest extends AbstractMcpE2eTest {
                     }
 
                     @Override
-                    public CompletionStage<ToolResult> handle(ToolRequest req, McpContext ctx) {
+                    public CompletionStage<ToolResult<?>> handle(ToolRequest req, McpContext ctx) {
                         ctx.server().mcpServer().tasks().createTask("sync-notif-task", null);
                         return CompletableFuture.completedFuture(ToolResult.text("ok"));
                     }

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/ToolCapabilitiesTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/ToolCapabilitiesTest.java
@@ -10,10 +10,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import dev.tachyonmcp.server.domain.ToolAnnotations;
 import dev.tachyonmcp.server.features.tasks.TaskSupport;
 import dev.tachyonmcp.server.features.tools.SyncToolHandler;
+import dev.tachyonmcp.server.features.tools.ToolArgs;
 import dev.tachyonmcp.server.features.tools.ToolHandler;
 import dev.tachyonmcp.server.features.tools.ToolResult;
 import dev.tachyonmcp.server.session.McpContext;
-import java.util.Map;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -181,14 +181,14 @@ class ToolCapabilitiesTest extends AbstractMcpE2eTest {
     @Test
     void shouldRegisterWithMinimalDescriptor() throws Exception {
         startEmptyServer();
-        server.registerTool(new SyncToolHandler<>() {
+        server.registerTool(new SyncToolHandler() {
             @Override
             public String name() {
                 return "minimal-tool";
             }
 
             @Override
-            public ToolResult handle(McpContext context, Map<String, JsonNode> arguments) {
+            public ToolResult<?> handle(McpContext context, ToolArgs arguments) {
                 return ToolResult.text("ok");
             }
         });
@@ -211,7 +211,7 @@ class ToolCapabilitiesTest extends AbstractMcpE2eTest {
     void shouldRegisterWithFullDescriptor() throws Exception {
         var annotations = ToolAnnotations.of(null, true, false, null, null);
         startEmptyServer();
-        server.registerTool(new SyncToolHandler<>() {
+        server.registerTool(new SyncToolHandler() {
             @Override
             public String name() {
                 return "full-tool";
@@ -248,7 +248,7 @@ class ToolCapabilitiesTest extends AbstractMcpE2eTest {
             }
 
             @Override
-            public ToolResult handle(McpContext context, Map<String, JsonNode> arguments) {
+            public ToolResult<?> handle(McpContext context, ToolArgs arguments) {
                 return ToolResult.text("ok");
             }
         });
@@ -270,7 +270,7 @@ class ToolCapabilitiesTest extends AbstractMcpE2eTest {
 
     // region: Tool Handler Implementations
 
-    private record OutputSchemaToolHandler(JsonNode outputSchemaNode) implements SyncToolHandler<ToolResult> {
+    private record OutputSchemaToolHandler(JsonNode outputSchemaNode) implements SyncToolHandler {
         @Override
         public String name() {
             return "output-schema-tool";
@@ -292,12 +292,12 @@ class ToolCapabilitiesTest extends AbstractMcpE2eTest {
         }
 
         @Override
-        public ToolResult handle(McpContext context, Map<String, JsonNode> arguments) {
+        public ToolResult<?> handle(McpContext context, ToolArgs arguments) {
             return ToolResult.text("ok");
         }
     }
 
-    private record SimpleToolHandler(String name, String description) implements SyncToolHandler<ToolResult> {
+    private record SimpleToolHandler(String name, String description) implements SyncToolHandler {
         @Override
         public String name() {
             return name;
@@ -314,12 +314,12 @@ class ToolCapabilitiesTest extends AbstractMcpE2eTest {
         }
 
         @Override
-        public ToolResult handle(McpContext context, Map<String, JsonNode> arguments) {
+        public ToolResult<?> handle(McpContext context, ToolArgs arguments) {
             return ToolResult.text("ok");
         }
     }
 
-    private record TaskAwareToolHandler(TaskSupport taskSupport) implements SyncToolHandler<ToolResult> {
+    private record TaskAwareToolHandler(TaskSupport taskSupport) implements SyncToolHandler {
         @Override
         public String name() {
             return "task-aware-tool";
@@ -341,7 +341,7 @@ class ToolCapabilitiesTest extends AbstractMcpE2eTest {
         }
 
         @Override
-        public ToolResult handle(McpContext context, Map<String, JsonNode> arguments) {
+        public ToolResult<?> handle(McpContext context, ToolArgs arguments) {
             return ToolResult.text("ok");
         }
     }

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/ToolErrorTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/ToolErrorTest.java
@@ -7,10 +7,10 @@ package dev.tachyonmcp.e2e;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import dev.tachyonmcp.server.features.tools.SyncToolHandler;
+import dev.tachyonmcp.server.features.tools.ToolArgs;
 import dev.tachyonmcp.server.features.tools.ToolResult;
 import dev.tachyonmcp.server.session.McpContext;
 import java.util.Map;
-import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.node.JsonNodeFactory;
@@ -38,7 +38,7 @@ class ToolErrorTest extends AbstractMcpE2eTest {
         }
     }
 
-    private static class ThrowingToolHandler implements SyncToolHandler<ToolResult> {
+    private static class ThrowingToolHandler implements SyncToolHandler {
 
         @Override
         public String name() {
@@ -56,7 +56,7 @@ class ToolErrorTest extends AbstractMcpE2eTest {
         }
 
         @Override
-        public ToolResult handle(McpContext context, @Nullable Map<String, JsonNode> arguments) {
+        public ToolResult<?> handle(McpContext context, ToolArgs arguments) {
             context.notifications().send("notifications/before-boom", Map.of());
             throw new RuntimeException("Simulated handler failure. Ignore it");
         }

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/ToolNotificationsTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/ToolNotificationsTest.java
@@ -7,11 +7,11 @@ package dev.tachyonmcp.e2e;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import dev.tachyonmcp.server.features.tools.AbstractSyncToolHandler;
+import dev.tachyonmcp.server.features.tools.ToolArgs;
 import dev.tachyonmcp.server.features.tools.ToolDescriptor;
 import dev.tachyonmcp.server.features.tools.ToolResult;
 import dev.tachyonmcp.server.session.McpContext;
 import java.util.Map;
-import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 import tools.jackson.databind.JsonNode;
 
@@ -48,7 +48,7 @@ class ToolNotificationsTest extends AbstractMcpE2eTest {
         }
     }
 
-    private static class NotifyingToolHandler extends AbstractSyncToolHandler<ToolResult> {
+    private static class NotifyingToolHandler extends AbstractSyncToolHandler {
 
         NotifyingToolHandler() {
             super(ToolDescriptor.builder("notifier")
@@ -58,13 +58,11 @@ class ToolNotificationsTest extends AbstractMcpE2eTest {
         }
 
         @Override
-        public ToolResult handle(McpContext context, @Nullable Map<String, JsonNode> arguments) {
+        public ToolResult handle(McpContext context, ToolArgs arguments) {
             String text = "";
-            if (arguments != null) {
-                var msg = arguments.get("message");
-                if (msg instanceof JsonNode node) {
-                    text = node.asString();
-                }
+            var msg = arguments.raw("message");
+            if (msg instanceof JsonNode node) {
+                text = node.asString();
             }
 
             context.notifications().send("notifications/tool/test", Map.of("message", text));

--- a/examples/weather/src/main/java/com/example/weather/GetWeatherTool.java
+++ b/examples/weather/src/main/java/com/example/weather/GetWeatherTool.java
@@ -4,6 +4,7 @@
 package com.example.weather;
 
 import dev.tachyonmcp.server.features.tools.AbstractSyncToolHandler;
+import dev.tachyonmcp.server.features.tools.ToolArgs;
 import dev.tachyonmcp.server.features.tools.ToolDescriptor;
 import dev.tachyonmcp.server.features.tools.ToolResult;
 import dev.tachyonmcp.server.session.McpContext;
@@ -11,10 +12,9 @@ import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 
 import java.util.List;
-import java.util.Map;
 import java.util.random.RandomGenerator;
 
-class GetWeatherTool extends AbstractSyncToolHandler<ToolResult> {
+class GetWeatherTool extends AbstractSyncToolHandler {
     private static final RandomGenerator RANDOM = RandomGenerator.getDefault();
     // language=json
     private static final JsonNode INPUT_SCHEMA = new ObjectMapper().readTree("""
@@ -45,15 +45,10 @@ class GetWeatherTool extends AbstractSyncToolHandler<ToolResult> {
 
 
     @Override
-    public ToolResult handle(McpContext context, Map<String, JsonNode> args) {
-        var city = args.containsKey("city") ? args.get("city").asString() : "";
-        var units = args.containsKey("units") ? args.get("units").asString() : "celsius";
-        if (!city.isBlank()) {
-            var weather = generateWeather(city, units);
-            return ToolResult.text(weather);
-        } else {
-            return ToolResult.error("Parameter `city` is required");
-        }
+    public ToolResult<?> handle(McpContext context, ToolArgs args) {
+        var city = args.string("city");
+        var units = args.stringOr("units", "celsius");
+        return ToolResult.text(generateWeather(city, units));
     }
 
     private static String generateWeather(String city, String units) {

--- a/tachyon-server/src/main/java/dev/tachyonmcp/protocol/ContextProvider.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/protocol/ContextProvider.java
@@ -6,8 +6,13 @@ package dev.tachyonmcp.protocol;
 
 import org.jspecify.annotations.Nullable;
 
+/**
+ * Provides server-level dependencies to protocol implementations
+ * when creating per-channel interaction contexts.
+ */
 @FunctionalInterface
 public interface ContextProvider {
+    /** Returns a dependency of the given type, or {@code null} if unavailable. */
     @Nullable
     <T> T provide(Class<T> type);
 }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/protocol/ProtocolMappers.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/protocol/ProtocolMappers.java
@@ -8,6 +8,9 @@ import java.util.List;
 import java.util.ServiceLoader;
 import org.jspecify.annotations.Nullable;
 
+/**
+ * Registry of {@link ProtocolResponseMapper} implementations discovered via {@link ServiceLoader}.
+ */
 public class ProtocolMappers {
 
     private ProtocolMappers() {}
@@ -23,6 +26,7 @@ public class ProtocolMappers {
         }
     }
 
+    /** Returns the mapper for the given protocol family and version, or {@code null} if none registered. */
     @Nullable
     public static ProtocolResponseMapper getMapper(String protocolName, String protocolVersion) {
         for (var mapper : MAPPERS) {

--- a/tachyon-server/src/main/java/dev/tachyonmcp/protocol/ProtocolResponseMapper.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/protocol/ProtocolResponseMapper.java
@@ -19,39 +19,62 @@ import java.util.Map;
 import org.jspecify.annotations.Nullable;
 import tools.jackson.databind.JsonNode;
 
+/**
+ * Maps domain objects to protocol-specific response shapes.
+ *
+ * <p>Each protocol version (e.g. MCP 2025-11-25) provides its own implementation
+ * registered via {@link java.util.ServiceLoader}.
+ */
 public interface ProtocolResponseMapper {
 
+    /** Returns {@code true} when this mapper handles the given protocol family and version. */
     boolean supports(String protocolName, String protocolVersion);
 
+    /** Returns the protocol-specific empty result sent for methods that return no data. */
     Object emptyResult();
 
+    /** Builds a completion result from a list of candidate values with optional pagination. */
     Object completeResult(List<String> values, @Nullable Double total, @Nullable Boolean hasMore);
 
+    /** Maps the server's initialize response into protocol-specific shape. */
     Object initializeResult(InitializeResponse response);
 
+    /** Maps a paginated list of tool descriptors into protocol-specific shape. */
     Object listToolsResult(List<ToolDescriptor> tools, @Nullable String nextCursor);
 
-    <R extends ToolResult> Object callToolResult(R result);
+    /** Maps a tool call result into protocol-specific shape. */
+    Object callToolResult(ToolResult<?> result);
 
+    /** Maps a paginated list of resource descriptors into protocol-specific shape. */
     Object listResourcesResult(List<ResourceDescriptor> resources, @Nullable String nextCursor);
 
+    /** Maps a paginated list of resource template entries into protocol-specific shape. */
     Object listResourceTemplatesResult(List<ResourceTemplateEntry> templates, @Nullable String nextCursor);
 
+    /** Maps a resource contents list (from a read operation) into protocol-specific shape. */
     Object readResourceResult(List<ResourceContents> contents);
 
+    /** Maps a paginated list of prompt descriptors into protocol-specific shape. */
     Object listPromptsResult(List<PromptDescriptor> prompts, @Nullable String nextCursor);
 
+    /** Maps prompt messages plus optional description into protocol-specific shape. */
     Object getPromptResult(@Nullable String description, List<PromptMessage> messages);
 
+    /** Maps input-required metadata into protocol-specific shape. */
     Object inputRequiredResult(Map<String, ? extends InputRequest> inputRequests, @Nullable String requestState);
 
+    /** Maps a paginated list of task entries into protocol-specific shape. */
     Object listTasksResult(List<TaskEntry> entries, @Nullable String nextCursor);
 
+    /** Maps a single task entry (get result) into protocol-specific shape. */
     Object getTaskResult(TaskEntry entry);
 
+    /** Maps a cancelled task entry into protocol-specific shape. */
     Object cancelTaskResult(TaskEntry entry);
 
+    /** Maps a task's result payload into protocol-specific shape. */
     Object getTaskPayloadResult(@Nullable JsonNode result);
 
+    /** Builds the params object for a tasks/status notification from a task entry. */
     Object taskStatusNotificationParams(TaskEntry entry);
 }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/protocol/mcp/v2025_11_25/codecs/McpResponseMapper.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/protocol/mcp/v2025_11_25/codecs/McpResponseMapper.java
@@ -27,6 +27,9 @@ import dev.tachyonmcp.server.features.resources.ResourceTemplateEntry;
 import dev.tachyonmcp.server.features.tasks.TaskEntry;
 import dev.tachyonmcp.server.features.tools.ToolDescriptor;
 import dev.tachyonmcp.server.features.tools.ToolResult;
+import dev.tachyonmcp.server.features.tools.ToolResult.InputRequired;
+import dev.tachyonmcp.server.features.tools.ToolResult.Success;
+import dev.tachyonmcp.server.features.tools.ToolResult.WithMeta;
 import java.io.IOException;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -88,14 +91,38 @@ public final class McpResponseMapper implements ProtocolResponseMapper {
     }
 
     @Override
-    public Object callToolResult(ToolResult result) {
-        if (result.inputRequests() != null) {
-            return new InputRequiredPayload(result.inputRequests(), result.requestState());
+    public Object callToolResult(ToolResult<?> result) {
+        @Nullable Map<String, JsonNode> meta = null;
+        ToolResult<?> unwrapped = result;
+        if (result instanceof WithMeta<?> wm) {
+            meta = wm.meta().isEmpty() ? null : wm.meta();
+            unwrapped = wm.inner();
         }
-        var protocolContent = result.content().stream()
-                .map(McpToolMapper::toProtocolContentBlock)
-                .toList();
-        return new CallToolResult(protocolContent, result.structuredContent(), result.isError(), result.meta(), null);
+        final var resolvedMeta = meta;
+        return switch (unwrapped) {
+            case InputRequired ir -> new InputRequiredPayload(ir.inputRequests(), ir.requestState(), resolvedMeta);
+            case ToolResult.ErrorResult er ->
+                new CallToolResult(
+                        List.of(McpToolMapper.toProtocolContentBlock(TextContent.of(er.message()))),
+                        null,
+                        true,
+                        resolvedMeta,
+                        null);
+            case Success<?> s -> wireSuccess(s, resolvedMeta);
+            case WithMeta<?> ignored -> throw new AssertionError("WithMeta unwrapped above");
+        };
+    }
+
+    @SuppressWarnings("unchecked")
+    private Object wireSuccess(Success<?> s, @Nullable Map<String, JsonNode> meta) {
+        var blocks =
+                s.content().stream().map(McpToolMapper::toProtocolContentBlock).toList();
+        @Nullable Map<String, JsonNode> structured = null;
+        var sv = s.structuredValue();
+        if (sv instanceof Map<?, ?> rawMap) {
+            structured = (Map<String, JsonNode>) rawMap;
+        }
+        return new CallToolResult(blocks, structured, null, meta, null);
     }
 
     @Override
@@ -167,12 +194,13 @@ public final class McpResponseMapper implements ProtocolResponseMapper {
     @Override
     public Object inputRequiredResult(
             Map<String, ? extends InputRequest> inputRequests, @Nullable String requestState) {
-        return new InputRequiredPayload(inputRequests, requestState);
+        return new InputRequiredPayload(inputRequests, requestState, null);
     }
 
     private record InputRequiredPayload(
             @Nullable Map<String, ? extends InputRequest> inputRequests,
-            @Nullable String requestState) {}
+            @Nullable String requestState,
+            @Nullable Map<String, JsonNode> meta) {}
 
     private static final class InputRequiredPayloadCodec implements Codec<InputRequiredPayload> {
 
@@ -196,6 +224,14 @@ public final class McpResponseMapper implements ProtocolResponseMapper {
             }
             if (value.requestState() != null) {
                 gen.writeStringProperty("requestState", value.requestState());
+            }
+            if (value.meta() != null) {
+                gen.writeObjectPropertyStart("_meta");
+                for (var entry : value.meta().entrySet()) {
+                    gen.writeName(entry.getKey());
+                    gen.writeRawValue(entry.getValue().toString());
+                }
+                gen.writeEndObject();
             }
             gen.writeEndObject();
         }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/protocol/mcp/v2025_11_25/codecs/McpToolMapper.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/protocol/mcp/v2025_11_25/codecs/McpToolMapper.java
@@ -22,10 +22,10 @@ final class McpToolMapper {
 
     private McpToolMapper() {}
 
-    public static ToolResult toDomainResult(Object result) {
-        if (result instanceof ToolResult r) return r;
+    public static ToolResult<?> toDomainResult(Object result) {
+        if (result instanceof ToolResult<?> r) return r;
         var text = TextContent.of(result != null ? result.toString() : "");
-        return ToolResult.of(List.of(text));
+        return ToolResult.blocks(text);
     }
 
     public static Tool toTool(ToolDescriptor d) {

--- a/tachyon-server/src/main/java/dev/tachyonmcp/runtime/Cancellation.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/runtime/Cancellation.java
@@ -4,9 +4,12 @@
 
 package dev.tachyonmcp.runtime;
 
+/** Tracks whether an operation has been cancelled. */
 public interface Cancellation {
 
+    /** Returns {@code true} if cancellation has been requested. */
     boolean isCancelled();
 
+    /** Throws {@link CancellationException} if cancellation has been requested. */
     void throwIfCancelled() throws CancellationException;
 }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/runtime/CancellationException.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/runtime/CancellationException.java
@@ -4,6 +4,7 @@
 
 package dev.tachyonmcp.runtime;
 
+/** Thrown when a cancelled handler is detected. */
 public class CancellationException extends RuntimeException {
 
     public CancellationException() {

--- a/tachyon-server/src/main/java/dev/tachyonmcp/runtime/Extension.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/runtime/Extension.java
@@ -4,13 +4,22 @@
 
 package dev.tachyonmcp.runtime;
 
+/**
+ * Extension point that can hook into the connection lifecycle and register custom handlers.
+ *
+ * @param <T> the interaction context type
+ */
 public interface Extension<T> {
 
+    /** Unique identifier for this extension. */
     String extensionId();
 
+    /** Called after connection initialization is complete. */
     default void onConnectionInit(T context) {}
 
+    /** Called when the connection is being closed. */
     default void onConnectionClose(T context) {}
 
+    /** Called during server shutdown to release resources. */
     default void shutdown() {}
 }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/runtime/McpHeaderNames.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/runtime/McpHeaderNames.java
@@ -4,10 +4,14 @@
 
 package dev.tachyonmcp.runtime;
 
+/** Constants for MCP-related HTTP header names. */
 public final class McpHeaderNames {
 
+    /** Header carrying the session identifier. */
     public static final String MCP_SESSION_ID = "MCP-Session-Id";
+    /** Header carrying the protocol version. */
     public static final String MCP_PROTOCOL_VERSION = "MCP-Protocol-Version";
+    /** SSE {@code Last-Event-ID} header for reconnection. */
     public static final String LAST_EVENT_ID = "Last-Event-ID";
 
     private McpHeaderNames() {}

--- a/tachyon-server/src/main/java/dev/tachyonmcp/runtime/RequestContext.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/runtime/RequestContext.java
@@ -4,4 +4,5 @@
 
 package dev.tachyonmcp.runtime;
 
+/** Marker interface for a context associated with a single JSON-RPC request. */
 public interface RequestContext {}

--- a/tachyon-server/src/main/java/dev/tachyonmcp/runtime/Session.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/runtime/Session.java
@@ -8,6 +8,7 @@ import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 import org.jspecify.annotations.Nullable;
 
+/** Base class for sessions identified by a unique string ID with lifecycle state tracking. */
 public abstract class Session {
 
     private final String id;
@@ -20,22 +21,27 @@ public abstract class Session {
         this.lastActivityNanos = System.nanoTime();
     }
 
+    /** Returns the unique session identifier. */
     public String id() {
         return id;
     }
 
+    /** Returns the current session state. */
     public SessionState state() {
         return state.get();
     }
 
+    /** Returns the nanosecond timestamp of the last activity on this session. */
     public long lastActivityNanos() {
         return lastActivityNanos;
     }
 
+    /** Updates the last-activity timestamp to now. */
     public void touch() {
         this.lastActivityNanos = System.nanoTime();
     }
 
+    /** Transitions from {@link SessionState#INITIALIZING} to {@link SessionState#ACTIVE}. */
     public boolean activate() {
         if (state.compareAndSet(SessionState.INITIALIZING, SessionState.ACTIVE)) {
             this.lastActivityNanos = System.nanoTime();

--- a/tachyon-server/src/main/java/dev/tachyonmcp/runtime/SessionState.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/runtime/SessionState.java
@@ -4,9 +4,14 @@
 
 package dev.tachyonmcp.runtime;
 
+/** Lifecycle states for a session. */
 public enum SessionState {
+    /** Session created, not yet initialized. */
     INITIALIZING,
+    /** Session ready for normal operation. */
     ACTIVE,
+    /** Session is draining — no new requests but in-flight ones complete. */
     DRAINING,
+    /** Session terminated and resources released. */
     CLOSED
 }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/JsonSchemaValidator.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/JsonSchemaValidator.java
@@ -7,11 +7,14 @@ package dev.tachyonmcp.server;
 import java.util.List;
 import tools.jackson.databind.JsonNode;
 
+/** Validates JSON data against a JSON Schema. */
 @FunctionalInterface
 public interface JsonSchemaValidator {
 
+    /** Validates the given arguments against the schema and returns any errors. */
     List<SchemaValidationError> validate(JsonNode schema, JsonNode arguments);
 
+    /** Returns a no-op validator that accepts all input. */
     static JsonSchemaValidator noop() {
         return (schema, arguments) -> List.of();
     }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/McpDispatcher.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/McpDispatcher.java
@@ -38,6 +38,7 @@ import org.slf4j.LoggerFactory;
  * {@code v2025_11_25} models/codecs. The version-specific call-sites (marked below) move behind an
  * {@code McpDialect} when a second spec version is wired.
  */
+/** Dispatches parsed JSON-RPC messages to registered method handlers and manages the dispatch lifecycle. */
 public class McpDispatcher {
 
     private static final Logger logger = LoggerFactory.getLogger(McpDispatcher.class);

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/McpMethodHandler.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/McpMethodHandler.java
@@ -6,9 +6,12 @@ package dev.tachyonmcp.server;
 
 import dev.tachyonmcp.server.session.McpContext;
 
+/** Handles a single JSON-RPC method. */
 public interface McpMethodHandler {
 
+    /** The JSON-RPC method name this handler dispatches to. */
     String method();
 
+    /** Handles the method and returns the result to serialize as JSON-RPC response. */
     Object handle(McpContext context, Object params) throws Exception;
 }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/McpResourceType.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/McpResourceType.java
@@ -4,6 +4,8 @@
 
 package dev.tachyonmcp.server;
 
+/** Common interface for named MCP resource types (tools, resources, prompts, tasks). */
 public interface McpResourceType {
+    /** Unique name of this resource type. */
     String name();
 }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/McpServer.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/McpServer.java
@@ -29,6 +29,10 @@ import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Core MCP server that manages sessions, registries, method handlers, and
+ * extension lifecycle. Created via {@link ServerBuilder}.
+ */
 public class McpServer implements Closeable {
 
     private static final Logger logger = LoggerFactory.getLogger(McpServer.class);
@@ -59,6 +63,7 @@ public class McpServer implements Closeable {
         RESPONSE_MAPPERS = List.copyOf(mappers);
     }
 
+    /** Returns the protocol response mapper for the default MCP version. */
     public ProtocolResponseMapper responseMapper() {
         for (var mapper : RESPONSE_MAPPERS) {
             if (mapper.supports("mcp", "2025-11-25")) {
@@ -68,26 +73,35 @@ public class McpServer implements Closeable {
         throw new IllegalStateException("No protocol response mapper found");
     }
 
+    /** Returns the server configuration. */
     public ServerConfig config() {
         return config;
     }
 
+    /** Returns {@code true} when running in stateless mode (no session persistence). */
     public boolean isStateless() {
         return config.session().stateless();
     }
 
+    /** Returns the virtual-thread-per-task executor used for handler dispatch. */
     public ExecutorService executor() {
         return virtualThreadExecutor;
     }
 
+    /** Sets the logging level for a session. */
     public void setLoggingLevel(String sessionId, LoggingLevel level) {
         loggingLevels.put(sessionId, level);
     }
 
+    /** Returns the logging level for a session, or {@code null} if not set. */
     public LoggingLevel getLoggingLevel(String sessionId) {
         return loggingLevels.get(sessionId);
     }
 
+    /**
+     * Emits a log notification for the given session if the requested level meets
+     * the configured threshold.
+     */
     public void log(McpSession session, LoggingLevel requested, String logger, Object data) {
         var configured = loggingLevels.get(session.id());
         if (configured == null) return;
@@ -100,6 +114,7 @@ public class McpServer implements Closeable {
         return requested.ordinal() >= configured.ordinal();
     }
 
+    /** Resolves effective capabilities based on configuration and registered features. */
     public ServerCapabilities resolveCapabilities() {
         final var builder = ServerCapabilities.builder();
 
@@ -202,6 +217,7 @@ public class McpServer implements Closeable {
         broadcastNotification(method, java.util.Map.of());
     }
 
+    /** Sends a notification to all active sessions. */
     public void broadcastNotification(String method, Object params) {
         for (var entry : sessionManager.allSessions()) {
             if (entry.state() == SessionState.ACTIVE) {
@@ -221,16 +237,19 @@ public class McpServer implements Closeable {
         CompletionHandlers.register(methodHandlers);
     }
 
+    /** Registers a method handler keyed by its own method name. */
     public void registerHandler(McpMethodHandler handler) {
         methodHandlers.put(handler.method(), handler);
         logger.info("Handler registered: {}", handler.method());
     }
 
+    /** Registers a method handler with an explicit method name. */
     public void registerHandler(String method, McpMethodHandler handler) {
         methodHandlers.put(method, handler);
         logger.info("Handler registered: {}", method);
     }
 
+    /** Returns the handler for a method, or {@code null} if not registered. */
     @Nullable
     public McpMethodHandler getHandler(String method) {
         return methodHandlers.get(method);
@@ -256,58 +275,71 @@ public class McpServer implements Closeable {
         }
     }
 
+    /** Returns the registered extensions. */
     public List<McpExtension> extensions() {
         return Collections.unmodifiableList(extensions);
     }
 
+    /** Returns the extension ID that owns the given method, or {@code null} if none. */
     public @Nullable String extensionForMethod(String method) {
         return extensionMethodOwners.get(method);
     }
 
+    /** Returns {@code true} if the given extension requires the meta envelope for its methods. */
     public boolean extensionRequiresMeta(String extensionId) {
         var ext = extensionsById.get(extensionId);
         return ext != null && ext.requiresMetaEnvelope();
     }
 
-    public void registerTool(SyncToolHandler<?> handler) {
+    /** Registers a synchronous tool handler. */
+    public void registerTool(SyncToolHandler handler) {
         toolRegistry.register(handler);
         logger.info("Tool registered: {}", handler.name());
     }
 
-    public void registerTool(AsyncToolHandler<?> handler) {
+    /** Registers an asynchronous tool handler. */
+    public void registerTool(AsyncToolHandler handler) {
         toolRegistry.register(handler);
         logger.info("Tool registered: {}", handler.name());
     }
 
-    public void registerTool(ToolHandler<?> handler) {
+    /** Registers a tool handler. */
+    public void registerTool(ToolHandler handler) {
         toolRegistry.register(handler);
         logger.info("Tool registered: {}", handler.descriptor().name());
     }
 
+    /** Returns the descriptor for a tool by name, or {@code null} if not registered. */
     public @Nullable ToolDescriptor getTool(String name) {
         return toolRegistry.getDescriptor(name);
     }
 
+    /** Returns the resource registry. */
     public ResourceRegistry resources() {
         return resourceRegistry;
     }
 
+    /** Returns the prompt registry. */
     public PromptRegistry prompts() {
         return promptRegistry;
     }
 
+    /** Returns the task registry. */
     public TaskRegistry tasks() {
         return taskRegistry;
     }
 
+    /** Creates and registers a new session with the given ID. */
     public McpSession createSession(String sessionId) {
         return sessionManager.createSession(sessionId);
     }
 
+    /** Returns the session with the given ID, if present. */
     public Optional<McpSession> getSession(String sessionId) {
         return sessionManager.getSession(sessionId);
     }
 
+    /** Removes and closes the session with the given ID. */
     public void removeSession(String sessionId) {
         sessionManager.removeSession(sessionId);
     }
@@ -324,10 +356,12 @@ public class McpServer implements Closeable {
         return sseEvent;
     }
 
+    /** Sends a notification to the given session. */
     public void sendNotification(McpSession session, String method, Object params) {
         sendNotification(session, method, params, null);
     }
 
+    /** Sends a notification to the given session, optionally via a bound outbound SSE stream. */
     public void sendNotification(
             McpSession session, String method, @Nullable Object params, @Nullable OutboundSseStream stream) {
         if (session.state() == SessionState.CLOSED) {
@@ -360,10 +394,12 @@ public class McpServer implements Closeable {
 
     static final Duration PENDING_REQUEST_TIMEOUT = Duration.ofSeconds(60);
 
+    /** Sends a request to the client and returns a future that completes with the response. */
     public CompletableFuture<String> sendRequest(McpSession session, String method, Object params) {
         return sendRequest(session, method, params, null);
     }
 
+    /** Sends a request to the client, optionally via a bound outbound SSE stream, and returns a future. */
     public CompletableFuture<String> sendRequest(
             McpSession session, String method, Object params, @Nullable OutboundSseStream stream) {
         var paramsStr = params instanceof Map || params instanceof List
@@ -399,6 +435,7 @@ public class McpServer implements Closeable {
         return future;
     }
 
+    /** Completes a pending client request with the given result JSON. */
     public boolean completePendingRequest(Object requestId, String resultJson) {
         var future = pendingRequests.remove(requestId);
         if (future != null) {
@@ -408,6 +445,7 @@ public class McpServer implements Closeable {
         return false;
     }
 
+    /** Fails a pending client request with the given error message. */
     public boolean failPendingRequest(Object requestId, String message) {
         var future = pendingRequests.remove(requestId);
         if (future != null) {
@@ -417,6 +455,7 @@ public class McpServer implements Closeable {
         return false;
     }
 
+    /** Registers a pending request with a timeout. */
     public void registerPendingRequest(Object requestId, CompletableFuture<String> future) {
         pendingRequests.put(requestId, future);
         future.orTimeout(PENDING_REQUEST_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
@@ -452,14 +491,17 @@ public class McpServer implements Closeable {
         return sb.toString();
     }
 
+    /** Appends an event to the session log. */
     public void appendEvent(SessionEvent event) {
         router.append(event);
     }
 
+    /** Replays session events after the given sequence number. */
     public List<SessionEvent> replay(String sessionId, long lastSeq) {
         return router.replay(sessionId, lastSeq);
     }
 
+    /** Returns and increments the event ID counter. */
     public long nextEventId() {
         return eventIdCounter.incrementAndGet();
     }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/McpServerHandle.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/McpServerHandle.java
@@ -24,10 +24,12 @@ public final class McpServerHandle implements Closeable {
         this.transport = transport;
     }
 
+    /** Returns the port the server is bound to. */
     public int port() {
         return port;
     }
 
+    /** Returns the underlying {@link McpServer}. */
     public McpServer server() {
         return server;
     }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/NetworkntJsonSchemaValidator.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/NetworkntJsonSchemaValidator.java
@@ -13,6 +13,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import tools.jackson.databind.JsonNode;
 
+/** JSON Schema validator backed by {@code networknt/json-schema-validator}. */
 public class NetworkntJsonSchemaValidator implements JsonSchemaValidator {
 
     private final SchemaRegistry registry;

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/Notifications.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/Notifications.java
@@ -6,15 +6,21 @@ package dev.tachyonmcp.server;
 
 import org.jspecify.annotations.Nullable;
 
+/** Sends MCP notifications from within a handler dispatch context. */
 public interface Notifications {
 
+    /** Sends a generic notification with the given method and params. */
     void send(String method, Object params);
 
+    /** Sends a progress notification. */
     void progress(@Nullable Object progressToken, double progress, double total, String message);
 
+    /** Sends an info-level log message. */
     void info(String logger, Object data);
 
+    /** Sends a warning-level log message. */
     void warning(String logger, Object data);
 
+    /** Sends an error-level log message. */
     void error(String logger, Object data);
 }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/SchemaValidationError.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/SchemaValidationError.java
@@ -4,4 +4,11 @@
 
 package dev.tachyonmcp.server;
 
+/**
+ * A single schema validation error.
+ *
+ * @param path    JSON pointer to the failing field
+ * @param keyword the validation keyword that failed
+ * @param message human-readable error description
+ */
 public record SchemaValidationError(String path, String keyword, String message) {}

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/ServerBuilder.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/ServerBuilder.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.function.Consumer;
 import org.jspecify.annotations.Nullable;
 
+/** Fluent builder for {@link McpServer}. Supports feature registration and configuration. */
 public final class ServerBuilder {
 
     private final ServerIdentityBuilder identityBuilder =
@@ -42,31 +43,37 @@ public final class ServerBuilder {
 
     // === Configuration groups ===
 
+    /** Configures server identity (name, version, etc.). */
     public ServerBuilder info(Consumer<ServerIdentityBuilder> configurer) {
         configurer.accept(identityBuilder);
         return this;
     }
 
+    /** Configures which MCP capabilities are enabled. */
     public ServerBuilder capabilities(Consumer<CapabilitiesConfig.Builder> configurer) {
         configurer.accept(capabilitiesConfig);
         return this;
     }
 
+    /** Configures session lifecycle settings. */
     public ServerBuilder session(Consumer<SessionConfig.Builder> configurer) {
         configurer.accept(sessionBuilder);
         return this;
     }
 
+    /** Configures network settings (host, port, CORS, etc.). */
     public ServerBuilder network(Consumer<NetworkConfig.Builder> configurer) {
         configurer.accept(networkBuilder);
         return this;
     }
 
+    /** Sets the server name (shorthand for {@code info(b -> b.name(name))}). */
     public ServerBuilder name(String name) {
         identityBuilder.name(name);
         return this;
     }
 
+    /** Sets the listen port (shorthand for {@code network(b -> b.port(port))}). */
     public ServerBuilder port(int port) {
         networkBuilder.port(port);
         return this;
@@ -74,46 +81,55 @@ public final class ServerBuilder {
 
     // === Feature registration ===
 
+    /** Registers a tool handler. */
     public ServerBuilder tool(ToolHandler handler) {
         featuresConfig.tools.add(handler);
         return this;
     }
 
-    public ServerBuilder tool(SyncToolHandler<?> handler) {
+    /** Registers a synchronous tool handler. */
+    public ServerBuilder tool(SyncToolHandler handler) {
         featuresConfig.tools.add(handler);
         return this;
     }
 
-    public ServerBuilder tool(AsyncToolHandler<?> handler) {
+    /** Registers an asynchronous tool handler. */
+    public ServerBuilder tool(AsyncToolHandler handler) {
         featuresConfig.tools.add(handler);
         return this;
     }
 
+    /** Registers a resource with no read handler (returns empty content). */
     public ServerBuilder resource(ResourceDescriptor descriptor) {
         featuresConfig.resources.add(new FeaturesConfig.ResourceRegistration(descriptor, null));
         return this;
     }
 
+    /** Registers a resource with a read handler. */
     public ServerBuilder resource(ResourceDescriptor descriptor, ResourceHandler handler) {
         featuresConfig.resources.add(new FeaturesConfig.ResourceRegistration(descriptor, handler));
         return this;
     }
 
+    /** Registers a prompt with static messages (no handler, messages provided directly). */
     public ServerBuilder prompt(PromptDescriptor descriptor, List<PromptMessage> messages) {
         featuresConfig.prompts.add(new FeaturesConfig.PromptRegistration(descriptor, args -> messages));
         return this;
     }
 
+    /** Registers a prompt with a dynamic handler. */
     public ServerBuilder prompt(PromptDescriptor descriptor, PromptHandler handler) {
         featuresConfig.prompts.add(new FeaturesConfig.PromptRegistration(descriptor, handler));
         return this;
     }
 
+    /** Registers a server extension. */
     public ServerBuilder extension(McpExtension extension) {
         featuresConfig.extensions.add(extension);
         return this;
     }
 
+    /** Sets a custom JSON schema validator. */
     public ServerBuilder jsonSchemaValidator(JsonSchemaValidator validator) {
         featuresConfig.jsonSchemaValidator = validator;
         return this;
@@ -121,6 +137,7 @@ public final class ServerBuilder {
 
     // === Transport escape hatch ===
 
+    /** Provides a customizer for the Netty channel pipeline. */
     public ServerBuilder pipelineCustomizer(@Nullable Consumer<ChannelPipeline> customizer) {
         this.pipelineCustomizer = customizer;
         return this;
@@ -128,6 +145,7 @@ public final class ServerBuilder {
 
     // === Terminal methods ===
 
+    /** Builds the {@link McpServer} without binding a transport. */
     public McpServer build() {
         var sessionConfig = sessionBuilder.build();
         var router = sessionConfig.sessionLogRouter() != null
@@ -151,6 +169,7 @@ public final class ServerBuilder {
         return server;
     }
 
+    /** Builds the server and binds the Netty transport. Requires a port to be set. */
     public McpServerHandle bind() {
         var networkConfig = networkBuilder.build();
         if (networkConfig.port() < 0) {
@@ -174,6 +193,7 @@ public final class ServerBuilder {
         return new McpServerHandle(server, netty.port(), netty);
     }
 
+    /** Builds the {@link ServerConfig} from the current builder state. */
     public ServerConfig buildConfig() {
         return new ServerConfig(
                 identityBuilder.build(), capabilitiesConfig.build(), sessionBuilder.build(), networkBuilder.build());

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/ServerCapabilities.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/ServerCapabilities.java
@@ -9,6 +9,17 @@ import org.immutables.value.Value;
 import org.jspecify.annotations.Nullable;
 import tools.jackson.databind.JsonNode;
 
+/**
+ * Capabilities the server advertises to the client during initialization.
+ *
+ * @param prompts      prompt capabilities ({@code null} = not supported)
+ * @param resources    resource capabilities ({@code null} = not supported)
+ * @param tools        tool capabilities ({@code null} = not supported)
+ * @param logging      whether logging is supported
+ * @param completions  whether completion is supported
+ * @param tasks        task capabilities ({@code null} = not supported)
+ * @param experimental experimental capability extensions
+ */
 @Value.Builder
 public record ServerCapabilities(
         @Nullable Prompts prompts,
@@ -27,10 +38,13 @@ public record ServerCapabilities(
         experimental = experimental == null ? null : Map.copyOf(experimental);
     }
 
+    /** Prompt capabilities. */
     public record Prompts(boolean listChanged) {}
 
+    /** Tool capabilities. */
     public record Tools(boolean listChanged) {}
 
+    /** Resource capabilities. */
     public record Resources(boolean subscribe, boolean listChanged) {}
 
     /**

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/ServerContext.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/ServerContext.java
@@ -9,19 +9,26 @@ import dev.tachyonmcp.server.session.McpSession;
 import java.util.concurrent.CompletableFuture;
 import org.jspecify.annotations.Nullable;
 
+/** Server-level operations available within a handler dispatch context. */
 public interface ServerContext {
 
+    /** Returns the current session ID. */
     String sessionId();
 
+    /** Sets the logging level for the current session. */
     void setLoggingLevel(LoggingLevel level);
 
+    /** Returns the logging level for the current session. */
     @Nullable
     LoggingLevel getLoggingLevel();
 
+    /** Sends a request to the client and returns a future that completes with the response. */
     CompletableFuture<String> sendRequest(String method, Object params);
 
+    /** Returns the current session, or {@code null} in stateless mode. */
     @Nullable
     McpSession session();
 
+    /** Returns the owning {@link McpServer}. */
     McpServer mcpServer();
 }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/config/CapabilitiesConfig.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/config/CapabilitiesConfig.java
@@ -4,76 +4,91 @@ package dev.tachyonmcp.server.config;
 
 import org.immutables.value.Value;
 
+/** Configuration of which MCP capabilities to enable and their behaviour. */
 @Value.Immutable
 @Value.Style(visibility = Value.Style.ImplementationVisibility.PACKAGE)
 public abstract class CapabilitiesConfig {
 
+    /** Controls whether tools are exposed ({@code ON}), hidden ({@code OFF}), or auto-detected ({@code AUTO}). */
     @Value.Default
     public Mode toolsMode() {
         return Mode.AUTO;
     }
 
+    /** Whether to emit notifications when the tool list changes. */
     @Value.Default
     public boolean toolsListChanged() {
         return false;
     }
 
+    /** Controls whether resources are exposed ({@code ON}), hidden ({@code OFF}), or auto-detected ({@code AUTO}). */
     @Value.Default
     public Mode resourcesMode() {
         return Mode.AUTO;
     }
 
+    /** Whether clients can subscribe to resource change notifications. */
     @Value.Default
     public boolean resourcesSubscribe() {
         return false;
     }
 
+    /** Whether to emit notifications when the resource list changes. */
     @Value.Default
     public boolean resourcesListChanged() {
         return false;
     }
 
+    /** Controls whether prompts are exposed ({@code ON}), hidden ({@code OFF}), or auto-detected ({@code AUTO}). */
     @Value.Default
     public Mode promptsMode() {
         return Mode.AUTO;
     }
 
+    /** Whether to emit notifications when the prompt list changes. */
     @Value.Default
     public boolean promptsListChanged() {
         return false;
     }
 
+    /** Whether the server supports {@code tasks/list}. */
     @Value.Default
     public boolean tasksList() {
         return false;
     }
 
+    /** Whether the server supports {@code tasks/cancel}. */
     @Value.Default
     public boolean tasksCancel() {
         return false;
     }
 
+    /** Whether the server supports task-augmented tool call requests. */
     @Value.Default
     public boolean tasksRequests() {
         return false;
     }
 
+    /** Whether the server supports completion. */
     @Value.Default
     public boolean completions() {
         return false;
     }
 
+    /** Whether the server supports logging. */
     @Value.Default
     public boolean logging() {
         return false;
     }
 
+    /** Default configuration with all capabilities auto-detected and change notifications off. */
     public static final CapabilitiesConfig DEFAULT = builder().build();
 
     public static Builder builder() {
         return ImmutableCapabilitiesConfig.builder();
     }
 
+    /** Builder for {@link CapabilitiesConfig}. */
     public interface Builder {
 
         Builder toolsMode(Mode mode);

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/config/Mode.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/config/Mode.java
@@ -4,8 +4,12 @@
 
 package dev.tachyonmcp.server.config;
 
+/** Controls whether a capability is enabled, disabled, or auto-detected from registered features. */
 public enum Mode {
+    /** Enabled only when features of this type are registered. */
     AUTO,
+    /** Always enabled. */
     ON,
+    /** Always disabled. */
     OFF
 }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/config/NetworkConfig.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/config/NetworkConfig.java
@@ -11,6 +11,20 @@ import java.time.Duration;
 import java.util.List;
 import org.jspecify.annotations.Nullable;
 
+/**
+ * Network-level server configuration.
+ *
+ * @param host               bind address (default {@code "127.0.0.1"})
+ * @param port               listen port (must be set before {@code bind()})
+ * @param endpointPath       HTTP path for MCP endpoints (default {@code "/mcp"})
+ * @param readerIdleTimeout  idle timeout for reading (default 60s)
+ * @param writerIdleTimeout  idle timeout for writing (default 5min)
+ * @param maxContentLength   maximum HTTP body size in bytes
+ * @param allowedOrigins     CORS allowed origins ({@code null} = defaults)
+ * @param allowNullOrigin    whether to allow {@code Origin: null}
+ * @param allowPrivateNetworks whether to allow private network CORS
+ * @param allowedHeaders     additional allowed CORS headers
+ */
 public record NetworkConfig(
         String host,
         int port,
@@ -39,6 +53,7 @@ public record NetworkConfig(
         return new Builder();
     }
 
+    /** Builder for {@link NetworkConfig}. */
     public static final class Builder {
         private String host = "127.0.0.1";
         private int port = -1;
@@ -55,6 +70,7 @@ public record NetworkConfig(
 
         private Builder() {}
 
+        /** Sets the bind address. Mutually exclusive with {@link #address}. */
         public Builder host(String host) {
             if (addressExplicitlySet) {
                 throw new IllegalStateException("Cannot combine host() with address()");
@@ -64,6 +80,7 @@ public record NetworkConfig(
             return this;
         }
 
+        /** Sets the listen port. Mutually exclusive with {@link #address}. */
         public Builder port(int port) {
             if (addressExplicitlySet) {
                 throw new IllegalStateException("Cannot combine port() with address()");
@@ -73,6 +90,7 @@ public record NetworkConfig(
             return this;
         }
 
+        /** Sets the bind address and port from a {@link SocketAddress}. Mutually exclusive with {@link #host}/{@link #port}. */
         public Builder address(SocketAddress addr) {
             if (hostPortExplicitlySet) {
                 throw new IllegalStateException("Cannot combine address() with host()/port()");
@@ -85,21 +103,25 @@ public record NetworkConfig(
             return this;
         }
 
+        /** Sets the HTTP path for MCP endpoints. */
         public Builder endpointPath(String endpointPath) {
             this.endpointPath = endpointPath;
             return this;
         }
 
+        /** Sets the reader idle timeout. */
         public Builder readerIdleTimeout(Duration timeout) {
             this.readerIdleTimeout = timeout;
             return this;
         }
 
+        /** Sets the writer idle timeout. */
         public Builder writerIdleTimeout(Duration timeout) {
             this.writerIdleTimeout = timeout;
             return this;
         }
 
+        /** Sets the maximum HTTP body size in bytes (must be positive). */
         public Builder maxContentLength(int bytes) {
             if (bytes <= 0) {
                 throw new IllegalArgumentException("maxContentLength must be positive");
@@ -108,26 +130,31 @@ public record NetworkConfig(
             return this;
         }
 
+        /** Sets the CORS allowed origins. */
         public Builder allowedOrigins(String... origins) {
             this.allowedOrigins = List.of(origins);
             return this;
         }
 
+        /** Sets whether to allow {@code Origin: null}. */
         public Builder allowNullOrigin(boolean allow) {
             this.allowNullOrigin = allow;
             return this;
         }
 
+        /** Sets whether to allow private network CORS. */
         public Builder allowPrivateNetworks(boolean allow) {
             this.allowPrivateNetworks = allow;
             return this;
         }
 
+        /** Sets additional allowed CORS headers. */
         public Builder allowedHeaders(String... headers) {
             this.allowedHeaders = List.of(headers);
             return this;
         }
 
+        /** Builds the {@link NetworkConfig}. */
         public NetworkConfig build() {
             return new NetworkConfig(
                     host,

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/config/ServerConfig.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/config/ServerConfig.java
@@ -6,6 +6,14 @@ package dev.tachyonmcp.server.config;
 
 import java.util.Objects;
 
+/**
+ * Aggregated server configuration grouping identity, capabilities, session, and network settings.
+ *
+ * @param identity     server identity metadata (name, version, etc.)
+ * @param capabilities which MCP features are enabled
+ * @param session      session lifecycle and persistence settings
+ * @param network      transport-level settings (host, port, CORS, etc.)
+ */
 public record ServerConfig(
         ServerIdentity identity, CapabilitiesConfig capabilities, SessionConfig session, NetworkConfig network) {
 

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/config/ServerIdentity.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/config/ServerIdentity.java
@@ -10,6 +10,17 @@ import java.util.Objects;
 import org.immutables.value.Value;
 import org.jspecify.annotations.Nullable;
 
+/**
+ * Server identity metadata sent to the client during initialization.
+ *
+ * @param name         server name (required)
+ * @param version      server version (required)
+ * @param description  optional human-readable description
+ * @param title        optional display title
+ * @param websiteUrl   optional URL to the server's website
+ * @param instructions optional instructions for how to use the server
+ * @param icons        optional list of icon entries
+ */
 @Value.Builder
 @Value.Style(visibility = Value.Style.ImplementationVisibility.PACKAGE, typeImmutable = "Default*")
 public record ServerIdentity(

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/config/SessionConfig.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/config/SessionConfig.java
@@ -9,6 +9,14 @@ import dev.tachyonmcp.server.session.SessionStore;
 import java.time.Duration;
 import org.jspecify.annotations.Nullable;
 
+/**
+ * Session lifecycle and persistence configuration.
+ *
+ * @param stateless        when {@code true}, no session is created and no TTL tracking occurs
+ * @param sessionTtl       duration after which idle sessions are evicted (default 30s)
+ * @param sessionLogRouter optional custom event log router; {@code null} uses in-memory default
+ * @param sessionStore     optional custom session store; {@code null} uses in-memory default
+ */
 public record SessionConfig(
         boolean stateless,
         Duration sessionTtl,
@@ -21,6 +29,7 @@ public record SessionConfig(
         return new Builder();
     }
 
+    /** Builder for {@link SessionConfig}. */
     public static final class Builder {
         private boolean stateless;
         private Duration sessionTtl = Duration.ofSeconds(30);
@@ -29,26 +38,31 @@ public record SessionConfig(
 
         private Builder() {}
 
+        /** Enables stateless mode (no session persistence). */
         public Builder stateless(boolean stateless) {
             this.stateless = stateless;
             return this;
         }
 
+        /** Sets the session TTL (idle sessions are evicted after this duration). */
         public Builder sessionTtl(Duration sessionTtl) {
             this.sessionTtl = sessionTtl;
             return this;
         }
 
+        /** Sets a custom session event log router. */
         public Builder sessionLogRouter(@Nullable SessionLogRouter router) {
             this.sessionLogRouter = router;
             return this;
         }
 
+        /** Sets a custom session store implementation. */
         public Builder sessionStore(@Nullable SessionStore store) {
             this.sessionStore = store;
             return this;
         }
 
+        /** Builds the {@link SessionConfig}. */
         public SessionConfig build() {
             return new SessionConfig(stateless, sessionTtl, sessionLogRouter, sessionStore);
         }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/domain/EmptyResult.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/domain/EmptyResult.java
@@ -8,4 +8,5 @@ import java.util.Map;
 import org.jspecify.annotations.Nullable;
 import tools.jackson.databind.JsonNode;
 
+/** An empty response carrying only optional metadata. */
 public record EmptyResult(@Nullable Map<String, JsonNode> meta) implements HasMeta {}

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/domain/FormInputRequest.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/domain/FormInputRequest.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import org.immutables.value.Value;
 import tools.jackson.databind.JsonNode;
 
+/** Requests user input via a form described by a JSON schema. */
 @Value.Immutable
 @Value.Style(
         allParameters = true,
@@ -13,8 +14,10 @@ import tools.jackson.databind.JsonNode;
         typeImmutable = "Default*")
 public non-sealed interface FormInputRequest extends InputRequest {
 
+    /** Prompt message shown to the user. */
     String message();
 
+    /** JSON schema describing the expected form fields. */
     Map<String, JsonNode> requestedSchema();
 
     static DefaultFormInputRequest.Builder builder() {

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/domain/HasMeta.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/domain/HasMeta.java
@@ -8,7 +8,9 @@ import java.util.Map;
 import org.jspecify.annotations.Nullable;
 import tools.jackson.databind.JsonNode;
 
+/** Marks types that carry optional metadata ({@code _meta}) for protocol extensions. */
 public interface HasMeta {
+    /** Optional metadata map for protocol extensions. */
     @Nullable
     Map<String, JsonNode> meta();
 }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/domain/InitializeResponse.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/domain/InitializeResponse.java
@@ -10,6 +10,15 @@ import java.util.Map;
 import org.jspecify.annotations.Nullable;
 import tools.jackson.databind.JsonNode;
 
+/**
+ * Server response to the {@code initialize} request.
+ *
+ * @param protocolVersion      the negotiated protocol version string
+ * @param capabilities         the server's capabilities
+ * @param serverIdentity       server identity metadata
+ * @param instructions         optional server-level instructions for the client
+ * @param negotiatedExtensions extension-specific negotiated data
+ */
 public record InitializeResponse(
         String protocolVersion,
         ServerCapabilities capabilities,

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/domain/InputRequest.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/domain/InputRequest.java
@@ -2,4 +2,5 @@
 
 package dev.tachyonmcp.server.domain;
 
+/** A request for additional user input during a tool call or prompt get. */
 public sealed interface InputRequest permits FormInputRequest, UrlInputRequest, RpcMethodRequest {}

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/domain/InputRequestBundle.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/domain/InputRequestBundle.java
@@ -1,0 +1,22 @@
+/* Copyright (c) 2026 Konstantin Pavlov. */
+
+package dev.tachyonmcp.server.domain;
+
+import java.util.Map;
+import java.util.Objects;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Shared payload for an MCP {@code input_required} outcome: the pending input requests keyed by
+ * name, plus optional opaque continuation state. Values must be non-null; the map is defensively
+ * copied and made immutable.
+ */
+public record InputRequestBundle(
+        Map<String, ? extends InputRequest> inputRequests,
+        @Nullable String requestState) {
+
+    public InputRequestBundle {
+        Objects.requireNonNull(inputRequests, "inputRequests");
+        inputRequests = Map.copyOf(inputRequests);
+    }
+}

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/domain/LoggingLevel.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/domain/LoggingLevel.java
@@ -4,6 +4,7 @@
 
 package dev.tachyonmcp.server.domain;
 
+/** Logging levels matching the MCP protocol specification. Ordered by severity ascending. */
 public enum LoggingLevel {
     DEBUG("debug"),
     INFO("info"),
@@ -20,10 +21,12 @@ public enum LoggingLevel {
         this.value = value;
     }
 
+    /** Returns the wire-level string for this logging level. */
     public String getValue() {
         return value;
     }
 
+    /** Parses a logging level from its wire-level string. */
     public static LoggingLevel fromValue(String value) {
         for (var v : values()) {
             if (v.value.equals(value)) return v;

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/domain/RpcMethodRequest.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/domain/RpcMethodRequest.java
@@ -6,6 +6,7 @@ import org.immutables.value.Value;
 import org.jspecify.annotations.Nullable;
 import tools.jackson.databind.JsonNode;
 
+/** Requests user input by invoking another RPC method. */
 @Value.Immutable
 @Value.Style(
         allParameters = true,
@@ -13,8 +14,10 @@ import tools.jackson.databind.JsonNode;
         typeImmutable = "Default*")
 public non-sealed interface RpcMethodRequest extends InputRequest {
 
+    /** The RPC method to invoke for input. */
     String method();
 
+    /** Optional parameters for the RPC method. */
     @Nullable
     JsonNode params();
 

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/domain/UrlInputRequest.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/domain/UrlInputRequest.java
@@ -4,6 +4,7 @@ package dev.tachyonmcp.server.domain;
 
 import org.immutables.value.Value;
 
+/** Requests user input by opening a URL (e.g. for OAuth or form fill). */
 @Value.Immutable
 @Value.Style(
         allParameters = true,
@@ -11,10 +12,13 @@ import org.immutables.value.Value;
         typeImmutable = "Default*")
 public non-sealed interface UrlInputRequest extends InputRequest {
 
+    /** Prompt message shown to the user. */
     String message();
 
+    /** Identifier linking the response back to the elicitation context. */
     String elicitationId();
 
+    /** URL to open for user input. */
     String url();
 
     static DefaultUrlInputRequest.Builder builder() {

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/extensions/McpExtension.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/extensions/McpExtension.java
@@ -12,20 +12,26 @@ import java.util.Set;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.node.JsonNodeFactory;
 
+/** Pluggable server extension that can add custom methods, capabilities, and lifecycle hooks. */
 public interface McpExtension extends Extension<McpContext> {
+    /** Returns the server settings to advertise in the initialize response. */
     default JsonNode serverSettings() {
         return JsonNodeFactory.instance.objectNode();
     }
 
+    /** Returns the set of JSON-RPC methods this extension handles. */
     default Set<String> methods() {
         return Set.of();
     }
 
+    /** Whether the extension expects a meta envelope for its handler params. */
     default boolean requiresMetaEnvelope() {
         return true;
     }
 
+    /** Bootstraps the extension during server startup. */
     default void bootstrap(McpServer server) {}
 
+    /** Called when a new client connection is initialised with the extension's client settings. */
     default void onConnectionInit(McpContext context, Map<String, JsonNode> clientSettings) {}
 }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/features/PaginatedResult.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/features/PaginatedResult.java
@@ -13,13 +13,17 @@ import org.jspecify.annotations.Nullable;
         allParameters = true,
         visibility = Value.Style.ImplementationVisibility.PACKAGE,
         typeImmutable = "Default*")
+/** A paginated result with an optional cursor for the next page. */
 public interface PaginatedResult<R> {
 
+    /** The items on this page. */
     List<R> items();
 
+    /** Cursor for the next page, or {@code null} if this is the last page. */
     @Nullable
     String nextCursor();
 
+    /** Returns {@code true} if there are more items beyond this page. */
     default boolean hasMore() {
         return nextCursor() != null;
     }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/features/Registry.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/features/Registry.java
@@ -13,6 +13,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Predicate;
 import org.jspecify.annotations.Nullable;
 
+/** Base registry for named, paginated MCP resource types. */
 public abstract class Registry<R extends McpResourceType> {
 
     private final ConcurrentHashMap<String, R> items = new ConcurrentHashMap<>();
@@ -21,15 +22,18 @@ public abstract class Registry<R extends McpResourceType> {
 
     private @Nullable Runnable onChange;
 
+    /** Registers a callback invoked when the registry contents change. */
     public void onChange(@Nullable Runnable callback) {
         this.onChange = callback;
     }
 
+    /** Adds or replaces an item by name. */
     public void add(R item) {
         items.put(item.name(), item);
         fireOnChange();
     }
 
+    /** Removes the item with the given name. */
     public void remove(String name) {
         var removed = items.remove(name);
         if (removed != null) {
@@ -43,10 +47,12 @@ public abstract class Registry<R extends McpResourceType> {
         }
     }
 
+    /** Returns the item by name, or {@code null} if not found. */
     public @Nullable R get(String name) {
         return items.get(name);
     }
 
+    /** Returns all registered items. */
     public Collection<R> getAll() {
         return items.values();
     }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/features/prompts/PromptHandler.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/features/prompts/PromptHandler.java
@@ -8,8 +8,10 @@ import dev.tachyonmcp.server.domain.PromptMessage;
 import java.util.List;
 import org.jspecify.annotations.Nullable;
 
+/** Generates prompt messages from optional arguments. */
 @FunctionalInterface
 public interface PromptHandler {
 
+    /** Returns the list of prompt messages for the given argument string. */
     List<PromptMessage> getMessages(@Nullable String arguments) throws Exception;
 }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/features/prompts/PromptHandlerResult.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/features/prompts/PromptHandlerResult.java
@@ -5,18 +5,30 @@
 package dev.tachyonmcp.server.features.prompts;
 
 import dev.tachyonmcp.server.domain.InputRequest;
+import dev.tachyonmcp.server.domain.InputRequestBundle;
 import dev.tachyonmcp.server.domain.PromptMessage;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import org.jspecify.annotations.Nullable;
 
 public sealed interface PromptHandlerResult permits PromptHandlerResult.Messages, PromptHandlerResult.InputRequired {
 
     record Messages(@Nullable List<PromptMessage> messages) implements PromptHandlerResult {}
 
-    record InputRequired(
-            Map<String, ? extends InputRequest> inputRequests,
-            @Nullable String requestState) implements PromptHandlerResult {}
+    record InputRequired(InputRequestBundle request) implements PromptHandlerResult {
+        public InputRequired {
+            Objects.requireNonNull(request, "request");
+        }
+
+        public Map<String, ? extends InputRequest> inputRequests() {
+            return request.inputRequests();
+        }
+
+        public @Nullable String requestState() {
+            return request.requestState();
+        }
+    }
 
     static PromptHandlerResult messages(@Nullable List<PromptMessage> messages) {
         return new Messages(messages);
@@ -24,6 +36,6 @@ public sealed interface PromptHandlerResult permits PromptHandlerResult.Messages
 
     static PromptHandlerResult inputRequired(
             Map<String, ? extends InputRequest> inputRequests, @Nullable String requestState) {
-        return new InputRequired(inputRequests, requestState);
+        return new InputRequired(new InputRequestBundle(inputRequests, requestState));
     }
 }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/features/resources/ResourceHandler.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/features/resources/ResourceHandler.java
@@ -8,8 +8,10 @@ import dev.tachyonmcp.server.domain.ReadResourceRequest;
 import dev.tachyonmcp.server.domain.ResourceContents;
 import dev.tachyonmcp.server.session.McpContext;
 
+/** Reads a resource's contents. One handler per resource. */
 @FunctionalInterface
 public interface ResourceHandler {
 
+    /** Reads and returns the resource contents. */
     ResourceContents read(McpContext context, ReadResourceRequest request);
 }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/features/resources/ResourceRegistry.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/features/resources/ResourceRegistry.java
@@ -20,6 +20,7 @@ import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.function.Predicate;
 import org.jspecify.annotations.Nullable;
 
+/** Registry for resources, templates, and subscriptions. */
 public class ResourceRegistry {
 
     private final ConcurrentHashMap<String, ResourceEntry> byName = new ConcurrentHashMap<>();
@@ -32,6 +33,7 @@ public class ResourceRegistry {
 
     private static final int DEFAULT_PAGE_SIZE = 50;
 
+    /** Creates a resource registry bound to the given server (for broadcasting subscription notifications). */
     public ResourceRegistry(McpServer server) {
         this.server = server;
     }
@@ -66,6 +68,7 @@ public class ResourceRegistry {
         return this;
     }
 
+    /** Returns the resource descriptor by name. */
     public @Nullable ResourceDescriptor get(String name) {
         var entry = byName.get(name);
         return entry != null ? entry.descriptor() : null;
@@ -174,11 +177,13 @@ public class ResourceRegistry {
         registry.put("resources/unsubscribe", new ResourcesUnsubscribeHandler(this));
     }
 
+    /** Returns whether the given session is subscribed to the resource URI. */
     public boolean isSubscribed(String uri, String sessionId) {
         var subs = subscriptions.get(uri);
         return subs != null && subs.contains(sessionId);
     }
 
+    /** Notifies all subscribed sessions that a resource has been updated. */
     public void notifyResourceUpdated(String uri) {
         var subscribedSessionIds = subscriptions.get(uri);
         if (subscribedSessionIds == null || subscribedSessionIds.isEmpty()) {

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tasks/TaskRegistry.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tasks/TaskRegistry.java
@@ -25,6 +25,7 @@ import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/** Registry for long-running tasks with create/cancel/complete lifecycle and TTL janitor. */
 public class TaskRegistry extends Registry<TaskEntry> {
 
     private static final Logger logger = LoggerFactory.getLogger(TaskRegistry.class);
@@ -37,6 +38,7 @@ public class TaskRegistry extends Registry<TaskEntry> {
     private final McpServer server;
     private volatile @Nullable ScheduledExecutorService ttlJanitor;
 
+    /** Creates a task registry bound to the given server (for broadcasting status notifications). */
     public TaskRegistry(McpServer server) {
         this.server = server;
     }
@@ -60,22 +62,27 @@ public class TaskRegistry extends Registry<TaskEntry> {
         }
     }
 
+    /** Returns the task with the given unique ID. */
     public @Nullable TaskEntry getById(String id) {
         return byId.get(id);
     }
 
+    /** Creates a task with the given name and optional description (no TTL). */
     public TaskEntry createTask(String name, @Nullable String description) {
         return createTask(name, description, 0.0);
     }
 
+    /** Creates a task with the given name, description, and TTL in seconds (0 = no TTL). */
     public TaskEntry createTask(String name, @Nullable String description, double ttl) {
         return createTask(TaskDescriptor.of(name, description), ttl);
     }
 
+    /** Creates a task from a descriptor (no TTL). */
     public TaskEntry createTask(TaskDescriptor descriptor) {
         return createTask(descriptor, 0.0);
     }
 
+    /** Creates a task from a descriptor with the given TTL in seconds (0 = no TTL). */
     public TaskEntry createTask(TaskDescriptor descriptor, double ttl) {
         var id = UUID.randomUUID().toString();
         var entry = new TaskEntry(descriptor, id, TaskState.WORKING, ttl);
@@ -84,6 +91,7 @@ public class TaskRegistry extends Registry<TaskEntry> {
         return entry;
     }
 
+    /** Cancels the task with the given ID. */
     public boolean cancelTask(String taskId) {
         var entry = byId.get(taskId);
         if (entry == null) {
@@ -97,6 +105,7 @@ public class TaskRegistry extends Registry<TaskEntry> {
         return true;
     }
 
+    /** Marks the task as completed with an optional result JSON. */
     public boolean completeTask(String taskId, @Nullable String resultJson) {
         var entry = byId.get(taskId);
         if (entry == null) {
@@ -111,6 +120,7 @@ public class TaskRegistry extends Registry<TaskEntry> {
         return true;
     }
 
+    /** Marks the task as failed with an optional result JSON. */
     public boolean failTask(String taskId, @Nullable String resultJson) {
         var entry = byId.get(taskId);
         if (entry == null) {
@@ -125,6 +135,7 @@ public class TaskRegistry extends Registry<TaskEntry> {
         return true;
     }
 
+    /** Updates task status from a client notification. */
     public boolean updateStatusFromClientNotification(
             String taskId, @Nullable TaskState newStatus, @Nullable String statusMessage) {
         var entry = byId.get(taskId);
@@ -149,6 +160,7 @@ public class TaskRegistry extends Registry<TaskEntry> {
 
     private final AtomicBoolean ttlJanitorStarted = new AtomicBoolean();
 
+    /** Starts the background janitor that expires stale tasks. Idempotent. */
     public void startTtlJanitor() {
         if (!ttlJanitorStarted.compareAndSet(false, true)) {
             return;
@@ -163,6 +175,7 @@ public class TaskRegistry extends Registry<TaskEntry> {
                 this::expireStaleTasks, TTL_JANITOR_INTERVAL_SECONDS, TTL_JANITOR_INTERVAL_SECONDS, TimeUnit.SECONDS);
     }
 
+    /** Stops the task TTL janitor. */
     public void stopTtlJanitor() {
         var executor = ttlJanitor;
         if (executor != null) {

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tasks/TasksExtension.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tasks/TasksExtension.java
@@ -10,15 +10,14 @@ import dev.tachyonmcp.server.domain.TextResourceContents;
 import dev.tachyonmcp.server.extensions.McpExtension;
 import dev.tachyonmcp.server.features.resources.ResourceTemplateEntry;
 import dev.tachyonmcp.server.features.tools.AbstractAsyncToolHandler;
+import dev.tachyonmcp.server.features.tools.ToolArgs;
 import dev.tachyonmcp.server.features.tools.ToolDescriptor;
 import dev.tachyonmcp.server.features.tools.ToolResult;
 import dev.tachyonmcp.server.session.McpContext;
-import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
-import org.jspecify.annotations.Nullable;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.node.JsonNodeFactory;
 
@@ -69,7 +68,7 @@ public class TasksExtension implements McpExtension {
                         }));
     }
 
-    private static final class CreateTaskHandler extends AbstractAsyncToolHandler<ToolResult> {
+    private static final class CreateTaskHandler extends AbstractAsyncToolHandler {
 
         private final TaskRegistry tasks;
         private final Executor executor;
@@ -81,21 +80,15 @@ public class TasksExtension implements McpExtension {
         }
 
         @Override
-        public CompletionStage<ToolResult> handleAsync(McpContext context, @Nullable Map<String, JsonNode> arguments) {
+        public CompletionStage<? extends ToolResult<?>> handleAsync(McpContext context, ToolArgs args) {
             var sessionId = OutboundSseStreamMessageRouter.currentSessionId();
             var outboundStream = OutboundSseStreamMessageRouter.currentOutboundSseStream();
             return CompletableFuture.supplyAsync(
                     () -> {
                         try {
                             return OutboundSseStreamMessageRouter.withDispatchContext(sessionId, outboundStream, () -> {
-                                String name = "unnamed";
-                                String description = null;
-                                if (arguments != null) {
-                                    var nameNode = arguments.get("name");
-                                    if (nameNode != null && nameNode.isString()) name = nameNode.asString();
-                                    var descNode = arguments.get("description");
-                                    if (descNode != null && descNode.isString()) description = descNode.asString();
-                                }
+                                var name = args.stringOr("name", "unnamed");
+                                var description = args.stringOpt("description").orElse(null);
                                 return ToolResult.text(
                                         tasks.createTask(name, description).id());
                             });

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tools/AbstractAsyncToolHandler.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tools/AbstractAsyncToolHandler.java
@@ -1,11 +1,8 @@
-/*
- * Copyright (c) 2026 Konstantin Pavlov.
- */
+/* Copyright (c) 2026 Konstantin Pavlov. */
 
 package dev.tachyonmcp.server.features.tools;
 
-public abstract class AbstractAsyncToolHandler<R extends ToolResult> extends AbstractToolHandler<R>
-        implements AsyncToolHandler<R> {
+public abstract class AbstractAsyncToolHandler extends AbstractToolHandler implements AsyncToolHandler {
 
     public AbstractAsyncToolHandler(ToolDescriptor descriptor) {
         super(descriptor);

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tools/AbstractSyncToolHandler.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tools/AbstractSyncToolHandler.java
@@ -1,11 +1,8 @@
-/*
- * Copyright (c) 2026 Konstantin Pavlov.
- */
+/* Copyright (c) 2026 Konstantin Pavlov. */
 
 package dev.tachyonmcp.server.features.tools;
 
-public abstract class AbstractSyncToolHandler<R extends ToolResult> extends AbstractToolHandler<R>
-        implements SyncToolHandler<R> {
+public abstract class AbstractSyncToolHandler extends AbstractToolHandler implements SyncToolHandler {
 
     public AbstractSyncToolHandler(ToolDescriptor descriptor) {
         super(descriptor);

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tools/AbstractToolHandler.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tools/AbstractToolHandler.java
@@ -1,12 +1,10 @@
-/*
- * Copyright (c) 2026 Konstantin Pavlov.
- */
+/* Copyright (c) 2026 Konstantin Pavlov. */
 
 package dev.tachyonmcp.server.features.tools;
 
 import java.util.Objects;
 
-public abstract class AbstractToolHandler<R extends ToolResult> implements ToolHandler<R> {
+public abstract class AbstractToolHandler implements ToolHandler {
 
     private final ToolDescriptor descriptor;
 

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tools/AsyncToolHandler.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tools/AsyncToolHandler.java
@@ -1,20 +1,18 @@
-/*
- * Copyright (c) 2026 Konstantin Pavlov.
- */
+/* Copyright (c) 2026 Konstantin Pavlov. */
 
 package dev.tachyonmcp.server.features.tools;
 
 import dev.tachyonmcp.server.domain.ToolAnnotations;
 import dev.tachyonmcp.server.features.tasks.TaskSupport;
 import dev.tachyonmcp.server.session.McpContext;
-import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import org.jspecify.annotations.Nullable;
 import tools.jackson.databind.JsonNode;
 
-public interface AsyncToolHandler<R extends ToolResult> extends ToolHandler<R> {
+/** Convenient base for asynchronous (non-blocking) tool handlers. */
+public interface AsyncToolHandler extends ToolHandler {
 
     String name();
 
@@ -43,7 +41,8 @@ public interface AsyncToolHandler<R extends ToolResult> extends ToolHandler<R> {
         return null;
     }
 
-    CompletionStage<R> handleAsync(McpContext context, @Nullable Map<String, JsonNode> arguments) throws Exception;
+    /** Executes the tool asynchronously. */
+    CompletionStage<? extends ToolResult<?>> handleAsync(McpContext context, ToolArgs args) throws Exception;
 
     @Nullable
     default ToolAnnotations annotations() {
@@ -63,13 +62,14 @@ public interface AsyncToolHandler<R extends ToolResult> extends ToolHandler<R> {
     }
 
     @Override
-    default CompletionStage<R> handle(ToolRequest request, McpContext context) throws Exception {
-        return handleAsync(context, request.arguments());
+    default CompletionStage<? extends ToolResult<?>> handle(ToolRequest request, McpContext context) throws Exception {
+        return handleAsync(context, ToolArgs.of(request.arguments()));
     }
 
-    static <R extends ToolResult> AsyncToolHandler<R> adapt(SyncToolHandler<R> sync) {
+    /** Wraps a synchronous tool handler as an async one. */
+    static AsyncToolHandler adapt(SyncToolHandler sync) {
         Objects.requireNonNull(sync, "sync");
-        return new AsyncToolHandler<>() {
+        return new AsyncToolHandler() {
             @Override
             public String name() {
                 return sync.name();
@@ -81,9 +81,9 @@ public interface AsyncToolHandler<R extends ToolResult> extends ToolHandler<R> {
             }
 
             @Override
-            public CompletionStage<R> handleAsync(McpContext ctx, @Nullable Map<String, JsonNode> input) {
+            public CompletionStage<? extends ToolResult<?>> handleAsync(McpContext ctx, ToolArgs args) {
                 try {
-                    return CompletableFuture.completedFuture(sync.handle(ctx, input));
+                    return CompletableFuture.completedFuture(sync.handle(ctx, args));
                 } catch (Exception e) {
                     return CompletableFuture.failedFuture(e);
                 }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tools/InvalidArgumentException.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tools/InvalidArgumentException.java
@@ -1,0 +1,17 @@
+/* Copyright (c) 2026 Konstantin Pavlov. */
+
+package dev.tachyonmcp.server.features.tools;
+
+public final class InvalidArgumentException extends RuntimeException {
+
+    private final String argName;
+
+    public InvalidArgumentException(String argName, String message) {
+        super(message);
+        this.argName = argName;
+    }
+
+    public String argName() {
+        return argName;
+    }
+}

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tools/SyncToolHandler.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tools/SyncToolHandler.java
@@ -1,21 +1,20 @@
-/*
- * Copyright (c) 2026 Konstantin Pavlov.
- */
+/* Copyright (c) 2026 Konstantin Pavlov. */
 
 package dev.tachyonmcp.server.features.tools;
 
 import dev.tachyonmcp.server.domain.ToolAnnotations;
 import dev.tachyonmcp.server.features.tasks.TaskSupport;
 import dev.tachyonmcp.server.session.McpContext;
-import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.function.BiFunction;
 import org.jspecify.annotations.Nullable;
 import tools.jackson.databind.JsonNode;
 
-public interface SyncToolHandler<R extends ToolResult> extends ToolHandler<R> {
+/** Convenient base for synchronous (blocking) tool handlers. */
+public interface SyncToolHandler extends ToolHandler {
 
+    /** The tool name. */
     String name();
 
     @Nullable
@@ -43,7 +42,8 @@ public interface SyncToolHandler<R extends ToolResult> extends ToolHandler<R> {
         return null;
     }
 
-    R handle(McpContext context, @Nullable Map<String, JsonNode> arguments) throws Exception;
+    /** Executes the tool synchronously. */
+    ToolResult<?> handle(McpContext context, ToolArgs args) throws Exception;
 
     @Nullable
     default ToolAnnotations annotations() {
@@ -63,16 +63,17 @@ public interface SyncToolHandler<R extends ToolResult> extends ToolHandler<R> {
     }
 
     @Override
-    default CompletionStage<R> handle(ToolRequest request, McpContext context) throws Exception {
-        return CompletableFuture.completedFuture(handle(context, request.arguments()));
+    default CompletionStage<? extends ToolResult<?>> handle(ToolRequest request, McpContext context) throws Exception {
+        return CompletableFuture.completedFuture(handle(context, ToolArgs.of(request.arguments())));
     }
 
-    static <R extends ToolResult> SyncToolHandler<R> of(
+    /** Creates a simple SyncToolHandler from a name, description, schema, and function. */
+    static SyncToolHandler of(
             String name,
             @Nullable String description,
             @Nullable JsonNode inputSchema,
-            BiFunction<McpContext, @Nullable Map<String, JsonNode>, R> fn) {
-        return new SyncToolHandler<>() {
+            BiFunction<McpContext, ToolArgs, ToolResult<?>> fn) {
+        return new SyncToolHandler() {
             @Override
             public String name() {
                 return name;
@@ -91,7 +92,7 @@ public interface SyncToolHandler<R extends ToolResult> extends ToolHandler<R> {
             }
 
             @Override
-            public R handle(McpContext ctx, @Nullable Map<String, JsonNode> args) throws Exception {
+            public ToolResult<?> handle(McpContext ctx, ToolArgs args) throws Exception {
                 return fn.apply(ctx, args);
             }
         };

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tools/ToolArgs.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tools/ToolArgs.java
@@ -1,0 +1,64 @@
+/* Copyright (c) 2026 Konstantin Pavlov. */
+
+package dev.tachyonmcp.server.features.tools;
+
+import java.util.Map;
+import java.util.Optional;
+import org.jspecify.annotations.Nullable;
+import tools.jackson.databind.JsonNode;
+
+public final class ToolArgs {
+
+    private final Map<String, JsonNode> raw;
+
+    private ToolArgs(@Nullable Map<String, JsonNode> raw) {
+        this.raw = raw == null ? Map.of() : raw;
+    }
+
+    public static ToolArgs of(@Nullable Map<String, JsonNode> raw) {
+        return new ToolArgs(raw);
+    }
+
+    public boolean isEmpty() {
+        return raw.isEmpty();
+    }
+
+    public boolean has(String key) {
+        return raw.containsKey(key);
+    }
+
+    public String string(String key) {
+        return node(key).asString();
+    }
+
+    public int intValue(String key) {
+        return node(key).asInt();
+    }
+
+    public boolean boolValue(String key) {
+        return node(key).asBoolean();
+    }
+
+    public double doubleValue(String key) {
+        return node(key).asDouble();
+    }
+
+    public Optional<String> stringOpt(String key) {
+        return has(key) ? Optional.of(raw.get(key).asString()) : Optional.empty();
+    }
+
+    public String stringOr(String key, String fallback) {
+        return has(key) ? raw.get(key).asString() : fallback;
+    }
+
+    public JsonNode node(String key) {
+        var n = raw.get(key);
+        if (n == null) throw new InvalidArgumentException(key, "required argument missing");
+        return n;
+    }
+
+    @Nullable
+    public JsonNode raw(String key) {
+        return raw.get(key);
+    }
+}

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tools/ToolHandler.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tools/ToolHandler.java
@@ -1,15 +1,16 @@
-/*
- * Copyright (c) 2026 Konstantin Pavlov.
- */
+/* Copyright (c) 2026 Konstantin Pavlov. */
 
 package dev.tachyonmcp.server.features.tools;
 
 import dev.tachyonmcp.server.session.McpContext;
 import java.util.concurrent.CompletionStage;
 
-public interface ToolHandler<R extends ToolResult> {
+/** Handles tool execution. One handler per tool. */
+public interface ToolHandler {
 
+    /** Returns the metadata descriptor for this tool. */
     ToolDescriptor descriptor();
 
-    CompletionStage<R> handle(ToolRequest request, McpContext context) throws Exception;
+    /** Executes the tool with the given request and context. */
+    CompletionStage<? extends ToolResult<?>> handle(ToolRequest request, McpContext context) throws Exception;
 }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tools/ToolRegistry.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tools/ToolRegistry.java
@@ -15,12 +15,7 @@ import dev.tachyonmcp.server.SchemaValidationError;
 import dev.tachyonmcp.server.features.PaginatedResult;
 import dev.tachyonmcp.server.session.McpContext;
 import dev.tachyonmcp.transport.jsonrpc.JsonRpcCodec;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
+import java.util.*;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Predicate;
@@ -32,17 +27,19 @@ import org.slf4j.LoggerFactory;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.node.JsonNodeFactory;
 
+/** Registry for tool handlers with input/output schema validation. */
 public class ToolRegistry {
 
     private static final Logger logger = LoggerFactory.getLogger(ToolRegistry.class);
 
-    private final ConcurrentHashMap<String, ToolHandler<? extends ToolResult>> handlers = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, ToolHandler> handlers = new ConcurrentHashMap<>();
     private final JsonSchemaValidator validator;
 
     private @Nullable Runnable onChange;
 
     private static final int DEFAULT_PAGE_SIZE = 50;
 
+    /** Creates a tool registry with the given schema validator. */
     public ToolRegistry(JsonSchemaValidator validator) {
         this.validator = validator;
     }
@@ -57,7 +54,8 @@ public class ToolRegistry {
         }
     }
 
-    public void register(ToolHandler<? extends ToolResult> handler) {
+    /** Registers a tool handler. */
+    public void register(ToolHandler handler) {
         Objects.requireNonNull(handler, "ToolHandler must not be null");
         var descriptor = handler.descriptor();
         Objects.requireNonNull(descriptor, "ToolDescriptor must not be null");
@@ -82,25 +80,30 @@ public class ToolRegistry {
 
     private static final Pattern VALID_NAME_PATTERN = Pattern.compile("[a-zA-Z0-9_\\-./]+");
 
+    /** Removes the tool with the given name. */
     public void remove(String name) {
         if (handlers.remove(name) != null) {
             fireOnChange();
         }
     }
 
-    public @Nullable ToolHandler<? extends ToolResult> get(String name) {
+    /** Returns the tool handler by name. */
+    public @Nullable ToolHandler get(String name) {
         return handlers.get(name);
     }
 
+    /** Returns the tool descriptor by name. */
     public @Nullable ToolDescriptor getDescriptor(String name) {
         var handler = handlers.get(name);
         return handler != null ? handler.descriptor() : null;
     }
 
-    public Collection<ToolHandler<? extends ToolResult>> getAll() {
+    /** Returns all registered tool handlers. */
+    public Collection<ToolHandler> getAll() {
         return handlers.values();
     }
 
+    /** Returns whether the registry is empty. */
     public boolean isEmpty() {
         return handlers.isEmpty();
     }
@@ -219,7 +222,7 @@ public class ToolRegistry {
             var progressToken = parseProgressToken(parsed.meta());
             var request = ToolRequest.builder()
                     .name(parsed.name())
-                    .arguments(parsed.args())
+                    .arguments(parsed.args() != null ? parsed.args() : Collections.emptyMap())
                     .meta(parsed.meta())
                     .progressToken(progressToken)
                     .inputResponses(parsed.inputResponses())
@@ -232,8 +235,13 @@ public class ToolRegistry {
                 sendLoggingIfEnabled(context, parsed.name(), "completed");
                 validateOutput(handler.descriptor().outputSchema(), toolResult);
                 return context.responseMapper().callToolResult(toolResult);
+            } catch (InvalidArgumentException e) {
+                return invalidRequest("invalid argument '" + e.argName() + "': " + e.getMessage());
             } catch (CompletionException e) {
                 var cause = e.getCause();
+                if (cause instanceof InvalidArgumentException ia) {
+                    return invalidRequest("invalid argument '" + ia.argName() + "': " + ia.getMessage());
+                }
                 if (cause instanceof Exception ex) throw ex;
                 throw new RuntimeException(cause);
             }
@@ -294,10 +302,17 @@ public class ToolRegistry {
             return joinMessages(errors);
         }
 
-        private void validateOutput(@Nullable JsonNode schema, ToolResult result) {
-            if (schema == null || result.structuredContent() == null) return;
+        private void validateOutput(@Nullable JsonNode schema, ToolResult<?> result) {
+            if (schema == null) return;
+            var inner = result instanceof ToolResult.WithMeta<?> wm ? wm.inner() : result;
+            if (!(inner instanceof ToolResult.Success<?> s)) return;
+            if (!(s.structuredValue() instanceof java.util.Map<?, ?> map)) return;
             var contentNode = JsonNodeFactory.instance.objectNode();
-            contentNode.setAll(result.structuredContent());
+            for (var entry : map.entrySet()) {
+                if (entry.getKey() instanceof String k && entry.getValue() instanceof JsonNode v) {
+                    contentNode.set(k, v);
+                }
+            }
             var errors = validator.validate(schema, contentNode);
             if (!errors.isEmpty()) {
                 logger.debug("Tool output failed schema validation (advisory only): {}", joinMessages(errors));

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tools/ToolRequest.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tools/ToolRequest.java
@@ -6,6 +6,7 @@ package dev.tachyonmcp.server.features.tools;
 
 import dev.tachyonmcp.runtime.Cancellation;
 import dev.tachyonmcp.server.domain.HasMeta;
+import java.util.Collections;
 import java.util.Map;
 import org.immutables.value.Value;
 import org.jspecify.annotations.Nullable;
@@ -20,8 +21,10 @@ public interface ToolRequest extends HasMeta {
 
     String name();
 
-    @Nullable
-    Map<String, JsonNode> arguments();
+    @Value.Default
+    default Map<String, JsonNode> arguments() {
+        return Map.of();
+    }
 
     @Nullable
     Map<String, JsonNode> meta();
@@ -48,11 +51,19 @@ public interface ToolRequest extends HasMeta {
             @Nullable Map<String, JsonNode> meta,
             @Nullable Object progressToken,
             @Nullable Cancellation cancellation) {
-        return DefaultToolRequest.of(name, arguments, meta, progressToken, cancellation, null, null);
+        return DefaultToolRequest.of(
+                name,
+                arguments != null ? arguments : Collections.emptyMap(),
+                meta,
+                progressToken,
+                cancellation,
+                null,
+                null);
     }
 
     static ToolRequest of(
             String name, @Nullable Map<String, JsonNode> arguments, @Nullable Map<String, JsonNode> meta) {
-        return DefaultToolRequest.of(name, arguments, meta, null, null, null, null);
+        return DefaultToolRequest.of(
+                name, arguments != null ? arguments : Collections.emptyMap(), meta, null, null, null, null);
     }
 }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tools/ToolResult.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tools/ToolResult.java
@@ -1,72 +1,92 @@
-/*
- * Copyright (c) 2026 Konstantin Pavlov.
- */
+/* Copyright (c) 2026 Konstantin Pavlov. */
 
 package dev.tachyonmcp.server.features.tools;
 
 import dev.tachyonmcp.server.domain.ContentBlock;
-import dev.tachyonmcp.server.domain.HasMeta;
 import dev.tachyonmcp.server.domain.InputRequest;
+import dev.tachyonmcp.server.domain.InputRequestBundle;
 import dev.tachyonmcp.server.domain.TextContent;
-import java.util.List;
-import java.util.Map;
-import org.immutables.value.Value;
+import java.util.*;
 import org.jspecify.annotations.Nullable;
 import tools.jackson.databind.JsonNode;
 
-@Value.Immutable
-@Value.Style(
-        allParameters = true,
-        visibility = Value.Style.ImplementationVisibility.PACKAGE,
-        typeImmutable = "Default*")
-public interface ToolResult extends HasMeta {
+public sealed interface ToolResult<T>
+        permits ToolResult.Success, ToolResult.ErrorResult, ToolResult.WithMeta, ToolResult.InputRequired {
 
-    List<ContentBlock> content();
+    record Success<T>(@Nullable T structuredValue, List<ContentBlock> content) implements ToolResult<T> {
+        public Success {
+            Objects.requireNonNull(content, "content");
+            content = List.copyOf(content);
+        }
 
-    @Nullable
-    Boolean isError();
-
-    @Nullable
-    Map<String, JsonNode> structuredContent();
-
-    @Nullable
-    Map<String, JsonNode> meta();
-
-    @Nullable
-    Map<String, InputRequest> inputRequests();
-
-    @Nullable
-    String requestState();
-
-    static DefaultToolResult.Builder builder() {
-        return DefaultToolResult.builder();
+        public Optional<T> structured() {
+            return Optional.ofNullable(structuredValue);
+        }
     }
 
-    static ToolResult text(String text) {
-        return DefaultToolResult.of(List.of(TextContent.of(text)), null, null, null, null, null);
+    record ErrorResult(String message) implements ToolResult<Object> {}
+
+    record WithMeta<T>(ToolResult<T> inner, Map<String, JsonNode> meta) implements ToolResult<T> {
+        public WithMeta {
+            Objects.requireNonNull(inner, "inner");
+            Objects.requireNonNull(meta, "meta");
+            meta = Map.copyOf(meta);
+        }
     }
 
-    static ToolResult error(String message) {
-        return DefaultToolResult.of(List.of(TextContent.of(message)), true, null, null, null, null);
+    record InputRequired(InputRequestBundle request) implements ToolResult<Object> {
+        public InputRequired {
+            Objects.requireNonNull(request, "request");
+        }
+
+        public Map<String, ? extends InputRequest> inputRequests() {
+            return request.inputRequests();
+        }
+
+        public @Nullable String requestState() {
+            return request.requestState();
+        }
     }
 
-    static ToolResult of(List<ContentBlock> content) {
-        return DefaultToolResult.of(content, null, null, null, null, null);
+    default ToolResult<T> withMeta(Map<String, JsonNode> m) {
+        if (m.isEmpty()) return this;
+        if (this instanceof WithMeta<T>(ToolResult<T> inner, Map<String, JsonNode> meta)) {
+            var merged = new HashMap<>(meta);
+            merged.putAll(m);
+            return new WithMeta<>(inner, merged);
+        }
+        return new WithMeta<>(this, m);
     }
 
-    static ToolResult of(ContentBlock... content) {
-        return DefaultToolResult.of(List.of(content), null, null, null, null, null);
+    default ToolResult<T> withMeta(String key, JsonNode value) {
+        return withMeta(Map.of(key, value));
     }
 
-    static ToolResult empty() {
-        return DefaultToolResult.of(List.of(), null, null, null, null, null);
+    static ToolResult<String> text(String t) {
+        return new Success<>(null, List.of(TextContent.of(t)));
     }
 
-    static ToolResult inputRequired(Map<String, ? extends InputRequest> inputRequests, @Nullable String requestState) {
-        return DefaultToolResult.builder()
-                .content(List.of())
-                .inputRequests(inputRequests)
-                .requestState(requestState)
-                .build();
+    static ToolResult<Void> blocks(ContentBlock... blocks) {
+        return new Success<>(null, List.of(blocks));
+    }
+
+    static <T> ToolResult<T> of(T payload, String text) {
+        return new Success<>(payload, List.of(TextContent.of(text)));
+    }
+
+    static <T> ToolResult<T> of(T payload) {
+        return new Success<>(payload, List.of(TextContent.of(Objects.toString(payload))));
+    }
+
+    static ToolResult<Object> error(String message) {
+        return new ErrorResult(message);
+    }
+
+    static ToolResult<Object> empty() {
+        return new Success<>(null, List.of());
+    }
+
+    static ToolResult<Object> inputRequired(Map<String, ? extends InputRequest> reqs, @Nullable String state) {
+        return new InputRequired(new InputRequestBundle(reqs, state));
     }
 }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/session/McpContext.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/session/McpContext.java
@@ -11,25 +11,32 @@ import dev.tachyonmcp.server.OutboundSseStream;
 import dev.tachyonmcp.server.ServerContext;
 import org.jspecify.annotations.Nullable;
 
+/** Dispatch context for a single handler invocation, providing access to the server, session, and notifications. */
 public interface McpContext extends InteractionContext<McpSession> {
 
+    /** Returns the server-level context. */
     ServerContext server();
 
+    /** Returns the notification sender bound to this context. */
     Notifications notifications();
 
     @Override
     @Nullable
     McpSession session();
 
+    /** Returns the protocol response mapper for the current protocol version. */
     default ProtocolResponseMapper responseMapper() {
         return server().mcpServer().responseMapper();
     }
 
+    /** Returns the outbound SSE stream, or {@code null} if not yet upgraded. */
     @Nullable
     OutboundSseStream outboundStream();
 
+    /** Sets the outbound SSE stream for this dispatch. */
     void setOutboundStream(@Nullable OutboundSseStream stream);
 
+    /** Marks an extension as enabled for this session. */
     void enableExtension(String extensionId);
 
     default boolean isExtensionEnabled(String extensionId) {

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/session/McpSession.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/session/McpSession.java
@@ -14,6 +14,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
+/** Server-side session representing a single MCP client connection. */
 public class McpSession extends Session {
 
     private final AtomicReference<SseConnection> connection;
@@ -29,39 +30,48 @@ public class McpSession extends Session {
         this.cursor = new AtomicLong(-1);
     }
 
+    /** Returns the current SSE connection. */
     public SseConnection connection() {
         return connection.get();
     }
 
+    /** Replaces the SSE connection (e.g. after reconnection). */
     public void connection(SseConnection connection) {
         this.connection.set(Objects.requireNonNull(connection, "connection"));
         this.lastActivityNanos = System.nanoTime();
     }
 
+    /** Returns the current backpressure state. */
     public Backpressure backpressure() {
         return backpressure.get();
     }
 
+    /** Returns the last replayed SSE event cursor. */
     public long cursor() {
         return cursor.get();
     }
 
+    /** Sets the replayed SSE event cursor. */
     public void cursor(long position) {
         cursor.set(position);
     }
 
+    /** Enables an extension for this session. */
     public void enableExtension(String extensionId) {
         enabledExtensions.add(extensionId);
     }
 
+    /** Returns whether the given extension is enabled for this session. */
     public boolean isExtensionEnabled(String extensionId) {
         return enabledExtensions.contains(extensionId);
     }
 
+    /** Returns the read-write lock for this session's state. */
     public ReadWriteLock lock() {
         return lock;
     }
 
+    /** Recomputes and returns the backpressure state based on stream writability. */
     public Backpressure computeBackpressure() {
         return backpressure.updateAndGet(current -> {
             if (!connection.get().isWritable()) {
@@ -71,13 +81,12 @@ public class McpSession extends Session {
         });
     }
 
+    /** Returns {@code true} if the session should throttle outbound events. */
     public boolean shouldThrottle() {
         return computeBackpressure() != Backpressure.HOT;
     }
 
-    /**
-     * @return {@code true} if the event was delivered; {@code false} if the session is CLOSED
-     */
+    /** Sends an SSE event to the client. */
     public boolean send(SseEvent event) {
         var conn = connection.get();
         if (conn == SseConnection.NOOP) {

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/session/SessionEvent.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/session/SessionEvent.java
@@ -4,23 +4,30 @@
 
 package dev.tachyonmcp.server.session;
 
+/** A recorded session event — request, response, notification, or cancellation. */
 public sealed interface SessionEvent {
 
+    /** The session this event belongs to. */
     String sessionId();
 
+    /** Timestamp of the event (epoch millis). */
     long timestamp();
 
+    /** SSE event ID (for replay), or -1 if not assigned. */
     default long sseEventId() {
         return -1;
     }
 
+    /** An inbound request from the client. */
     record RequestEvent(String sessionId, Object requestId, String method, String paramsJson, long timestamp)
             implements SessionEvent {}
 
+    /** An outbound (server-to-client) request. */
     record OutboundRequestEvent(
             String sessionId, Object requestId, String method, String paramsJson, long timestamp, long sseEventId)
             implements SessionEvent {}
 
+    /** A response sent to the client. */
     record ResponseEvent(String sessionId, Object requestId, String resultJson, long timestamp, long sseEventId)
             implements SessionEvent {
 
@@ -29,8 +36,10 @@ public sealed interface SessionEvent {
         }
     }
 
+    /** A cancellation request. */
     record CancelEvent(String sessionId, Object requestId, long timestamp) implements SessionEvent {}
 
+    /** A notification sent to or received from the client. */
     record NotificationEvent(String sessionId, String method, String paramsJson, long timestamp, long sseEventId)
             implements SessionEvent {
 

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/session/SessionLogRouter.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/session/SessionLogRouter.java
@@ -8,10 +8,14 @@ import java.io.Closeable;
 import java.util.List;
 import java.util.function.Predicate;
 
+/** Persists and replays session events (request/responses, notifications). */
 public interface SessionLogRouter extends Closeable {
+    /** Appends an event to the log. */
     void append(SessionEvent event);
 
+    /** Returns all events for the session with sequence number greater than {@code lastSeq}. */
     List<SessionEvent> replay(String sessionId, long lastSeq);
 
+    /** Pumps events to the processor, one at a time, until exhausted and returns the last cursor. */
     long pump(String sessionId, long cursor, Predicate<SessionEvent> processor);
 }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/session/SessionManager.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/session/SessionManager.java
@@ -15,6 +15,7 @@ import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/** Manages the lifecycle of MCP sessions. */
 public class SessionManager implements AutoCloseable {
 
     private static final Logger logger = LoggerFactory.getLogger(SessionManager.class);
@@ -22,6 +23,7 @@ public class SessionManager implements AutoCloseable {
     private final SessionStore store;
     private final ScheduledExecutorService janitor;
 
+    /** Creates a session manager backed by the given store. */
     public SessionManager(SessionStore store) {
         this.store = store;
         this.janitor = Executors.newSingleThreadScheduledExecutor(r -> {
@@ -31,10 +33,12 @@ public class SessionManager implements AutoCloseable {
         });
     }
 
+    /** Creates a session with no initial connection. */
     public McpSession createSession(String sessionId) {
         return createSession(sessionId, SseConnection.NOOP);
     }
 
+    /** Creates a session with the given SSE connection. */
     public McpSession createSession(String sessionId, SseConnection connection) {
         var session = new McpSession(sessionId, connection);
         var previous = store.put(sessionId, session);
@@ -46,6 +50,7 @@ public class SessionManager implements AutoCloseable {
         return session;
     }
 
+    /** Returns the session for the given ID, if present. */
     public Optional<McpSession> getSession(@Nullable String sessionId) {
         if (sessionId == null) {
             return Optional.empty();
@@ -53,10 +58,12 @@ public class SessionManager implements AutoCloseable {
         return store.get(sessionId);
     }
 
+    /** Returns all active sessions. */
     public Collection<McpSession> allSessions() {
         return store.values();
     }
 
+    /** Removes and closes the session with the given ID. */
     public void removeSession(String sessionId) {
         var session = store.remove(sessionId);
         if (session != null) {
@@ -65,6 +72,7 @@ public class SessionManager implements AutoCloseable {
         }
     }
 
+    /** Starts the background janitor that closes expired sessions. */
     public void startJanitor(Duration ttl) {
         final var ttlNanos = ttl.toNanos();
         janitor.scheduleWithFixedDelay(

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/session/SessionStore.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/session/SessionStore.java
@@ -9,17 +9,23 @@ import java.util.Optional;
 import java.util.function.Function;
 import org.jspecify.annotations.Nullable;
 
+/** Storage abstraction for MCP sessions. */
 public interface SessionStore extends AutoCloseable {
 
+    /** Stores a session, returning any previous session with the same ID. */
     @Nullable
     McpSession put(String sessionId, McpSession session);
 
+    /** Returns the session for the given ID, if present. */
     Optional<McpSession> get(String sessionId);
 
+    /** Returns the existing session or creates and stores a new one via the factory. */
     McpSession computeIfAbsent(String sessionId, Function<String, McpSession> factory);
 
+    /** Returns all stored sessions. */
     Collection<McpSession> values();
 
+    /** Removes and returns the session for the given ID. */
     @Nullable
     McpSession remove(String sessionId);
 }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/session/SseConnection.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/session/SseConnection.java
@@ -4,12 +4,16 @@
 
 package dev.tachyonmcp.server.session;
 
+/** A writable SSE connection to a client. */
 public interface SseConnection {
 
+    /** Returns {@code true} if the underlying channel is writable. */
     boolean isWritable();
 
+    /** Sends an SSE event to the client. */
     void send(SseEvent event);
 
+    /** Closes the connection. Idempotent. */
     default void close() {}
 
     SseConnection NOOP = new SseConnection() {

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/session/SseEvent.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/session/SseEvent.java
@@ -6,6 +6,7 @@ package dev.tachyonmcp.server.session;
 
 import java.util.Objects;
 
+/** A single Server-Sent Event with an ID, event type, and data payload. */
 public record SseEvent(String id, String event, String data) {
 
     public SseEvent(String id, String event, String data) {

--- a/tachyon-server/src/main/java/dev/tachyonmcp/transport/jsonrpc/JsonRpcCodec.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/transport/jsonrpc/JsonRpcCodec.java
@@ -21,6 +21,7 @@ import tools.jackson.core.json.JsonFactory;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.node.JsonNodeFactory;
 
+/** Low-level JSON-RPC 2.0 codec: parse and serialize messages to/from Netty {@link ByteBuf}. */
 public final class JsonRpcCodec {
 
     public static final ObjectReadContext TREE_READ_CONTEXT = new ObjectReadContext.Base() {
@@ -50,6 +51,7 @@ public final class JsonRpcCodec {
 
     private JsonRpcCodec() {}
 
+    /** Parses a JSON-RPC message from a {@link ByteBuf}. */
     public static JsonRpcMessage parseRequest(ByteBuf buf) {
         try (var in = new ByteBufInputStream(buf);
                 JsonParser p = FACTORY.createParser(ObjectReadContext.empty(), (InputStream) in)) {
@@ -59,6 +61,7 @@ public final class JsonRpcCodec {
         }
     }
 
+    /** Serializes a JSON-RPC response. */
     public static ByteBuf serializeResponse(Object id, @Nullable String resultJson) {
         return serialize(gen -> {
             gen.writeStartObject();
@@ -74,6 +77,7 @@ public final class JsonRpcCodec {
         });
     }
 
+    /** Serializes a JSON-RPC error response. */
     public static ByteBuf serializeError(Object id, int code, String message, @Nullable String dataJson) {
         return serialize(gen -> {
             gen.writeStartObject();
@@ -101,6 +105,7 @@ public final class JsonRpcCodec {
         }
     }
 
+    /** Serializes a JSON-RPC request. */
     public static ByteBuf serializeRequest(Object id, String method, String paramsJson) {
         return serialize(gen -> {
             gen.writeStartObject();
@@ -113,6 +118,7 @@ public final class JsonRpcCodec {
         });
     }
 
+    /** Serializes a JSON-RPC notification (no ID). */
     public static ByteBuf serializeNotification(String method, String paramsJson) {
         return serialize(gen -> {
             gen.writeStartObject();
@@ -124,6 +130,7 @@ public final class JsonRpcCodec {
         });
     }
 
+    /** Serializes a JSON-RPC notification to a string. */
     public static String serializeNotificationAsString(String method, String paramsJson) {
         return serializeToString(gen -> {
             gen.writeStartObject();
@@ -135,6 +142,7 @@ public final class JsonRpcCodec {
         });
     }
 
+    /** Serializes a JSON-RPC request to a string. */
     public static String serializeRequestAsString(Object id, String method, String paramsJson) {
         return serializeToString(gen -> {
             gen.writeStartObject();
@@ -238,6 +246,7 @@ public final class JsonRpcCodec {
         };
     }
 
+    /** Reads the remainder of the current JSON value as a raw JSON string. */
     public static String readRawJson(JsonParser p) {
         var writer = new StringWriter();
         try (JsonGenerator gen = FACTORY.createGenerator(ObjectWriteContext.empty(), writer)) {
@@ -246,6 +255,7 @@ public final class JsonRpcCodec {
         return writer.toString();
     }
 
+    /** Reads the current JSON value as a {@link JsonNode}. */
     public static JsonNode readTreeValue(JsonParser p) throws IOException {
         return switch (p.currentToken()) {
             case START_OBJECT -> readObjectNode(p);
@@ -278,6 +288,7 @@ public final class JsonRpcCodec {
         return node;
     }
 
+    /** Deserializes a JSON string to a generic Java object (Map, List, String, Number, Boolean, or null). */
     public static @Nullable Object readValue(String json) {
         try (var p = FACTORY.createParser(ObjectReadContext.empty(), json)) {
             p.nextToken();
@@ -287,6 +298,7 @@ public final class JsonRpcCodec {
         }
     }
 
+    /** Reads the current JSON token as a generic Java value. */
     public static @Nullable Object readGenericValue(JsonParser p) throws IOException {
         return switch (p.currentToken()) {
             case START_OBJECT -> readObject(p);
@@ -319,6 +331,7 @@ public final class JsonRpcCodec {
         return list;
     }
 
+    /** Serializes a Java object to a JSON string, using registered codecs when available. */
     @Nullable
     @SuppressWarnings({"unchecked", "rawtypes"})
     public static String writeValueAsString(@Nullable Object value) {
@@ -346,6 +359,7 @@ public final class JsonRpcCodec {
         return ValueSerializer.writeValueAsString(value);
     }
 
+    /** Writes a Java object as a JSON value via the given generator. */
     public static void writeJsonValue(JsonGenerator gen, @Nullable Object value) {
         ValueSerializer.writeJsonValue(gen, value);
     }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/transport/jsonrpc/JsonRpcError.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/transport/jsonrpc/JsonRpcError.java
@@ -6,8 +6,16 @@ package dev.tachyonmcp.transport.jsonrpc;
 
 import org.jspecify.annotations.Nullable;
 
+/**
+ * A JSON-RPC error object.
+ *
+ * @param code    the error code
+ * @param message a short description of the error
+ * @param data    optional additional error data
+ */
 public record JsonRpcError(
         int code, String message, @Nullable String data) {
+    /** Creates an error with no additional data. */
     public JsonRpcError(int code, String message) {
         this(code, message, null);
     }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/transport/jsonrpc/JsonRpcErrors.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/transport/jsonrpc/JsonRpcErrors.java
@@ -4,37 +4,50 @@
 
 package dev.tachyonmcp.transport.jsonrpc;
 
+/** Standard JSON-RPC error codes and factory methods. */
 public final class JsonRpcErrors {
 
+    /** Invalid JSON was received. */
     public static final int PARSE_ERROR = -32700;
+    /** The JSON sent is not a valid Request object. */
     public static final int INVALID_REQUEST = -32600;
+    /** The method does not exist / is not available. */
     public static final int METHOD_NOT_FOUND = -32601;
+    /** Invalid method parameter(s). */
     public static final int INVALID_PARAMS = -32602;
+    /** Internal JSON-RPC error. */
     public static final int INTERNAL_ERROR = -32603;
+    /** Resource not found (custom error). */
     public static final int RESOURCE_NOT_FOUND = -32002;
 
     private JsonRpcErrors() {}
 
+    /** Creates a parse error. */
     public static JsonRpcError parseError() {
         return new JsonRpcError(PARSE_ERROR, "Parse error");
     }
 
+    /** Creates an invalid-request error with the given detail. */
     public static JsonRpcError invalidRequest(String detail) {
         return new JsonRpcError(INVALID_REQUEST, detail);
     }
 
+    /** Creates a method-not-found error with the given detail. */
     public static JsonRpcError methodNotFound(String detail) {
         return new JsonRpcError(METHOD_NOT_FOUND, detail);
     }
 
+    /** Creates an invalid-params error with the given detail. */
     public static JsonRpcError invalidParams(String detail) {
         return new JsonRpcError(INVALID_PARAMS, detail);
     }
 
+    /** Creates an internal-error with the given detail. */
     public static JsonRpcError internalError(String detail) {
         return new JsonRpcError(INTERNAL_ERROR, detail);
     }
 
+    /** Creates a resource-not-found error with the given detail. */
     public static JsonRpcError resourceNotFound(String detail) {
         return new JsonRpcError(RESOURCE_NOT_FOUND, detail);
     }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/transport/jsonrpc/JsonRpcMessage.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/transport/jsonrpc/JsonRpcMessage.java
@@ -7,11 +7,14 @@ package dev.tachyonmcp.transport.jsonrpc;
 import java.util.Objects;
 import org.jspecify.annotations.Nullable;
 
+/** A parsed JSON-RPC 2.0 message: request, notification, response, or error. */
 public sealed interface JsonRpcMessage {
 
+    /** The request/response ID, or {@code null} for notifications. */
     @Nullable
     Object id();
 
+    /** A JSON-RPC request with an ID (expecting a response). */
     record Request<T>(Object id, String method, @Nullable T params) implements JsonRpcMessage {
 
         public Request {
@@ -19,6 +22,7 @@ public sealed interface JsonRpcMessage {
         }
     }
 
+    /** A JSON-RPC success response. */
     record Response(Object id, String resultJson) implements JsonRpcMessage {
 
         public Response {
@@ -26,6 +30,7 @@ public sealed interface JsonRpcMessage {
         }
     }
 
+    /** A JSON-RPC error response. */
     record Error(
             Object id, int code, String message, @Nullable String dataJson) implements JsonRpcMessage {
 
@@ -34,6 +39,7 @@ public sealed interface JsonRpcMessage {
         }
     }
 
+    /** A JSON-RPC notification (no ID, no response expected). */
     record Notification<T>(String method, @Nullable T params) implements JsonRpcMessage {
 
         public Notification {

--- a/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/NettyServer.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/NettyServer.java
@@ -42,6 +42,7 @@ public final class NettyServer implements Closeable {
     private final Channel serverChannel;
     private final DefaultChannelGroup childChannels = new DefaultChannelGroup(GlobalEventExecutor.INSTANCE);
 
+    /** Returns the port the server is bound to. */
     public int port() {
         return ((InetSocketAddress) serverChannel.localAddress()).getPort();
     }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/NettyServerConfig.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/NettyServerConfig.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.function.Consumer;
 import org.jspecify.annotations.Nullable;
 
+/** Configuration for the Netty transport. */
 public record NettyServerConfig(
         String host,
         int port,
@@ -22,6 +23,7 @@ public record NettyServerConfig(
         @Nullable CorsConfig corsConfig,
         @Nullable Consumer<ChannelPipeline> pipelineCustomizer) {
 
+    /** Builds a CORS configuration from the given parameters. */
     public static CorsConfig buildCorsConfig(
             @Nullable List<String> allowedOrigins,
             boolean allowNullOrigin,

--- a/tachyon-server/src/test/java/dev/tachyonmcp/protocol/mcp/v2025_11_25/codecs/McpToolMapperTest.java
+++ b/tachyon-server/src/test/java/dev/tachyonmcp/protocol/mcp/v2025_11_25/codecs/McpToolMapperTest.java
@@ -285,16 +285,17 @@ class McpToolMapperTest {
 
     @Test
     void toDomainResultPreservesToolResult() {
-        var original = ToolResult.of(List.of(TextContent.of("hello")));
+        var original = ToolResult.blocks(TextContent.of("hello"));
         var result = McpToolMapper.toDomainResult(original);
         assertThat(result).isSameAs(original);
     }
 
     @Test
     void toDomainResultConvertsObject() {
-        var result = McpToolMapper.toDomainResult("test");
-        assertThat(result.content()).hasSize(1);
-        assertThat(((TextContent) result.content().getFirst()).text()).isEqualTo("test");
+        var result = (ToolResult.Success<?>) McpToolMapper.toDomainResult("test");
+        var content = result.content();
+        assertThat(content).hasSize(1);
+        assertThat(((TextContent) content.getFirst()).text()).isEqualTo("test");
     }
 
     @Test

--- a/tachyon-server/src/test/java/dev/tachyonmcp/server/ServerTest.java
+++ b/tachyon-server/src/test/java/dev/tachyonmcp/server/ServerTest.java
@@ -12,6 +12,7 @@ import dev.tachyonmcp.server.domain.TextResourceContents;
 import dev.tachyonmcp.server.features.prompts.PromptDescriptor;
 import dev.tachyonmcp.server.features.resources.ResourceDescriptor;
 import dev.tachyonmcp.server.features.tools.SyncToolHandler;
+import dev.tachyonmcp.server.features.tools.ToolArgs;
 import dev.tachyonmcp.server.features.tools.ToolResult;
 import dev.tachyonmcp.server.session.*;
 import java.util.ArrayList;
@@ -220,7 +221,7 @@ class ServerTest {
             session.connection(conn);
             session.activate();
 
-            server.registerTool(new SyncToolHandler<>() {
+            server.registerTool(new SyncToolHandler() {
                 @Override
                 public String name() {
                     return "dynamic-tool";
@@ -237,8 +238,8 @@ class ServerTest {
                 }
 
                 @Override
-                public ToolResult handle(McpContext context, Map<String, JsonNode> args) {
-                    return ToolResult.of();
+                public ToolResult<?> handle(McpContext context, ToolArgs args) {
+                    return ToolResult.empty();
                 }
             });
 
@@ -336,7 +337,7 @@ class ServerTest {
             var session = server.createSession("sess_init");
             session.connection(conn);
 
-            server.registerTool(new SyncToolHandler<>() {
+            server.registerTool(new SyncToolHandler() {
                 @Override
                 public String name() {
                     return "tool-during-init";
@@ -353,8 +354,8 @@ class ServerTest {
                 }
 
                 @Override
-                public ToolResult handle(McpContext context, Map<String, JsonNode> args) {
-                    return ToolResult.of();
+                public ToolResult<?> handle(McpContext context, ToolArgs args) {
+                    return ToolResult.empty();
                 }
             });
 

--- a/tachyon-server/src/test/java/dev/tachyonmcp/server/features/tools/AsyncToolHandlerTest.java
+++ b/tachyon-server/src/test/java/dev/tachyonmcp/server/features/tools/AsyncToolHandlerTest.java
@@ -1,0 +1,188 @@
+/* Copyright (c) 2026 Konstantin Pavlov. */
+
+package dev.tachyonmcp.server.features.tools;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import dev.tachyonmcp.server.session.McpContext;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import org.junit.jupiter.api.Test;
+
+class AsyncToolHandlerTest {
+
+    @Test
+    void descriptorUsesAllOptionalFields() {
+        var handler = new AsyncToolHandler() {
+            @Override
+            public String name() {
+                return "my-tool";
+            }
+
+            @Override
+            public CompletionStage<? extends ToolResult<?>> handleAsync(McpContext ctx, ToolArgs args) {
+                return CompletableFuture.completedFuture(ToolResult.text("ok"));
+            }
+        };
+        var desc = handler.descriptor();
+        assertThat(desc.name()).isEqualTo("my-tool");
+        assertThat(desc.title()).isNull();
+        assertThat(desc.description()).isNull();
+        assertThat(desc.inputSchema()).isNull();
+        assertThat(desc.outputSchema()).isNull();
+        assertThat(desc.taskSupport()).isNull();
+        assertThat(desc.annotations()).isNull();
+    }
+
+    @Test
+    void handleDelegatesToHandleAsync() throws Exception {
+        var handler = new AsyncToolHandler() {
+            @Override
+            public String name() {
+                return "t";
+            }
+
+            @Override
+            public CompletionStage<? extends ToolResult<?>> handleAsync(McpContext ctx, ToolArgs args) {
+                return CompletableFuture.completedFuture(ToolResult.text("async"));
+            }
+        };
+        var request = ToolRequest.builder().name("t").build();
+        var result = handler.handle(request, null).toCompletableFuture().join();
+        assertThat(result).isInstanceOf(ToolResult.Success.class);
+    }
+
+    @Test
+    void adaptWrapsSyncHandler() {
+        var sync = SyncToolHandler.of("sync-tool", null, null, (ctx, args) -> ToolResult.text("sync"));
+        var async = AsyncToolHandler.adapt(sync);
+        assertThat(async.name()).isEqualTo("sync-tool");
+        assertThat(async.descriptor().name()).isEqualTo("sync-tool");
+    }
+
+    @Test
+    void adaptRejectsNull() {
+        assertThatThrownBy(() -> AsyncToolHandler.adapt(null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("sync");
+    }
+
+    @Test
+    void adaptHandleAsyncReturnsSyncResult() throws Exception {
+        var sync = SyncToolHandler.of("t", null, null, (ctx, args) -> ToolResult.text("sync-result"));
+        var async = AsyncToolHandler.adapt(sync);
+        var result =
+                async.handleAsync(null, ToolArgs.of(null)).toCompletableFuture().join();
+        assertThat(result).isInstanceOf(ToolResult.Success.class);
+    }
+
+    @Test
+    void adaptHandleAsyncWrapsSyncException() {
+        var sync = SyncToolHandler.of("t", null, null, (ctx, args) -> {
+            throw new IllegalArgumentException("sync fail");
+        });
+        var async = AsyncToolHandler.adapt(sync);
+        assertThatThrownBy(() -> async.handleAsync(null, ToolArgs.of(null))
+                        .toCompletableFuture()
+                        .join())
+                .hasCauseInstanceOf(IllegalArgumentException.class)
+                .hasStackTraceContaining("sync fail");
+    }
+
+    @Test
+    void defaultTitleIsNull() {
+        var handler = new AsyncToolHandler() {
+            @Override
+            public String name() {
+                return "t";
+            }
+
+            @Override
+            public CompletionStage<? extends ToolResult<?>> handleAsync(McpContext ctx, ToolArgs args) {
+                return CompletableFuture.completedFuture(ToolResult.text("ok"));
+            }
+        };
+        assertThat(handler.title()).isNull();
+    }
+
+    @Test
+    void defaultDescriptionIsNull() {
+        var handler = new AsyncToolHandler() {
+            @Override
+            public String name() {
+                return "t";
+            }
+
+            @Override
+            public CompletionStage<? extends ToolResult<?>> handleAsync(McpContext ctx, ToolArgs args) {
+                return CompletableFuture.completedFuture(ToolResult.text("ok"));
+            }
+        };
+        assertThat(handler.description()).isNull();
+    }
+
+    @Test
+    void defaultInputSchemaIsNull() {
+        var handler = new AsyncToolHandler() {
+            @Override
+            public String name() {
+                return "t";
+            }
+
+            @Override
+            public CompletionStage<? extends ToolResult<?>> handleAsync(McpContext ctx, ToolArgs args) {
+                return CompletableFuture.completedFuture(ToolResult.text("ok"));
+            }
+        };
+        assertThat(handler.inputSchema()).isNull();
+    }
+
+    @Test
+    void defaultOutputSchemaIsNull() {
+        var handler = new AsyncToolHandler() {
+            @Override
+            public String name() {
+                return "t";
+            }
+
+            @Override
+            public CompletionStage<? extends ToolResult<?>> handleAsync(McpContext ctx, ToolArgs args) {
+                return CompletableFuture.completedFuture(ToolResult.text("ok"));
+            }
+        };
+        assertThat(handler.outputSchema()).isNull();
+    }
+
+    @Test
+    void defaultTaskSupportIsNull() {
+        var handler = new AsyncToolHandler() {
+            @Override
+            public String name() {
+                return "t";
+            }
+
+            @Override
+            public CompletionStage<? extends ToolResult<?>> handleAsync(McpContext ctx, ToolArgs args) {
+                return CompletableFuture.completedFuture(ToolResult.text("ok"));
+            }
+        };
+        assertThat(handler.taskSupport()).isNull();
+    }
+
+    @Test
+    void defaultAnnotationsIsNull() {
+        var handler = new AsyncToolHandler() {
+            @Override
+            public String name() {
+                return "t";
+            }
+
+            @Override
+            public CompletionStage<? extends ToolResult<?>> handleAsync(McpContext ctx, ToolArgs args) {
+                return CompletableFuture.completedFuture(ToolResult.text("ok"));
+            }
+        };
+        assertThat(handler.annotations()).isNull();
+    }
+}

--- a/tachyon-server/src/test/java/dev/tachyonmcp/server/features/tools/InvalidArgumentExceptionTest.java
+++ b/tachyon-server/src/test/java/dev/tachyonmcp/server/features/tools/InvalidArgumentExceptionTest.java
@@ -1,0 +1,35 @@
+/* Copyright (c) 2026 Konstantin Pavlov. */
+
+package dev.tachyonmcp.server.features.tools;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class InvalidArgumentExceptionTest {
+
+    @Test
+    void shouldStoreArgName() {
+        var e = new InvalidArgumentException("my-arg", "some message");
+        assertThat(e.argName()).isEqualTo("my-arg");
+    }
+
+    @Test
+    void shouldStoreMessage() {
+        var e = new InvalidArgumentException("my-arg", "some message");
+        assertThat(e.getMessage()).isEqualTo("some message");
+    }
+
+    @Test
+    void isRuntimeException() {
+        var e = new InvalidArgumentException("x", "y");
+        assertThat(e).isInstanceOf(RuntimeException.class);
+    }
+
+    @Test
+    void shouldAcceptEmptyMessage() {
+        var e = new InvalidArgumentException("arg", "");
+        assertThat(e.getMessage()).isEmpty();
+        assertThat(e.argName()).isEqualTo("arg");
+    }
+}

--- a/tachyon-server/src/test/java/dev/tachyonmcp/server/features/tools/ToolArgsTest.java
+++ b/tachyon-server/src/test/java/dev/tachyonmcp/server/features/tools/ToolArgsTest.java
@@ -1,0 +1,134 @@
+/* Copyright (c) 2026 Konstantin Pavlov. */
+
+package dev.tachyonmcp.server.features.tools;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.node.JsonNodeFactory;
+
+class ToolArgsTest {
+
+    private static final JsonNodeFactory JSON = JsonNodeFactory.instance;
+
+    @Test
+    void ofNullRawProducesEmptyArgs() {
+        var args = ToolArgs.of(null);
+        assertThat(args.isEmpty()).isTrue();
+    }
+
+    @Test
+    void ofNonNullRawProducesNonEmptyArgs() {
+        var args = ToolArgs.of(Map.of("key", JSON.textNode("val")));
+        assertThat(args.isEmpty()).isFalse();
+    }
+
+    @Test
+    void hasReturnsTrueForExistingKey() {
+        var args = ToolArgs.of(Map.of("k", JSON.textNode("v")));
+        assertThat(args.has("k")).isTrue();
+    }
+
+    @Test
+    void hasReturnsFalseForMissingKey() {
+        var args = ToolArgs.of(Map.of());
+        assertThat(args.has("k")).isFalse();
+    }
+
+    @Test
+    void stringReturnsValue() {
+        var args = ToolArgs.of(Map.of("k", JSON.textNode("hello")));
+        assertThat(args.string("k")).isEqualTo("hello");
+    }
+
+    @Test
+    void intValueReturnsValue() {
+        var args = ToolArgs.of(Map.of("k", JSON.numberNode(42)));
+        assertThat(args.intValue("k")).isEqualTo(42);
+    }
+
+    @Test
+    void boolValueReturnsValue() {
+        var args = ToolArgs.of(Map.of("k", JSON.booleanNode(true)));
+        assertThat(args.boolValue("k")).isTrue();
+    }
+
+    @Test
+    void doubleValueReturnsValue() {
+        var args = ToolArgs.of(Map.of("k", JSON.numberNode(3.14)));
+        assertThat(args.doubleValue("k")).isEqualTo(3.14);
+    }
+
+    @Test
+    void stringOptReturnsValueWhenPresent() {
+        var args = ToolArgs.of(Map.of("k", JSON.textNode("v")));
+        assertThat(args.stringOpt("k")).contains("v");
+    }
+
+    @Test
+    void stringOptReturnsEmptyWhenMissing() {
+        var args = ToolArgs.of(Map.of());
+        assertThat(args.stringOpt("k")).isEmpty();
+    }
+
+    @Test
+    void stringOrReturnsValueWhenPresent() {
+        var args = ToolArgs.of(Map.of("k", JSON.textNode("v")));
+        assertThat(args.stringOr("k", "def")).isEqualTo("v");
+    }
+
+    @Test
+    void stringOrReturnsFallbackWhenMissing() {
+        var args = ToolArgs.of(Map.of());
+        assertThat(args.stringOr("k", "def")).isEqualTo("def");
+    }
+
+    @Test
+    void nodeReturnsValueWhenPresent() {
+        var args = ToolArgs.of(Map.of("k", JSON.textNode("v")));
+        assertThat(args.node("k").asText()).isEqualTo("v");
+    }
+
+    @Test
+    void nodeThrowsWhenMissing() {
+        var args = ToolArgs.of(Map.of());
+        assertThatThrownBy(() -> args.node("k"))
+                .isInstanceOf(InvalidArgumentException.class)
+                .hasMessage("required argument missing");
+    }
+
+    @Test
+    void nodeThrowsWithArgName() {
+        var args = ToolArgs.of(Map.of());
+        assertThatThrownBy(() -> args.node("missingArg"))
+                .isInstanceOf(InvalidArgumentException.class)
+                .satisfies(e ->
+                        assertThat(((InvalidArgumentException) e).argName()).isEqualTo("missingArg"));
+    }
+
+    @Test
+    void rawReturnsNullForMissingKey() {
+        var args = ToolArgs.of(Map.of());
+        assertThat(args.raw("k")).isNull();
+    }
+
+    @Test
+    void rawReturnsValueForPresentKey() {
+        var args = ToolArgs.of(Map.of("k", JSON.textNode("v")));
+        assertThat(args.raw("k")).isNotNull();
+    }
+
+    @Test
+    void rawReturnsNullForDifferentMissingKey() {
+        var args = ToolArgs.of(Map.of("a", JSON.textNode("x")));
+        assertThat(args.raw("b")).isNull();
+    }
+
+    @Test
+    void rawReturnsNodeWithText() {
+        var args = ToolArgs.of(Map.of("k", JSON.textNode("v")));
+        assertThat(args.raw("k").asText()).isEqualTo("v");
+    }
+}

--- a/tachyon-server/src/test/java/dev/tachyonmcp/server/features/tools/ToolRegistryTest.java
+++ b/tachyon-server/src/test/java/dev/tachyonmcp/server/features/tools/ToolRegistryTest.java
@@ -24,6 +24,8 @@ import dev.tachyonmcp.transport.jsonrpc.JsonRpcErrors;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
 import org.jspecify.annotations.Nullable;
@@ -66,7 +68,7 @@ class ToolRegistryTest {
             """);
         var annotations = ToolAnnotations.of(null, true, false, true, false);
         registry.register(
-                new AbstractSyncToolHandler<>(ToolDescriptor.builder("full-tool")
+                new AbstractSyncToolHandler(ToolDescriptor.builder("full-tool")
                         .title("Full Tool")
                         .description("Does everything")
                         .inputSchema(TEST_SCHEMA)
@@ -75,7 +77,7 @@ class ToolRegistryTest {
                         .annotations(annotations)
                         .build()) {
                     @Override
-                    public ToolResult handle(McpContext context, Map<String, JsonNode> arguments) {
+                    public ToolResult<?> handle(McpContext context, ToolArgs args) {
                         return ToolResult.text("ok");
                     }
                 });
@@ -246,10 +248,10 @@ class ToolRegistryTest {
         var handlers = new HashMap<String, McpMethodHandler>();
         registry.registerHandlers(handlers);
         registry.register(
-                new AbstractSyncToolHandler<>(
+                new AbstractSyncToolHandler(
                         ToolDescriptor.builder("ts-tool").taskSupport(enumValue).build()) {
                     @Override
-                    public ToolResult handle(McpContext context, Map<String, JsonNode> arguments) {
+                    public ToolResult<?> handle(McpContext context, ToolArgs args) {
                         return ToolResult.text("ok");
                     }
                 });
@@ -301,12 +303,12 @@ class ToolRegistryTest {
         registry.registerHandlers(handlers);
         var icon = Icon.of("https://example.com/tool-icon.png", "image/png", null, null);
         registry.register(
-                new AbstractSyncToolHandler<>(ToolDescriptor.builder("icon-tool")
+                new AbstractSyncToolHandler(ToolDescriptor.builder("icon-tool")
                         .description("Tool with icon")
                         .icons(List.of(icon))
                         .build()) {
                     @Override
-                    public ToolResult handle(McpContext context, Map<String, JsonNode> arguments) {
+                    public ToolResult<?> handle(McpContext context, ToolArgs args) {
                         return ToolResult.text("ok");
                     }
                 });
@@ -322,7 +324,206 @@ class ToolRegistryTest {
         assertThat(tool.icons().getFirst().mimeType()).isEqualTo("image/png");
     }
 
-    private static class TestTool extends AbstractSyncToolHandler<ToolResult> {
+    @Test
+    void getDescriptorReturnsNullForMissingTool() {
+        assertThat(registry.getDescriptor("nonexistent")).isNull();
+    }
+
+    @Test
+    void getDescriptorReturnsDescriptorForRegisteredTool() {
+        registry.register(new TestTool("desc-tool", "test desc", null));
+        var desc = registry.getDescriptor("desc-tool");
+        assertThat(desc).isNotNull();
+        assertThat(desc.name()).isEqualTo("desc-tool");
+        assertThat(desc.description()).isEqualTo("test desc");
+    }
+
+    @Test
+    void getAllReturnsAllHandlers() {
+        registry.register(new TestTool("t1", null, null));
+        registry.register(new TestTool("t2", null, null));
+        assertThat(registry.getAll()).hasSize(2);
+    }
+
+    @Test
+    void isEmptyReturnsTrueWhenEmpty() {
+        assertThat(registry.isEmpty()).isTrue();
+    }
+
+    @Test
+    void isEmptyReturnsFalseWhenNotEmpty() {
+        registry.register(new TestTool("t", null, null));
+        assertThat(registry.isEmpty()).isFalse();
+    }
+
+    @Test
+    void listWithZeroLimitUsesDefaultPageSize() {
+        registry.register(new TestTool("a", null, null));
+        registry.register(new TestTool("b", null, null));
+        var result = registry.list(0, null);
+        assertThat(result.items()).hasSize(2);
+    }
+
+    @Test
+    void listWithCursorSkipsPastCursor() {
+        registry.register(new TestTool("alpha", null, null));
+        registry.register(new TestTool("beta", null, null));
+        registry.register(new TestTool("gamma", null, null));
+        var result = registry.list(1, "alpha");
+        assertThat(result.items()).hasSize(1);
+        assertThat(result.items().getFirst().name()).isEqualTo("beta");
+    }
+
+    @Test
+    void listWithFilterExcludesMismatched() {
+        registry.register(new TestTool("keep", null, null));
+        registry.register(new TestTool("skip", null, null));
+        var result = registry.list(50, null, d -> d.name().startsWith("k"));
+        assertThat(result.items()).hasSize(1);
+        assertThat(result.items().getFirst().name()).isEqualTo("keep");
+    }
+
+    @Test
+    void listWithCustomDefaultLimit() {
+        registry.register(new TestTool("a", null, null));
+        registry.register(new TestTool("b", null, null));
+        var result = registry.list(0, null, 1);
+        assertThat(result.items()).hasSize(1);
+    }
+
+    @Test
+    void listReturnsCursorWhenMoreItemsAvailable() {
+        registry.register(new TestTool("a", null, null));
+        registry.register(new TestTool("b", null, null));
+        var result = registry.list(1, null);
+        assertThat(result.nextCursor()).isEqualTo("a");
+    }
+
+    @Test
+    void listReturnsNullCursorWhenAllItemsReturned() {
+        registry.register(new TestTool("a", null, null));
+        var result = registry.list(10, null);
+        assertThat(result.nextCursor()).isNull();
+    }
+
+    @Test
+    void parseLimitFromNumber() {
+        var params = Map.<String, Object>of("limit", 5);
+        assertThat(ToolRegistry.parseLimit(params)).isEqualTo(5);
+    }
+
+    @Test
+    void parseLimitFromNonNumberReturnsZero() {
+        var params = Map.<String, Object>of("limit", "not-a-number");
+        assertThat(ToolRegistry.parseLimit(params)).isZero();
+    }
+
+    @Test
+    void parseLimitFromNullParamsReturnsZero() {
+        assertThat(ToolRegistry.parseLimit(null)).isZero();
+    }
+
+    @Test
+    void parseLimitFromEmptyMapReturnsZero() {
+        assertThat(ToolRegistry.parseLimit(Map.of())).isZero();
+    }
+
+    @Test
+    void parseCursorFromString() {
+        var params = Map.<String, Object>of("cursor", "abc");
+        assertThat(ToolRegistry.parseCursor(params)).isEqualTo("abc");
+    }
+
+    @Test
+    void parseCursorFromNonStringReturnsNull() {
+        var params = Map.<String, Object>of("cursor", 123);
+        assertThat(ToolRegistry.parseCursor(params)).isNull();
+    }
+
+    @Test
+    void parseCursorFromNullParamsReturnsNull() {
+        assertThat(ToolRegistry.parseCursor(null)).isNull();
+    }
+
+    @Test
+    void parseCursorFromEmptyMapReturnsNull() {
+        assertThat(ToolRegistry.parseCursor(Map.of())).isNull();
+    }
+
+    @Test
+    void registerThrowsOnNullHandler() {
+        assertThatThrownBy(() -> registry.register(null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("ToolHandler");
+    }
+
+    @Test
+    void registerThrowsOnNullDescriptor() {
+        var handler = new ToolHandler() {
+            @Override
+            public ToolDescriptor descriptor() {
+                return null;
+            }
+
+            @Override
+            public CompletionStage<? extends ToolResult<?>> handle(ToolRequest request, McpContext context) {
+                return CompletableFuture.completedFuture(ToolResult.text("x"));
+            }
+        };
+        assertThatThrownBy(() -> registry.register(handler))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("ToolDescriptor");
+    }
+
+    @Test
+    void getReturnsNullForMissingTool() {
+        assertThat(registry.get("nonexistent")).isNull();
+    }
+
+    @Test
+    void removeNonExistentToolDoesNotThrow() {
+        registry.remove("nonexistent");
+        assertThat(registry.get("nonexistent")).isNull();
+    }
+
+    @Test
+    void registryResetBetweenTests() {
+        assertThat(registry.isEmpty()).isTrue();
+    }
+
+    @Test
+    void registerHandlersAddsBothMethods() {
+        var handlers = new java.util.HashMap<String, McpMethodHandler>();
+        registry.registerHandlers(handlers);
+        assertThat(handlers).containsOnlyKeys("tools/list", "tools/call");
+    }
+
+    @Test
+    void toolsListHandlerMethodName() {
+        var handlers = new java.util.HashMap<String, McpMethodHandler>();
+        registry.registerHandlers(handlers);
+        assertThat(handlers.get("tools/list").method()).isEqualTo("tools/list");
+    }
+
+    @Test
+    void toolsCallHandlerMethodName() {
+        var handlers = new java.util.HashMap<String, McpMethodHandler>();
+        registry.registerHandlers(handlers);
+        assertThat(handlers.get("tools/call").method()).isEqualTo("tools/call");
+    }
+
+    @Test
+    void shouldFireOnChangeWhenToolReRegistered() {
+        registry.register(new TestTool("re-register", null, null));
+
+        var callCount = new AtomicInteger(0);
+        registry.onChange(callCount::incrementAndGet);
+
+        registry.register(new TestTool("re-register", null, null));
+        assertThat(callCount).hasValue(1);
+    }
+
+    private static class TestTool extends AbstractSyncToolHandler {
 
         TestTool(String name, @Nullable String description, @Nullable JsonNode schema) {
             super(ToolDescriptor.builder(name)
@@ -332,7 +533,7 @@ class ToolRegistryTest {
         }
 
         @Override
-        public ToolResult handle(McpContext context, Map<String, JsonNode> arguments) {
+        public ToolResult<?> handle(McpContext context, ToolArgs args) {
             return ToolResult.text("ok");
         }
     }

--- a/tachyon-server/src/test/java/dev/tachyonmcp/server/features/tools/ToolRequestTest.java
+++ b/tachyon-server/src/test/java/dev/tachyonmcp/server/features/tools/ToolRequestTest.java
@@ -1,0 +1,112 @@
+/* Copyright (c) 2026 Konstantin Pavlov. */
+
+package dev.tachyonmcp.server.features.tools;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.JsonNodeFactory;
+
+class ToolRequestTest {
+
+    private static final JsonNodeFactory JSON = JsonNodeFactory.instance;
+
+    @Test
+    void builderSetsName() {
+        var req = ToolRequest.builder().name("my-tool").build();
+        assertThat(req.name()).isEqualTo("my-tool");
+    }
+
+    @Test
+    void argumentsDefaultsToEmptyMap() {
+        var req = ToolRequest.builder().name("t").build();
+        assertThat(req.arguments()).isEmpty();
+    }
+
+    @Test
+    void builderSetsArguments() {
+        var args = Map.of("k", JSON.textNode("v"));
+        var req = ToolRequest.builder().name("t").arguments(args).build();
+        assertThat(req.arguments()).isEqualTo(args);
+    }
+
+    @Test
+    void metaIsNullable() {
+        var req = ToolRequest.builder().name("t").build();
+        assertThat(req.meta()).isNull();
+    }
+
+    @Test
+    void builderSetsMeta() {
+        var meta = Map.of("mk", JSON.textNode("mv"));
+        var req = ToolRequest.builder().name("t").meta(meta).build();
+        assertThat(req.meta()).isEqualTo(meta);
+    }
+
+    @Test
+    void progressTokenIsNullable() {
+        var req = ToolRequest.builder().name("t").build();
+        assertThat(req.progressToken()).isNull();
+    }
+
+    @Test
+    void builderSetsProgressToken() {
+        var req = ToolRequest.builder().name("t").progressToken(42L).build();
+        assertThat(req.progressToken()).isEqualTo(42L);
+    }
+
+    @Test
+    void cancellationIsNullable() {
+        var req = ToolRequest.builder().name("t").build();
+        assertThat(req.cancellation()).isNull();
+    }
+
+    @Test
+    void inputResponsesIsNullable() {
+        var req = ToolRequest.builder().name("t").build();
+        assertThat(req.inputResponses()).isNull();
+    }
+
+    @Test
+    void requestStateIsNullable() {
+        var req = ToolRequest.builder().name("t").build();
+        assertThat(req.requestState()).isNull();
+    }
+
+    @Test
+    void ofFactoryWithAllParams() {
+        Map<String, JsonNode> args = Map.of("k", JSON.textNode("v"));
+        Map<String, JsonNode> meta = Map.of("m", JSON.textNode("mv"));
+        var req = ToolRequest.of("my-tool", args, meta, 99L, null);
+        assertThat(req.name()).isEqualTo("my-tool");
+        assertThat(req.arguments()).isEqualTo(args);
+        assertThat(req.meta()).isEqualTo(meta);
+        assertThat(req.progressToken()).isEqualTo(99L);
+        assertThat(req.cancellation()).isNull();
+    }
+
+    @Test
+    void ofFactoryWithNullArgumentsDefaultsToEmpty() {
+        var req = ToolRequest.of("my-tool", null, null);
+        assertThat(req.arguments()).isEmpty();
+        assertThat(req.meta()).isNull();
+    }
+
+    @Test
+    void ofFactoryWithThreeParams() {
+        Map<String, JsonNode> args = Map.of("k", JSON.textNode("v"));
+        var req = ToolRequest.of("my-tool", args, null);
+        assertThat(req.name()).isEqualTo("my-tool");
+        assertThat(req.arguments()).isEqualTo(args);
+    }
+
+    @Test
+    void metaIsAccessibleWhenPresent() {
+        Map<String, JsonNode> meta = Map.of("k", JSON.textNode("v"));
+        var req = ToolRequest.builder().name("t").meta(meta).build();
+        assertThat(req.meta()).isNotNull();
+        assertThat(req.meta().get("k").asText()).isEqualTo("v");
+    }
+}

--- a/tachyon-server/src/test/java/dev/tachyonmcp/server/features/tools/ToolResultTest.java
+++ b/tachyon-server/src/test/java/dev/tachyonmcp/server/features/tools/ToolResultTest.java
@@ -1,0 +1,162 @@
+/* Copyright (c) 2026 Konstantin Pavlov. */
+
+package dev.tachyonmcp.server.features.tools;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.tachyonmcp.server.domain.InputRequest;
+import dev.tachyonmcp.server.domain.TextContent;
+import dev.tachyonmcp.server.domain.UrlInputRequest;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.JsonNodeFactory;
+
+class ToolResultTest {
+
+    private static final JsonNodeFactory JSON = JsonNodeFactory.instance;
+
+    @Test
+    void blocksWithNoArgsIsEmptySuccess() {
+        var r = ToolResult.blocks();
+        assertThat(r).isInstanceOf(ToolResult.Success.class);
+        assertThat(((ToolResult.Success<?>) r).content()).isEmpty();
+    }
+
+    @Test
+    void successAllowsNullStructuredAndEmptyContent() {
+        var r = new ToolResult.Success<>(null, List.of());
+        assertThat(r.structured()).isEmpty();
+        assertThat(r.content()).isEmpty();
+    }
+
+    @Test
+    void successWithStructuredAndNoContentIsAllowed() {
+        var r = new ToolResult.Success<>("data", List.of());
+        assertThat(r.structured()).contains("data");
+        assertThat(r.content()).isEmpty();
+    }
+
+    @Test
+    void textFactoryProducesTextContentBlock() {
+        var r = ToolResult.text("hello");
+        assertThat(r).isInstanceOf(ToolResult.Success.class);
+        var s = (ToolResult.Success<?>) r;
+        assertThat(s.content()).hasSize(1);
+        assertThat(((TextContent) s.content().getFirst()).text()).isEqualTo("hello");
+        assertThat(s.structured()).isEmpty();
+    }
+
+    @Test
+    void withMetaMergesNotNests() {
+        var base = ToolResult.text("x").withMeta("a", JSON.numberNode(1));
+        var merged = base.withMeta("b", JSON.numberNode(2));
+
+        assertThat(merged).isInstanceOf(ToolResult.WithMeta.class);
+        var wm = (ToolResult.WithMeta<?>) merged;
+        assertThat(wm.inner()).isNotInstanceOf(ToolResult.WithMeta.class);
+        assertThat(wm.meta()).containsKey("a").containsKey("b");
+    }
+
+    @Test
+    void withMetaKeyOverridesMerges() {
+        var base = ToolResult.text("x").withMeta("k", JSON.numberNode(1));
+        var updated = base.withMeta("k", JSON.numberNode(99));
+
+        var wm = (ToolResult.WithMeta<?>) updated;
+        assertThat(wm.meta().get("k").asLong()).isEqualTo(99);
+    }
+
+    @Test
+    void withMetaEmptyMapReturnsThis() {
+        var r = ToolResult.text("x");
+        assertThat(r.withMeta(Map.of())).isSameAs(r);
+    }
+
+    @Test
+    void withMetaImmutability() {
+        var source = new HashMap<String, JsonNode>();
+        source.put("k", JSON.numberNode(1));
+        var r = ToolResult.text("x").withMeta(source);
+        source.put("injected", JSON.numberNode(99));
+        var wm = (ToolResult.WithMeta<?>) r;
+        assertThat(wm.meta()).doesNotContainKey("injected");
+    }
+
+    @Test
+    void successContentIsDefensiveCopy() {
+        var list = new java.util.ArrayList<dev.tachyonmcp.server.domain.ContentBlock>();
+        list.add(TextContent.of("a"));
+        var r = new ToolResult.Success<>(null, list);
+        list.add(TextContent.of("b"));
+        assertThat(r.content()).hasSize(1);
+    }
+
+    @Test
+    void errorIsErrorResult() {
+        ToolResult<Object> err = ToolResult.error("boom");
+
+        assertThat(err).isInstanceOf(ToolResult.ErrorResult.class);
+        assertThat(((ToolResult.ErrorResult) err).message()).isEqualTo("boom");
+    }
+
+    @Test
+    void emptyIsSuccessWithoutContent() {
+        ToolResult<Object> empty = ToolResult.empty();
+
+        assertThat(empty).isInstanceOf(ToolResult.Success.class);
+        var success = (ToolResult.Success<?>) empty;
+        assertThat(success.structuredValue()).isNull();
+        assertThat(success.content()).isEmpty();
+    }
+
+    @Test
+    void failureCanCarryMeta() {
+        ToolResult<Object> err = ToolResult.error("oops").withMeta("trace", JSON.stringNode("id-1"));
+        assertThat(err).isInstanceOf(ToolResult.WithMeta.class);
+        var wm = (ToolResult.WithMeta<?>) err;
+        assertThat(wm.inner()).isInstanceOf(ToolResult.ErrorResult.class);
+        assertThat(wm.meta().get("trace").asString()).isEqualTo("id-1");
+    }
+
+    @Test
+    void inputRequiredFactory() {
+        var req = new LinkedHashMap<String, InputRequest>();
+        req.put("field", UrlInputRequest.of("authenticate", "elic-1", "https://example.com/auth"));
+        var r = ToolResult.inputRequired(req, "state-1");
+        assertThat(r).isInstanceOf(ToolResult.InputRequired.class);
+        var ir = (ToolResult.InputRequired) r;
+        assertThat(ir.inputRequests()).containsOnlyKeys("field");
+        assertThat(ir.requestState()).isEqualTo("state-1");
+    }
+
+    @Test
+    void inputRequiredWithNullState() {
+        var req = Map.<String, dev.tachyonmcp.server.domain.InputRequest>of();
+        var r = ToolResult.inputRequired(req, null);
+        assertThat(r).isInstanceOf(ToolResult.InputRequired.class);
+        assertThat(((ToolResult.InputRequired) r).requestState()).isNull();
+    }
+
+    @Test
+    void ofFactoryWithPayload() {
+        ToolResult<Integer> r = ToolResult.of(42);
+        assertThat(r).isInstanceOf(ToolResult.Success.class);
+        var s = (ToolResult.Success<Integer>) r;
+        assertThat(s.structured()).contains(42);
+        assertThat(s.content()).isNotEmpty();
+    }
+
+    @Test
+    void ofFactoryWithPayloadAndText() {
+        ToolResult<String> r = ToolResult.of("data", "custom text");
+        assertThat(r).isInstanceOf(ToolResult.Success.class);
+        var s = (ToolResult.Success<String>) r;
+        assertThat(s.structured()).contains("data");
+        assertThat(((dev.tachyonmcp.server.domain.TextContent) s.content().getFirst()).text())
+                .isEqualTo("custom text");
+    }
+}

--- a/tachyon-server/src/test/java/dev/tachyonmcp/transport/netty/McpOperationHandlerRequestTest.java
+++ b/tachyon-server/src/test/java/dev/tachyonmcp/transport/netty/McpOperationHandlerRequestTest.java
@@ -52,14 +52,14 @@ class McpOperationHandlerRequestTest {
             .build();
 
     /** Emits two progress notifications (which upgrade the POST response to SSE), then returns a result. */
-    private static final ToolHandler<ToolResult> PROGRESS_TOOL = new ToolHandler<>() {
+    private static final ToolHandler PROGRESS_TOOL = new ToolHandler() {
         @Override
         public ToolDescriptor descriptor() {
             return PROGRESS_DESCRIPTOR;
         }
 
         @Override
-        public CompletionStage<ToolResult> handle(ToolRequest request, McpContext ctx) {
+        public CompletionStage<ToolResult<?>> handle(ToolRequest request, McpContext ctx) {
             var pt = request.progressToken();
             ctx.notifications().progress(pt, 0, 100, "Starting");
             ctx.notifications().progress(pt, 100, 100, "Complete");
@@ -169,15 +169,15 @@ class McpOperationHandlerRequestTest {
                         .putObject("properties"))
                 .build();
         var upgraded = new CountDownLatch(1);
-        var neverComplete = new CompletableFuture<ToolResult>();
-        ToolHandler<ToolResult> stalledTool = new ToolHandler<>() {
+        var neverComplete = new CompletableFuture<ToolResult<?>>();
+        ToolHandler stalledTool = new ToolHandler() {
             @Override
             public ToolDescriptor descriptor() {
                 return descriptor;
             }
 
             @Override
-            public CompletionStage<ToolResult> handle(ToolRequest request, McpContext ctx) {
+            public CompletionStage<ToolResult<?>> handle(ToolRequest request, McpContext ctx) {
                 ctx.notifications().progress(request.progressToken(), 0, 100, "working");
                 upgraded.countDown();
                 return neverComplete;

--- a/tachyon-server/src/test/java/dev/tachyonmcp/transport/netty/NettyServerThreadingTest.java
+++ b/tachyon-server/src/test/java/dev/tachyonmcp/transport/netty/NettyServerThreadingTest.java
@@ -10,17 +10,15 @@ import dev.tachyonmcp.server.McpDispatcher;
 import dev.tachyonmcp.server.McpServer;
 import dev.tachyonmcp.server.TachyonServer;
 import dev.tachyonmcp.server.features.tools.AbstractSyncToolHandler;
+import dev.tachyonmcp.server.features.tools.ToolArgs;
 import dev.tachyonmcp.server.features.tools.ToolResult;
 import dev.tachyonmcp.server.session.McpContext;
-import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
-import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
-import tools.jackson.databind.JsonNode;
 
 @Execution(ExecutionMode.SAME_THREAD)
 class NettyServerThreadingTest {
@@ -30,10 +28,10 @@ class NettyServerThreadingTest {
         var handlerThread = new CompletableFuture<String>();
 
         try (McpServer server = TachyonServer.builder()
-                        .tool(new AbstractSyncToolHandler<>("thread_probe") {
+                        .tool(new AbstractSyncToolHandler("thread_probe") {
 
                             @Override
-                            public ToolResult handle(McpContext context, @Nullable Map<String, JsonNode> args) {
+                            public ToolResult<?> handle(McpContext context, ToolArgs args) {
                                 Thread thread = Thread.currentThread();
                                 handlerThread.complete(thread.getName() + " virtual:" + thread.isVirtual());
                                 return ToolResult.empty();

--- a/tachyon-server/src/test/java/dev/tachyonmcp/transport/netty/NotificationDeliveryTest.java
+++ b/tachyon-server/src/test/java/dev/tachyonmcp/transport/netty/NotificationDeliveryTest.java
@@ -42,7 +42,7 @@ class NotificationDeliveryTest {
         }
 
         @Override
-        public CompletionStage<ToolResult> handle(ToolRequest request, McpContext ctx) {
+        public CompletionStage<ToolResult<?>> handle(ToolRequest request, McpContext ctx) {
             var pt = request.progressToken();
             ctx.notifications().progress(pt, 0, 100, "Starting");
             ctx.notifications().progress(pt, 50, 100, "Halfway");


### PR DESCRIPTION
Refactor the tool-handler API across the codebase: `ToolHandler`, `SyncToolHandler`, and `AsyncToolHandler` become non-generic, argument access moves from `Map<String, JsonNode>` to a new `ToolArgs` class, and `ToolResult` becomes a generic sealed interface with `Success`, `ErrorResult`, `WithMeta`, and `InputRequired` record variants. Protocol mappers, registry logic, examples, and tests are updated accordingly, and a new `InvalidArgumentException` is introduced for argument validation.