### PR TITLE
feat!: Async handler pipeline, injectable executor & coroutine-first Kotlin DSL

### DIFF
--- a/.agents/skills/tachyon-mcp/SKILL.md
+++ b/.agents/skills/tachyon-mcp/SKILL.md
@@ -13,7 +13,7 @@ Make **Java 21+** MCP server. Tachyon lib. Transport = Streamable HTTP (Netty).
 ## Core
 
 - `TachyonServer.builder()` → `ServerBuilder`. Start here.
-- `.bind()` → build `McpServer` + Netty transport → `McpServerHandle` (`Closeable`).
+- `.start()` (blocking) / `.startAsync()` (non-blocking) → build `McpServer` + Netty transport → `McpServerHandle` (`Closeable`).
 - `.build()` → `McpServer` only, no transport.
 - `McpServerHandle`: `.server()`, `.port()`.
 - `McpContext` → session + notifications + server ctx. Every handler gets it.
@@ -25,7 +25,7 @@ var handle = TachyonServer.builder()
     .name("my-server")
     .version("1.0")
     .port(8080)
-    .bind();
+    .start();
 // handle.port() → real bound port (matters when port=0)
 ```
 
@@ -131,7 +131,7 @@ Default `AUTO` → advertised only when registered. Force with `Mode.ON` / `Mode
 | Method | Default |
 |---|---|
 | `.host(s)` | `127.0.0.1` |
-| `.port(p)` | **required** before `bind()` |
+| `.port(p)` | **required** before `start()` |
 | `.endpointPath(p)` | `/mcp` |
 | `.readerIdleTimeout(d)` / `.writerIdleTimeout(d)` | 60s / 5min |
 | `.maxContentLength(b)` | 1MB |

--- a/.agents/skills/tachyon-mcp/SKILL.md
+++ b/.agents/skills/tachyon-mcp/SKILL.md
@@ -179,6 +179,54 @@ Register: `.extension(myExtension)`
 - E2E: `io.modelcontextprotocol.sdk:mcp-core:2.0.0-RC1` client.
 - `mvn test` (unit+e2e) · `mvn verify` (+conformance) · `mvn spotless:apply`.
 
+## Kotlin DSL
+
+Also available — Kotlin DSL with suspend tool handlers, `buildServer { }`, and `TachyonServer { }`.
+
+```kotlin
+// buildServer {} → McpServer without transport
+// TachyonServer(port) {} → McpServerHandle with Netty transport
+
+val handle = TachyonServer(port = 8080) {
+    info {
+        name = "demo-server"
+        version = "1.0"
+        description = "Demo MCP server"
+    }
+    capabilities {
+        tools(true)
+        resources(true, true)
+        prompts(true)
+    }
+    tool(name = "ping", description = "Simple ping") {
+        ToolResult.text("pong")
+    }
+    resource(
+        name = "config",
+        uri = "demo://config",
+        description = "Server configuration",
+    ) {
+        TextResourceContents.of(uri, "application/json", """{"mode":"production"}""")
+    }
+    prompt(name = "greet", description = "Generates a greeting") { _ ->
+        listOf(PromptMessage.user("Say hello"))
+    }
+}
+```
+
+Post-build registration with `registerTool`:
+
+```kotlin
+server.registerTool(
+    ToolDescriptor.builder("reverse-echo")
+        .description("Echo reversed message")
+        .inputSchema(schema)
+        .build(),
+) {
+    ToolResult.text(args.string("message").reversed())
+}
+```
+
 ## Resource files
 
 Load on demand (next to this skill):
@@ -188,3 +236,7 @@ Load on demand (next to this skill):
 - `resources/java/ResourceHandlerExample.java` — `ResourceDescriptor`, `ResourceTemplateEntry`, `ResourceHandler`
 - `resources/java/PromptHandlerExample.java` — `PromptDescriptor`, `PromptArgument`, `PromptHandler`
 - `resources/java/ConfigReference.java` — `CapabilitiesConfig.Builder`, `NetworkConfig.Builder`, `SessionConfig.Builder`
+- `resources/kotlin/ServerBasic.kt` — full server, all features (Kotlin DSL)
+- `resources/kotlin/ToolHandlerExample.kt` — suspend handler, `AbstractSyncToolHandler`, `AbstractAsyncToolHandler`, `registerTool`
+- `resources/kotlin/ResourceHandlerExample.kt` — static resources, URI templates (Kotlin DSL)
+- `resources/kotlin/PromptHandlerExample.kt` — prompt descriptors and handlers (Kotlin DSL)

--- a/.agents/skills/tachyon-mcp/SKILL.md
+++ b/.agents/skills/tachyon-mcp/SKILL.md
@@ -183,7 +183,7 @@ Register: `.extension(myExtension)`
 
 Load on demand (next to this skill):
 
-- `resources/java/ServerBasic.java` — full server, all features
+- [resources/java/ServerBasic.java](resources/java/ServerBasic.java) — full server, all features
 - `resources/java/ToolHandlerExample.java` — `ToolDescriptor`, `SyncToolHandler.of()`, `AbstractSyncToolHandler`
 - `resources/java/ResourceHandlerExample.java` — `ResourceDescriptor`, `ResourceTemplateEntry`, `ResourceHandler`
 - `resources/java/PromptHandlerExample.java` — `PromptDescriptor`, `PromptArgument`, `PromptHandler`

--- a/.agents/skills/tachyon-mcp/resources/java/ServerBasic.java
+++ b/.agents/skills/tachyon-mcp/resources/java/ServerBasic.java
@@ -40,7 +40,7 @@ public final class ServerBasic {
                         PromptDescriptor.of("greet", "Generates a greeting"),
                         args -> List.of(PromptMessage.user("Say hello")))
                 .port(port)
-                .bind();
+                .start();
 
         handle.server()
                 .resources()

--- a/.agents/skills/tachyon-mcp/resources/kotlin/PromptHandlerExample.kt
+++ b/.agents/skills/tachyon-mcp/resources/kotlin/PromptHandlerExample.kt
@@ -1,0 +1,35 @@
+// Copyright (c) 2026 Konstantin Pavlov.
+
+package dev.tachyonmcp.skill
+
+import dev.tachyonmcp.server.domain.PromptArgument
+import dev.tachyonmcp.server.domain.PromptMessage
+import dev.tachyonmcp.server.features.prompts.PromptDescriptor
+import dev.tachyonmcp.server.promptMessagesOf
+import dev.tachyonmcp.server.promptArgument
+import dev.tachyonmcp.server.promptDescriptor
+
+/**
+ * Demonstrates prompt descriptor construction patterns.
+ */
+
+/** Simplest — name + description. */
+fun simpleDescriptor(): PromptDescriptor =
+    PromptDescriptor.of("rewrite-forecast", "Rewrites a weather forecast in a given style")
+
+/** With typed arguments. */
+fun argDescriptor(): PromptDescriptor =
+    promptDescriptor("rewrite") {
+        description = "Rewrites text in a style"
+        title = "Rewrite Tool"
+        arguments = listOf(
+            promptArgument(name = "text", description = "Original text", required = true),
+            promptArgument(name = "style", description = "Desired writing style", required = false),
+        )
+    }
+
+/** Handler that reads the argument. */
+fun argHandler(args: String?): List<PromptMessage> {
+    val text = args ?: "default text"
+    return promptMessagesOf(PromptMessage.user("Rewrite this: $text"))
+}

--- a/.agents/skills/tachyon-mcp/resources/kotlin/ResourceHandlerExample.kt
+++ b/.agents/skills/tachyon-mcp/resources/kotlin/ResourceHandlerExample.kt
@@ -1,0 +1,47 @@
+// Copyright (c) 2026 Konstantin Pavlov.
+
+package dev.tachyonmcp.skill
+
+import dev.tachyonmcp.server.domain.TextResourceContents
+import dev.tachyonmcp.server.features.resources.ResourceDescriptor
+import dev.tachyonmcp.server.features.resources.ResourceTemplateEntry
+
+/**
+ * Demonstrates static resource URI and template construction.
+ */
+
+/** Static resource descriptor — fixed URI. */
+fun configDescriptor(): ResourceDescriptor =
+    ResourceDescriptor.of(
+        "server-config",
+        "myapp://config",
+        "Server configuration",
+        "application/json",
+    )
+
+/** URI template — {param} segments captured at runtime. */
+fun userProfileTemplate(): ResourceTemplateEntry =
+    ResourceTemplateEntry.of(
+        "user-profile",
+        "myapp://users/{userId}/profile",
+        "User profile data",
+        "application/json",
+    ) { _, uri, params ->
+        val userId = params["userId"]
+        TextResourceContents.of(uri, "application/json", """{"userId":"$userId"}""")
+    }
+
+/** URI template — multi-segment with static prefix matching. */
+fun forecastTemplate(): ResourceTemplateEntry =
+    ResourceTemplateEntry.of(
+        "forecast",
+        "weather://forecast/{city}",
+        "Weather forecast for a city",
+        "application/json",
+    ) { _, uri, params ->
+        TextResourceContents.of(
+            uri,
+            "application/json",
+            """{"city":"${params["city"]}","temp":22}""",
+        )
+    }

--- a/.agents/skills/tachyon-mcp/resources/kotlin/ServerBasic.kt
+++ b/.agents/skills/tachyon-mcp/resources/kotlin/ServerBasic.kt
@@ -1,0 +1,66 @@
+// Copyright (c) 2026 Konstantin Pavlov.
+
+package dev.tachyonmcp.skill
+
+import dev.tachyonmcp.server.McpServerHandle
+import dev.tachyonmcp.server.TachyonServer
+import dev.tachyonmcp.server.domain.PromptMessage
+import dev.tachyonmcp.server.domain.TextResourceContents
+import dev.tachyonmcp.server.features.resources.ResourceTemplateEntry
+import dev.tachyonmcp.server.features.tools.ToolResult
+import dev.tachyonmcp.server.promptMessagesOf
+import kotlin.time.Duration.Companion.minutes
+
+fun createServer(port: Int = 0): McpServerHandle = TachyonServer(port = port) {
+    info {
+        name = "demo-server"
+        version = "1.0"
+        description = "Demo MCP server"
+    }
+    capabilities {
+        tools(listChanged = true)
+        resources(subscribe = true, listChanged = true)
+        prompts(listChanged = true)
+    }
+    session {
+        stateless = false
+        sessionTtl = 5.minutes
+    }
+    network {
+        allowedOrigins.add("*")
+        allowNullOrigin = true
+    }
+    tool(name = "ping", description = "Simple ping") {
+        ToolResult.text("pong")
+    }
+    resource(
+        name = "config",
+        uri = "demo://config",
+        description = "Server configuration",
+    ) {
+        TextResourceContents.of(uri, "application/json", """{"mode":"production"}""")
+    }
+    prompt(name = "greet", description = "Generates a greeting") { _ ->
+        promptMessagesOf(PromptMessage.user("Say hello"))
+    }
+}
+
+fun addUserTemplate(handle: McpServerHandle) {
+    handle.server().resources().addTemplate(
+        ResourceTemplateEntry.of(
+            "user-profile",
+            "demo://users/{userId}/profile",
+            "User profile data",
+            "application/json",
+        ) { ctx, uri, params ->
+            val userId = params["userId"]
+            TextResourceContents.of(uri, "application/json", """{"userId":"$userId","name":"User"}""")
+        },
+    )
+}
+
+fun main() {
+    val handle = createServer(8080)
+    addUserTemplate(handle)
+    println("MCP server on http://localhost:${handle.port()}/mcp")
+}

--- a/.agents/skills/tachyon-mcp/resources/kotlin/ToolHandlerExample.kt
+++ b/.agents/skills/tachyon-mcp/resources/kotlin/ToolHandlerExample.kt
@@ -1,0 +1,95 @@
+// Copyright (c) 2026 Konstantin Pavlov.
+
+package dev.tachyonmcp.skill
+
+import dev.tachyonmcp.server.McpServer
+import dev.tachyonmcp.server.TachyonServerBuilder
+import dev.tachyonmcp.server.buildServer
+import dev.tachyonmcp.server.features.tools.AbstractAsyncToolHandler
+import dev.tachyonmcp.server.features.tools.AbstractSyncToolHandler
+import dev.tachyonmcp.server.features.tools.ToolArgs
+import dev.tachyonmcp.server.features.tools.ToolDescriptor
+import dev.tachyonmcp.server.features.tools.ToolResult
+import dev.tachyonmcp.server.registerTool
+import dev.tachyonmcp.server.session.McpContext
+import dev.tachyonmcp.server.toolDescriptor
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionStage
+import tools.jackson.databind.JsonNode
+import tools.jackson.databind.ObjectMapper
+
+private val MAPPER = ObjectMapper()
+private val GREET_SCHEMA: JsonNode = MAPPER.readTree("""
+    {"type":"object","properties":{"name":{"type":"string","description":"Name to greet"}},"required":["name"]}
+""")
+
+/**
+ * Registers a simple hello tool via DSL.
+ */
+fun TachyonServerBuilder.registerHello() {
+    tool(name = "hello", description = "Say hello") {
+        ToolResult.text("Hello, world!")
+    }
+}
+
+/**
+ * Suspend handler with input schema and arguments.
+ */
+fun TachyonServerBuilder.registerGreeting() {
+    tool(name = "greeting", description = "Generates a personalized greeting", inputSchema = GREET_SCHEMA) {
+        val name = args.string("name")
+        ToolResult.text("Hello, $name!")
+    }
+}
+
+/**
+ * Class-based — extend AbstractSyncToolHandler.
+ */
+class GreetingTool : AbstractSyncToolHandler(
+    toolDescriptor("greeting") {
+        title = "Greeting"
+        description = "Generates a personalized greeting"
+        inputSchema = GREET_SCHEMA
+    },
+) {
+    override fun handle(ctx: McpContext, args: ToolArgs): ToolResult<*> {
+        val name = args.string("name")
+        return ToolResult.text("Hello, $name!")
+    }
+}
+
+/**
+ * Async class-based — extend AbstractAsyncToolHandler.
+ */
+class AsyncGreetingTool : AbstractAsyncToolHandler(
+    toolDescriptor("async-greeting") {
+        title = "Async Greeting"
+        description = "Async personalized greeting"
+        inputSchema = GREET_SCHEMA
+    },
+) {
+    override fun handleAsync(ctx: McpContext, args: ToolArgs): CompletionStage<out ToolResult<*>> {
+        return CompletableFuture.completedFuture(ToolResult.text("Hello, Async!"))
+    }
+}
+
+/** Build a server using the DSL and register tools post-build. */
+fun buildWithPostRegistration(): McpServer {
+    val server = buildServer {
+        registerHello()
+        registerGreeting()
+        tool(name = "inline", description = "Registered inline") {
+            ToolResult.text("inline result")
+        }
+    }
+    server.registerTool(GreetingTool())
+    server.registerTool(AsyncGreetingTool())
+    server.registerTool(
+        toolDescriptor("post-register") {
+            description = "Added after build"
+        },
+    ) {
+        ToolResult.text("post-registered")
+    }
+    return server
+}

--- a/.agents/skills/tachyon-testing/SKILL.md
+++ b/.agents/skills/tachyon-testing/SKILL.md
@@ -14,6 +14,7 @@ description: Apply project specific rules when designing and writing tests
 - `JsonUnit` + AssertJ for JSON. Assert full JSON. `whenIgnoringPaths`, `IGNORING_ARRAY_ORDER`, `IGNORING_EXTRA_FIELDS`, `TREATING_NULL_AS_ABSENT`.
 - `// language=JSON` before JSON strings.
 - Awaitility for polling.
+- Kotlin: use kotest-assertions
 
 ## JSON Schemas
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -22,3 +22,22 @@ indent_size = 2
 
 [Makefile]
 indent_style = tab
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.java]
+indent_size = tab
+tab_width = 4
+ij_java_names_count_to_use_import_on_demand = 2147483647
+ij_java_packages_to_use_import_on_demand = unset
+
+# noinspection EditorConfigKeyCorrectness
+[*.{kt,kts}]
+indent_size = tab
+tab_width = 4
+max_line_length = 100
+ij_kotlin_name_count_to_use_star_import = 2147483647
+ij_kotlin_name_count_to_use_star_import_for_members = 2147483647
+ij_kotlin_packages_to_use_import_on_demand = unset
+ktlint_code_style = ktlint_official # intellij_idea or android_studio or ktlint_official (default)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,9 @@ jobs:
           cache: maven
 
       - name: Build and Verify
-        run: mvn verify --no-transfer-progress
+        run: |
+          mvn verify --no-transfer-progress
+          make examples
 
       - name: Publish test results
         uses: mikepenz/action-junit-report@v6
@@ -101,6 +103,8 @@ jobs:
           - 21
         example:
           - weather
+          - echo-kotlin
+
     runs-on: ubuntu-latest
     timeout-minutes: 7
 
@@ -117,7 +121,7 @@ jobs:
       - name: Install jar
         run: |
           rm -rf ~/.m2/repository/dev/tachyonmcp
-          mvn install -pl tachyon-server -am -DskipTests --no-transfer-progress
+          mvn install -pl tachyon-server-kotlin -am -DskipTests --no-transfer-progress
 
       - name: Verify examples
         run: mvn verify -f examples/${{ matrix.example }}/pom.xml -Dtachyon-server.version=1.0.0-SNAPSHOT --no-transfer-progress

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -25,6 +25,8 @@ jobs:
           - 21
         example:
           - weather
+          - echo-kotlin
+
     runs-on: ubuntu-latest
     timeout-minutes: 7
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,7 @@ mvn spotless:apply  # auto-fix
 
 - Talk concisely like smart Caveman
 - TDD + SOLID. TachyonServer is SUT in unit tests.
-- **Tests**: JUnit 6 + AssertJ + Awaitility. `@TempDir` for unit, port 0 for E2E. Prefer E2E for long scenarios. No tautologies. Many asserts per test.
+- **Tests**: JUnit 6 + Kotest (Kotlin) / AssertJ (Java) + Awaitility. `@TempDir` for unit, port 0 for E2E. Prefer E2E for long scenarios. No tautologies. Many asserts per test.
 - **Nullability**: JSpecify `@Nullable`/`@NonNull`. `@NullMarked` at package level.
 - **Copyright**: `/* Copyright (c) 2026 Konstantin Pavlov. */` everywhere.
 - **No comments** unless spec needs explain.
@@ -33,3 +33,10 @@ mvn spotless:apply  # auto-fix
 - `git mv` for files.
 - Use MCP tools.
 - **Format**: Spotless (Palantir). Check on `mvn verify`, fix with `mvn spotless:apply`.
+- **Kotlin DSL** (`tachyon-server-kotlin`):
+  - Each scope class gets its own `*Scope.kt` file.
+  - `@TachyonDsl` marker must be `public` (not `internal`) — `internal` breaks `@DslMarker` in inline extension call sites.
+  - `TachyonServerBuilder` wraps `ServerBuilder` as the DSL receiver. Scope methods on `TachyonServerBuilder` use clean names (`info`, `capabilities`, `network`, `session`) with zero Java member conflicts.
+  - Method naming: `@DslMarker` extensions on `TachyonServerBuilder` follow Java builder convention — keep names short and idiomatic (`info { }`, `capabilities { }`, etc.).
+  - Entry points: `TachyonServer { }` (type-named factory), `tachyonServer { }`, `buildServer { }`.
+  - Run Kotlin tests: `mvn test -am -f tachyon-server-kotlin/pom.xml`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ mvn spotless:apply  # auto-fix
 - TDD + SOLID. TachyonServer is SUT in unit tests.
 - **Tests**: JUnit 6 + Kotest (Kotlin) / AssertJ (Java) + Awaitility. `@TempDir` for unit, port 0 for E2E. Prefer E2E for long scenarios. No tautologies. Many asserts per test.
 - **Nullability**: JSpecify `@Nullable`/`@NonNull`. `@NullMarked` at package level.
-- **Copyright**: `/* Copyright (c) 2026 Konstantin Pavlov. */` everywhere.
+- **Copyright**: `Copyright (c) 2026 Konstantin Pavlov.` in file headers everywhere, `@author` in class java/kdocs. don't overwrite existing attributions.
 - **No comments** unless spec needs explain.
 - Unit tests only when E2E can't. Drop unit if E2E covers.
 - `git mv` for files.

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-.PHONY: build test lint package conformance e2e clean format all inspector example
+.PHONY: build test lint package conformance e2e clean format all inspector examples
 
-all: clean format build example
+all: clean format lint build examples
 
 build:
 	@echo "🏗️ Building..."
@@ -14,11 +14,12 @@ test:
 package:
 	@echo "📦 Packaging and installing tachyon-server to local repository..."
 	@rm -rf ~/.m2/repository/dev/tachyonmcp
-	@mvn install -pl tachyon-server -am -DskipTests -q
+	@mvn install -pl tachyon-server,tachyon-server-kotlin -am -DskipTests
 
-example: package
+examples: package
 	@echo "🌤️ Building and testing weather example..."
-	@mvn verify -f examples/weather/pom.xml -Dtachyon-server.version=1.0.0-SNAPSHOT
+	@#mvn verify -f examples/weather/pom.xml -Dtachyon-server.version=1.0.0-SNAPSHOT
+	@mvn verify -f examples/echo-kotlin/pom.xml -Dtachyon-server.version=1.0.0-SNAPSHOT
 
 conformance: package
 	@echo "🔄 Running MCP conformance suite..."
@@ -35,13 +36,16 @@ clean:
 	@mvn clean -q -f examples/weather/pom.xml
 
 format:
-	@echo "🎨 Formatting code with Spotless (Palantir)..."
+	@echo "🎨 Formatting code..."
 	@mvn spotless:apply -q
-
+	@mvn exec:java@detekt-format -pl tachyon-server-kotlin -q
+	@echo "✅ Done..."
 
 lint:
 	@echo "🔍 Linting code..."
-	@mvn spotless:check spotbugs:check -pl !reports
+	@mvn spotless:check -pl !reports
+	@mvn exec:java@detekt -pl tachyon-server-kotlin
+	@mvn spotbugs:check -pl !reports
 
 .PHONY: inspector
 inspector:

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ package:
 
 examples: package
 	@echo "🌤️ Building and testing weather example..."
-	@#mvn verify -f examples/weather/pom.xml -Dtachyon-server.version=1.0.0-SNAPSHOT
+	@mvn verify -f examples/weather/pom.xml -Dtachyon-server.version=1.0.0-SNAPSHOT
 	@mvn verify -f examples/echo-kotlin/pom.xml -Dtachyon-server.version=1.0.0-SNAPSHOT
 
 conformance: package

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Fully implements MCP spec **2025-11-25** Streamable HTTP transport with native I
             })
             .session(cfg -> cfg.stateless(true))
             .port(8080)
-            .bind();
+            .start();
     }
     ```
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ Add agent skill to write better code using this SDK:
 npx skills add kpavlov/tachyon --skill tachyon-mcp
 ```
 
+The skill includes compilable Java and Kotlin example sources under `.agents/skills/tachyon-mcp/resources/`.
+They are linked into `e2e/src/skill/` and compiled during `mvn test` to keep them valid.
+
 Check out [Skills CLI](https://github.com/vercel-labs/skills) for more options.
 
 ## Features

--- a/e2e/pom.xml
+++ b/e2e/pom.xml
@@ -27,6 +27,23 @@
             <artifactId>tachyon-server</artifactId>
         </dependency>
         <dependency>
+            <groupId>dev.tachyonmcp</groupId>
+            <artifactId>tachyon-server-kotlin</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlinx</groupId>
+            <artifactId>kotlinx-coroutines-core-jvm</artifactId>
+            <version>${kotlinx-coroutines.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-transport-classes-epoll</artifactId>
             <scope>runtime</scope>
@@ -97,6 +114,28 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-maven-plugin</artifactId>
+                <version>${kotlin.version}</version>
+                <executions>
+                    <execution>
+                        <id>compile-skill</id>
+                        <goals>
+                            <goal>test-compile</goal>
+                        </goals>
+                        <configuration>
+                            <sourceDirs>
+                                <sourceDir>${project.basedir}/../.agents/skills/tachyon-mcp/resources/kotlin</sourceDir>
+                            </sourceDirs>
+                        </configuration>
+                    </execution>
+                </executions>
+                <configuration>
+                    <javaParameters>true</javaParameters>
+                    <jvmTarget>${java.version}</jvmTarget>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
                 <executions>
@@ -128,6 +167,7 @@
                         <configuration>
                             <sources>
                                 <source>src/skill/java</source>
+                                <source>${project.basedir}/../.agents/skills/tachyon-mcp/resources/kotlin</source>
                             </sources>
                         </configuration>
                     </execution>

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/SharedE2eServer.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/SharedE2eServer.java
@@ -24,7 +24,7 @@ final class SharedE2eServer {
                 .capabilities(c -> c.tools())
                 .tool(new EchoToolHandler())
                 .network(n -> n.port(0))
-                .bind();
+                .start();
         started.set(true);
         Runtime.getRuntime().addShutdownHook(new Thread(handle::close));
         logger.info("Shared E2E server started on port {}", handle.port());

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/StatelessServerTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/StatelessServerTest.java
@@ -34,7 +34,7 @@ class StatelessServerTest {
                 .tool(new EchoToolHandler())
                 .session(s -> s.stateless(true))
                 .network(n -> n.host("localhost").port(0))
-                .bind();
+                .start();
         port = serverHandle.port();
     }
 

--- a/examples/echo-kotlin/pom.xml
+++ b/examples/echo-kotlin/pom.xml
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>dev.tachyonmcp.example</groupId>
+    <artifactId>echo-kotlin-example</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <name>Echo Kotlin MCP Example</name>
+    <description>Echo MCP server using Tachyon MCP Kotlin DSL</description>
+    <url>https://github.com/kpavlov/tachyon</url>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.release>21</maven.compiler.release>
+        <kotlin.version>2.2.21</kotlin.version>
+        <!--        <tachyon-server.version>1.0.0-beta.3</tachyon-server.version>-->
+<!--        <tachyon-server.version>1-SNAPSHOT</tachyon-server.version>-->
+        <tachyon-server.version>1.0.0-SNAPSHOT</tachyon-server.version>
+        <junit.version>6.1.1</junit.version>
+        <kotest.version>6.2.1</kotest.version>
+        <json-unit.version>5.1.2</json-unit.version>
+        <jackson.version>3.2.0</jackson.version>
+        <slf4j.version>2.0.18</slf4j.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>tools.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>${jackson.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>${junit.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>dev.tachyonmcp</groupId>
+            <artifactId>tachyon-server-kotlin</artifactId>
+            <version>${tachyon-server.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>${slf4j.version}</version>
+        </dependency>
+
+        <!-- Test -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-test-junit5</artifactId>
+            <version>${kotlin.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.kotest</groupId>
+            <artifactId>kotest-assertions-core-jvm</artifactId>
+            <version>${kotest.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.kotest</groupId>
+            <artifactId>kotest-assertions-json-jvm</artifactId>
+            <version>${kotest.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <sourceDirectory>${project.basedir}/src/main/kotlin</sourceDirectory>
+        <testSourceDirectory>${project.basedir}/src/test/kotlin</testSourceDirectory>
+        <plugins>
+            <plugin>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-maven-plugin</artifactId>
+                <version>${kotlin.version}</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <javaParameters>true</javaParameters>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.15.0</version>
+                <configuration>
+                    <release>${maven.compiler.release}</release>
+                    <parameters>true</parameters>
+                    <showWarnings>true</showWarnings>
+                    <debug>true</debug>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.5.0</version>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Main-Class>com.example.echo.EchoServer</Main-Class>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/examples/echo-kotlin/pom.xml
+++ b/examples/echo-kotlin/pom.xml
@@ -14,7 +14,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.release>21</maven.compiler.release>
+        <java.version>21</java.version>
         <kotlin.version>2.2.21</kotlin.version>
         <!--        <tachyon-server.version>1.0.0-beta.3</tachyon-server.version>-->
 <!--        <tachyon-server.version>1-SNAPSHOT</tachyon-server.version>-->
@@ -99,6 +99,7 @@
                 <version>${kotlin.version}</version>
                 <extensions>true</extensions>
                 <configuration>
+                    <jvmTarget>${java.version}</jvmTarget>
                     <javaParameters>true</javaParameters>
                 </configuration>
             </plugin>
@@ -107,7 +108,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.15.0</version>
                 <configuration>
-                    <release>${maven.compiler.release}</release>
+                    <release>${java.version}</release>
                     <parameters>true</parameters>
                     <showWarnings>true</showWarnings>
                     <debug>true</debug>

--- a/examples/echo-kotlin/src/main/kotlin/com/example/echo/EchoServer.kt
+++ b/examples/echo-kotlin/src/main/kotlin/com/example/echo/EchoServer.kt
@@ -1,0 +1,67 @@
+// Copyright (c) 2026 Konstantin Pavlov.
+
+package com.example.echo
+
+import dev.tachyonmcp.server.McpServerHandle
+import dev.tachyonmcp.server.TachyonServer
+import dev.tachyonmcp.server.config.Mode
+import dev.tachyonmcp.server.features.tools.ToolDescriptor
+import dev.tachyonmcp.server.features.tools.ToolResult
+import dev.tachyonmcp.server.registerTool
+import tools.jackson.databind.node.JsonNodeFactory
+
+fun createServer(port: Int = 0): McpServerHandle {
+    val inputSchema = buildEchoSchema()
+    val handle =
+        TachyonServer(port = port) {
+            info {
+                name = "echo-server"
+                title = "Echo Server"
+                version = "1.0.0"
+                description = "Echo MCP server built with Tachyon Kotlin DSL"
+            }
+            capabilities {
+                tools = Mode.ON
+            }
+            tool(
+                name = "echo",
+                description = "Echo message",
+                inputSchema = inputSchema,
+            ) {
+                ToolResult.text(args.string("message"))
+            }
+        }
+
+    handle
+        .server()
+        .registerTool(
+            ToolDescriptor
+                .builder()
+                .name("reverse-echo")
+                .description("Echo reverse message")
+                .inputSchema(inputSchema)
+                .build(),
+        ) {
+            val message = args.string("message")
+            ToolResult<*>.text(message.reversed())
+        }
+    return handle
+}
+
+private fun buildEchoSchema() =
+    JsonNodeFactory.instance.objectNode().apply {
+        put("type", "object")
+        putObject("properties").apply {
+            putObject("message").apply {
+                put("type", "string")
+                put("description", "Message to echo")
+            }
+        }
+        putArray("required").add("message")
+    }
+
+fun main() {
+    val handle = createServer(8080)
+    println("Echo server running. Connect your MCP client to http://localhost:${handle.port()}/mcp")
+    Thread.sleep(Long.MAX_VALUE)
+}

--- a/examples/echo-kotlin/src/test/kotlin/com/example/echo/EchoServerTest.kt
+++ b/examples/echo-kotlin/src/test/kotlin/com/example/echo/EchoServerTest.kt
@@ -1,0 +1,209 @@
+// Copyright (c) 2026 Konstantin Pavlov.
+
+package com.example.echo
+
+import io.kotest.assertions.json.shouldEqualJson
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+
+class EchoServerTest {
+    companion object {
+        private lateinit var handle: dev.tachyonmcp.server.McpServerHandle
+
+        @JvmStatic
+        @BeforeAll
+        fun beforeAll() {
+            handle = createServer(0)
+        }
+
+        @JvmStatic
+        @AfterAll
+        fun afterAll() {
+            handle.close()
+        }
+    }
+
+    @Test
+    fun `should list tools`() {
+        EchoTestClient(handle.port()).use { client ->
+            val sessionId = client.initialize()
+
+            // language=json
+            val response =
+                client.post(
+                    sessionId,
+                    """
+                    {"jsonrpc":"2.0","id":1,"method":"tools/list"}
+                    """.trimIndent(),
+                )
+
+            val json = response.body()
+            json shouldEqualJson
+                """
+                {"jsonrpc":"2.0","id":1,"result":{"tools":[
+                {
+                  "name":"echo",
+                  "description":"Echo message",
+                  "inputSchema":{
+                    "type":"object",
+                    "properties": {
+                      "message":{"type":"string","description":"Message to echo"}},
+                      "required":["message"]}},
+                {
+                  "name": "reverse-echo",
+                  "description": "Echo reverse message",
+                  "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "description": "Message to echo"
+                      }
+                    },
+                    "required": [
+                      "message"
+                    ]
+                  }
+
+                }
+                          ]}}
+                """.trimIndent()
+        }
+    }
+
+    @Test
+    fun `echo tool`() {
+        EchoTestClient(handle.port()).use { client ->
+            val sessionId = client.initialize()
+
+            // language=json
+            val response =
+                client.post(
+                    sessionId,
+                    """
+                    {"jsonrpc":"2.0","id":1,"method":"tools/call",
+                     "params":{"name":"echo","arguments":{"message":"Hello, MCP!"}}}
+                    """.trimIndent(),
+                )
+
+            val json = response.body()
+            json shouldEqualJson
+                """
+                {
+                  "jsonrpc": "2.0",
+                  "id": 1,
+                  "result": {
+                    "content": [
+                      {
+                        "type": "text",
+                        "text": "Hello, MCP!"
+                      }
+                    ]
+                  }
+                }
+                """.trimIndent()
+        }
+    }
+
+    @Test
+    fun `reverse echo tool`() {
+        EchoTestClient(handle.port()).use { client ->
+            val sessionId = client.initialize()
+
+            // language=json
+            val response =
+                client.post(
+                    sessionId,
+                    """
+                    {"jsonrpc":"2.0","id":1,"method":"tools/call",
+                     "params":{"name":"reverse-echo","arguments":{"message":"stressed"}}}
+                    """.trimIndent(),
+                )
+
+            val json = response.body()
+            json shouldEqualJson
+                """
+                {
+                  "jsonrpc": "2.0",
+                  "id": 1,
+                  "result": {
+                    "content": [
+                      {
+                        "type": "text",
+                        "text": "desserts"
+                      }
+                    ]
+                  }
+                }
+                """.trimIndent()
+        }
+    }
+
+    @Test
+    fun `should return error when message missing`() {
+        EchoTestClient(handle.port()).use { client ->
+            val sessionId = client.initialize()
+
+            // language=json
+            val response =
+                client.post(
+                    sessionId,
+                    """
+                    {"jsonrpc":"2.0","id":1,"method":"tools/call",
+                     "params":{"name":"echo","arguments":{}}}
+                    """.trimIndent(),
+                )
+
+            response.body() shouldEqualJson
+                """
+                {
+                  "jsonrpc": "2.0",
+                  "id": 1,
+                  "error": {
+                    "code": -32600,
+                    "message": "required property 'message' not found"
+                  }
+                }
+                """.trimIndent()
+        }
+    }
+
+    @Test
+    fun `should respond to initialize`() {
+        EchoTestClient(handle.port()).use { client ->
+            // language=json
+            val response =
+                client.post(
+                    null,
+                    """
+                    {"jsonrpc":"2.0",
+                      "id":1,
+                      "method":"initialize",
+                      "params":{"protocolVersion":"2025-11-25","capabilities":{},
+                               "clientInfo":{"name":"test","version":"1.0"}}}
+                    """.trimIndent(),
+                )
+
+            response.body() shouldEqualJson
+                """
+                {
+                  "jsonrpc": "2.0",
+                  "id": 1,
+                  "result": {
+                    "protocolVersion": "2025-11-25",
+                    "capabilities": {
+                      "tools": {}
+                    },
+                    "serverInfo": {
+                      "version": "1.0.0",
+                      "description": "Echo MCP server built with Tachyon Kotlin DSL",
+                      "name": "echo-server",
+                      "title": "Echo Server"
+                    }
+                  }
+                }
+                """.trimIndent()
+        }
+    }
+}

--- a/examples/echo-kotlin/src/test/kotlin/com/example/echo/EchoTestClient.kt
+++ b/examples/echo-kotlin/src/test/kotlin/com/example/echo/EchoTestClient.kt
@@ -1,0 +1,48 @@
+// Copyright (c) 2026 Konstantin Pavlov.
+
+package com.example.echo
+
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+
+class EchoTestClient(port: Int) : AutoCloseable {
+
+    private val httpClient = HttpClient.newHttpClient()
+    private val baseUri = URI.create("http://localhost:$port/mcp")
+
+    fun initialize(): String {
+        val response = post(null, """
+            {"jsonrpc":"2.0","id":1,"method":"initialize",
+             "params":{"protocolVersion":"2025-11-25","capabilities":{},
+                       "clientInfo":{"name":"test","version":"1.0"}}}
+            """.trimIndent())
+        val sessionId = response.headers().firstValue("MCP-Session-Id").orElseThrow()
+        sendInitialized(sessionId)
+        return sessionId
+    }
+
+    private fun sendInitialized(sessionId: String) {
+        post(sessionId, """
+            {"jsonrpc":"2.0","method":"notifications/initialized"}
+            """.trimIndent())
+    }
+
+    fun post(sessionId: String?, body: String): HttpResponse<String> {
+        val builder = HttpRequest.newBuilder()
+            .uri(baseUri)
+            .header("Content-Type", "application/json")
+            .header("Accept", "application/json, text/event-stream")
+            .header("MCP-Protocol-Version", "2025-11-25")
+            .POST(HttpRequest.BodyPublishers.ofString(body))
+        if (sessionId != null) {
+            builder.header("MCP-Session-Id", sessionId)
+        }
+        return httpClient.send(builder.build(), HttpResponse.BodyHandlers.ofString())
+    }
+
+    override fun close() {
+        httpClient.close()
+    }
+}

--- a/examples/weather/src/main/java/com/example/weather/WeatherServer.java
+++ b/examples/weather/src/main/java/com/example/weather/WeatherServer.java
@@ -58,7 +58,7 @@ public final class WeatherServer {
                     WeatherServer::handleRewriteForecast)
                 .session(s -> s.stateless(true))
                 .port(port)
-                .bind();
+                .start();
 
         handle.server().resources()
                 .addTemplate(ResourceTemplateEntry.of(

--- a/pom.xml
+++ b/pom.xml
@@ -348,11 +348,6 @@
                     <version>3.6.3</version>
                 </plugin>
                 <plugin>
-                    <groupId>org.detekt</groupId>
-                    <artifactId>detekt-maven-plugin</artifactId>
-                    <version>${detekt.version}</version>
-                </plugin>
-                <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>build-helper-maven-plugin</artifactId>
                     <version>3.6.1</version>

--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,7 @@
             java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.base/java.nio.channels.spi=ALL-UNNAMED
             -Dio.netty.leakDetection.level=PARANOID
         </argLine>
+        <kotlinx-coroutines.version>1.11.0</kotlinx-coroutines.version>
     </properties>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,7 @@
 
     <modules>
         <module>tachyon-server</module>
+        <module>tachyon-server-kotlin</module>
         <module>e2e</module>
         <module>conformance</module>
         <module>reports</module>
@@ -57,6 +58,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- Java -->
         <java.version>21</java.version>
+        <kotlin.version>2.2.21</kotlin.version>
 
         <!-- Dependencies -->
         <assertj.version>3.27.7</assertj.version>
@@ -70,6 +72,7 @@
         <junit.pioneer.version>2.3.0</junit.pioneer.version>
         <junit.platform.version>1.12.2</junit.platform.version>
         <junit.version>6.1.1</junit.version>
+        <kotest.version>6.2.1</kotest.version>
         <netty.version>4.2.15.Final</netty.version>
         <slf4j.version>2.0.18</slf4j.version>
 
@@ -82,6 +85,8 @@
         <palantir-java-format.version>2.92.0</palantir-java-format.version>
         <spotless-maven-plugin.version>3.8.0</spotless-maven-plugin.version>
         <spotbugs-maven-plugin.version>4.10.2.0</spotbugs-maven-plugin.version>
+        <detekt.version>2.0.0-alpha.5</detekt.version>
+        <ktlint.version>1.5.0</ktlint.version>
         <spotbugs.version>4.10.2</spotbugs.version>
 
         <!-- Test configuration -->
@@ -149,6 +154,14 @@
                         <artifactId>jackson-dataformat-yaml</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-bom</artifactId>
+                <version>${kotlin.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
 
             <dependency>
@@ -313,6 +326,11 @@
                                 <include>**/*.md</include>
                             </includes>
                         </markdown>
+                        <kotlin>
+                            <ktlint>
+                                <version>${ktlint.version}</version>
+                            </ktlint>
+                        </kotlin>
                     </configuration>
                     <executions>
                         <execution>
@@ -327,6 +345,11 @@
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>exec-maven-plugin</artifactId>
                     <version>3.6.3</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.detekt</groupId>
+                    <artifactId>detekt-maven-plugin</artifactId>
+                    <version>${detekt.version}</version>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>

--- a/reports/pom.xml
+++ b/reports/pom.xml
@@ -28,6 +28,12 @@
         <dependency>
             <groupId>dev.tachyonmcp</groupId>
             <artifactId>tachyon-server</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>dev.tachyonmcp</groupId>
+            <artifactId>tachyon-server-kotlin</artifactId>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>dev.tachyonmcp</groupId>

--- a/tachyon-server-kotlin/detekt.yml
+++ b/tachyon-server-kotlin/detekt.yml
@@ -1,0 +1,857 @@
+config:
+  validation: true
+  warningsAsErrors: true
+  checkExhaustiveness: false
+  # when writing own rules with new properties, exclude the property path e.g.: ['my_rule_set', '.*>.*>[my_property]']
+#  excludes: []
+
+processors:
+  active: true
+  exclude:
+  # - 'KtFileCountProcessor'
+  # - 'PackageCountProcessor'
+  # - 'ClassCountProcessor'
+  # - 'FunctionCountProcessor'
+  # - 'PropertyCountProcessor'
+  # - 'ProjectCyclomaticComplexityProcessor'
+  # - 'ProjectCognitiveComplexityProcessor'
+  # - 'ProjectLLOCProcessor'
+  # - 'ProjectCLOCProcessor'
+  # - 'ProjectLOCProcessor'
+  # - 'ProjectSLOCProcessor'
+#
+#console-reports:
+#  active: true
+#  exclude:
+#     - 'ProjectStatisticsReport'
+#     - 'ComplexityReport'
+#     - 'NotificationReport'
+#     - 'IssuesReport'
+#     - 'FileBasedIssuesReport'
+#  #  - 'LiteIssuesReport'
+#
+#comments:
+#  active: true
+#  AbsentOrWrongFileLicense:
+#    active: false
+#    licenseTemplateIsRegex: false
+#    licenseTemplate: ''
+#  DeprecatedBlockTag:
+#    active: false
+#  DocumentationOverPrivateFunction:
+#    active: false
+#  DocumentationOverPrivateProperty:
+#    active: false
+#  EndOfSentenceFormat:
+#    active: false
+#    endOfSentenceFormat: '([.?!][ \t\n\r\f<])|([.?!:]$)'
+#  KDocReferencesNonPublicProperty:
+#    active: false
+#    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**']
+#  OutdatedDocumentation:
+#    active: false
+#    matchTypeParameters: true
+#    matchDeclarationsOrder: true
+#    allowParamOnConstructorProperties: false
+#    exhaustive: true
+#  UndocumentedPublicClass:
+#    active: false
+#    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**']
+#    searchInNestedClass: true
+#    searchInInnerClass: true
+#    searchInInnerObject: true
+#    searchInInnerInterface: true
+#    searchInProtectedClass: false
+#    ignoreDefaultCompanionObject: false
+#  UndocumentedPublicFunction:
+#    active: false
+#    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**']
+#    searchProtectedFunction: false
+#  UndocumentedPublicProperty:
+#    active: false
+#    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**']
+#    searchProtectedProperty: false
+#    ignoreEnumEntries: false
+#
+#complexity:
+#  active: true
+#  CognitiveComplexMethod:
+#    active: false
+#    allowedComplexity: 15
+#  ComplexCondition:
+#    active: true
+#    allowedConditions: 3
+#  ComplexInterface:
+#    active: false
+#    allowedDefinitions: 10
+#    includeStaticDeclarations: false
+#    includePrivateDeclarations: false
+#    ignoreOverloaded: false
+#  CyclomaticComplexMethod:
+#    active: true
+#    allowedComplexity: 14
+#    ignoreSingleWhenExpression: false
+#    ignoreSimpleWhenEntries: false
+#    ignoreNestingFunctions: false
+#    ignoreLocalFunctions: false
+#    nestingFunctions:
+#      - 'also'
+#      - 'apply'
+#      - 'forEach'
+#      - 'isNotNull'
+#      - 'ifNull'
+#      - 'let'
+#      - 'run'
+#      - 'use'
+#      - 'with'
+#  LabeledExpression:
+#    active: false
+#    ignoredLabels: []
+#  LargeClass:
+#    active: true
+#    allowedLines: 600
+#  LongMethod:
+#    active: true
+#    allowedLines: 100
+#  LongParameterList:
+#    active: true
+#    allowedFunctionParameters: 5
+#    allowedConstructorParameters: 6
+#    ignoreDefaultParameters: false
+#    ignoreDataClasses: true
+#    ignoreAnnotatedParameter: []
+#  MethodOverloading:
+#    active: false
+#    allowedOverloads: 6
+#  NamedArguments:
+#    active: false
+#    allowedArguments: 3
+#    ignoreMethods: []
+#    ignoreArgumentsMatchingNames: false
+#  NestedBlockDepth:
+#    active: true
+#    allowedDepth: 4
+#  NestedScopeFunctions:
+#    active: false
+#    allowedDepth: 1
+#    functions:
+#      - 'kotlin.apply'
+#      - 'kotlin.run'
+#      - 'kotlin.with'
+#      - 'kotlin.let'
+#      - 'kotlin.also'
+#  ReplaceSafeCallChainWithRun:
+#    active: false
+#  StringLiteralDuplication:
+#    active: false
+#    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**']
+#    allowedDuplications: 2
+#    ignoreAnnotation: true
+#    allowedWithLengthLessThan: 5
+#    ignoreStringsRegex: '$^'
+#  TooManyFunctions:
+#    active: true
+#    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**']
+#    allowedFunctionsPerFile: 15
+#    allowedFunctionsPerClass: 15
+#    allowedFunctionsPerInterface: 11
+#    allowedFunctionsPerObject: 11
+#    allowedFunctionsPerEnum: 11
+#    ignoreDeprecated: false
+#    ignorePrivate: false
+#    ignoreInternal: false
+#    ignoreOverridden: false
+#    ignoreAnnotatedFunctions: []
+#
+#coroutines:
+#  active: true
+#  CoroutineLaunchedInTestWithoutRunTest:
+#    active: false
+#  GlobalCoroutineUsage:
+#    active: false
+#  InjectDispatcher:
+#    active: true
+#    dispatcherNames:
+#      - 'IO'
+#      - 'Default'
+#      - 'Unconfined'
+#  RedundantSuspendModifier:
+#    active: true
+#  SleepInsteadOfDelay:
+#    active: true
+#  SuspendFunInFinallySection:
+#    active: false
+#  SuspendFunSwallowedCancellation:
+#    active: false
+#  SuspendFunWithCoroutineScopeReceiver:
+#    active: false
+#    aliases: ['SuspendFunctionOnCoroutineScope']
+#  SuspendFunWithFlowReturnType:
+#    active: true
+#
+#empty-blocks:
+#  active: true
+#  EmptyCatchBlock:
+#    active: true
+#    allowedExceptionNameRegex: '_|(ignore|expected).*'
+#  EmptyClassBlock:
+#    active: true
+#  EmptyDefaultConstructor:
+#    active: true
+#  EmptyDoWhileBlock:
+#    active: true
+#  EmptyElseBlock:
+#    active: true
+#  EmptyFinallyBlock:
+#    active: true
+#  EmptyForBlock:
+#    active: true
+#  EmptyFunctionBlock:
+#    active: true
+#    ignoreOverridden: false
+#  EmptyIfBlock:
+#    active: true
+#  EmptyInitBlock:
+#    active: true
+#  EmptyKotlinFile:
+#    active: true
+#  EmptySecondaryConstructor:
+#    active: true
+#  EmptyTryBlock:
+#    active: true
+#  EmptyWhenBlock:
+#    active: true
+#  EmptyWhileBlock:
+#    active: true
+#
+#exceptions:
+#  active: true
+#  ErrorUsageWithThrowable:
+#    active: false
+#  ExceptionRaisedInUnexpectedLocation:
+#    active: true
+#    methodNames:
+#      - 'equals'
+#      - 'finalize'
+#      - 'hashCode'
+#      - 'toString'
+#  InstanceOfCheckForException:
+#    active: true
+#    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**']
+#  NotImplementedDeclaration:
+#    active: false
+#  ObjectExtendsThrowable:
+#    active: false
+#  PrintStackTrace:
+#    active: true
+#  RethrowCaughtException:
+#    active: true
+#  ReturnFromFinally:
+#    active: true
+#    ignoreLabeled: false
+#  SwallowedException:
+#    active: true
+#    ignoredExceptionTypes:
+#      - 'InterruptedException'
+#      - 'MalformedURLException'
+#      - 'NumberFormatException'
+#      - 'ParseException'
+#    allowedExceptionNameRegex: '_|(ignore|expected).*'
+#  ThrowingExceptionFromFinally:
+#    active: true
+#  ThrowingExceptionInMain:
+#    active: false
+#  ThrowingExceptionsWithoutMessageOrCause:
+#    active: true
+#    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**']
+#    exceptions:
+#      - 'ArrayIndexOutOfBoundsException'
+#      - 'Exception'
+#      - 'IllegalArgumentException'
+#      - 'IllegalMonitorStateException'
+#      - 'IllegalStateException'
+#      - 'IndexOutOfBoundsException'
+#      - 'NullPointerException'
+#      - 'RuntimeException'
+#      - 'Throwable'
+#  ThrowingNewInstanceOfSameException:
+#    active: true
+#  TooGenericExceptionCaught:
+#    active: true
+#    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**']
+#    exceptionNames:
+#      - 'ArrayIndexOutOfBoundsException'
+#      - 'Error'
+#      - 'Exception'
+#      - 'IllegalMonitorStateException'
+#      - 'IndexOutOfBoundsException'
+#      - 'NullPointerException'
+#      - 'RuntimeException'
+#      - 'Throwable'
+#    allowedExceptionNameRegex: '_|(ignore|expected).*'
+#  TooGenericExceptionThrown:
+#    active: true
+#    exceptionNames:
+#      - 'Error'
+#      - 'Exception'
+#      - 'RuntimeException'
+#      - 'Throwable'
+#
+#naming:
+#  active: true
+#  BooleanPropertyNaming:
+#    active: false
+#    allowedPattern: '^(is|has|are)'
+#  ClassNaming:
+#    active: true
+#    aliases: ['ClassName']
+#    classPattern: '[A-Z][a-zA-Z0-9]*'
+#  ConstructorParameterNaming:
+#    active: true
+#    parameterPattern: '[a-z][A-Za-z0-9]*'
+#    privateParameterPattern: '[a-z][A-Za-z0-9]*'
+#    excludeClassPattern: '$^'
+#  EnumNaming:
+#    active: true
+#    aliases: ['EnumEntryName']
+#    enumEntryPattern: '[A-Z][_a-zA-Z0-9]*'
+#  ForbiddenClassName:
+#    active: false
+#    forbiddenName: []
+#  FunctionNameMaxLength:
+#    active: false
+#    aliases: ['FunctionMaxNameLength']
+#    maximumFunctionNameLength: 30
+#  FunctionNameMinLength:
+#    active: false
+#    aliases: ['FunctionMinNameLength']
+#    minimumFunctionNameLength: 3
+#  FunctionNaming:
+#    active: true
+#    aliases: ['FunctionName']
+#    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**']
+#    functionPattern: '[a-z][a-zA-Z0-9]*'
+#    excludeClassPattern: '$^'
+#  FunctionParameterNaming:
+#    active: true
+#    parameterPattern: '[a-z][A-Za-z0-9]*'
+#    excludeClassPattern: '$^'
+#  InvalidPackageDeclaration:
+#    active: true
+#    aliases: ['PackageDirectoryMismatch']
+#    rootPackage: ''
+#    requireRootInDeclaration: false
+#  LambdaParameterNaming:
+#    active: false
+#    parameterPattern: '[a-z][A-Za-z0-9]*|_'
+#  MatchingDeclarationName:
+#    active: true
+#    mustBeFirst: true
+#    multiplatformTargets:
+#      - 'ios'
+#      - 'android'
+#      - 'js'
+#      - 'jvm'
+#      - 'native'
+#      - 'iosArm64'
+#      - 'iosX64'
+#      - 'macosX64'
+#      - 'mingwX64'
+#      - 'linuxX64'
+#  MemberNameEqualsClassName:
+#    active: true
+#    ignoreOverridden: true
+#  NoNameShadowing:
+#    active: true
+#  NonBooleanPropertyPrefixedWithIs:
+#    active: false
+#    allowSingleTypedGenerics: false
+#  ObjectPropertyNaming:
+#    active: true
+#    aliases: ['ObjectPropertyName']
+#    constantPattern: '[A-Za-z][_A-Za-z0-9]*'
+#    propertyPattern: '[A-Za-z][_A-Za-z0-9]*'
+#    privatePropertyPattern: '(_)?[A-Za-z][_A-Za-z0-9]*'
+#  PackageNaming:
+#    active: true
+#    aliases: ['PackageName']
+#    packagePattern: '[a-z]+(\.[a-z][A-Za-z0-9]*)*'
+#  TopLevelPropertyNaming:
+#    active: true
+#    constantPattern: '[A-Z][_A-Z0-9]*'
+#    propertyPattern: '[A-Za-z][_A-Za-z0-9]*'
+#    privatePropertyPattern: '_?[A-Za-z][_A-Za-z0-9]*'
+#  VariableMaxLength:
+#    active: false
+#    maximumVariableNameLength: 64
+#  VariableMinLength:
+#    active: false
+#    minimumVariableNameLength: 1
+#  VariableNaming:
+#    active: true
+#    aliases: ['PropertyName']
+#    variablePattern: '[a-z][A-Za-z0-9]*'
+#    privateVariablePattern: '(_)?[a-z][A-Za-z0-9]*'
+#    excludeClassPattern: '$^'
+#
+#performance:
+#  active: true
+#  ArrayPrimitive:
+#    active: true
+#  CouldBeSequence:
+#    active: false
+#    allowedOperations: 2
+#  ForEachOnRange:
+#    active: true
+#    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**']
+#  SpreadOperator:
+#    active: true
+#    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**']
+#  UnnecessaryInitOnArray:
+#    active: false
+#  UnnecessaryPartOfBinaryExpression:
+#    active: false
+#  UnnecessaryTemporaryInstantiation:
+#    active: true
+#  UnnecessaryTypeCasting:
+#    active: false
+#
+#potential-bugs:
+#  active: true
+#  AvoidReferentialEquality:
+#    active: true
+#    forbiddenTypePatterns:
+#      - 'kotlin.String'
+#  CastNullableToNonNullableType:
+#    active: false
+#    ignorePlatformTypes: true
+#  CastToNullableType:
+#    active: false
+#  CharArrayToStringCall:
+#    active: false
+#  Deprecation:
+#    active: false
+#    aliases: ['DEPRECATION']
+#  DontDowncastCollectionTypes:
+#    active: false
+#  DoubleMutabilityForCollection:
+#    active: true
+#    aliases: ['DoubleMutability']
+#    mutableTypes:
+#      - 'kotlin.collections.MutableList'
+#      - 'kotlin.collections.MutableMap'
+#      - 'kotlin.collections.MutableSet'
+#      - 'java.util.ArrayList'
+#      - 'java.util.LinkedHashSet'
+#      - 'java.util.HashSet'
+#      - 'java.util.LinkedHashMap'
+#      - 'java.util.HashMap'
+#  ElseCaseInsteadOfExhaustiveWhen:
+#    active: false
+#    ignoredSubjectTypes: []
+#  EqualsAlwaysReturnsTrueOrFalse:
+#    active: true
+#  EqualsWithHashCodeExist:
+#    active: true
+#  ExitOutsideMain:
+#    active: false
+#  ExplicitGarbageCollectionCall:
+#    active: true
+#  HasPlatformType:
+#    active: true
+#  IgnoredReturnValue:
+#    active: true
+#    restrictToConfig: true
+#    returnValueAnnotations:
+#      - 'CheckResult'
+#      - '*.CheckResult'
+#      - 'CheckReturnValue'
+#      - '*.CheckReturnValue'
+#    ignoreReturnValueAnnotations:
+#      - 'CanIgnoreReturnValue'
+#      - '*.CanIgnoreReturnValue'
+#    returnValueTypes:
+#      - 'kotlin.Function*'
+#      - 'kotlin.sequences.Sequence'
+#      - 'kotlinx.coroutines.flow.*Flow'
+#      - 'java.util.stream.*Stream'
+#    ignoreFunctionCall: []
+#  ImplicitDefaultLocale:
+#    active: true
+#  ImplicitUnitReturnType:
+#    active: false
+#    ignoreAnnotated: ['Test']
+#    allowExplicitReturnType: true
+#  InvalidRange:
+#    active: true
+#  IteratorHasNextCallsNextMethod:
+#    active: true
+#  IteratorNotThrowingNoSuchElementException:
+#    active: true
+#  LateinitUsage:
+#    active: false
+#    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**']
+#    ignoreOnClassesPattern: ''
+#  MapGetWithNotNullAssertionOperator:
+#    active: true
+#  MissingPackageDeclaration:
+#    active: false
+#    excludes: ['**/*.kts']
+#  MissingSuperCall:
+#    active: false
+#    mustInvokeSuperAnnotations:
+#      - 'androidx.annotation.CallSuper'
+#      - 'javax.annotation.OverridingMethodsMustInvokeSuper'
+#  MissingUseCall:
+#    active: false
+#    ignoreClass:
+#      - 'java.io.ByteArrayInputStream'
+#      - 'java.io.ByteArrayOutputStream'
+#  NullCheckOnMutableProperty:
+#    active: false
+#  NullableToStringCall:
+#    active: false
+#  PropertyUsedBeforeDeclaration:
+#    active: false
+#  UnconditionalJumpStatementInLoop:
+#    active: false
+#  UnnamedParameterUse:
+#    active: false
+#    allowAdjacentDifferentTypeParams: true
+#    allowSingleParamUse: true
+#    ignoreArgumentsMatchingNames: true
+#    ignoreFunctionCall: []
+#  UnnecessaryNotNullCheck:
+#    active: false
+#  UnnecessaryNotNullOperator:
+#    active: true
+#  UnnecessarySafeCall:
+#    active: true
+#  UnreachableCatchBlock:
+#    active: true
+#  UnreachableCode:
+#    active: true
+#  UnsafeCallOnNullableType:
+#    active: true
+#    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**']
+#  UnsafeCast:
+#    active: true
+#    aliases: ['UNCHECKED_CAST']
+#  UnusedUnaryOperator:
+#    active: true
+#  UselessPostfixExpression:
+#    active: true
+#  WrongEqualsTypeParameter:
+#    active: true
+#
+#style:
+#  active: true
+#  AbstractClassCanBeConcreteClass:
+#    active: true
+#  AbstractClassCanBeInterface:
+#    active: true
+#  AlsoCouldBeApply:
+#    active: false
+#  BracesOnIfStatements:
+#    active: false
+#    singleLine: 'never'
+#    multiLine: 'always'
+#  BracesOnWhenStatements:
+#    active: false
+#    singleLine: 'necessary'
+#    multiLine: 'consistent'
+#  CanBeNonNullable:
+#    active: false
+#  CascadingCallWrapping:
+#    active: false
+#    includeElvis: true
+#  ClassOrdering:
+#    active: false
+#  CollapsibleIfStatements:
+#    active: false
+#  DataClassContainsFunctions:
+#    active: false
+#    conversionFunctionPrefix:
+#      - 'to'
+#    allowOperators: false
+#  DataClassShouldBeImmutable:
+#    active: false
+#  DestructuringDeclarationWithTooManyEntries:
+#    active: true
+#    maxDestructuringEntries: 3
+#  DoubleNegativeExpression:
+#    active: false
+#  DoubleNegativeLambda:
+#    active: false
+#    negativeFunctions:
+#      - reason: 'Use `takeIf` instead.'
+#        value: 'takeUnless'
+#      - reason: 'Use `all` instead.'
+#        value: 'none'
+#    negativeFunctionNameParts:
+#      - 'not'
+#      - 'non'
+#  EqualsNullCall:
+#    active: true
+#  EqualsOnSignatureLine:
+#    active: false
+#  ExplicitCollectionElementAccessMethod:
+#    active: false
+#  ExplicitItLambdaMultipleParameters:
+#    active: true
+#  ExplicitItLambdaParameter:
+#    active: true
+#  ExpressionBodySyntax:
+#    active: false
+#    includeLineWrapping: false
+#  ForbiddenAnnotation:
+#    active: false
+#    annotations:
+#      - reason: 'it is a java annotation. Use `Suppress` instead.'
+#        value: 'java.lang.SuppressWarnings'
+#      - reason: 'it is a java annotation. Use `kotlin.Deprecated` instead.'
+#        value: 'java.lang.Deprecated'
+#      - reason: 'it is a java annotation. Use `kotlin.annotation.MustBeDocumented` instead.'
+#        value: 'java.lang.annotation.Documented'
+#      - reason: 'it is a java annotation. Use `kotlin.annotation.Target` instead.'
+#        value: 'java.lang.annotation.Target'
+#      - reason: 'it is a java annotation. Use `kotlin.annotation.Retention` instead.'
+#        value: 'java.lang.annotation.Retention'
+#      - reason: 'it is a java annotation. Use `kotlin.annotation.Repeatable` instead.'
+#        value: 'java.lang.annotation.Repeatable'
+#  ForbiddenComment:
+#    active: true
+#    comments:
+#      - reason: 'Forbidden FIXME todo marker in comment, please fix the problem.'
+#        value: 'FIXME:'
+#      - reason: 'Forbidden STOPSHIP todo marker in comment, please address the problem before shipping the code.'
+#        value: 'STOPSHIP:'
+#      - reason: 'Forbidden TODO todo marker in comment, please do the changes.'
+#        value: 'TODO:'
+#    allowedPatterns: ''
+#  ForbiddenImport:
+#    active: false
+#    forbiddenImports: []
+#    allowedImports: []
+#  ForbiddenMethodCall:
+#    active: false
+#    methods:
+#      - reason: 'print does not allow you to configure the output stream. Use a logger instead.'
+#        value: 'kotlin.io.print'
+#      - reason: 'println does not allow you to configure the output stream. Use a logger instead.'
+#        value: 'kotlin.io.println'
+#      - reason: 'using `BigDecimal(Double)` can result in unexpected floating point precision behavior. Use `BigDecimal.valueOf(Double)` or `String.toBigDecimalOrNull()` instead.'
+#        value: 'java.math.BigDecimal.<init>(kotlin.Double)'
+#      - reason: 'using `BigDecimal(String)` can result in a `NumberFormatException`. Use `String.toBigDecimalOrNull()`'
+#        value: 'java.math.BigDecimal.<init>(kotlin.String)'
+#      - reason: 'It is marked as obsolete. Use `kotlin.time.measureTime` instead.'
+#        value: 'kotlin.system.measureTimeMillis'
+#  ForbiddenNamedParam:
+#    active: false
+#    methods: []
+#  ForbiddenOptIn:
+#    active: false
+#    markerClasses: []
+#  ForbiddenSuppress:
+#    active: false
+#    rules: []
+#  ForbiddenVoid:
+#    active: true
+#    ignoreOverridden: false
+#    ignoreUsageInGenerics: false
+#  FunctionOnlyReturningConstant:
+#    active: true
+#    ignoreOverridableFunction: true
+#    ignoreActualFunction: true
+#    excludedFunctions: []
+#  LoopWithTooManyJumpStatements:
+#    active: true
+#    maxJumpCount: 1
+#  MagicNumber:
+#    active: true
+#    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**', '**/*.kts']
+#    ignoreNumbers:
+#      - '-1'
+#      - '0'
+#      - '1'
+#      - '2'
+#    ignoreHashCodeFunction: true
+#    ignorePropertyDeclaration: true
+#    ignoreLocalVariableDeclaration: true
+#    ignoreConstantDeclaration: true
+#    ignoreCompanionObjectPropertyDeclaration: true
+#    ignoreAnnotation: false
+#    ignoreNamedArgument: true
+#    ignoreEnums: false
+#    ignoreRanges: false
+#    ignoreExtensionFunctions: true
+#  MandatoryBracesLoops:
+#    active: false
+#  MaxChainedCallsOnSameLine:
+#    active: false
+#    maxChainedCalls: 5
+#  MaxLineLength:
+#    active: true
+#    maxLineLength: 140
+#    excludePackageStatements: true
+#    excludeImportStatements: true
+#    excludeCommentStatements: false
+#    excludeRawStrings: true
+#  MayBeConstant:
+#    active: true
+#  ModifierOrder:
+#    active: true
+#  MultilineLambdaItParameter:
+#    active: false
+#  MultilineRawStringIndentation:
+#    active: false
+#    indentSize: 4
+#    trimmingMethods:
+#      - 'trimIndent'
+#      - 'trimMargin'
+#  NestedClassesVisibility:
+#    active: true
+#  NewLineAtEndOfFile:
+#    active: true
+#  NoTabs:
+#    active: false
+#  NullableBooleanCheck:
+#    active: false
+#  ObjectLiteralToLambda:
+#    active: true
+#  OptionalAbstractKeyword:
+#    active: true
+#  OptionalUnit:
+#    active: false
+#  ProtectedMemberInFinalClass:
+#    active: true
+#  RangeUntilInsteadOfRangeTo:
+#    active: false
+#  RedundantConstructorKeyword:
+#    active: false
+#  RedundantExplicitType:
+#    active: false
+#  RedundantHigherOrderMapUsage:
+#    active: true
+#  RedundantVisibilityModifier:
+#    active: false
+#  ReturnCount:
+#    active: true
+#    max: 2
+#    excludedFunctions:
+#      - 'equals'
+#    excludeLabeled: false
+#    excludeReturnFromLambda: true
+#    excludeGuardClauses: false
+#  SafeCast:
+#    active: true
+#  SerialVersionUIDInSerializableClass:
+#    active: true
+#  SpacingAfterPackageAndImports:
+#    active: false
+#  StringShouldBeRawString:
+#    active: false
+#    maxEscapedCharacterCount: 2
+#    ignoredCharacters: []
+#  ThrowsCount:
+#    active: true
+#    max: 2
+#    excludeGuardClauses: false
+#  TrailingWhitespace:
+#    active: false
+#  TrimMultilineRawString:
+#    active: false
+#    trimmingMethods:
+#      - 'trimIndent'
+#      - 'trimMargin'
+#  UnderscoresInNumericLiterals:
+#    active: false
+#    acceptableLength: 4
+#    allowNonStandardGrouping: false
+#  UnnecessaryAny:
+#    active: false
+#  UnnecessaryApply:
+#    active: true
+#  UnnecessaryBackticks:
+#    active: false
+#  UnnecessaryBracesAroundTrailingLambda:
+#    active: false
+#  UnnecessaryFilter:
+#    active: true
+#  UnnecessaryFullyQualifiedName:
+#    active: false
+#  UnnecessaryInheritance:
+#    active: true
+#  UnnecessaryInnerClass:
+#    active: false
+#  UnnecessaryLet:
+#    active: false
+#  UnnecessaryParentheses:
+#    active: false
+#    allowForUnclearPrecedence: false
+#  UnnecessaryReversed:
+#    active: false
+#  UnusedImport:
+#    active: false
+#    additionalOperatorSet: []
+#  UnusedParameter:
+#    active: true
+#    aliases: ['UNUSED_PARAMETER', 'unused']
+#    allowedNames: 'ignored|expected'
+#  UnusedPrivateClass:
+#    active: true
+#    aliases: ['unused']
+#  UnusedPrivateFunction:
+#    active: true
+#    aliases: ['unused']
+#    allowedNames: ''
+#  UnusedPrivateProperty:
+#    active: true
+#    aliases: ['unused']
+#    allowedNames: 'ignored|expected|serialVersionUID'
+#  UnusedVariable:
+#    active: true
+#    aliases: ['UNUSED_VARIABLE', 'unused']
+#    allowedNames: 'ignored|_'
+#  UseAnyOrNoneInsteadOfFind:
+#    active: true
+#  UseArrayLiteralsInAnnotations:
+#    active: true
+#  UseCheckNotNull:
+#    active: true
+#  UseCheckOrError:
+#    active: true
+#  UseDataClass:
+#    active: false
+#    allowVars: false
+#  UseEmptyCounterpart:
+#    active: false
+#  UseIfEmptyOrIfBlank:
+#    active: false
+#  UseIfInsteadOfWhen:
+#    active: false
+#    ignoreWhenContainingVariableDeclaration: false
+#  UseIsNullOrEmpty:
+#    active: true
+#  UseLet:
+#    active: false
+#  UseOrEmpty:
+#    active: true
+#  UseRequire:
+#    active: true
+#  UseRequireNotNull:
+#    active: true
+#  UseSumOfInsteadOfFlatMapSize:
+#    active: false
+#  UselessCallOnNotNull:
+#    active: true
+#  UtilityClassWithPublicConstructor:
+#    active: true
+#  VarCouldBeVal:
+#    active: true
+#    aliases: ['CanBeVal']
+#    ignoreLateinitVar: false
+#  WildcardImport:
+#    active: true
+#    excludeImports:
+#      - 'java.util.*'

--- a/tachyon-server-kotlin/pom.xml
+++ b/tachyon-server-kotlin/pom.xml
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>org.jetbrains.kotlinx</groupId>
             <artifactId>kotlinx-coroutines-core-jvm</artifactId>
-            <version>1.11.0</version>
+            <version>${kotlinx-coroutines.version}</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -76,6 +76,7 @@
                 <extensions>true</extensions>
                 <configuration>
                     <javaParameters>true</javaParameters>
+                    <jvmTarget>${java.version}</jvmTarget>
                     <args>
                         <arg>-Xexplicit-api=strict</arg>
                         <arg>-Werror</arg>

--- a/tachyon-server-kotlin/pom.xml
+++ b/tachyon-server-kotlin/pom.xml
@@ -1,0 +1,192 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2026 Konstantin Pavlov.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>dev.tachyonmcp</groupId>
+        <artifactId>tachyon-root</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>tachyon-server-kotlin</artifactId>
+
+    <name>Tachyon MCP Server Kotlin</name>
+    <description>Kotlin extension module for Tachyon MCP server</description>
+
+    <properties>
+        <spotbugs.skip>true</spotbugs.skip>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>dev.tachyonmcp</groupId>
+            <artifactId>tachyon-server</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlinx</groupId>
+            <artifactId>kotlinx-coroutines-core-jvm</artifactId>
+            <version>1.11.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+
+        <!-- Test -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-test-junit5</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.kotest</groupId>
+            <artifactId>kotest-assertions-core-jvm</artifactId>
+            <version>${kotest.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <sourceDirectory>${project.basedir}/src/main/kotlin</sourceDirectory>
+        <testSourceDirectory>${project.basedir}/src/test/kotlin</testSourceDirectory>
+        <plugins>
+            <plugin>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-maven-plugin</artifactId>
+                <version>${kotlin.version}</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <javaParameters>true</javaParameters>
+                    <args>
+                        <arg>-Xexplicit-api=strict</arg>
+                        <arg>-Werror</arg>
+                    </args>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <dependencies>
+                    <dependency>
+                        <groupId>dev.detekt</groupId>
+                        <artifactId>detekt-cli</artifactId>
+                        <version>${detekt.version}</version>
+                        <classifier>all</classifier>
+                    </dependency>
+                </dependencies>
+                <executions>
+                    <execution>
+                        <id>detekt</id>
+                        <phase>process-test-classes</phase>
+                        <goals>
+                            <goal>java</goal>
+                        </goals>
+                        <configuration>
+                            <blockSystemExit>true</blockSystemExit>
+                            <mainClass>dev.detekt.cli.Main</mainClass>
+                            <arguments>
+                                <argument>--config</argument>
+                                <argument>${project.basedir}/detekt.yml</argument>
+                                <argument>--input</argument>
+                                <argument>${project.basedir}/src/main/kotlin:${project.basedir}/src/test/kotlin</argument>
+                                <argument>--excludes</argument>
+                                <argument>**/build/**:**/.gradle/**</argument>
+                                <argument>--jvm-target</argument>
+                                <argument>${java.version}</argument>
+                                <argument>--language-version</argument>
+                                <argument>2.2</argument>
+                                <argument>--debug</argument>
+                                <argument>--report</argument>
+                                <argument>html:${project.build.directory}/detekt/detekt.html</argument>
+                                <argument>--report</argument>
+                                <argument>checkstyle:${project.build.directory}/detekt/detekt.xml</argument>
+                            </arguments>
+                            <includePluginDependencies>true</includePluginDependencies>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>detekt-format</id>
+                        <goals>
+                            <goal>java</goal>
+                        </goals>
+                        <configuration>
+                            <mainClass>dev.detekt.cli.Main</mainClass>
+                            <arguments>
+                                <argument>--config</argument>
+                                <argument>${project.basedir}/detekt.yml</argument>
+                                <argument>--input</argument>
+                                <argument>${project.basedir}/src/main/kotlin:${project.basedir}/src/test/kotlin</argument>
+                                <argument>--excludes</argument>
+                                <argument>**/build/**:**/.gradle/**</argument>
+                                <argument>--jvm-target</argument>
+                                <argument>21</argument>
+                                <argument>--language-version</argument>
+                                <argument>2.2</argument>
+                                <argument>--auto-correct</argument>
+                            </arguments>
+                            <includePluginDependencies>true</includePluginDependencies>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.jetbrains.dokka</groupId>
+                <artifactId>dokka-maven-plugin</artifactId>
+                <version>2.2.0</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>javadocJar</goal>
+                        </goals>
+                        <phase>package</phase>
+                        <configuration>
+                            <attach>true</attach>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/tachyon-server-kotlin/pom.xml
+++ b/tachyon-server-kotlin/pom.xml
@@ -138,7 +138,6 @@
                                 <argument>${java.version}</argument>
                                 <argument>--language-version</argument>
                                 <argument>2.2</argument>
-                                <argument>--debug</argument>
                                 <argument>--report</argument>
                                 <argument>html:${project.build.directory}/detekt/detekt.html</argument>
                                 <argument>--report</argument>
@@ -162,7 +161,7 @@
                                 <argument>--excludes</argument>
                                 <argument>**/build/**:**/.gradle/**</argument>
                                 <argument>--jvm-target</argument>
-                                <argument>21</argument>
+                                <argument>${java.version}</argument>
                                 <argument>--language-version</argument>
                                 <argument>2.2</argument>
                                 <argument>--auto-correct</argument>

--- a/tachyon-server-kotlin/pom.xml
+++ b/tachyon-server-kotlin/pom.xml
@@ -59,6 +59,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
             <scope>test</scope>

--- a/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/AbstractAsyncToolHandlerExtensions.kt
+++ b/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/AbstractAsyncToolHandlerExtensions.kt
@@ -9,36 +9,29 @@ import dev.tachyonmcp.server.features.tools.ToolArgs
 import dev.tachyonmcp.server.features.tools.ToolDescriptor
 import dev.tachyonmcp.server.features.tools.ToolResult
 import dev.tachyonmcp.server.session.McpContext
-import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.asCoroutineDispatcher
-import kotlinx.coroutines.launch
-import java.util.concurrent.CompletableFuture
+import kotlinx.coroutines.future.future
 import java.util.concurrent.CompletionStage
 
 @JvmSynthetic
-internal fun McpServer.asyncHandler(
+internal fun asyncHandler(
     descriptor: ToolDescriptor,
     block: suspend ToolScope.() -> ToolResult<*>,
 ): AbstractAsyncToolHandler =
     object : AbstractAsyncToolHandler(descriptor) {
-        private val dispatcher = this@asyncHandler.executor().asCoroutineDispatcher()
-
         override fun handleAsync(
             context: McpContext,
             args: ToolArgs,
         ): CompletionStage<out ToolResult<*>> {
-            val future = CompletableFuture<ToolResult<*>>()
-            val scope = ToolScope(context, args)
-            CoroutineScope(dispatcher).launch {
-                try {
-                    future.complete(block(scope))
-                } catch (_: CancellationException) {
-                    future.cancel(false)
-                } catch (e: Exception) {
-                    future.completeExceptionally(e)
-                }
-            }
-            return future
+            val dispatcher =
+                context
+                    .server()
+                    .mcpServer()
+                    .executor()
+                    .asCoroutineDispatcher()
+            return CoroutineScope(dispatcher + CoroutineName("tool:${descriptor.name()}"))
+                .future { ToolScope(context, args).block() }
         }
     }

--- a/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/AbstractAsyncToolHandlerExtensions.kt
+++ b/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/AbstractAsyncToolHandlerExtensions.kt
@@ -9,6 +9,7 @@ import dev.tachyonmcp.server.features.tools.ToolArgs
 import dev.tachyonmcp.server.features.tools.ToolDescriptor
 import dev.tachyonmcp.server.features.tools.ToolResult
 import dev.tachyonmcp.server.session.McpContext
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.asCoroutineDispatcher
@@ -21,17 +22,22 @@ internal fun asyncHandler(
     block: suspend ToolScope.() -> ToolResult<*>,
 ): AbstractAsyncToolHandler =
     object : AbstractAsyncToolHandler(descriptor) {
+        @Volatile
+        private var cachedDispatcher: CoroutineDispatcher? = null
+        private val coroutineName = CoroutineName("tool:${descriptor.name()}")
+
         override fun handleAsync(
             context: McpContext,
             args: ToolArgs,
         ): CompletionStage<out ToolResult<*>> {
             val dispatcher =
-                context
+                cachedDispatcher ?: context
                     .server()
                     .mcpServer()
                     .executor()
                     .asCoroutineDispatcher()
-            return CoroutineScope(dispatcher + CoroutineName("tool:${descriptor.name()}"))
+                    .also { cachedDispatcher = it }
+            return CoroutineScope(dispatcher + coroutineName)
                 .future { ToolScope(context, args).block() }
         }
     }

--- a/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/AbstractAsyncToolHandlerExtensions.kt
+++ b/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/AbstractAsyncToolHandlerExtensions.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026 Konstantin Pavlov.
+ */
+
+package dev.tachyonmcp.server
+
+import dev.tachyonmcp.server.features.tools.AbstractAsyncToolHandler
+import dev.tachyonmcp.server.features.tools.ToolArgs
+import dev.tachyonmcp.server.features.tools.ToolDescriptor
+import dev.tachyonmcp.server.features.tools.ToolResult
+import dev.tachyonmcp.server.session.McpContext
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.launch
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionStage
+
+@JvmSynthetic
+internal fun McpServer.asyncHandler(
+    descriptor: ToolDescriptor,
+    block: suspend ToolScope.() -> ToolResult<*>,
+): AbstractAsyncToolHandler =
+    object : AbstractAsyncToolHandler(descriptor) {
+        private val dispatcher = this@asyncHandler.executor().asCoroutineDispatcher()
+
+        override fun handleAsync(
+            context: McpContext,
+            args: ToolArgs,
+        ): CompletionStage<out ToolResult<*>> {
+            val future = CompletableFuture<ToolResult<*>>()
+            val scope = ToolScope(context, args)
+            CoroutineScope(dispatcher).launch {
+                try {
+                    future.complete(block(scope))
+                } catch (_: CancellationException) {
+                    future.cancel(false)
+                } catch (e: Exception) {
+                    future.completeExceptionally(e)
+                }
+            }
+            return future
+        }
+    }

--- a/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/CapabilitiesScope.kt
+++ b/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/CapabilitiesScope.kt
@@ -1,0 +1,37 @@
+// Copyright (c) 2026 Konstantin Pavlov.
+
+package dev.tachyonmcp.server
+
+import dev.tachyonmcp.server.config.CapabilitiesConfig
+import dev.tachyonmcp.server.config.Mode
+
+@TachyonDsl
+public class CapabilitiesScope
+    @PublishedApi
+    internal constructor() {
+        public var tools: Mode = Mode.AUTO
+        public var toolsListChanged: Boolean = false
+        public var resources: Boolean = false
+        public var resourcesSubscribe: Boolean = false
+        public var resourcesListChanged: Boolean = false
+        public var prompts: Boolean = false
+        public var promptsListChanged: Boolean = false
+        public var tasks: Boolean = false
+        public var tasksCancel: Boolean = false
+        public var tasksRequests: Boolean = false
+        public var completions: Boolean = false
+        public var logging: Boolean = false
+
+        @PublishedApi
+        internal fun applyTo(builder: CapabilitiesConfig.Builder) {
+            builder.toolsMode(tools)
+            if (tools != Mode.OFF) {
+                builder.tools(toolsListChanged)
+            }
+            if (resources) builder.resources(resourcesSubscribe, resourcesListChanged)
+            if (prompts) builder.prompts(promptsListChanged)
+            if (tasks) builder.tasks(true, tasksCancel, tasksRequests)
+            if (completions) builder.completions()
+            if (logging) builder.logging()
+        }
+    }

--- a/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/CapabilitiesScope.kt
+++ b/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/CapabilitiesScope.kt
@@ -22,6 +22,25 @@ public class CapabilitiesScope
         public var completions: Boolean = false
         public var logging: Boolean = false
 
+        public fun tools(listChanged: Boolean = false) {
+            tools = Mode.ON
+            toolsListChanged = listChanged
+        }
+
+        public fun resources(
+            subscribe: Boolean = false,
+            listChanged: Boolean = false,
+        ) {
+            resources = true
+            resourcesSubscribe = subscribe
+            resourcesListChanged = listChanged
+        }
+
+        public fun prompts(listChanged: Boolean = false) {
+            prompts = true
+            promptsListChanged = listChanged
+        }
+
         @PublishedApi
         internal fun applyTo(builder: CapabilitiesConfig.Builder) {
             builder.toolsMode(tools)

--- a/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/McpServerExtensions.kt
+++ b/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/McpServerExtensions.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2026 Konstantin Pavlov.
+ */
+
+package dev.tachyonmcp.server
+
+import dev.tachyonmcp.server.features.tools.DefaultToolDescriptor
+import dev.tachyonmcp.server.features.tools.ToolDescriptor
+import dev.tachyonmcp.server.features.tools.ToolResult
+import tools.jackson.databind.JsonNode
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
+
+@JvmSynthetic
+public fun McpServer.registerTool(
+    name: String,
+    description: String? = null,
+    inputSchema: JsonNode? = null,
+    block: suspend ToolScope.() -> ToolResult<*>,
+): McpServer =
+    registerTool(configure = {
+        name(name)
+        description(description)
+        inputSchema(inputSchema)
+    }, block = block)
+
+@JvmSynthetic
+@OptIn(ExperimentalContracts::class)
+public inline fun McpServer.registerTool(
+    configure: DefaultToolDescriptor.Builder.() -> Unit = {},
+    noinline block: suspend ToolScope.() -> ToolResult<*>,
+): McpServer {
+    contract { callsInPlace(configure, InvocationKind.EXACTLY_ONCE) }
+    return registerTool(
+        descriptor = ToolDescriptor.builder().apply(configure).build(),
+        block = block,
+    )
+}
+
+@JvmSynthetic
+public fun McpServer.registerTool(
+    descriptor: ToolDescriptor,
+    block: suspend ToolScope.() -> ToolResult<*>,
+): McpServer {
+    this.registerTool(asyncHandler(descriptor, block))
+    return this
+}

--- a/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/NetworkScope.kt
+++ b/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/NetworkScope.kt
@@ -1,0 +1,36 @@
+// Copyright (c) 2026 Konstantin Pavlov.
+
+package dev.tachyonmcp.server
+
+import dev.tachyonmcp.server.config.NetworkConfig
+import kotlin.time.Duration
+import kotlin.time.toJavaDuration
+
+@TachyonDsl
+public class NetworkScope
+    @PublishedApi
+    internal constructor() {
+        public var host: String? = null
+        public var port: Int? = null
+        public var endpointPath: String? = null
+        public var allowNullOrigin: Boolean? = null
+        public var allowPrivateNetworks: Boolean? = null
+        public var readerIdleTimeout: Duration? = null
+        public var writerIdleTimeout: Duration? = null
+        public var maxContentLength: Int? = null
+        public val allowedOrigins: MutableList<String> = mutableListOf()
+        public val allowedHeaders: MutableList<String> = mutableListOf()
+
+        @PublishedApi internal fun applyTo(builder: NetworkConfig.Builder) {
+            host?.let(builder::host)
+            port?.let(builder::port)
+            endpointPath?.let(builder::endpointPath)
+            if (allowedOrigins.isNotEmpty()) builder.allowedOrigins(*allowedOrigins.toTypedArray())
+            allowNullOrigin?.let(builder::allowNullOrigin)
+            allowPrivateNetworks?.let(builder::allowPrivateNetworks)
+            if (allowedHeaders.isNotEmpty()) builder.allowedHeaders(*allowedHeaders.toTypedArray())
+            readerIdleTimeout?.let { builder.readerIdleTimeout(it.toJavaDuration()) }
+            writerIdleTimeout?.let { builder.writerIdleTimeout(it.toJavaDuration()) }
+            maxContentLength?.let(builder::maxContentLength)
+        }
+    }

--- a/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/PromptArgumentScope.kt
+++ b/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/PromptArgumentScope.kt
@@ -1,0 +1,33 @@
+// Copyright (c) 2026 Konstantin Pavlov.
+
+package dev.tachyonmcp.server
+
+import dev.tachyonmcp.server.domain.PromptArgument
+
+@TachyonDsl
+public class PromptArgumentScope
+    @PublishedApi
+    internal constructor() {
+        public var name: String? = null
+        public var title: String? = null
+        public var description: String? = null
+        public var required: Boolean? = null
+
+        @PublishedApi
+        internal fun build(): PromptArgument {
+            val n = requireNotNull(name) { "PromptArgument.name is required" }
+            return PromptArgument.of(n, title, description, required)
+        }
+    }
+
+public fun promptArgument(
+    name: String,
+    description: String? = null,
+    required: Boolean? = null,
+): PromptArgument = PromptArgument.of(name, null, description, required)
+
+public fun promptArgument(configure: PromptArgumentScope.() -> Unit): PromptArgument =
+    PromptArgumentScope()
+        .apply {
+            configure()
+        }.build()

--- a/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/PromptDescriptorScope.kt
+++ b/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/PromptDescriptorScope.kt
@@ -1,0 +1,34 @@
+// Copyright (c) 2026 Konstantin Pavlov.
+
+package dev.tachyonmcp.server
+
+import dev.tachyonmcp.server.domain.PromptArgument
+import dev.tachyonmcp.server.features.prompts.PromptDescriptor
+import tools.jackson.databind.JsonNode
+
+@TachyonDsl
+public class PromptDescriptorScope
+    @PublishedApi
+    internal constructor() {
+        public var name: String? = null
+        public var description: String? = null
+        public var title: String? = null
+        public var arguments: List<PromptArgument>? = null
+        public var inputSchema: JsonNode? = null
+
+        @PublishedApi
+        internal fun build(): PromptDescriptor {
+            val n = requireNotNull(name) { "PromptDescriptor.name is required" }
+            return PromptDescriptor.of(n, description, title, arguments, inputSchema)
+        }
+    }
+
+public fun promptDescriptor(
+    name: String,
+    configure: PromptDescriptorScope.() -> Unit = {},
+): PromptDescriptor =
+    PromptDescriptorScope()
+        .apply {
+            this.name = name
+            configure()
+        }.build()

--- a/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/PromptMessageExtensions.kt
+++ b/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/PromptMessageExtensions.kt
@@ -1,0 +1,7 @@
+// Copyright (c) 2026 Konstantin Pavlov.
+
+package dev.tachyonmcp.server
+
+import dev.tachyonmcp.server.domain.PromptMessage
+
+public fun promptMessagesOf(vararg messages: PromptMessage): List<PromptMessage> = messages.toList()

--- a/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/ResourceDescriptorScope.kt
+++ b/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/ResourceDescriptorScope.kt
@@ -1,0 +1,49 @@
+// Copyright (c) 2026 Konstantin Pavlov.
+
+package dev.tachyonmcp.server
+
+import dev.tachyonmcp.server.domain.Annotations
+import dev.tachyonmcp.server.domain.Icon
+import dev.tachyonmcp.server.features.resources.ResourceDescriptor
+
+@TachyonDsl
+public class ResourceDescriptorScope
+    @PublishedApi
+    internal constructor() {
+        public var name: String? = null
+        public var uri: String? = null
+        public var description: String? = null
+        public var mimeType: String? = null
+        public var title: String? = null
+        public var annotations: Annotations? = null
+        public var size: Double? = null
+        public var icons: List<Icon>? = null
+
+        @PublishedApi
+        internal fun build(): ResourceDescriptor {
+            val n = requireNotNull(name) { "ResourceDescriptor.name is required" }
+            val u = requireNotNull(uri) { "ResourceDescriptor.uri is required" }
+            return ResourceDescriptor.of(
+                n,
+                u,
+                description,
+                mimeType,
+                title,
+                annotations,
+                size,
+                icons,
+            )
+        }
+    }
+
+public fun resourceDescriptor(
+    name: String,
+    uri: String,
+    configure: ResourceDescriptorScope.() -> Unit = {},
+): ResourceDescriptor =
+    ResourceDescriptorScope()
+        .apply {
+            this.name = name
+            this.uri = uri
+            configure()
+        }.build()

--- a/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/ResourceScope.kt
+++ b/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/ResourceScope.kt
@@ -1,0 +1,30 @@
+// Copyright (c) 2026 Konstantin Pavlov.
+
+package dev.tachyonmcp.server
+
+import dev.tachyonmcp.server.domain.ReadResourceRequest
+import dev.tachyonmcp.server.domain.ResourceContents
+import dev.tachyonmcp.server.features.resources.ResourceDescriptor
+import dev.tachyonmcp.server.session.McpContext
+
+@TachyonDsl
+public class ResourceScope
+    @PublishedApi
+    internal constructor(
+        public val ctx: McpContext,
+        public val request: ReadResourceRequest,
+    ) {
+        public val uri: String
+            get() = request.uri()
+    }
+
+public fun ServerBuilder.resource(
+    name: String,
+    uri: String,
+    description: String? = null,
+    mimeType: String = "application/json",
+    handler: ResourceScope.() -> ResourceContents,
+): ServerBuilder =
+    resource(ResourceDescriptor.of(name, uri, description, mimeType)) { ctx, req ->
+        ResourceScope(ctx, req).handler()
+    }

--- a/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/ServerInfoScope.kt
+++ b/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/ServerInfoScope.kt
@@ -1,0 +1,31 @@
+// Copyright (c) 2026 Konstantin Pavlov.
+
+package dev.tachyonmcp.server
+
+import dev.tachyonmcp.server.config.ServerIdentityBuilder
+import dev.tachyonmcp.server.domain.Icon
+
+@TachyonDsl
+public class ServerInfoScope
+    @PublishedApi
+    internal constructor() {
+        public var name: String? = null
+        public var title: String? = null
+        public val icons: MutableList<Icon> = mutableListOf()
+        public var version: String? = null
+        public var description: String? = null
+        public var instructions: String? = null
+        public var websiteUrl: String? = null
+
+        @PublishedApi internal fun applyTo(builder: ServerIdentityBuilder) {
+            name?.let(builder::name)
+            version?.let(builder::version)
+            description?.let(builder::description)
+            instructions?.let(builder::instructions)
+            title?.let(builder::title)
+            websiteUrl?.let(builder::websiteUrl)
+            if (!icons.isEmpty()) {
+                icons.let(builder::icons)
+            }
+        }
+    }

--- a/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/SessionScope.kt
+++ b/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/SessionScope.kt
@@ -1,0 +1,26 @@
+// Copyright (c) 2026 Konstantin Pavlov.
+
+package dev.tachyonmcp.server
+
+import dev.tachyonmcp.server.config.SessionConfig
+import dev.tachyonmcp.server.session.SessionLogRouter
+import dev.tachyonmcp.server.session.SessionStore
+import kotlin.time.Duration
+import kotlin.time.toJavaDuration
+
+@TachyonDsl
+public class SessionScope
+    @PublishedApi
+    internal constructor() {
+        public var stateless: Boolean = false
+        public var sessionTtl: Duration? = null
+        public var sessionStore: SessionStore? = null
+        public var sessionLogRouter: SessionLogRouter? = null
+
+        @PublishedApi internal fun applyTo(builder: SessionConfig.Builder) {
+            builder.stateless(stateless)
+            sessionTtl?.let { builder.sessionTtl(it.toJavaDuration()) }
+            sessionStore?.let(builder::sessionStore)
+            sessionLogRouter?.let(builder::sessionLogRouter)
+        }
+    }

--- a/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/TachyonDsl.kt
+++ b/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/TachyonDsl.kt
@@ -1,0 +1,8 @@
+// Copyright (c) 2026 Konstantin Pavlov.
+
+package dev.tachyonmcp.server
+
+@DslMarker
+@Target(AnnotationTarget.CLASS, AnnotationTarget.TYPE)
+@Retention(AnnotationRetention.BINARY)
+public annotation class TachyonDsl

--- a/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/TachyonServer.kt
+++ b/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/TachyonServer.kt
@@ -1,0 +1,34 @@
+// Copyright (c) 2026 Konstantin Pavlov.
+
+package dev.tachyonmcp.server
+
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
+
+@Suppress("FunctionName")
+@OptIn(ExperimentalContracts::class)
+public inline fun TachyonServer(
+    port: Int = 8080,
+    configure: (@TachyonDsl TachyonServerBuilder).() -> Unit = {},
+): McpServerHandle {
+    contract { callsInPlace(configure, InvocationKind.EXACTLY_ONCE) }
+    return tachyonServer(port, configure)
+}
+
+@OptIn(ExperimentalContracts::class)
+public inline fun tachyonServer(
+    port: Int = 8080,
+    configure: (@TachyonDsl TachyonServerBuilder).() -> Unit = {},
+): McpServerHandle {
+    contract { callsInPlace(configure, InvocationKind.EXACTLY_ONCE) }
+    return TachyonServerBuilder().apply(configure).applyPort(port).bind()
+}
+
+@OptIn(ExperimentalContracts::class)
+public inline fun buildServer(
+    configure: (@TachyonDsl TachyonServerBuilder).() -> Unit = {},
+): McpServer {
+    contract { callsInPlace(configure, InvocationKind.EXACTLY_ONCE) }
+    return TachyonServerBuilder().apply(configure).build()
+}

--- a/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/TachyonServer.kt
+++ b/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/TachyonServer.kt
@@ -9,7 +9,7 @@ import kotlin.contracts.contract
 @Suppress("FunctionName")
 @OptIn(ExperimentalContracts::class)
 public inline fun TachyonServer(
-    port: Int = 8080,
+    port: Int? = null,
     configure: (@TachyonDsl TachyonServerBuilder).() -> Unit = {},
 ): McpServerHandle {
     contract { callsInPlace(configure, InvocationKind.EXACTLY_ONCE) }
@@ -18,11 +18,13 @@ public inline fun TachyonServer(
 
 @OptIn(ExperimentalContracts::class)
 public inline fun tachyonServer(
-    port: Int = 8080,
+    port: Int? = null,
     configure: (@TachyonDsl TachyonServerBuilder).() -> Unit = {},
 ): McpServerHandle {
     contract { callsInPlace(configure, InvocationKind.EXACTLY_ONCE) }
-    return TachyonServerBuilder().apply(configure).applyPort(port).bind()
+    val builder = TachyonServerBuilder().apply(configure)
+    builder.applyPort(port)
+    return builder.bind()
 }
 
 @OptIn(ExperimentalContracts::class)

--- a/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/TachyonServer.kt
+++ b/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/TachyonServer.kt
@@ -24,7 +24,7 @@ public inline fun tachyonServer(
     contract { callsInPlace(configure, InvocationKind.EXACTLY_ONCE) }
     val builder = TachyonServerBuilder().apply(configure)
     builder.applyPort(port)
-    return builder.bind()
+    return builder.start()
 }
 
 @OptIn(ExperimentalContracts::class)

--- a/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/TachyonServerBuilder.kt
+++ b/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/TachyonServerBuilder.kt
@@ -10,6 +10,7 @@ import dev.tachyonmcp.server.features.tools.ToolDescriptor
 import dev.tachyonmcp.server.features.tools.ToolResult
 import io.netty.channel.ChannelPipeline
 import tools.jackson.databind.JsonNode
+import java.util.concurrent.CompletableFuture
 
 @TachyonDsl
 public class TachyonServerBuilder
@@ -112,7 +113,11 @@ public class TachyonServerBuilder
                 }
             }
 
-        @PublishedApi internal fun bind(): McpServerHandle = delegate.bind()
+        @PublishedApi internal fun start(): McpServerHandle = delegate.start()
+
+        @PublishedApi internal fun startAsync(): CompletableFuture<McpServerHandle> =
+            delegate
+                .startAsync()
 
         @PublishedApi internal fun build(): McpServer = delegate.build()
     }

--- a/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/TachyonServerBuilder.kt
+++ b/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/TachyonServerBuilder.kt
@@ -6,7 +6,7 @@ import dev.tachyonmcp.server.domain.PromptMessage
 import dev.tachyonmcp.server.domain.ResourceContents
 import dev.tachyonmcp.server.features.prompts.PromptDescriptor
 import dev.tachyonmcp.server.features.resources.ResourceDescriptor
-import dev.tachyonmcp.server.features.tools.SyncToolHandler
+import dev.tachyonmcp.server.features.tools.ToolDescriptor
 import dev.tachyonmcp.server.features.tools.ToolResult
 import io.netty.channel.ChannelPipeline
 import tools.jackson.databind.JsonNode
@@ -50,13 +50,18 @@ public class TachyonServerBuilder
             name: String,
             description: String? = null,
             inputSchema: JsonNode? = null,
-            handler: ToolScope.() -> ToolResult<*>,
+            handler: suspend ToolScope.() -> ToolResult<*>,
         ): TachyonServerBuilder =
             this.also {
                 delegate.tool(
-                    SyncToolHandler.of(name, description, inputSchema) { ctx, args ->
-                        ToolScope(ctx, args).handler()
-                    },
+                    asyncHandler(
+                        ToolDescriptor
+                            .builder(name)
+                            .description(description)
+                            .inputSchema(inputSchema)
+                            .build(),
+                        handler,
+                    ),
                 )
             }
 

--- a/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/TachyonServerBuilder.kt
+++ b/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/TachyonServerBuilder.kt
@@ -1,0 +1,101 @@
+// Copyright (c) 2026 Konstantin Pavlov.
+
+package dev.tachyonmcp.server
+
+import dev.tachyonmcp.server.domain.PromptMessage
+import dev.tachyonmcp.server.domain.ResourceContents
+import dev.tachyonmcp.server.features.prompts.PromptDescriptor
+import dev.tachyonmcp.server.features.resources.ResourceDescriptor
+import dev.tachyonmcp.server.features.tools.SyncToolHandler
+import dev.tachyonmcp.server.features.tools.ToolResult
+import io.netty.channel.ChannelPipeline
+import tools.jackson.databind.JsonNode
+
+@TachyonDsl
+public class TachyonServerBuilder
+    @PublishedApi
+    internal constructor() {
+        @PublishedApi
+        internal val delegate: ServerBuilder = TachyonServer.builder()
+
+        public inline fun info(
+            crossinline configure: (@TachyonDsl ServerInfoScope).() -> Unit,
+        ): TachyonServerBuilder {
+            delegate.info { ServerInfoScope().apply(configure).applyTo(it) }
+            return this
+        }
+
+        public inline fun capabilities(
+            crossinline configure: (@TachyonDsl CapabilitiesScope).() -> Unit,
+        ): TachyonServerBuilder {
+            delegate.capabilities { CapabilitiesScope().apply(configure).applyTo(it) }
+            return this
+        }
+
+        public inline fun network(
+            crossinline configure: (@TachyonDsl NetworkScope).() -> Unit,
+        ): TachyonServerBuilder {
+            delegate.network { NetworkScope().apply(configure).applyTo(it) }
+            return this
+        }
+
+        public inline fun session(
+            crossinline configure: (@TachyonDsl SessionScope).() -> Unit,
+        ): TachyonServerBuilder {
+            delegate.session { SessionScope().apply(configure).applyTo(it) }
+            return this
+        }
+
+        public fun tool(
+            name: String,
+            description: String? = null,
+            inputSchema: JsonNode? = null,
+            handler: ToolScope.() -> ToolResult<*>,
+        ): TachyonServerBuilder =
+            this.also {
+                delegate.tool(
+                    SyncToolHandler.of(name, description, inputSchema) { ctx, args ->
+                        ToolScope(ctx, args).handler()
+                    },
+                )
+            }
+
+        public fun resource(
+            name: String,
+            uri: String,
+            description: String? = null,
+            mimeType: String = "application/json",
+            handler: ResourceScope.() -> ResourceContents,
+        ): TachyonServerBuilder =
+            this.also {
+                delegate.resource(
+                    ResourceDescriptor.of(name, uri, description, mimeType),
+                ) { ctx, req ->
+                    ResourceScope(ctx, req).handler()
+                }
+            }
+
+        public fun prompt(
+            name: String,
+            description: String,
+            handler: (arguments: String?) -> List<PromptMessage>,
+        ): TachyonServerBuilder =
+            this.also {
+                delegate.prompt(PromptDescriptor.of(name, description)) { args -> handler(args) }
+            }
+
+        public fun name(name: String): TachyonServerBuilder = this.also { delegate.name(name) }
+
+        public fun pipelineCustomizer(
+            customizer: (@TachyonDsl ChannelPipeline).() -> Unit,
+        ): TachyonServerBuilder = this.also { delegate.pipelineCustomizer { it.customizer() } }
+
+        @PublishedApi internal fun applyPort(port: Int): TachyonServerBuilder =
+            this.also {
+                delegate.port(port)
+            }
+
+        @PublishedApi internal fun bind(): McpServerHandle = delegate.bind()
+
+        @PublishedApi internal fun build(): McpServer = delegate.build()
+    }

--- a/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/TachyonServerBuilder.kt
+++ b/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/TachyonServerBuilder.kt
@@ -18,6 +18,9 @@ public class TachyonServerBuilder
         @PublishedApi
         internal val delegate: ServerBuilder = TachyonServer.builder()
 
+        @PublishedApi
+        internal var networkPortExplicitlySet: Boolean = false
+
         public inline fun info(
             crossinline configure: (@TachyonDsl ServerInfoScope).() -> Unit,
         ): TachyonServerBuilder {
@@ -35,7 +38,12 @@ public class TachyonServerBuilder
         public inline fun network(
             crossinline configure: (@TachyonDsl NetworkScope).() -> Unit,
         ): TachyonServerBuilder {
-            delegate.network { NetworkScope().apply(configure).applyTo(it) }
+            val scope = NetworkScope()
+            scope.configure()
+            delegate.network { scope.applyTo(it) }
+            if (scope.port != null) {
+                networkPortExplicitlySet = true
+            }
             return this
         }
 
@@ -95,9 +103,13 @@ public class TachyonServerBuilder
             customizer: (@TachyonDsl ChannelPipeline).() -> Unit,
         ): TachyonServerBuilder = this.also { delegate.pipelineCustomizer { it.customizer() } }
 
-        @PublishedApi internal fun applyPort(port: Int): TachyonServerBuilder =
+        @PublishedApi internal fun applyPort(port: Int?): TachyonServerBuilder =
             this.also {
-                delegate.port(port)
+                if (port != null) {
+                    delegate.port(port)
+                } else if (!networkPortExplicitlySet) {
+                    delegate.port(8080)
+                }
             }
 
         @PublishedApi internal fun bind(): McpServerHandle = delegate.bind()

--- a/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/TemplateScope.kt
+++ b/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/TemplateScope.kt
@@ -1,0 +1,34 @@
+// Copyright (c) 2026 Konstantin Pavlov.
+
+package dev.tachyonmcp.server
+
+import dev.tachyonmcp.server.domain.ResourceContents
+import dev.tachyonmcp.server.features.resources.ResourceTemplateEntry
+import dev.tachyonmcp.server.session.McpContext
+
+@TachyonDsl
+public class TemplateScope
+    @PublishedApi
+    internal constructor(
+        public val ctx: McpContext,
+        public val uri: String,
+        public val params: Map<String, String>,
+    ) {
+        public fun param(name: String): String =
+            params[name] ?: throw IllegalArgumentException("missing template variable: $name")
+    }
+
+public fun McpServer.resourceTemplate(
+    name: String,
+    uriTemplate: String,
+    description: String? = null,
+    mimeType: String = "application/json",
+    handler: TemplateScope.() -> ResourceContents,
+) {
+    resources()
+        .addTemplate(
+            ResourceTemplateEntry.of(name, uriTemplate, description, mimeType) { ctx, uri, params ->
+                TemplateScope(ctx, uri, params).handler()
+            },
+        )
+}

--- a/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/ToolDescriptorScope.kt
+++ b/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/ToolDescriptorScope.kt
@@ -1,0 +1,44 @@
+// Copyright (c) 2026 Konstantin Pavlov.
+
+package dev.tachyonmcp.server
+
+import dev.tachyonmcp.server.domain.ToolAnnotations
+import dev.tachyonmcp.server.features.tasks.TaskSupport
+import dev.tachyonmcp.server.features.tools.ToolDescriptor
+import tools.jackson.databind.JsonNode
+
+@TachyonDsl
+public class ToolDescriptorScope
+    @PublishedApi
+    internal constructor() {
+        public var name: String? = null
+        public var title: String? = null
+        public var description: String? = null
+        public var inputSchema: JsonNode? = null
+        public var outputSchema: JsonNode? = null
+        public var taskSupport: TaskSupport? = null
+        public var annotations: ToolAnnotations? = null
+
+        @PublishedApi
+        internal fun build(): ToolDescriptor {
+            val n = requireNotNull(name) { "ToolDescriptor.name is required" }
+            val builder = ToolDescriptor.builder(n)
+            title?.let(builder::title)
+            description?.let(builder::description)
+            inputSchema?.let(builder::inputSchema)
+            outputSchema?.let(builder::outputSchema)
+            taskSupport?.let(builder::taskSupport)
+            annotations?.let(builder::annotations)
+            return builder.build()
+        }
+    }
+
+public fun toolDescriptor(
+    name: String,
+    configure: ToolDescriptorScope.() -> Unit = {},
+): ToolDescriptor =
+    ToolDescriptorScope()
+        .apply {
+            this.name = name
+            configure()
+        }.build()

--- a/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/ToolScope.kt
+++ b/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/ToolScope.kt
@@ -1,0 +1,31 @@
+// Copyright (c) 2026 Konstantin Pavlov.
+
+package dev.tachyonmcp.server
+
+import dev.tachyonmcp.server.features.tools.SyncToolHandler
+import dev.tachyonmcp.server.features.tools.ToolArgs
+import dev.tachyonmcp.server.features.tools.ToolResult
+import dev.tachyonmcp.server.session.McpContext
+import tools.jackson.databind.JsonNode
+
+@TachyonDsl
+public class ToolScope
+    @PublishedApi
+    internal constructor(
+        public val ctx: McpContext,
+        public val args: ToolArgs,
+    )
+
+public fun ServerBuilder.tool(
+    name: String,
+    description: String? = null,
+    inputSchema: JsonNode? = null,
+    handler: ToolScope.() -> ToolResult<*>,
+): ServerBuilder =
+    tool(
+        SyncToolHandler.of(
+            name,
+            description,
+            inputSchema,
+        ) { ctx, args -> ToolScope(ctx, args).handler() },
+    )

--- a/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/ToolScope.kt
+++ b/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/ToolScope.kt
@@ -2,8 +2,8 @@
 
 package dev.tachyonmcp.server
 
-import dev.tachyonmcp.server.features.tools.SyncToolHandler
 import dev.tachyonmcp.server.features.tools.ToolArgs
+import dev.tachyonmcp.server.features.tools.ToolDescriptor
 import dev.tachyonmcp.server.features.tools.ToolResult
 import dev.tachyonmcp.server.session.McpContext
 import tools.jackson.databind.JsonNode
@@ -20,12 +20,15 @@ public fun ServerBuilder.tool(
     name: String,
     description: String? = null,
     inputSchema: JsonNode? = null,
-    handler: ToolScope.() -> ToolResult<*>,
+    handler: suspend ToolScope.() -> ToolResult<*>,
 ): ServerBuilder =
     tool(
-        SyncToolHandler.of(
-            name,
-            description,
-            inputSchema,
-        ) { ctx, args -> ToolScope(ctx, args).handler() },
+        asyncHandler(
+            ToolDescriptor
+                .builder(name)
+                .description(description)
+                .inputSchema(inputSchema)
+                .build(),
+            handler,
+        ),
     )

--- a/tachyon-server-kotlin/src/test/kotlin/dev/tachyonmcp/server/AsyncHandlerTest.kt
+++ b/tachyon-server-kotlin/src/test/kotlin/dev/tachyonmcp/server/AsyncHandlerTest.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026 Konstantin Pavlov.
+ */
+
+package dev.tachyonmcp.server
+
+import dev.tachyonmcp.server.features.tools.ToolDescriptor
+import dev.tachyonmcp.server.features.tools.ToolResult
+import dev.tachyonmcp.server.session.DefaultMcpContext
+import io.kotest.assertions.assertSoftly
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+import java.util.concurrent.CompletableFuture
+
+internal class AsyncHandlerTest {
+    @Test
+    fun `cancelling future cancels coroutine`() {
+        val started = CompletableDeferred<Unit>()
+        val handler =
+            asyncHandler(
+                ToolDescriptor.builder("cancel-test").build(),
+            ) {
+                started.complete(Unit)
+                while (true) {
+                    Thread.sleep(100)
+                }
+                @Suppress("UNREACHABLE_CODE")
+                ToolResult.text("never")
+            }
+
+        TachyonServer.builder().build().use { server ->
+            val ctx = DefaultMcpContext.stateless(server)
+            val future =
+                handler.handleAsync(
+                    ctx,
+                    dev.tachyonmcp.server.features.tools.ToolArgs
+                        .of(null),
+                ) as CompletableFuture<out ToolResult<*>>
+
+            runBlocking { started.await() }
+            future.cancel(true)
+
+            assertSoftly {
+                future.isCancelled() shouldBe true
+            }
+        }
+    }
+}

--- a/tachyon-server-kotlin/src/test/kotlin/dev/tachyonmcp/server/AsyncHandlerTest.kt
+++ b/tachyon-server-kotlin/src/test/kotlin/dev/tachyonmcp/server/AsyncHandlerTest.kt
@@ -4,27 +4,34 @@
 
 package dev.tachyonmcp.server
 
+import dev.tachyonmcp.server.features.tools.ToolArgs
 import dev.tachyonmcp.server.features.tools.ToolDescriptor
 import dev.tachyonmcp.server.features.tools.ToolResult
 import dev.tachyonmcp.server.session.DefaultMcpContext
 import io.kotest.assertions.assertSoftly
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
+import org.awaitility.Awaitility.await
 import org.junit.jupiter.api.Test
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.atomic.AtomicBoolean
 
 internal class AsyncHandlerTest {
     @Test
     fun `cancelling future cancels coroutine`() {
         val started = CompletableDeferred<Unit>()
+        val cancelled = AtomicBoolean(false)
         val handler =
             asyncHandler(
                 ToolDescriptor.builder("cancel-test").build(),
             ) {
                 started.complete(Unit)
-                while (true) {
-                    Thread.sleep(100)
+                try {
+                    delay(Long.MAX_VALUE)
+                } finally {
+                    cancelled.set(true)
                 }
                 @Suppress("UNREACHABLE_CODE")
                 ToolResult.text("never")
@@ -33,16 +40,14 @@ internal class AsyncHandlerTest {
         TachyonServer.builder().build().use { server ->
             val ctx = DefaultMcpContext.stateless(server)
             val future =
-                handler.handleAsync(
-                    ctx,
-                    dev.tachyonmcp.server.features.tools.ToolArgs
-                        .of(null),
-                ) as CompletableFuture<out ToolResult<*>>
+                handler.handleAsync(ctx, ToolArgs.of(null)) as CompletableFuture<out ToolResult<*>>
 
             runBlocking { started.await() }
             future.cancel(true)
 
+            await().untilTrue(cancelled)
             assertSoftly {
+                cancelled.get() shouldBe true
                 future.isCancelled() shouldBe true
             }
         }

--- a/tachyon-server-kotlin/src/test/kotlin/dev/tachyonmcp/server/McpProbe.kt
+++ b/tachyon-server-kotlin/src/test/kotlin/dev/tachyonmcp/server/McpProbe.kt
@@ -1,0 +1,61 @@
+// Copyright (c) 2026 Konstantin Pavlov.
+
+package dev.tachyonmcp.server
+
+import java.io.Closeable
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+
+/** Minimal raw-HTTP MCP client for probing a bound server in tests. */
+internal class McpProbe(
+    private val port: Int,
+) : Closeable {
+    private val http = HttpClient.newHttpClient()
+    private var sessionId: String? = null
+
+    fun initialize(): HttpResponse<String> {
+        val response =
+            post(
+                """
+                {"jsonrpc":"2.0","id":1,"method":"initialize",
+                 "params":{"protocolVersion":"2025-11-25","capabilities":{},
+                           "clientInfo":{"name":"kt-probe","version":"1.0"}}}
+                """.trimIndent(),
+            )
+        sessionId = response.headers().firstValue("MCP-Session-Id").orElseThrow()
+        post("""{"jsonrpc":"2.0","method":"notifications/initialized"}""")
+        return response
+    }
+
+    fun callTool(
+        name: String,
+        arguments: String = "{}",
+    ): HttpResponse<String> =
+        post(
+            """{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"$name","arguments":$arguments}}""",
+        )
+
+    fun request(
+        id: Int,
+        method: String,
+    ): HttpResponse<String> = post("""{"jsonrpc":"2.0","id":$id,"method":"$method"}""")
+
+    fun post(body: String): HttpResponse<String> {
+        val builder =
+            HttpRequest
+                .newBuilder()
+                .uri(URI.create("http://localhost:$port/mcp"))
+                .header("Content-Type", "application/json")
+                .header("Accept", "application/json, text/event-stream")
+                .header("MCP-Protocol-Version", "2025-11-25")
+                .POST(HttpRequest.BodyPublishers.ofString(body))
+        sessionId?.let { builder.header("MCP-Session-Id", it) }
+        return http.send(builder.build(), HttpResponse.BodyHandlers.ofString())
+    }
+
+    override fun close() {
+        http.close()
+    }
+}

--- a/tachyon-server-kotlin/src/test/kotlin/dev/tachyonmcp/server/TachyonServerTest.kt
+++ b/tachyon-server-kotlin/src/test/kotlin/dev/tachyonmcp/server/TachyonServerTest.kt
@@ -203,4 +203,31 @@ internal class TachyonServerTest {
             }
         }
     }
+
+    @Test
+    fun `notification sent during suspend tool arrives on the request stream`() {
+        TachyonServer(port = 0) {
+            name("notify-test")
+            tool("notify", "Notifies mid-run") {
+                delay(10.milliseconds)
+                ctx.notifications().info("notify-test", "mid-run-note")
+                delay(10.milliseconds)
+                ToolResult.text("notify-done")
+            }
+        }.use { handle ->
+            McpProbe(handle.port()).use { probe ->
+                probe.initialize()
+                val response = probe.callTool("notify")
+                response.statusCode() shouldBe 200
+                response.headers().firstValue("content-type").orElse("") shouldContain
+                    "text/event-stream"
+
+                val body = response.body()
+                body shouldContain "notifications/message"
+                body shouldContain "mid-run-note"
+                body shouldContain "notify-done"
+                (body.indexOf("mid-run-note") < body.indexOf("notify-done")) shouldBe true
+            }
+        }
+    }
 }

--- a/tachyon-server-kotlin/src/test/kotlin/dev/tachyonmcp/server/TachyonServerTest.kt
+++ b/tachyon-server-kotlin/src/test/kotlin/dev/tachyonmcp/server/TachyonServerTest.kt
@@ -13,7 +13,9 @@ import dev.tachyonmcp.server.session.InMemorySessionStore
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.string.shouldContain
+import kotlinx.coroutines.delay
 import org.junit.jupiter.api.Test
+import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.toJavaDuration
 
@@ -165,5 +167,40 @@ internal class TachyonServerTest {
             }
         server.getTool("build") shouldNotBe null
         server.close()
+    }
+
+    @Test
+    fun `suspend tool with delay returns correct result`() {
+        TachyonServer(port = 0) {
+            name("delay-test")
+            tool("slow", "Delayed") {
+                delay(10.milliseconds)
+                ToolResult.text("delayed-ok")
+            }
+        }.use { handle ->
+            McpProbe(handle.port()).use { probe ->
+                val init = probe.initialize()
+                init.statusCode() shouldBe 200
+
+                val response = probe.callTool("slow")
+                response.statusCode() shouldBe 200
+                response.body() shouldContain "delayed-ok"
+            }
+        }
+    }
+
+    @Test
+    fun `sync tool body compiles and works with suspend signature`() {
+        TachyonServer(port = 0) {
+            name("sync-test")
+            tool("ping", "Health check") { ToolResult.text("pong") }
+        }.use { handle ->
+            McpProbe(handle.port()).use { probe ->
+                probe.initialize()
+                val response = probe.callTool("ping")
+                response.statusCode() shouldBe 200
+                response.body() shouldContain "pong"
+            }
+        }
     }
 }

--- a/tachyon-server-kotlin/src/test/kotlin/dev/tachyonmcp/server/TachyonServerTest.kt
+++ b/tachyon-server-kotlin/src/test/kotlin/dev/tachyonmcp/server/TachyonServerTest.kt
@@ -1,0 +1,169 @@
+// Copyright (c) 2026 Konstantin Pavlov.
+
+package dev.tachyonmcp.server
+
+import dev.tachyonmcp.server.config.Mode
+import dev.tachyonmcp.server.domain.Icon
+import dev.tachyonmcp.server.domain.PromptMessage
+import dev.tachyonmcp.server.domain.TextContent
+import dev.tachyonmcp.server.domain.TextResourceContents
+import dev.tachyonmcp.server.features.tools.ToolResult
+import dev.tachyonmcp.server.session.InMemorySessionLogRouter
+import dev.tachyonmcp.server.session.InMemorySessionStore
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.string.shouldContain
+import org.junit.jupiter.api.Test
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.toJavaDuration
+
+@Suppress("LongMethod")
+internal class TachyonServerTest {
+    @Test
+    fun `all DSL parameters`() {
+        val appName = "tachyon-e2e"
+        TachyonServer(port = 0) {
+            info {
+                name = appName
+                title = "My Test MCP Server"
+                icons +=
+                    Icon.of(
+                        "https://example.com/s/icon.png",
+                        "image/png",
+                        listOf("64x64"),
+                        "white",
+                    )
+                websiteUrl = "https://example.com/mcp"
+                version = "2.0.0"
+                description = "e2e test server"
+                instructions = "ignore me"
+            }
+            capabilities {
+                tools = Mode.ON
+                toolsListChanged = true
+                resources = true
+                resourcesSubscribe = true
+                resourcesListChanged = true
+                prompts = true
+                promptsListChanged = true
+                tasks = true
+                tasksCancel = true
+                tasksRequests = true
+                completions = true
+                logging = true
+            }
+            network {
+                host = "127.0.0.1"
+                port = 0
+                endpointPath = "/mcp"
+                allowedOrigins.add("*")
+                allowNullOrigin = true
+                allowPrivateNetworks = true
+                readerIdleTimeout = 124.seconds
+                writerIdleTimeout = 60.seconds
+                maxContentLength = 1_000_000
+            }
+            session {
+                stateless = false
+                sessionTtl = 15.seconds
+                sessionStore = InMemorySessionStore()
+                sessionLogRouter = InMemorySessionLogRouter()
+            }
+            pipelineCustomizer { }
+            tool("ping", "Health check") { ToolResult.text("pong") }
+            resource(
+                "config",
+                "file:///config.yaml",
+                description = "App config",
+                mimeType = "text/yaml",
+            ) {
+                TextResourceContents.of(uri, "text/yaml", "key: value")
+            }
+            prompt("greet", "Say hello") {
+                listOf(PromptMessage.user(TextContent.of("Hello, ${it ?: "world"}!")))
+            }
+        }.use { handle ->
+            (handle.port() > 0) shouldBe true
+            val server = handle.server()
+            val config = server.config()
+
+            // identity
+            with(config.identity) {
+                name shouldBe appName
+                title shouldBe "My Test MCP Server"
+                version shouldBe "2.0.0"
+                description shouldBe "e2e test server"
+                instructions shouldBe "ignore me"
+                websiteUrl shouldBe "https://example.com/mcp"
+                icons shouldBe
+                    listOf(
+                        Icon.of(
+                            "https://example.com/s/icon.png",
+                            "image/png",
+                            listOf("64x64"),
+                            "white",
+                        ),
+                    )
+                websiteUrl shouldBe "https://example.com/mcp"
+            }
+
+            // capabilities
+            with(config.capabilities()) {
+                toolsMode() shouldBe Mode.ON
+                toolsListChanged() shouldBe true
+                resourcesMode() shouldBe Mode.ON
+                resourcesSubscribe() shouldBe true
+                resourcesListChanged() shouldBe true
+                promptsMode() shouldBe Mode.ON
+                promptsListChanged() shouldBe true
+                tasksList() shouldBe true
+                tasksCancel() shouldBe true
+                tasksRequests() shouldBe true
+                completions() shouldBe true
+                logging() shouldBe true
+            }
+
+            // session
+            config.session.stateless shouldBe false
+            config.session.sessionTtl shouldBe 15.seconds.toJavaDuration()
+
+            // network
+            with(config.network) {
+                host shouldBe "127.0.0.1"
+                endpointPath shouldBe "/mcp"
+                allowNullOrigin shouldBe true
+                readerIdleTimeout shouldBe 124.seconds.toJavaDuration()
+                writerIdleTimeout shouldBe 60.seconds.toJavaDuration()
+                maxContentLength shouldBe 1_000_000
+                allowPrivateNetworks shouldBe true
+            }
+
+            // registered features
+            server.getTool("ping") shouldNotBe null
+            server.prompts()["greet"] shouldNotBe null
+            server.resources()["config"] shouldNotBe null
+
+            // MCP initialize
+            McpProbe(handle.port()).use { probe ->
+                val init = probe.initialize()
+                init.statusCode() shouldBe 200
+                init.body() shouldContain appName
+                init.body() shouldContain "2.0.0"
+            }
+        }
+    }
+
+    @Test
+    fun `buildServer without binding`() {
+        val server =
+            buildServer {
+                name("kotlin-build")
+                capabilities {
+                    tools = Mode.AUTO
+                }
+                tool("build", "Build test") { ToolResult.text("built") }
+            }
+        server.getTool("build") shouldNotBe null
+        server.close()
+    }
+}

--- a/tachyon-server-kotlin/src/test/resources/junit-platform.properties
+++ b/tachyon-server-kotlin/src/test/resources/junit-platform.properties
@@ -1,0 +1,6 @@
+junit.jupiter.execution.parallel.config.executor-service=WORKER_THREAD_POOL
+junit.jupiter.execution.parallel.enabled = true
+junit.jupiter.execution.parallel.mode.classes.default = concurrent
+junit.jupiter.execution.parallel.mode.default = concurrent
+junit.jupiter.execution.timeout.default = 15 s
+

--- a/tachyon-server-kotlin/src/test/resources/slf4j-simple.properties
+++ b/tachyon-server-kotlin/src/test/resources/slf4j-simple.properties
@@ -1,0 +1,1 @@
+org.slf4j.simpleLogger.log.dev.tachyonmcp = debug

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/HandlerWatchdog.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/HandlerWatchdog.java
@@ -13,52 +13,31 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Fires a log entry at configurable thresholds when a handler takes longer than expected.
- *
- * <p>Log level is chosen by the handler thread's state at the moment the watchdog fires:
- *
- * <ul>
- *   <li>{@code BLOCKED} → WARN (waiting on a monitor — lock contention or deadlock)
- *   <li>{@code RUNNABLE} → DEBUG (long computation or hidden blocking)
- *   <li>{@code WAITING} / {@code TIMED_WAITING} → DEBUG (virtual thread parked — expected for
- *       async I/O)
- * </ul>
+ * Does not capture a thread reference — suitable for async handler pipelines where the
+ * continuation may run on any thread.
  */
 public final class HandlerWatchdog {
 
     private static final Logger logger = LoggerFactory.getLogger(HandlerWatchdog.class);
 
-    // Single daemon platform thread — scheduling infrastructure, not application I/O.
     private static final ScheduledExecutorService SCHEDULER = Executors.newSingleThreadScheduledExecutor(r -> {
         var t = new Thread(r, "handler-watchdog");
         t.setDaemon(true);
         return t;
     });
 
-    private static final String MSG =
-            "Handler slow: method={}, id={}, elapsed={}ms, state={}, thread={}#{} virtual={}{}";
-
     private HandlerWatchdog() {}
 
     /**
-     * Schedules a watchdog that fires after {@code delayMs} milliseconds and logs the live stack
-     * trace of {@code handlerThread} at a level determined by its state. Cancel the returned
-     * {@link Future} (with {@code cancel(false)}) when the handler completes normally.
+     * Schedules a watchdog that fires after {@code delayMs} milliseconds and logs a warning.
+     * Cancel the returned {@link Future} (with {@code cancel(false)}) when the handler completes normally.
      */
-    public static Future<?> watch(Object method, Object id, long startNs, Thread handlerThread, long delayMs) {
-        return SCHEDULER.schedule(() -> fire(method, id, startNs, handlerThread), delayMs, TimeUnit.MILLISECONDS);
+    public static Future<?> watch(Object method, Object id, long startNs, long delayMs) {
+        return SCHEDULER.schedule(() -> fire(method, id, startNs), delayMs, TimeUnit.MILLISECONDS);
     }
 
-    private static void fire(Object method, Object id, long startNs, Thread thread) {
+    private static void fire(Object method, Object id, long startNs) {
         var elapsedMs = (System.nanoTime() - startNs) / 1_000_000;
-        var state = thread.getState();
-        var frames = thread.getStackTrace();
-        var sb = new StringBuilder();
-        for (var f : frames) sb.append("\n    at ").append(f);
-        if (state == Thread.State.BLOCKED) {
-            logger.warn(MSG, method, id, elapsedMs, state, thread.getName(), thread.threadId(), thread.isVirtual(), sb);
-        } else {
-            logger.debug(
-                    MSG, method, id, elapsedMs, state, thread.getName(), thread.threadId(), thread.isVirtual(), sb);
-        }
+        logger.warn("Handler slow: method={}, id={}, elapsed={}ms", method, id, elapsedMs);
     }
 }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/HandlerWatchdog.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/HandlerWatchdog.java
@@ -38,6 +38,6 @@ public final class HandlerWatchdog {
 
     private static void fire(Object method, Object id, long startNs) {
         var elapsedMs = (System.nanoTime() - startNs) / 1_000_000;
-        logger.warn("Handler slow: method={}, id={}, elapsed={}ms", method, id, elapsedMs);
+        logger.debug("Handler slow: method={}, id={}, elapsed={}ms", method, id, elapsedMs);
     }
 }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/McpDispatcher.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/McpDispatcher.java
@@ -125,7 +125,7 @@ public class McpDispatcher {
                 return CompletableFuture.completedFuture(
                         errorResult(id, JsonRpcErrors.METHOD_NOT_FOUND, "Method not found"));
             }
-            return invokeHandlerAsync(id, method, params, outboundSseStream, statelessIc, null);
+            return invokeHandlerAsync(id, method, params, outboundSseStream, statelessIc, null, handler);
         }
 
         if (sessionId == null) {
@@ -141,10 +141,10 @@ public class McpDispatcher {
         var session = sessionOpt.get();
         session.touch();
 
-        if (ic != null) {
-            ic.setSession(session);
-            ic.setOutboundStream(outboundSseStream);
-        }
+        var protocol = ic != null ? ic.getProtocol() : Protocols.versions().get(0);
+        var requestCtx = new DefaultMcpContext(protocol, server);
+        requestCtx.setSession(session);
+        requestCtx.setOutboundStream(outboundSseStream);
 
         var sessionState = session.state();
         if (sessionState == SessionState.CLOSED) {
@@ -156,13 +156,13 @@ public class McpDispatcher {
                     errorResult(id, JsonRpcErrors.INVALID_REQUEST, "Session is not yet active, only ping allowed"));
         }
 
-        var handler = lookupHandler(method, params, ic);
+        var handler = lookupHandler(method, params, requestCtx);
         if (handler == null) {
             return CompletableFuture.completedFuture(
                     errorResult(id, JsonRpcErrors.METHOD_NOT_FOUND, "Method not found"));
         }
 
-        return invokeHandlerAsync(id, method, params, outboundSseStream, ic, session);
+        return invokeHandlerAsync(id, method, params, outboundSseStream, requestCtx, session, handler);
     }
 
     private @Nullable McpMethodHandler lookupHandler(String method, Object params, McpContext ic) {
@@ -180,13 +180,8 @@ public class McpDispatcher {
             Object params,
             @Nullable OutboundSseStream outboundSseStream,
             McpContext context,
-            @Nullable McpSession session) {
-        var handler = server.getHandler(method);
-        if (handler == null) {
-            return CompletableFuture.completedFuture(
-                    errorResult(id, JsonRpcErrors.METHOD_NOT_FOUND, "Method not found"));
-        }
-
+            @Nullable McpSession session,
+            McpMethodHandler handler) {
         var paramsStr = params instanceof Map || params instanceof List
                 ? JsonRpcCodec.writeValueAsString(params)
                 : params instanceof String s ? s : null;
@@ -216,13 +211,11 @@ public class McpDispatcher {
                                             try {
                                                 return handler.handleAsync(context, params);
                                             } catch (Exception e) {
-                                                return CompletableFuture.<Object>failedFuture(e);
+                                                return CompletableFuture.failedFuture(e);
                                             }
                                         });
                             } catch (Exception e) {
-                                return CompletableFuture.<Object>failedFuture(e);
-                            } finally {
-                                context.setOutboundStream(null);
+                                return CompletableFuture.failedFuture(e);
                             }
                         },
                         executor)
@@ -381,7 +374,7 @@ public class McpDispatcher {
                                 try {
                                     return handler.handleAsync(statelessIc, rawParams);
                                 } catch (Exception e) {
-                                    return CompletableFuture.<Object>failedFuture(e);
+                                    return CompletableFuture.failedFuture(e);
                                 }
                             },
                             executor)
@@ -406,7 +399,7 @@ public class McpDispatcher {
                             try {
                                 return handler.handleAsync(ic, rawParams);
                             } catch (Exception e) {
-                                return CompletableFuture.<Object>failedFuture(e);
+                                return CompletableFuture.failedFuture(e);
                             }
                         },
                         executor)

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/McpDispatcher.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/McpDispatcher.java
@@ -23,7 +23,9 @@ import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.Executor;
+import java.util.function.Function;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -111,13 +113,19 @@ public class McpDispatcher {
             if (sessionId == null) {
                 return dispatchInitializeAsync(id, params, ic);
             }
-            // initialize with an existing session ID → reject (E2: prevents re-initialization)
             var err = JsonRpcErrors.invalidRequest("Session already initialized");
             return CompletableFuture.completedFuture(errorResult(id, err.code(), err.message()));
         }
 
         if (server.isStateless() || (METHOD_PING.equals(method) && sessionId == null)) {
-            return dispatchStatelessAsync(id, method, params, outboundSseStream);
+            var statelessIc = DefaultMcpContext.stateless(server);
+            statelessIc.setOutboundStream(outboundSseStream);
+            var handler = lookupHandler(method, params, statelessIc);
+            if (handler == null) {
+                return CompletableFuture.completedFuture(
+                        errorResult(id, JsonRpcErrors.METHOD_NOT_FOUND, "Method not found"));
+            }
+            return invokeHandlerAsync(id, method, params, outboundSseStream, statelessIc, null);
         }
 
         if (sessionId == null) {
@@ -133,8 +141,6 @@ public class McpDispatcher {
         var session = sessionOpt.get();
         session.touch();
 
-        // Always bind the current session and outbound stream to the IC per-request
-        // (keep-alive connections reuse the channel IC across multiple sessions)
         if (ic != null) {
             ic.setSession(session);
             ic.setOutboundStream(outboundSseStream);
@@ -150,137 +156,97 @@ public class McpDispatcher {
                     errorResult(id, JsonRpcErrors.INVALID_REQUEST, "Session is not yet active, only ping allowed"));
         }
 
+        var handler = lookupHandler(method, params, ic);
+        if (handler == null) {
+            return CompletableFuture.completedFuture(
+                    errorResult(id, JsonRpcErrors.METHOD_NOT_FOUND, "Method not found"));
+        }
+
+        return invokeHandlerAsync(id, method, params, outboundSseStream, ic, session);
+    }
+
+    private @Nullable McpMethodHandler lookupHandler(String method, Object params, McpContext ic) {
+        var owningExtensionId = server.extensionForMethod(method);
+        if (owningExtensionId != null) {
+            if (!ic.isExtensionEnabled(owningExtensionId)) return null;
+            if (server.extensionRequiresMeta(owningExtensionId) && !hasMetaKey(params, owningExtensionId)) return null;
+        }
+        return server.getHandler(method);
+    }
+
+    private CompletableFuture<DispatchResult> invokeHandlerAsync(
+            Object id,
+            String method,
+            Object params,
+            @Nullable OutboundSseStream outboundSseStream,
+            McpContext context,
+            @Nullable McpSession session) {
+        var handler = server.getHandler(method);
+        if (handler == null) {
+            return CompletableFuture.completedFuture(
+                    errorResult(id, JsonRpcErrors.METHOD_NOT_FOUND, "Method not found"));
+        }
+
         var paramsStr = params instanceof Map || params instanceof List
                 ? JsonRpcCodec.writeValueAsString(params)
                 : params instanceof String s ? s : null;
 
-        var owningExtensionId = server.extensionForMethod(method);
-        if (owningExtensionId != null) {
-            if (!ic.isExtensionEnabled(owningExtensionId)) {
-                return CompletableFuture.completedFuture(
-                        errorResult(id, JsonRpcErrors.METHOD_NOT_FOUND, "Method not found"));
-            }
-            if (server.extensionRequiresMeta(owningExtensionId) && !hasMetaKey(params, owningExtensionId)) {
-                return CompletableFuture.completedFuture(
-                        errorResult(id, JsonRpcErrors.METHOD_NOT_FOUND, "Method not found"));
-            }
-        }
-
-        var handler = server.getHandler(method);
-        if (handler == null) {
-            var err = JsonRpcErrors.methodNotFound("Method not found");
-            return CompletableFuture.completedFuture(errorResult(id, err.code(), err.message()));
-        }
-
         return CompletableFuture.supplyAsync(
-                () -> {
-                    // E12: hold read lock so concurrent session.close() (write lock) must wait
-                    var readLock = session.lock().readLock();
-                    readLock.lock();
-                    try {
-                        if (session.state() == SessionState.CLOSED) {
-                            return errorResult(id, JsonRpcErrors.INVALID_REQUEST, "Session closed");
-                        }
-                        server.appendEvent(new SessionEvent.RequestEvent(
-                                session.id(), id, method, paramsStr, System.currentTimeMillis()));
-                        var thread = Thread.currentThread();
-                        var startNs = System.nanoTime();
-                        logger.debug(
-                                "Handler start: method={}, id={}, thread={}#{} virtual={}",
-                                method,
-                                id,
-                                thread.getName(),
-                                thread.threadId(),
-                                thread.isVirtual());
-
-                        var watchdog = HandlerWatchdog.watch(method, id, startNs, thread, SLOW_HANDLER_MS);
-
-                        try {
-                            Object resultValue;
-                            resultValue = OutboundSseStreamMessageRouter.withDispatchContext(
-                                    session.id(), outboundSseStream, () -> handler.handle(ic, params));
-                            var elapsedMs = (System.nanoTime() - startNs) / 1_000_000;
-                            watchdog.cancel(false);
-                            if (elapsedMs > SLOW_HANDLER_MS) {
-                                logger.debug(
-                                        "Handler completed (was slow): method={}, id={}, elapsed={}ms,"
-                                                + " thread={}#{} virtual={}",
-                                        method,
-                                        id,
-                                        elapsedMs,
-                                        thread.getName(),
-                                        thread.threadId(),
-                                        thread.isVirtual());
-                            } else {
-                                logger.debug("Handler done: method={}, id={}, elapsed={}ms", method, id, elapsedMs);
-                            }
-                            if (resultValue instanceof JsonRpcError error) {
-                                logger.debug("Handler error for {}: {}", method, error.message());
-                                return errorResult(id, error.code(), error.message());
-                            }
-                            return new DispatchResult.Response(encodeResponse(id, resultValue), null);
-                        } catch (CancellationException e) {
-                            var elapsedMs = (System.nanoTime() - startNs) / 1_000_000;
-                            watchdog.cancel(false);
-                            logger.debug("Handler cancelled: method={}, id={}, elapsed={}ms", method, id, elapsedMs);
-                            return errorResult(id, JsonRpcErrors.INTERNAL_ERROR, "Internal error");
-                        } catch (Exception e) {
-                            var elapsedMs = (System.nanoTime() - startNs) / 1_000_000;
-                            watchdog.cancel(false);
-                            logger.warn(
-                                    "Handler exception: method={}, id={}, elapsed={}ms,"
-                                            + " thread={}#{} virtual={}: {}",
+                        () -> {
+                            var startNs = System.nanoTime();
+                            var thread = Thread.currentThread();
+                            logger.debug(
+                                    "Handler start: method={}, id={}, thread={}#{} virtual={}",
                                     method,
                                     id,
-                                    elapsedMs,
                                     thread.getName(),
                                     thread.threadId(),
-                                    thread.isVirtual(),
-                                    e.getMessage(),
-                                    e);
-                            return errorResult(id, JsonRpcErrors.INTERNAL_ERROR, "Internal error");
-                        }
-                    } finally {
-                        if (ic != null) {
-                            ic.setOutboundStream(null);
-                        }
-                        readLock.unlock();
+                                    thread.isVirtual());
+
+                            if (session != null) {
+                                server.appendEvent(new SessionEvent.RequestEvent(
+                                        session.id(), id, method, paramsStr, System.currentTimeMillis()));
+                            }
+
+                            var watchdog = HandlerWatchdog.watch(method, id, startNs, SLOW_HANDLER_MS);
+
+                            try {
+                                return OutboundSseStreamMessageRouter.withDispatchContext(
+                                        session != null ? session.id() : null, outboundSseStream, () -> {
+                                            try {
+                                                return handler.handleAsync(context, params);
+                                            } catch (Exception e) {
+                                                return CompletableFuture.<Object>failedFuture(e);
+                                            }
+                                        });
+                            } catch (Exception e) {
+                                return CompletableFuture.<Object>failedFuture(e);
+                            } finally {
+                                context.setOutboundStream(null);
+                            }
+                        },
+                        executor)
+                .thenCompose(Function.identity())
+                .handle((result, ex) -> {
+                    if (ex != null) {
+                        return handleHandlerError(id, method, ex);
                     }
-                },
-                executor);
+                    if (result instanceof JsonRpcError error) {
+                        logger.debug("Handler error for {}: {}", method, error.message());
+                        return errorResult(id, error.code(), error.message());
+                    }
+                    return new DispatchResult.Response(encodeResponse(id, result), null);
+                });
     }
 
-    private CompletableFuture<DispatchResult> dispatchStatelessAsync(
-            Object id, String method, Object params, @Nullable OutboundSseStream outboundSseStream) {
-        var owningExtensionId = server.extensionForMethod(method);
-        if (owningExtensionId != null) {
-            return CompletableFuture.completedFuture(
-                    errorResult(id, JsonRpcErrors.METHOD_NOT_FOUND, "Method not found"));
+    private DispatchResult handleHandlerError(Object id, String method, Throwable ex) {
+        var unwrapped = ex instanceof CompletionException ce && ce.getCause() != null ? ce.getCause() : ex;
+        if (unwrapped instanceof CancellationException) {
+            logger.debug("Handler cancelled: method={}, id={}", method, id);
+            return errorResult(id, JsonRpcErrors.INTERNAL_ERROR, "Internal error");
         }
-        var handler = server.getHandler(method);
-        if (handler == null) {
-            var err = JsonRpcErrors.methodNotFound("Method not found");
-            return CompletableFuture.completedFuture(errorResult(id, err.code(), err.message()));
-        }
-        return CompletableFuture.supplyAsync(
-                () -> {
-                    var context = DefaultMcpContext.stateless(server);
-                    context.setOutboundStream(outboundSseStream);
-                    try {
-                        var result = OutboundSseStreamMessageRouter.withDispatchContext(
-                                null, outboundSseStream, () -> handler.handle(context, params));
-                        if (result instanceof JsonRpcError error) {
-                            return errorResult(id, error.code(), error.message());
-                        }
-                        return new DispatchResult.Response(encodeResponse(id, result), null);
-                    } catch (Exception e) {
-                        logger.warn("Stateless handler exception: method={}", method, e);
-                        return errorResult(id, JsonRpcErrors.INTERNAL_ERROR, "Internal error");
-                    } finally {
-                        context.setOutboundStream(null);
-                    }
-                },
-                executor);
+        logger.warn("Handler exception: method={}, id={}: {}", method, id, unwrapped.getMessage(), unwrapped);
+        return errorResult(id, JsonRpcErrors.INTERNAL_ERROR, "Internal error");
     }
 
     public DispatchResult dispatchNotification(String method, @Nullable Object params, @Nullable String sessionId) {
@@ -402,42 +368,60 @@ public class McpDispatcher {
     }
 
     private CompletableFuture<DispatchResult> dispatchInitializeAsync(Object id, Object rawParams, McpContext ic) {
-        return CompletableFuture.supplyAsync(
-                () -> {
-                    logger.debug("Client initialize: id={} stateless={}", id, server.isStateless());
-                    var handler = server.getHandler("initialize");
-                    if (handler == null) {
-                        return errorResult(id, JsonRpcErrors.METHOD_NOT_FOUND, "Method not found: initialize");
-                    }
-                    if (server.isStateless()) {
-                        try {
-                            var result = handler.handle(DefaultMcpContext.stateless(server), rawParams);
-                            if (result instanceof JsonRpcError error) {
-                                logger.debug("Initialize handler error (stateless): {}", error.message());
-                                return errorResult(id, error.code(), error.message());
-                            }
-                            return new DispatchResult.Response(encodeResponse(id, result), null);
-                        } catch (Exception e) {
-                            logger.warn("Initialize handler exception (stateless)", e);
+        logger.debug("Client initialize: id={} stateless={}", id, server.isStateless());
+        var handler = server.getHandler("initialize");
+        if (handler == null) {
+            return CompletableFuture.completedFuture(
+                    errorResult(id, JsonRpcErrors.METHOD_NOT_FOUND, "Method not found: initialize"));
+        }
+        if (server.isStateless()) {
+            var statelessIc = DefaultMcpContext.stateless(server);
+            return CompletableFuture.supplyAsync(
+                            () -> {
+                                try {
+                                    return handler.handleAsync(statelessIc, rawParams);
+                                } catch (Exception e) {
+                                    return CompletableFuture.<Object>failedFuture(e);
+                                }
+                            },
+                            executor)
+                    .thenCompose(Function.identity())
+                    .handle((result, ex) -> {
+                        if (ex != null) {
+                            logger.warn("Initialize handler exception (stateless)", ex);
                             return errorResult(id, JsonRpcErrors.INTERNAL_ERROR, "Internal error");
                         }
-                    }
-                    var sessionId = generateSessionId();
-                    var session = server.createSession(sessionId);
-                    try {
-                        ic.setSession(session);
-                        var result = handler.handle(ic, rawParams);
                         if (result instanceof JsonRpcError error) {
-                            logger.debug("Initialize handler error: {}", error.message());
+                            logger.debug("Initialize handler error (stateless): {}", error.message());
                             return errorResult(id, error.code(), error.message());
                         }
-                        return new DispatchResult.Response(encodeResponse(id, result), sessionId);
-                    } catch (Exception e) {
-                        logger.warn("Initialize handler exception", e);
+                        return new DispatchResult.Response(encodeResponse(id, result), null);
+                    });
+        }
+        var sessionId = generateSessionId();
+        var session = server.createSession(sessionId);
+        ic.setSession(session);
+        return CompletableFuture.supplyAsync(
+                        () -> {
+                            try {
+                                return handler.handleAsync(ic, rawParams);
+                            } catch (Exception e) {
+                                return CompletableFuture.<Object>failedFuture(e);
+                            }
+                        },
+                        executor)
+                .thenCompose(Function.identity())
+                .handle((result, ex) -> {
+                    if (ex != null) {
+                        logger.warn("Initialize handler exception", ex);
                         return errorResult(id, JsonRpcErrors.INTERNAL_ERROR, "Internal error");
                     }
-                },
-                executor);
+                    if (result instanceof JsonRpcError error) {
+                        logger.debug("Initialize handler error: {}", error.message());
+                        return errorResult(id, error.code(), error.message());
+                    }
+                    return new DispatchResult.Response(encodeResponse(id, result), sessionId);
+                });
     }
 
     private DispatchResult errorResult(Object id, int code, String message) {

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/McpMethodHandler.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/McpMethodHandler.java
@@ -5,6 +5,8 @@
 package dev.tachyonmcp.server;
 
 import dev.tachyonmcp.server.session.McpContext;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 /** Handles a single JSON-RPC method. */
 public interface McpMethodHandler {
@@ -14,4 +16,12 @@ public interface McpMethodHandler {
 
     /** Handles the method and returns the result to serialize as JSON-RPC response. */
     Object handle(McpContext context, Object params) throws Exception;
+
+    /**
+     * Handles the method asynchronously. Default delegates to {@link #handle}.
+     * Override for async handlers that return a future directly.
+     */
+    default CompletionStage<Object> handleAsync(McpContext context, Object params) throws Exception {
+        return CompletableFuture.completedFuture(handle(context, params));
+    }
 }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/McpServer.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/McpServer.java
@@ -50,7 +50,8 @@ public class McpServer implements Closeable {
     private final Map<String, McpMethodHandler> methodHandlers = new ConcurrentHashMap<>();
     final Map<String, LoggingLevel> loggingLevels = new ConcurrentHashMap<>();
     final ConcurrentHashMap<Object, CompletableFuture<String>> pendingRequests = new ConcurrentHashMap<>();
-    private final ExecutorService virtualThreadExecutor = Executors.newVirtualThreadPerTaskExecutor();
+    private final ExecutorService executor;
+    private final boolean ownsExecutor;
     private final List<McpExtension> extensions;
     private final Map<String, String> extensionMethodOwners = new ConcurrentHashMap<>();
     private final Map<String, McpExtension> extensionsById = new ConcurrentHashMap<>();
@@ -83,9 +84,9 @@ public class McpServer implements Closeable {
         return config.session().stateless();
     }
 
-    /** Returns the virtual-thread-per-task executor used for handler dispatch. */
+    /** Returns the executor used for handler dispatch. */
     public ExecutorService executor() {
-        return virtualThreadExecutor;
+        return executor;
     }
 
     /** Sets the logging level for a session. */
@@ -166,20 +167,16 @@ public class McpServer implements Closeable {
         return builder.build();
     }
 
-    public McpServer() {
-        this(new InMemorySessionLogRouter(), new InMemorySessionStore(), ServerConfig.DEFAULT, null, List.of());
-    }
-
-    public McpServer(SessionLogRouter router, SessionStore sessionStore, JsonSchemaValidator validator) {
-        this(router, sessionStore, ServerConfig.DEFAULT, validator, List.of());
-    }
-
-    public McpServer(
+    McpServer(
+            ExecutorService executor,
+            boolean ownsExecutor,
             SessionLogRouter router,
             SessionStore sessionStore,
             ServerConfig config,
             @Nullable JsonSchemaValidator validator,
             @Nullable List<McpExtension> extensions) {
+        this.executor = executor;
+        this.ownsExecutor = ownsExecutor;
         this.config = Objects.requireNonNull(config, "config cannot be null");
         this.router = Objects.requireNonNull(router, "router cannot be null");
         this.extensions = extensions != null ? extensions : List.of();
@@ -195,6 +192,39 @@ public class McpServer implements Closeable {
         if (!config.session().stateless()) {
             sessionManager.startJanitor(config.session().sessionTtl());
         }
+    }
+
+    public McpServer() {
+        this(
+                defaultExecutor(),
+                true,
+                new InMemorySessionLogRouter(),
+                new InMemorySessionStore(),
+                ServerConfig.DEFAULT,
+                null,
+                List.of());
+    }
+
+    public McpServer(SessionLogRouter router, SessionStore sessionStore, JsonSchemaValidator validator) {
+        this(defaultExecutor(), true, router, sessionStore, ServerConfig.DEFAULT, validator, List.of());
+    }
+
+    public McpServer(
+            SessionLogRouter router,
+            SessionStore sessionStore,
+            ServerConfig config,
+            @Nullable JsonSchemaValidator validator,
+            @Nullable List<McpExtension> extensions) {
+        this(defaultExecutor(), true, router, sessionStore, config, validator, extensions);
+    }
+
+    static ExecutorService defaultExecutorForBuilder() {
+        return defaultExecutor();
+    }
+
+    private static ExecutorService defaultExecutor() {
+        return Executors.newThreadPerTaskExecutor(
+                Thread.ofVirtual().name("tachyon-", 0).factory());
     }
 
     private void setupChangeListeners(ServerConfig config) {
@@ -549,14 +579,16 @@ public class McpServer implements Closeable {
         try {
             logger.info("Shutting down TachyonServer");
             shutdownExtensions();
-            virtualThreadExecutor.shutdown();
-            try {
-                if (!virtualThreadExecutor.awaitTermination(10, TimeUnit.SECONDS)) {
-                    virtualThreadExecutor.shutdownNow();
+            if (ownsExecutor) {
+                executor.shutdown();
+                try {
+                    if (!executor.awaitTermination(10, TimeUnit.SECONDS)) {
+                        executor.shutdownNow();
+                    }
+                } catch (InterruptedException e) {
+                    executor.shutdownNow();
+                    Thread.currentThread().interrupt();
                 }
-            } catch (InterruptedException e) {
-                virtualThreadExecutor.shutdownNow();
-                Thread.currentThread().interrupt();
             }
             taskRegistry.stopTtlJanitor();
             sessionManager.close();

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/McpServerHandle.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/McpServerHandle.java
@@ -8,7 +8,7 @@ import java.io.Closeable;
 import java.io.IOException;
 
 /**
- * Handle returned by the server builder's {@code bind()} method.
+ * Handle returned by the server builder's {@code start()} / {@code startAsync()} method.
  * Combines the logical {@link McpServer} and the bound transport.
  * Call {@link #close()} to shut down both.
  */

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/ServerBuilder.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/ServerBuilder.java
@@ -23,6 +23,7 @@ import io.netty.channel.ChannelPipeline;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
@@ -221,11 +222,11 @@ public final class ServerBuilder {
         return server;
     }
 
-    /** Builds the server and binds the Netty transport. Requires a port to be set. */
-    public McpServerHandle bind() {
+    /** Builds the server and starts the Netty transport (blocking). Requires a port to be set. */
+    public McpServerHandle start() {
         var networkConfig = networkBuilder.build();
         if (networkConfig.port() < 0) {
-            throw new IllegalStateException("Port must be set before bind()");
+            throw new IllegalStateException("Port must be set before start()");
         }
         var server = build();
         var nettyConfig = new NettyServerConfig(
@@ -243,6 +244,11 @@ public final class ServerBuilder {
                 pipelineCustomizer);
         var netty = new NettyServer(server, nettyConfig);
         return new McpServerHandle(server, netty.port(), netty);
+    }
+
+    /** Builds the server and starts the Netty transport (non-blocking). */
+    public CompletableFuture<McpServerHandle> startAsync() {
+        return CompletableFuture.supplyAsync(this::start);
     }
 
     /** Builds the {@link ServerConfig} from the current builder state. */

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/ServerBuilder.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/ServerBuilder.java
@@ -43,8 +43,8 @@ public final class ServerBuilder {
     @Nullable
     Consumer<ChannelPipeline> pipelineCustomizer;
 
-    private ExecutorService executor;
-    private ThreadFactory threadFactory;
+    private @Nullable ExecutorService executor;
+    private @Nullable ThreadFactory threadFactory;
 
     ServerBuilder() {}
 
@@ -185,9 +185,6 @@ public final class ServerBuilder {
         var store = sessionConfig.sessionStore() != null ? sessionConfig.sessionStore() : new InMemorySessionStore();
         var allExtensions = Collections.unmodifiableList(featuresConfig.extensions);
         var serverConfig = buildConfig();
-        if (executor != null && threadFactory != null) {
-            throw new IllegalStateException("executor() and threadFactory() are mutually exclusive");
-        }
         ExecutorService resolvedExecutor;
         boolean ownsExecutor;
         if (executor != null) {

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/ServerBuilder.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/ServerBuilder.java
@@ -23,6 +23,9 @@ import io.netty.channel.ChannelPipeline;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
 import java.util.function.Consumer;
 import org.jspecify.annotations.Nullable;
 
@@ -38,6 +41,9 @@ public final class ServerBuilder {
 
     @Nullable
     Consumer<ChannelPipeline> pipelineCustomizer;
+
+    private ExecutorService executor;
+    private ThreadFactory threadFactory;
 
     ServerBuilder() {}
 
@@ -135,6 +141,30 @@ public final class ServerBuilder {
         return this;
     }
 
+    /**
+     * Sets a caller-owned executor for handler dispatch. The server will not shut it down on close.
+     * Mutually exclusive with {@link #threadFactory}.
+     */
+    public ServerBuilder executor(ExecutorService executor) {
+        if (threadFactory != null) {
+            throw new IllegalStateException("executor() and threadFactory() are mutually exclusive");
+        }
+        this.executor = executor;
+        return this;
+    }
+
+    /**
+     * Sets a thread factory for virtual-thread-per-task executor creation. The server owns this
+     * executor and will shut it down on close. Mutually exclusive with {@link #executor}.
+     */
+    public ServerBuilder threadFactory(ThreadFactory threadFactory) {
+        if (executor != null) {
+            throw new IllegalStateException("executor() and threadFactory() are mutually exclusive");
+        }
+        this.threadFactory = threadFactory;
+        return this;
+    }
+
     // === Transport escape hatch ===
 
     /** Provides a customizer for the Netty channel pipeline. */
@@ -154,7 +184,29 @@ public final class ServerBuilder {
         var store = sessionConfig.sessionStore() != null ? sessionConfig.sessionStore() : new InMemorySessionStore();
         var allExtensions = Collections.unmodifiableList(featuresConfig.extensions);
         var serverConfig = buildConfig();
-        var server = new McpServer(router, store, serverConfig, featuresConfig.jsonSchemaValidator, allExtensions);
+        if (executor != null && threadFactory != null) {
+            throw new IllegalStateException("executor() and threadFactory() are mutually exclusive");
+        }
+        ExecutorService resolvedExecutor;
+        boolean ownsExecutor;
+        if (executor != null) {
+            resolvedExecutor = executor;
+            ownsExecutor = false;
+        } else if (threadFactory != null) {
+            resolvedExecutor = Executors.newThreadPerTaskExecutor(threadFactory);
+            ownsExecutor = true;
+        } else {
+            resolvedExecutor = McpServer.defaultExecutorForBuilder();
+            ownsExecutor = true;
+        }
+        var server = new McpServer(
+                resolvedExecutor,
+                ownsExecutor,
+                router,
+                store,
+                serverConfig,
+                featuresConfig.jsonSchemaValidator,
+                allExtensions);
         featuresConfig.tools.forEach(server::registerTool);
         featuresConfig.resources.forEach(r -> {
             var d = r.descriptor();

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/features/prompts/PromptEntry.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/features/prompts/PromptEntry.java
@@ -6,7 +6,7 @@ package dev.tachyonmcp.server.features.prompts;
 
 import dev.tachyonmcp.server.McpResourceType;
 
-record PromptEntry(PromptDescriptor descriptor, InputRequiredPromptHandler handler) implements McpResourceType {
+public record PromptEntry(PromptDescriptor descriptor, InputRequiredPromptHandler handler) implements McpResourceType {
 
     static PromptEntry of(PromptDescriptor descriptor, PromptHandler simple) {
         return new PromptEntry(

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tools/AsyncToolHandler.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tools/AsyncToolHandler.java
@@ -41,8 +41,13 @@ public interface AsyncToolHandler extends ToolHandler {
         return null;
     }
 
-    /** Executes the tool asynchronously. */
-    CompletionStage<? extends ToolResult<?>> handleAsync(McpContext context, ToolArgs args) throws Exception;
+    /** Executes the tool asynchronously with parsed args. */
+    CompletionStage<? extends ToolResult<?>> handleAsync(McpContext context, ToolArgs args);
+
+    /** Executes the tool asynchronously with the full request (includes meta/progressToken). */
+    default CompletionStage<? extends ToolResult<?>> handleAsync(McpContext context, ToolRequest request) {
+        return handleAsync(context, ToolArgs.of(request.arguments()));
+    }
 
     @Nullable
     default ToolAnnotations annotations() {
@@ -62,8 +67,8 @@ public interface AsyncToolHandler extends ToolHandler {
     }
 
     @Override
-    default CompletionStage<? extends ToolResult<?>> handle(ToolRequest request, McpContext context) throws Exception {
-        return handleAsync(context, ToolArgs.of(request.arguments()));
+    default CompletionStage<? extends ToolResult<?>> handle(ToolRequest request, McpContext context) {
+        return handleAsync(context, request);
     }
 
     /** Wraps a synchronous tool handler as an async one. */

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tools/SyncToolHandler.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tools/SyncToolHandler.java
@@ -63,8 +63,12 @@ public interface SyncToolHandler extends ToolHandler {
     }
 
     @Override
-    default CompletionStage<? extends ToolResult<?>> handle(ToolRequest request, McpContext context) throws Exception {
-        return CompletableFuture.completedFuture(handle(context, ToolArgs.of(request.arguments())));
+    default CompletionStage<? extends ToolResult<?>> handle(ToolRequest request, McpContext context) {
+        try {
+            return CompletableFuture.completedFuture(handle(context, ToolArgs.of(request.arguments())));
+        } catch (Exception e) {
+            return CompletableFuture.failedFuture(e);
+        }
     }
 
     /** Creates a simple SyncToolHandler from a name, description, schema, and function. */

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tools/ToolDescriptor.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tools/ToolDescriptor.java
@@ -13,10 +13,7 @@ import org.jspecify.annotations.Nullable;
 import tools.jackson.databind.JsonNode;
 
 @Value.Immutable
-@Value.Style(
-        allParameters = true,
-        visibility = Value.Style.ImplementationVisibility.PACKAGE,
-        typeImmutable = "Default*")
+@Value.Style(allParameters = true, typeImmutable = "Default*")
 public interface ToolDescriptor {
 
     String name();

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tools/ToolHandler.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tools/ToolHandler.java
@@ -12,5 +12,5 @@ public interface ToolHandler {
     ToolDescriptor descriptor();
 
     /** Executes the tool with the given request and context. */
-    CompletionStage<? extends ToolResult<?>> handle(ToolRequest request, McpContext context) throws Exception;
+    CompletionStage<? extends ToolResult<?>> handle(ToolRequest request, McpContext context);
 }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tools/ToolRegistry.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tools/ToolRegistry.java
@@ -16,7 +16,9 @@ import dev.tachyonmcp.server.features.PaginatedResult;
 import dev.tachyonmcp.server.session.McpContext;
 import dev.tachyonmcp.transport.jsonrpc.JsonRpcCodec;
 import java.util.*;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
@@ -204,18 +206,25 @@ public class ToolRegistry {
 
         @Override
         public Object handle(McpContext context, Object params) throws Exception {
+            return handleAsync(context, params).toCompletableFuture().join();
+        }
+
+        @Override
+        public CompletionStage<Object> handleAsync(McpContext context, Object params) {
             var parsed = parseCallParams(params);
-            if (parsed == null) return invalidRequest("Invalid params");
-            if (parsed.name().isBlank()) return invalidRequest("Missing tool name");
-            if (parsed.name().length() > 64) return invalidRequest("Tool name exceeds maximum length (SEP-986)");
+            if (parsed == null) return CompletableFuture.completedFuture(invalidRequest("Invalid params"));
+            if (parsed.name().isBlank()) return CompletableFuture.completedFuture(invalidRequest("Missing tool name"));
+            if (parsed.name().length() > 64)
+                return CompletableFuture.completedFuture(invalidRequest("Tool name exceeds maximum length (SEP-986)"));
 
             var handler = registry.get(parsed.name());
-            if (handler == null) return methodNotFound("Method not found");
+            if (handler == null) return CompletableFuture.completedFuture(methodNotFound("Method not found"));
             var extId = handler.descriptor().extensionId();
-            if (extId != null && !context.isExtensionEnabled(extId)) return methodNotFound("Method not found");
+            if (extId != null && !context.isExtensionEnabled(extId))
+                return CompletableFuture.completedFuture(methodNotFound("Method not found"));
 
             var validationError = validateInput(handler.descriptor().inputSchema(), parsed.args());
-            if (validationError != null) return invalidRequest(validationError);
+            if (validationError != null) return CompletableFuture.completedFuture(invalidRequest(validationError));
 
             sendLoggingIfEnabled(context, parsed.name(), "started");
 
@@ -229,22 +238,33 @@ public class ToolRegistry {
                     .requestState(parsed.requestState())
                     .build();
 
+            CompletionStage<? extends ToolResult<?>> toolStage;
             try {
-                var toolResult =
-                        handler.handle(request, context).toCompletableFuture().join();
-                sendLoggingIfEnabled(context, parsed.name(), "completed");
-                validateOutput(handler.descriptor().outputSchema(), toolResult);
-                return context.responseMapper().callToolResult(toolResult);
-            } catch (InvalidArgumentException e) {
-                return invalidRequest("invalid argument '" + e.argName() + "': " + e.getMessage());
-            } catch (CompletionException e) {
-                var cause = e.getCause();
-                if (cause instanceof InvalidArgumentException ia) {
-                    return invalidRequest("invalid argument '" + ia.argName() + "': " + ia.getMessage());
-                }
-                if (cause instanceof Exception ex) throw ex;
-                throw new RuntimeException(cause);
+                toolStage = handler.handle(request, context);
+            } catch (Exception e) {
+                return CompletableFuture.completedFuture(wrapToolError(e));
             }
+
+            return toolStage
+                    .thenApply(toolResult -> {
+                        sendLoggingIfEnabled(context, parsed.name(), "completed");
+                        validateOutput(handler.descriptor().outputSchema(), toolResult);
+                        return context.responseMapper().callToolResult(toolResult);
+                    })
+                    .exceptionally(e -> {
+                        var cause = CompletionException.class.isInstance(e) && e.getCause() != null ? e.getCause() : e;
+                        if (cause instanceof InvalidArgumentException ia) {
+                            return invalidRequest("invalid argument '" + ia.argName() + "': " + ia.getMessage());
+                        }
+                        throw new CompletionException(cause);
+                    });
+        }
+
+        private static Object wrapToolError(Exception e) {
+            if (e instanceof InvalidArgumentException ia) {
+                return invalidRequest("invalid argument '" + ia.argName() + "': " + ia.getMessage());
+            }
+            throw new CompletionException(e);
         }
 
         private static @Nullable Object parseProgressToken(@Nullable Map<String, JsonNode> meta) {

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/session/DefaultMcpContext.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/session/DefaultMcpContext.java
@@ -101,6 +101,18 @@ public class DefaultMcpContext extends DefaultInteractionContext<McpSession> imp
     }
 
     @Override
+    public void enableExtension(String extensionId) {
+        var s = session();
+        if (s != null) s.enableExtension(extensionId);
+    }
+
+    @Override
+    public boolean isExtensionEnabled(String extensionId) {
+        var s = session();
+        return s != null && s.isExtensionEnabled(extensionId);
+    }
+
+    @Override
     public ProtocolResponseMapper responseMapper() {
         return mcpServer.responseMapper();
     }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/session/McpSession.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/session/McpSession.java
@@ -11,8 +11,6 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.concurrent.locks.ReadWriteLock;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 /** Server-side session representing a single MCP client connection. */
 public class McpSession extends Session {
@@ -21,7 +19,6 @@ public class McpSession extends Session {
     private final AtomicReference<Backpressure> backpressure;
     private final AtomicLong cursor;
     private final Set<String> enabledExtensions = ConcurrentHashMap.newKeySet();
-    private final ReadWriteLock lock = new ReentrantReadWriteLock();
 
     public McpSession(String id, SseConnection connection) {
         super(id);
@@ -66,11 +63,6 @@ public class McpSession extends Session {
         return enabledExtensions.contains(extensionId);
     }
 
-    /** Returns the read-write lock for this session's state. */
-    public ReadWriteLock lock() {
-        return lock;
-    }
-
     /** Recomputes and returns the backpressure state based on stream writability. */
     public Backpressure computeBackpressure() {
         return backpressure.updateAndGet(current -> {
@@ -98,19 +90,14 @@ public class McpSession extends Session {
 
     @Override
     public boolean close() {
-        lock.writeLock().lock();
-        try {
-            var closed = state.compareAndSet(SessionState.ACTIVE, SessionState.CLOSED)
-                    || state.compareAndSet(SessionState.DRAINING, SessionState.CLOSED)
-                    || state.compareAndSet(SessionState.INITIALIZING, SessionState.CLOSED);
-            if (closed) {
-                var conn = connection.getAndSet(SseConnection.NOOP);
-                conn.close();
-            }
-            return closed;
-        } finally {
-            lock.writeLock().unlock();
+        var closed = state.compareAndSet(SessionState.ACTIVE, SessionState.CLOSED)
+                || state.compareAndSet(SessionState.DRAINING, SessionState.CLOSED)
+                || state.compareAndSet(SessionState.INITIALIZING, SessionState.CLOSED);
+        if (closed) {
+            var conn = connection.getAndSet(SseConnection.NOOP);
+            conn.close();
         }
+        return closed;
     }
 
     @Override

--- a/tachyon-server/src/test/java/dev/tachyonmcp/server/features/tools/ToolArgsTest.java
+++ b/tachyon-server/src/test/java/dev/tachyonmcp/server/features/tools/ToolArgsTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Map;
+import java.util.Objects;
 import org.junit.jupiter.api.Test;
 import tools.jackson.databind.node.JsonNodeFactory;
 
@@ -21,13 +22,13 @@ class ToolArgsTest {
 
     @Test
     void ofNonNullRawProducesNonEmptyArgs() {
-        var args = ToolArgs.of(Map.of("key", JSON.textNode("val")));
+        var args = ToolArgs.of(Map.of("key", JSON.stringNode("val")));
         assertThat(args.isEmpty()).isFalse();
     }
 
     @Test
     void hasReturnsTrueForExistingKey() {
-        var args = ToolArgs.of(Map.of("k", JSON.textNode("v")));
+        var args = ToolArgs.of(Map.of("k", JSON.stringNode("v")));
         assertThat(args.has("k")).isTrue();
     }
 
@@ -39,7 +40,7 @@ class ToolArgsTest {
 
     @Test
     void stringReturnsValue() {
-        var args = ToolArgs.of(Map.of("k", JSON.textNode("hello")));
+        var args = ToolArgs.of(Map.of("k", JSON.stringNode("hello")));
         assertThat(args.string("k")).isEqualTo("hello");
     }
 
@@ -63,7 +64,7 @@ class ToolArgsTest {
 
     @Test
     void stringOptReturnsValueWhenPresent() {
-        var args = ToolArgs.of(Map.of("k", JSON.textNode("v")));
+        var args = ToolArgs.of(Map.of("k", JSON.stringNode("v")));
         assertThat(args.stringOpt("k")).contains("v");
     }
 
@@ -75,7 +76,7 @@ class ToolArgsTest {
 
     @Test
     void stringOrReturnsValueWhenPresent() {
-        var args = ToolArgs.of(Map.of("k", JSON.textNode("v")));
+        var args = ToolArgs.of(Map.of("k", JSON.stringNode("v")));
         assertThat(args.stringOr("k", "def")).isEqualTo("v");
     }
 
@@ -87,8 +88,8 @@ class ToolArgsTest {
 
     @Test
     void nodeReturnsValueWhenPresent() {
-        var args = ToolArgs.of(Map.of("k", JSON.textNode("v")));
-        assertThat(args.node("k").asText()).isEqualTo("v");
+        var args = ToolArgs.of(Map.of("k", JSON.stringNode("v")));
+        assertThat(args.node("k").asString()).isEqualTo("v");
     }
 
     @Test
@@ -116,19 +117,19 @@ class ToolArgsTest {
 
     @Test
     void rawReturnsValueForPresentKey() {
-        var args = ToolArgs.of(Map.of("k", JSON.textNode("v")));
+        var args = ToolArgs.of(Map.of("k", JSON.stringNode("v")));
         assertThat(args.raw("k")).isNotNull();
     }
 
     @Test
     void rawReturnsNullForDifferentMissingKey() {
-        var args = ToolArgs.of(Map.of("a", JSON.textNode("x")));
+        var args = ToolArgs.of(Map.of("a", JSON.stringNode("x")));
         assertThat(args.raw("b")).isNull();
     }
 
     @Test
     void rawReturnsNodeWithText() {
-        var args = ToolArgs.of(Map.of("k", JSON.textNode("v")));
-        assertThat(args.raw("k").asText()).isEqualTo("v");
+        var args = ToolArgs.of(Map.of("k", JSON.stringNode("v")));
+        assertThat(Objects.requireNonNull(args.raw("k")).asString()).isEqualTo("v");
     }
 }

--- a/tachyon-server/src/test/java/dev/tachyonmcp/server/features/tools/ToolRegistryTest.java
+++ b/tachyon-server/src/test/java/dev/tachyonmcp/server/features/tools/ToolRegistryTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import dev.tachyonmcp.protocol.Protocols;
 import dev.tachyonmcp.protocol.mcp.v2025_11_25.models.CallToolResult;
 import dev.tachyonmcp.protocol.mcp.v2025_11_25.models.ListToolsResult;
+import dev.tachyonmcp.protocol.mcp.v2025_11_25.models.TextContent;
 import dev.tachyonmcp.server.JsonSchemaValidator;
 import dev.tachyonmcp.server.McpMethodHandler;
 import dev.tachyonmcp.server.TachyonServer;
@@ -26,6 +27,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
 import org.jspecify.annotations.Nullable;
@@ -510,6 +513,77 @@ class ToolRegistryTest {
         var handlers = new java.util.HashMap<String, McpMethodHandler>();
         registry.registerHandlers(handlers);
         assertThat(handlers.get("tools/call").method()).isEqualTo("tools/call");
+    }
+
+    @Test
+    void asyncToolHandlerCompletesFromSeparateThread() throws Exception {
+        var handlers = new HashMap<String, McpMethodHandler>();
+        registry.registerHandlers(handlers);
+        var executor = Executors.newSingleThreadExecutor(r -> new Thread(r, "async-tool-pool"));
+        registry.register(new AsyncToolHandler() {
+            @Override
+            public String name() {
+                return "async-thread";
+            }
+
+            @Override
+            public CompletionStage<ToolResult<?>> handleAsync(McpContext context, ToolRequest request) {
+                return CompletableFuture.supplyAsync(() -> ToolResult.text("from-thread"), executor);
+            }
+
+            @Override
+            public CompletionStage<? extends ToolResult<?>> handleAsync(McpContext context, ToolArgs args) {
+                return handleAsync(context, ToolRequest.of(name(), null, null));
+            }
+        });
+
+        try (var server = TachyonServer.builder().build()) {
+            var session = server.createSession("s-async-thread");
+            session.activate();
+            var callHandler = handlers.get("tools/call");
+            var ctx = new DefaultMcpContext(Protocols.versions().get(0), server);
+            ctx.setSession(session);
+            var params = Map.of("name", "async-thread", "arguments", Map.of());
+            var stage = callHandler.handleAsync(ctx, params);
+            var result = (CallToolResult) stage.toCompletableFuture().get(5, TimeUnit.SECONDS);
+            assertThat(result.content()).isNotEmpty();
+            assertThat(((TextContent) result.content().getFirst()).text()).isEqualTo("from-thread");
+        }
+        executor.shutdown();
+    }
+
+    @Test
+    void asyncToolHandlerInvalidArgumentExceptionMapsToInvalidRequest() throws Exception {
+        var handlers = new HashMap<String, McpMethodHandler>();
+        registry.registerHandlers(handlers);
+        registry.register(new AsyncToolHandler() {
+            @Override
+            public String name() {
+                return "invalid-arg-async";
+            }
+
+            @Override
+            public CompletionStage<ToolResult<?>> handleAsync(McpContext context, ToolRequest request) {
+                return CompletableFuture.failedFuture(new InvalidArgumentException("arg", "bad input"));
+            }
+
+            @Override
+            public CompletionStage<? extends ToolResult<?>> handleAsync(McpContext context, ToolArgs args) {
+                return handleAsync(context, ToolRequest.of(name(), null, null));
+            }
+        });
+
+        try (var server = TachyonServer.builder().build()) {
+            var session = server.createSession("s-inv-arg");
+            session.activate();
+            var callHandler = handlers.get("tools/call");
+            var ctx = new DefaultMcpContext(Protocols.versions().get(0), server);
+            ctx.setSession(session);
+            var params = Map.of("name", "invalid-arg-async", "arguments", Map.of());
+            var result = callHandler.handle(ctx, params);
+            assertThat(result).isInstanceOf(JsonRpcError.class);
+            assertThat(((JsonRpcError) result).code()).isEqualTo(JsonRpcErrors.INVALID_REQUEST);
+        }
     }
 
     @Test

--- a/tachyon-server/src/test/java/dev/tachyonmcp/server/features/tools/ToolRequestTest.java
+++ b/tachyon-server/src/test/java/dev/tachyonmcp/server/features/tools/ToolRequestTest.java
@@ -27,7 +27,7 @@ class ToolRequestTest {
 
     @Test
     void builderSetsArguments() {
-        var args = Map.of("k", JSON.textNode("v"));
+        var args = Map.of("k", JSON.stringNode("v"));
         var req = ToolRequest.builder().name("t").arguments(args).build();
         assertThat(req.arguments()).isEqualTo(args);
     }
@@ -40,7 +40,7 @@ class ToolRequestTest {
 
     @Test
     void builderSetsMeta() {
-        var meta = Map.of("mk", JSON.textNode("mv"));
+        var meta = Map.of("mk", JSON.stringNode("mv"));
         var req = ToolRequest.builder().name("t").meta(meta).build();
         assertThat(req.meta()).isEqualTo(meta);
     }
@@ -77,8 +77,8 @@ class ToolRequestTest {
 
     @Test
     void ofFactoryWithAllParams() {
-        Map<String, JsonNode> args = Map.of("k", JSON.textNode("v"));
-        Map<String, JsonNode> meta = Map.of("m", JSON.textNode("mv"));
+        Map<String, JsonNode> args = Map.of("k", JSON.stringNode("v"));
+        Map<String, JsonNode> meta = Map.of("m", JSON.stringNode("mv"));
         var req = ToolRequest.of("my-tool", args, meta, 99L, null);
         assertThat(req.name()).isEqualTo("my-tool");
         assertThat(req.arguments()).isEqualTo(args);
@@ -96,7 +96,7 @@ class ToolRequestTest {
 
     @Test
     void ofFactoryWithThreeParams() {
-        Map<String, JsonNode> args = Map.of("k", JSON.textNode("v"));
+        Map<String, JsonNode> args = Map.of("k", JSON.stringNode("v"));
         var req = ToolRequest.of("my-tool", args, null);
         assertThat(req.name()).isEqualTo("my-tool");
         assertThat(req.arguments()).isEqualTo(args);
@@ -104,9 +104,9 @@ class ToolRequestTest {
 
     @Test
     void metaIsAccessibleWhenPresent() {
-        Map<String, JsonNode> meta = Map.of("k", JSON.textNode("v"));
+        Map<String, JsonNode> meta = Map.of("k", JSON.stringNode("v"));
         var req = ToolRequest.builder().name("t").meta(meta).build();
         assertThat(req.meta()).isNotNull();
-        assertThat(req.meta().get("k").asText()).isEqualTo("v");
+        assertThat(req.meta().get("k").asString()).isEqualTo("v");
     }
 }

--- a/tachyon-server/src/test/java/dev/tachyonmcp/server/handlers/ExtensionNegotiationTest.java
+++ b/tachyon-server/src/test/java/dev/tachyonmcp/server/handlers/ExtensionNegotiationTest.java
@@ -89,6 +89,16 @@ class ExtensionNegotiationTest {
                 .build();
     }
 
+    @Test
+    void sessionBackedExtensionStateIsSharedAcrossContexts() {
+        var ctxA = context(session, server);
+        var ctxB = context(session, server);
+
+        ctxA.enableExtension("test-ext");
+        assertThat(ctxA.isExtensionEnabled("test-ext")).isTrue();
+        assertThat(ctxB.isExtensionEnabled("test-ext")).isTrue();
+    }
+
     private static class TestExtension implements McpExtension {
 
         final AtomicBoolean initCalled = new AtomicBoolean();

--- a/tachyon-server/src/test/java/dev/tachyonmcp/transport/netty/NettyServerThreadingTest.java
+++ b/tachyon-server/src/test/java/dev/tachyonmcp/transport/netty/NettyServerThreadingTest.java
@@ -15,7 +15,9 @@ import dev.tachyonmcp.server.features.tools.ToolResult;
 import dev.tachyonmcp.server.session.McpContext;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
@@ -62,5 +64,59 @@ class NettyServerThreadingTest {
                     .as("tool handler must run on a virtual thread")
                     .endsWith("virtual:true");
         }
+    }
+
+    @Test
+    void customThreadFactoryAddsNamePrefix() throws Exception {
+        var handlerThreadName = new CompletableFuture<String>();
+
+        try (McpServer server = TachyonServer.builder()
+                .threadFactory(Thread.ofVirtual().name("tenant-", 0).factory())
+                .tool(new AbstractSyncToolHandler("name_probe") {
+                    @Override
+                    public ToolResult<?> handle(McpContext context, ToolArgs args) {
+                        handlerThreadName.complete(Thread.currentThread().getName());
+                        return ToolResult.empty();
+                    }
+                })
+                .build()) {
+            server.createSession("sess-name").activate();
+            var dispatcher = new McpDispatcher(server, server.executor());
+            dispatcher
+                    .dispatchRequestAsync(
+                            1,
+                            "tools/call",
+                            java.util.Map.of("name", "name_probe", "arguments", java.util.Map.of()),
+                            "sess-name")
+                    .join();
+
+            String name = handlerThreadName.get(10, TimeUnit.SECONDS);
+            assertThat(name).as("thread name must use tenant prefix").startsWith("tenant-");
+        }
+    }
+
+    @Test
+    void callerSuppliedExecutorIsNotShutDownByServerClose() throws Exception {
+        var executor = Executors.newSingleThreadExecutor();
+        var closed = new AtomicBoolean(false);
+
+        var server = TachyonServer.builder()
+                .executor(executor)
+                .tool(new AbstractSyncToolHandler("exec_probe") {
+                    @Override
+                    public ToolResult<?> handle(McpContext context, ToolArgs args) {
+                        return ToolResult.empty();
+                    }
+                })
+                .build();
+        server.close();
+
+        // The executor should still be usable (not shut down)
+        closed.set(false);
+        var result = executor.submit(() -> closed.set(true)).get(5, TimeUnit.SECONDS);
+        assertThat(closed)
+                .as("caller-owned executor must remain active after server.close()")
+                .isTrue();
+        executor.shutdown();
     }
 }

--- a/tachyon-server/src/test/java/dev/tachyonmcp/transport/netty/NettyServerThreadingTest.java
+++ b/tachyon-server/src/test/java/dev/tachyonmcp/transport/netty/NettyServerThreadingTest.java
@@ -112,8 +112,7 @@ class NettyServerThreadingTest {
         server.close();
 
         // The executor should still be usable (not shut down)
-        closed.set(false);
-        var result = executor.submit(() -> closed.set(true)).get(5, TimeUnit.SECONDS);
+        executor.submit(() -> closed.set(true)).get(5, TimeUnit.SECONDS);
         assertThat(closed)
                 .as("caller-owned executor must remain active after server.close()")
                 .isTrue();


### PR DESCRIPTION
## Changes

**Async dispatch (breaking)**
- `McpMethodHandler.handleAsync` — dispatcher composes `CompletionStage`s instead of blocking; `tools/call` no longer `join()`s, so `AsyncToolHandler` futures complete without pinning a dispatch thread
- `ToolHandler.handle` / `AsyncToolHandler.handleAsync` no longer declare `throws Exception` (failed stage instead); new `handleAsync(ctx, ToolRequest)` overload exposes meta/progressToken
- Deleted the per-session RW-lock (E12) — session state is checked once, stale responses are dropped; `McpSession.close()` is pure CAS
- Per-request `DefaultMcpContext` replaces mutation of the shared per-channel context — fixes outbound-SSE stream lifetime for async tools and the keep-alive race
- Extension state moved from channel-local set to `McpSession` — negotiated extensions now work across pooled connections

**Executor injection (multitenancy hook)**
- `ServerBuilder.executor(ExecutorService)` — caller-owned, not shut down by `close()`
- `ServerBuilder.threadFactory(ThreadFactory)` — server-owned VT-per-task executor (e.g. tenant-named virtual threads)
- Default unchanged: virtual-thread-per-task (`tachyon-` prefix)

**Kotlin DSL (breaking)**
- `tool {}` is now `suspend` — sync bodies compile unchanged, `delay()`/IO just work; single entry point, no overload ambiguity
- Coroutine bridge rewritten on `future {}`: bidirectional cancellation (future.cancel → coroutine cancelled), no orphaned scopes
- `bind()` → `start()` rename; DSL idiom cleanups

## Tests
- E2E: suspend tool over HTTP; mid-suspend notification delivered on the POST-SSE request stream (ordered before result); custom thread-factory prefix observed in handler; caller-owned executor survives `close()`
- Unit: future→coroutine cancellation propagation (Awaitility); async tool completing from foreign thread; async `InvalidArgumentException` → invalid-request; session-backed extension state shared across contexts