### PR TITLE
feat: configurable shutdownGracePeriod

### DIFF
--- a/.agents/skills/tachyon-mcp/SKILL.md
+++ b/.agents/skills/tachyon-mcp/SKILL.md
@@ -35,7 +35,7 @@ var handle = TachyonServer.builder()
 |---|---|
 | `.info(cfg)` | name, version, description, title, websiteUrl, instructions |
 | `.capabilities(cfg)` | tools/resources/prompts/tasks/completions/logging |
-| `.session(cfg)` | stateless, sessionTtl, SessionLogRouter, SessionStore |
+| `.session(cfg)` | stateless, sessionTtl, shutdownGracePeriod, SessionLogRouter, SessionStore |
 | `.network(cfg)` | host, port, endpointPath, timeouts, CORS, maxContentLength |
 | `.name(s)` `.port(p)` | shorthands |
 | `.tool(handler)` | Sync/Async/ToolHandler |
@@ -142,6 +142,7 @@ Default `AUTO` → advertised only when registered. Force with `Mode.ON` / `Mode
 |---|---|
 | `.stateless(b)` | false |
 | `.sessionTtl(d)` | 30s |
+| `.shutdownGracePeriod(d)` | 5s (drain in-flight handlers on close; `ZERO` = interrupt now) |
 | `.sessionLogRouter(r)` / `.sessionStore(s)` | null (in-memory) |
 
 ## JSON Schema

--- a/.agents/skills/tachyon-mcp/resources/java/ConfigReference.java
+++ b/.agents/skills/tachyon-mcp/resources/java/ConfigReference.java
@@ -65,6 +65,7 @@ final class ConfigReference {
         return SessionConfig.builder()
                 .stateless(false)
                 .sessionTtl(Duration.ofMinutes(10))
+                .shutdownGracePeriod(Duration.ofSeconds(5))
                 .build();
     }
 }

--- a/.agents/skills/tachyon-mcp/resources/java/ServerBasic.java
+++ b/.agents/skills/tachyon-mcp/resources/java/ServerBasic.java
@@ -27,7 +27,9 @@ public final class ServerBasic {
         var handle = TachyonServer.builder()
                 .info(it -> it.name("demo-server").version("1.0").description("Demo MCP server"))
                 .capabilities(c -> c.tools(true).resources(true, true).prompts(true))
-                .session(s -> s.stateless(false).sessionTtl(java.time.Duration.ofMinutes(5)))
+                .session(s -> s.stateless(false)
+                        .sessionTtl(java.time.Duration.ofMinutes(5))
+                        .shutdownGracePeriod(java.time.Duration.ofSeconds(5)))
                 .network(n -> n.allowedOrigins("*").allowNullOrigin(true))
                 .tool(SyncToolHandler.of("ping", null, null, (ctx, args) -> ToolResult.text("pong")))
                 .resource(

--- a/.agents/skills/tachyon-mcp/resources/kotlin/ServerBasic.kt
+++ b/.agents/skills/tachyon-mcp/resources/kotlin/ServerBasic.kt
@@ -10,6 +10,7 @@ import dev.tachyonmcp.server.features.resources.ResourceTemplateEntry
 import dev.tachyonmcp.server.features.tools.ToolResult
 import dev.tachyonmcp.server.promptMessagesOf
 import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
 
 fun createServer(port: Int = 0): ServerHandle = TachyonServer(port = port) {
     info {
@@ -25,6 +26,7 @@ fun createServer(port: Int = 0): ServerHandle = TachyonServer(port = port) {
     session {
         stateless = false
         sessionTtl = 5.minutes
+        shutdownGracePeriod = 5.seconds
     }
     network {
         allowedOrigins.add("*")

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,7 +124,8 @@ jobs:
           mvn install -pl tachyon-server-kotlin -am -DskipTests
 
       - name: Verify examples
-        run: mvn verify -f examples/${{ matrix.example }}/pom.xml -Dtachyon-server.version=1.0.0-SNAPSHOT --no-transfer-progress
+        working-directory: 'examples/${{ matrix.example }}'
+        run: mvn verify -Dtachyon-server.version=1.0.0-SNAPSHOT --no-transfer-progress
 
       - name: Publish test results
         uses: mikepenz/action-junit-report@v6

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ test:
 package:
 	@echo "📦 Packaging and installing tachyon-server to local repository..."
 	@rm -rf ~/.m2/repository/dev/tachyonmcp
-	@mvn install -pl tachyon-server,tachyon-server-kotlin,e2e -am -DskipTests
+	@mvn install -pl tachyon-server,tachyon-server-kotlin -am -DskipTests
 
 examples: package
 	@echo "🌤️ Building and testing weather example..."

--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ Check out [Skills CLI](https://github.com/vercel-labs/skills) for more options.
 - Session Janitor — 5s sweep, 30s TTL
 - SSE disconnect ≠ session removal (supports reconnect)
 - Event log replay on reconnection
+- Graceful shutdown — drains in-flight handlers for `shutdownGracePeriod` (default 5s) before force-interrupt
 
 ---
 

--- a/docs/kotlin.md
+++ b/docs/kotlin.md
@@ -84,7 +84,7 @@ For class-based handlers, extend `AbstractSyncToolHandler` or `AbstractAsyncTool
 | `ServerInfoScope` | `info { }` | `name`, `version`, `description`, `title`, `instructions` |
 | `CapabilitiesScope` | `capabilities { }` | `tools()`, `resources()`, `prompts()`, `tasks()`, `logging()`, `completions()` |
 | `NetworkScope` | `network { }` | `host`, `port`, `endpointPath`, `allowedOrigins`, `maxContentLength` |
-| `SessionScope` | `session { }` | `stateless`, `sessionTtl` |
+| `SessionScope` | `session { }` | `stateless`, `sessionTtl`, `shutdownGracePeriod` |
 | `ToolScope` | tool lambda | `ctx`, `args` |
 | `ResourceScope` | resource lambda | `ctx`, `request`, `uri` |
 

--- a/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/SessionScope.kt
+++ b/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/SessionScope.kt
@@ -14,12 +14,14 @@ public class SessionScope
     internal constructor() {
         public var stateless: Boolean = false
         public var sessionTtl: Duration? = null
+        public var shutdownGracePeriod: Duration? = null
         public var sessionStore: SessionStore? = null
         public var sessionLogRouter: SessionLogRouter? = null
 
         @PublishedApi internal fun applyTo(builder: SessionConfig.Builder) {
             builder.stateless(stateless)
             sessionTtl?.let { builder.sessionTtl(it.toJavaDuration()) }
+            shutdownGracePeriod?.let { builder.shutdownGracePeriod(it.toJavaDuration()) }
             sessionStore?.let(builder::sessionStore)
             sessionLogRouter?.let(builder::sessionLogRouter)
         }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/runtime/Session.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/runtime/Session.java
@@ -120,10 +120,18 @@ public class Session {
         return computeBackpressure() != Backpressure.HOT;
     }
 
-    /** Sends an SSE event to the client. */
+    /**
+     * Sends an SSE event to the client. Returns {@code false} without sending when no connection
+     * is attached or the stream is throttled ({@link Backpressure#COLD}) — a slow client must not
+     * accumulate events in the channel's outbound buffer. Dropped events stay in the event log and
+     * are replayable via {@code Last-Event-ID} on reconnect.
+     */
     public boolean send(SseEvent event) {
         var conn = connection.get();
         if (conn == SseConnection.NOOP) {
+            return false;
+        }
+        if (shouldThrottle()) {
             return false;
         }
         conn.send(event);

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/Server.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/Server.java
@@ -588,7 +588,8 @@ public class Server implements Closeable {
             if (ownsExecutor) {
                 executor.shutdown();
                 try {
-                    if (!executor.awaitTermination(10, TimeUnit.SECONDS)) {
+                    var grace = config.session().shutdownGracePeriod();
+                    if (!executor.awaitTermination(grace.toMillis(), TimeUnit.MILLISECONDS)) {
                         executor.shutdownNow();
                     }
                 } catch (InterruptedException e) {

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/ServerHandle.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/ServerHandle.java
@@ -44,8 +44,11 @@ public final class ServerHandle implements Closeable {
     public void close() {
         if (transport instanceof NettyServer netty) {
             netty.stopAccepting();
-            server.close();
-            netty.close();
+            try {
+                server.close();
+            } finally {
+                netty.close();
+            }
             return;
         }
         try {

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/ServerHandle.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/ServerHandle.java
@@ -4,6 +4,7 @@
 
 package dev.tachyonmcp.server;
 
+import dev.tachyonmcp.transport.netty.NettyServer;
 import java.io.Closeable;
 import java.io.IOException;
 
@@ -34,8 +35,19 @@ public final class ServerHandle implements Closeable {
         return server;
     }
 
+    /**
+     * Shuts down transport and server. For the Netty transport the order is: stop accepting new
+     * connections, drain in-flight handlers while event loops are still alive (so responses can
+     * flush), then tear down channels and event loops.
+     */
     @Override
     public void close() {
+        if (transport instanceof NettyServer netty) {
+            netty.stopAccepting();
+            server.close();
+            netty.close();
+            return;
+        }
         try {
             transport.close();
         } catch (IOException e) {

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/config/SessionConfig.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/config/SessionConfig.java
@@ -12,18 +12,22 @@ import org.jspecify.annotations.Nullable;
 /**
  * Session lifecycle and persistence configuration.
  *
- * @param stateless        when {@code true}, no session is created and no TTL tracking occurs
- * @param sessionTtl       duration after which idle sessions are evicted (default 30s)
- * @param sessionLogRouter optional custom event log router; {@code null} uses in-memory default
- * @param sessionStore     optional custom session store; {@code null} uses in-memory default
+ * @param stateless           when {@code true}, no session is created and no TTL tracking occurs
+ * @param sessionTtl          duration after which idle sessions are evicted (default 30s)
+ * @param shutdownGracePeriod time an owned executor is given to drain in-flight handlers on
+ *                            {@code close()} before they are force-interrupted (default 5s)
+ * @param sessionLogRouter    optional custom event log router; {@code null} uses in-memory default
+ * @param sessionStore        optional custom session store; {@code null} uses in-memory default
  */
 public record SessionConfig(
         boolean stateless,
         Duration sessionTtl,
+        Duration shutdownGracePeriod,
         @Nullable SessionLogRouter sessionLogRouter,
         @Nullable SessionStore sessionStore) {
 
-    public static final SessionConfig DEFAULT = new SessionConfig(false, Duration.ofSeconds(30), null, null);
+    public static final SessionConfig DEFAULT =
+            new SessionConfig(false, Duration.ofSeconds(30), Duration.ofSeconds(5), null, null);
 
     public static Builder builder() {
         return new Builder();
@@ -33,6 +37,7 @@ public record SessionConfig(
     public static final class Builder {
         private boolean stateless;
         private Duration sessionTtl = Duration.ofSeconds(30);
+        private Duration shutdownGracePeriod = Duration.ofSeconds(5);
         private @Nullable SessionLogRouter sessionLogRouter;
         private @Nullable SessionStore sessionStore;
 
@@ -50,6 +55,16 @@ public record SessionConfig(
             return this;
         }
 
+        /**
+         * Sets the shutdown grace period: how long an owned executor is given to drain in-flight
+         * handlers on {@code close()} before they are force-interrupted. {@code Duration.ZERO}
+         * interrupts running handlers immediately.
+         */
+        public Builder shutdownGracePeriod(Duration shutdownGracePeriod) {
+            this.shutdownGracePeriod = shutdownGracePeriod;
+            return this;
+        }
+
         /** Sets a custom session event log router. */
         public Builder sessionLogRouter(@Nullable SessionLogRouter router) {
             this.sessionLogRouter = router;
@@ -64,7 +79,7 @@ public record SessionConfig(
 
         /** Builds the {@link SessionConfig}. */
         public SessionConfig build() {
-            return new SessionConfig(stateless, sessionTtl, sessionLogRouter, sessionStore);
+            return new SessionConfig(stateless, sessionTtl, shutdownGracePeriod, sessionLogRouter, sessionStore);
         }
     }
 }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/McpOperationHandler.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/McpOperationHandler.java
@@ -28,6 +28,7 @@ import io.netty.handler.timeout.IdleStateEvent;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
+import java.util.concurrent.RejectedExecutionException;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -101,28 +102,33 @@ public class McpOperationHandler extends ChannelInboundHandlerAdapter {
             server.getSession(sessionId).ifPresent(Session::touch);
         }
         var body = req.content().retain();
-        CompletableFuture.runAsync(
-                        () -> {
-                            final JsonRpcMessage message;
-                            try {
-                                message = dispatcher.parseMessage(body);
-                            } finally {
-                                body.release();
-                            }
-                            dispatchPostMessage(ctx, sessionId, message, origin);
-                        },
-                        executor)
-                .exceptionally(ex -> {
-                    logger.error("Failed to parse POST body", ex);
-                    ctx.executor()
-                            .execute(() -> sendResponseAndClose(
-                                    ctx,
-                                    HttpResponseStatus.BAD_REQUEST,
-                                    "application/json",
-                                    dispatcher.parseError(),
-                                    origin));
-                    return null;
-                });
+        try {
+            CompletableFuture.runAsync(
+                            () -> {
+                                final JsonRpcMessage message;
+                                try {
+                                    message = dispatcher.parseMessage(body);
+                                } finally {
+                                    body.release();
+                                }
+                                dispatchPostMessage(ctx, sessionId, message, origin);
+                            },
+                            executor)
+                    .exceptionally(ex -> {
+                        logger.error("Failed to parse POST body", ex);
+                        ctx.executor()
+                                .execute(() -> sendResponseAndClose(
+                                        ctx,
+                                        HttpResponseStatus.BAD_REQUEST,
+                                        "application/json",
+                                        dispatcher.parseError(),
+                                        origin));
+                        return null;
+                    });
+        } catch (RejectedExecutionException e) {
+            body.release();
+            sendPlainTextAndClose(ctx, HttpResponseStatus.SERVICE_UNAVAILABLE, "Server shutting down", origin);
+        }
     }
 
     private void dispatchPostMessage(
@@ -194,59 +200,89 @@ public class McpOperationHandler extends ChannelInboundHandlerAdapter {
         final MutableInteractionContext ic = ChannelHandlerUtils.requireInteractionContext(ctx);
         dispatcher
                 .dispatchRequestAsync(requestId, method, req.params(), sessionId, postStream, ic)
-                .whenComplete((result, ex) -> ctx.executor().execute(() -> {
-                    var elapsedMs = (System.nanoTime() - startNs) / 1_000_000;
-                    if (ex != null) {
-                        logger.error(
-                                "Dispatch failed: id={}, method={}, elapsed={}ms", requestId, method, elapsedMs, ex);
-                        if (postStream.started()) {
-                            postStream.close();
-                        } else {
-                            // Neutralize the stream so a late server→client message cannot start a
-                            // second HTTP response on this channel, then send the JSON error.
-                            postStream.close();
-                            sendInternalError(ctx, requestId, origin);
-                        }
-                        return;
+                .whenComplete((result, ex) -> {
+                    try {
+                        ctx.executor()
+                                .execute(() -> completePostRequest(
+                                        ctx, requestId, method, sessionId, origin, postStream, startNs, result, ex));
+                    } catch (RejectedExecutionException e) {
+                        releaseResult(result);
+                        logger.debug(
+                                "Event loop rejected response marshal during shutdown: id={}, method={}",
+                                requestId,
+                                method);
                     }
-                    if (postStream.started()) {
-                        finalizePostSseResponse(requestId, sessionId, postStream, result);
-                        if (elapsedMs > 500) {
-                            logger.warn(
-                                    "Slow POST-SSE response: id={}, method={}, elapsed={}ms",
-                                    requestId,
-                                    method,
-                                    elapsedMs);
-                        } else {
-                            logger.debug(
-                                    "POST-SSE response: id={}, method={}, elapsed={}ms", requestId, method, elapsedMs);
-                        }
-                        return;
-                    }
-                    // A keep-alive JSON/202 response is about to be written; neutralize the unused
-                    // stream so a server→client message that arrives after this check (e.g. an async
-                    // tool's status notification) cannot open a second response on the pooled socket
-                    // and corrupt the next request's reuse of it.
-                    postStream.close();
-                    if (result instanceof McpDispatcher.DispatchResult.Accepted) {
-                        sendAccepted(ctx, origin);
-                        return;
-                    }
-                    if (elapsedMs > 500) {
-                        logger.warn("Slow POST response: id={}, method={}, elapsed={}ms", requestId, method, elapsedMs);
-                    } else {
-                        logger.debug("POST response: id={}, method={}, elapsed={}ms", requestId, method, elapsedMs);
-                    }
-                    var response = (McpDispatcher.DispatchResult.Response) result;
-                    sendJsonResponse(ctx, response.responseBody(), response.sessionId(), origin);
-                }));
+                });
+    }
+
+    private void completePostRequest(
+            ChannelHandlerContext ctx,
+            Object requestId,
+            String method,
+            @Nullable String sessionId,
+            @Nullable String origin,
+            PostSseStream postStream,
+            long startNs,
+            McpDispatcher.@Nullable DispatchResult result,
+            @Nullable Throwable ex) {
+        var elapsedMs = (System.nanoTime() - startNs) / 1_000_000;
+        if (ex != null) {
+            logger.error("Dispatch failed: id={}, method={}, elapsed={}ms", requestId, method, elapsedMs, ex);
+            if (postStream.started()) {
+                postStream.close();
+            } else {
+                // Neutralize the stream so a late server→client message cannot start a
+                // second HTTP response on this channel, then send the JSON error.
+                postStream.close();
+                sendInternalError(ctx, requestId, origin);
+            }
+            return;
+        }
+        if (postStream.started()) {
+            if (elapsedMs > 500) {
+                logger.warn("Slow POST-SSE response: id={}, method={}, elapsed={}ms", requestId, method, elapsedMs);
+            } else {
+                logger.debug("POST-SSE response: id={}, method={}, elapsed={}ms", requestId, method, elapsedMs);
+            }
+            // Finalization decodes the response body and appends to the event log —
+            // too heavy for the event loop. PostSseStream writes marshal themselves.
+            try {
+                executor.execute(() -> finalizePostSseResponse(requestId, sessionId, postStream, result));
+            } catch (RejectedExecutionException e) {
+                releaseResult(result);
+                postStream.close();
+            }
+            return;
+        }
+        // A keep-alive JSON/202 response is about to be written; neutralize the unused
+        // stream so a server→client message that arrives after this check (e.g. an async
+        // tool's status notification) cannot open a second response on the pooled socket
+        // and corrupt the next request's reuse of it.
+        postStream.close();
+        if (result instanceof McpDispatcher.DispatchResult.Accepted) {
+            sendAccepted(ctx, origin);
+            return;
+        }
+        if (elapsedMs > 500) {
+            logger.warn("Slow POST response: id={}, method={}, elapsed={}ms", requestId, method, elapsedMs);
+        } else {
+            logger.debug("POST response: id={}, method={}, elapsed={}ms", requestId, method, elapsedMs);
+        }
+        var response = (McpDispatcher.DispatchResult.Response) result;
+        sendJsonResponse(ctx, response.responseBody(), response.sessionId(), origin);
+    }
+
+    private static void releaseResult(McpDispatcher.@Nullable DispatchResult result) {
+        if (result instanceof McpDispatcher.DispatchResult.Response r) {
+            r.responseBody().release();
+        }
     }
 
     private void finalizePostSseResponse(
             Object requestId,
             @Nullable String sessionId,
             PostSseStream postStream,
-            McpDispatcher.DispatchResult result) {
+            McpDispatcher.@Nullable DispatchResult result) {
         if (!(result instanceof McpDispatcher.DispatchResult.Response response)) {
             postStream.close();
             return;

--- a/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/NettyServer.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/NettyServer.java
@@ -122,6 +122,19 @@ public final class NettyServer implements Closeable {
         }
     }
 
+    /**
+     * Stops accepting new connections by closing the server channel. Existing child channels and
+     * event loops stay alive so in-flight requests can complete and flush. Idempotent;
+     * {@link #close()} finishes the teardown.
+     */
+    public void stopAccepting() {
+        try {
+            serverChannel.close().sync();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
     @Override
     public void close() {
         logger.debug("Shutting down NettyServer");

--- a/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/sse/SseManager.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/sse/SseManager.java
@@ -88,7 +88,7 @@ public class SseManager {
                 if (sseId < 0 || sseId <= lastSseId) continue;
                 var sseEvent = Server.toSseEvent(event);
                 if (sseEvent == null) continue;
-                if (!session.send(sseEvent)) break; // session closed mid-replay
+                if (!session.send(sseEvent)) break; // session closed or throttled mid-replay
             }
         } catch (NumberFormatException e) {
             logger.warn("Invalid Last-Event-ID: {}", lastEventId);

--- a/tachyon-server/src/test/java/dev/tachyonmcp/runtime/SessionTest.java
+++ b/tachyon-server/src/test/java/dev/tachyonmcp/runtime/SessionTest.java
@@ -91,6 +91,43 @@ class SessionTest {
     }
 
     @Test
+    void sendDeliversWhenWritable() {
+        connection.writable = true;
+        var event = new SseEvent("1", "message", "{}");
+        assertThat(session.send(event)).isTrue();
+        assertThat(connection.sent).containsExactly(event);
+        assertThat(session.backpressure()).isEqualTo(Backpressure.HOT);
+    }
+
+    @Test
+    void sendDropsWhenThrottled() {
+        connection.writable = false;
+        var event = new SseEvent("1", "message", "{}");
+        assertThat(session.send(event)).isFalse();
+        assertThat(connection.sent).isEmpty();
+        assertThat(session.backpressure()).isEqualTo(Backpressure.COLD);
+    }
+
+    @Test
+    void sendResumesWhenWritableAgain() {
+        connection.writable = false;
+        assertThat(session.send(new SseEvent("1", "message", "{}"))).isFalse();
+        connection.writable = true;
+        var event = new SseEvent("2", "message", "{}");
+        assertThat(session.send(event)).isTrue();
+        assertThat(connection.sent).containsExactly(event);
+        assertThat(session.backpressure()).isEqualTo(Backpressure.HOT);
+    }
+
+    @Test
+    void sendReturnsFalseAfterClose() {
+        session.activate();
+        session.close();
+        assertThat(session.send(new SseEvent("1", "message", "{}"))).isFalse();
+        assertThat(connection.sent).isEmpty();
+    }
+
+    @Test
     void throwsOnNullId() {
         assertThatThrownBy(() -> new Session(null, connection)).isInstanceOf(NullPointerException.class);
     }
@@ -120,6 +157,7 @@ class SessionTest {
 
         volatile boolean writable = true;
         volatile boolean closed;
+        final java.util.List<SseEvent> sent = new java.util.concurrent.CopyOnWriteArrayList<>();
 
         @Override
         public boolean isWritable() {
@@ -132,6 +170,8 @@ class SessionTest {
         }
 
         @Override
-        public void send(@NonNull SseEvent event) {}
+        public void send(@NonNull SseEvent event) {
+            sent.add(event);
+        }
     }
 }

--- a/tachyon-server/src/test/java/dev/tachyonmcp/server/ServerShutdownGraceTest.java
+++ b/tachyon-server/src/test/java/dev/tachyonmcp/server/ServerShutdownGraceTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2026 Konstantin Pavlov.
+ */
+
+package dev.tachyonmcp.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.tachyonmcp.runtime.InteractionContext;
+import dev.tachyonmcp.server.config.SessionConfig;
+import dev.tachyonmcp.server.features.tools.AbstractSyncToolHandler;
+import dev.tachyonmcp.server.features.tools.ToolArgs;
+import dev.tachyonmcp.server.features.tools.ToolResult;
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
+/**
+ * Verifies that {@link Server#close()} drains in-flight handlers for the configured
+ * {@code shutdownGracePeriod} before force-interrupting them.
+ *
+ * @author Konstantin Pavlov
+ */
+@Execution(ExecutionMode.SAME_THREAD)
+class ServerShutdownGraceTest {
+
+    @Test
+    void defaultGracePeriodIsFiveSeconds() {
+        assertThat(SessionConfig.DEFAULT.shutdownGracePeriod()).isEqualTo(Duration.ofSeconds(5));
+    }
+
+    @Test
+    void closeIsImmediateWhenIdle() {
+        var server = TachyonServer.builder().build();
+
+        long start = System.nanoTime();
+        server.close();
+        long elapsedMs = (System.nanoTime() - start) / 1_000_000L;
+
+        assertThat(elapsedMs)
+                .as("idle close must not wait for the grace period")
+                .isLessThan(1_000L);
+    }
+
+    @Test
+    void closeWaitsConfiguredGraceThenInterruptsInFlightHandler() throws Exception {
+        var started = new CountDownLatch(1);
+        var interrupted = new CountDownLatch(1);
+
+        var server = TachyonServer.builder()
+                .session(s -> s.shutdownGracePeriod(Duration.ofMillis(400)))
+                .tool(new AbstractSyncToolHandler("slow_probe") {
+                    @Override
+                    public ToolResult handle(InteractionContext context, ToolArgs args) {
+                        started.countDown();
+                        try {
+                            new CountDownLatch(1).await(30, TimeUnit.SECONDS);
+                        } catch (InterruptedException e) {
+                            interrupted.countDown();
+                            Thread.currentThread().interrupt();
+                        }
+                        return ToolResult.empty();
+                    }
+                })
+                .build();
+
+        server.createSession("sess-slow").activate();
+        var dispatcher = new McpDispatcher(server, server.executor());
+        dispatcher.dispatchRequestAsync(
+                1, "tools/call", Map.of("name", "slow_probe", "arguments", Map.of()), "sess-slow");
+
+        assertThat(started.await(5, TimeUnit.SECONDS))
+                .as("handler must be running before close")
+                .isTrue();
+
+        long start = System.nanoTime();
+        server.close();
+        long elapsedMs = (System.nanoTime() - start) / 1_000_000L;
+
+        assertThat(elapsedMs)
+                .as("close must wait the configured grace, not the old 10s")
+                .isBetween(300L, 3_000L);
+        assertThat(interrupted.await(5, TimeUnit.SECONDS))
+                .as("in-flight handler must be force-interrupted after the grace period")
+                .isTrue();
+    }
+}


### PR DESCRIPTION
# Configurable shutdownGracePeriod, fix backpressure

- 10-seconds in-flight stall is now a tunable `shutdownGracePeriod`, default 5s:
  - `SessionConfig` — new Duration shutdownGracePeriod record component + Builder setter (default 5s; Duration.ZERO = interrupt-now). 
  - `Server.close()` — reads `config.session().shutdownGracePeriod()` instead of hardcoded 10s. 
  - `SessionScope.kt` — Kotlin DSL parity (`shutdownGracePeriod = 5.seconds`).

- **Fixed SSE backpressure.** Session.send() (Session.java:124) now consults shouldThrottle() before pushing: a non-writable (COLD) stream drops the live push instead of piling events into the channel's outbound buffer. Safe because every event is already appended to the event log first — clients recover via Last-Event-ID replay. Replay itself also stops on throttle (SseManager.java:91). 4 new SessionTest cases: deliver-when-HOT, drop-when-COLD, resume-when-writable-again, drop-after-close. **Stalled SSE client now loses live pushes until it drains or reconnects (recoverable via replay) — previously it would buffer unboundedly. That's the intended trade-off.**

- Fixed Shutdown ordering . New NettyServer.stopAccepting() closes only the server channel. ServerHandle.close() now does: stop accepting → server.close() (drains in-flight handlers while event loops are still alive, so responses actually flush) → netty.close(). Plus the REE guard: the response marshal in McpOperationHandler catches RejectedExecutionException and releases the response ByteBuf — no leak when a handler completes after loops die (the direct try-with-resources pattern). Bonus: handlePost now releases the retained body and answers 503 if the executor rejects during shutdown, instead of leaking + stack-tracing.

- Fixed EventLoop offload. finalizePost + event-log append for potentially large tool results) now runs on the virtual-thread executor instead of the I/O loop. Safe: PostSseStream writes self-marshal to the loop, and the started() check stays on therace the code comments guard against remainsclosed. REE-guarded with release.