### PR TITLE
fix!: NettyIoEngine with AUTO-detection of native transports

### DIFF
--- a/.agents/skills/tachyon-mcp/SKILL.md
+++ b/.agents/skills/tachyon-mcp/SKILL.md
@@ -36,7 +36,7 @@ var handle = TachyonServer.builder()
 | `.info(cfg)` | name, version, description, title, websiteUrl, instructions |
 | `.capabilities(cfg)` | tools/resources/prompts/tasks/completions/logging |
 | `.session(cfg)` | stateless, sessionTtl, shutdownGracePeriod, SessionLogRouter, SessionStore |
-| `.network(cfg)` | host, port, endpointPath, timeouts, CORS, maxContentLength |
+| `.network(cfg)` | host, port, endpointPath, timeouts, CORS, maxContentLength, ioEngine |
 | `.name(s)` `.port(p)` | shorthands |
 | `.tool(handler)` | Sync/Async/ToolHandler |
 | `.resource(descriptor[, handler])` | static resource (no handler = external URI) |
@@ -136,6 +136,9 @@ Default `AUTO` → advertised only when registered. Force with `Mode.ON` / `Mode
 | `.allowedOrigins(...)` | none (all denied) |
 | `.allowNullOrigin(b)` / `.allowPrivateNetworks(b)` | false |
 | `.allowedHeaders(...)` | none |
+| `.ioEngine(e)` | `NettyIoEngine.AUTO` (io_uring → epoll → kqueue → NIO) |
+
+Native transports need optional runtime jars (`netty-transport-native-epoll` / `-kqueue` / `-io_uring` with `${os.detected.classifier}`); without them `AUTO` falls back to NIO. Explicit unavailable engine throws `UnsupportedOperationException`. See `docs/configuration.md`.
 
 ### Session `session(cfg -> ...)`
 | Method | Default |

--- a/.agents/skills/tachyon-mcp/resources/java/ConfigReference.java
+++ b/.agents/skills/tachyon-mcp/resources/java/ConfigReference.java
@@ -6,6 +6,7 @@ import dev.tachyonmcp.server.config.CapabilitiesConfig;
 import dev.tachyonmcp.server.config.Mode;
 import dev.tachyonmcp.server.config.NetworkConfig;
 import dev.tachyonmcp.server.config.SessionConfig;
+import dev.tachyonmcp.transport.netty.NettyIoEngine;
 import java.time.Duration;
 
 /**
@@ -57,6 +58,7 @@ final class ConfigReference {
                 .allowNullOrigin(false)
                 .allowPrivateNetworks(true)
                 .allowedHeaders("X-Custom-Header")
+                .ioEngine(NettyIoEngine.AUTO) // io_uring > epoll > kqueue > NIO; native jars optional
                 .build();
     }
 

--- a/.agents/skills/tachyon-mcp/resources/kotlin/ServerBasic.kt
+++ b/.agents/skills/tachyon-mcp/resources/kotlin/ServerBasic.kt
@@ -9,6 +9,7 @@ import dev.tachyonmcp.server.domain.TextResourceContents
 import dev.tachyonmcp.server.features.resources.ResourceTemplateEntry
 import dev.tachyonmcp.server.features.tools.ToolResult
 import dev.tachyonmcp.server.promptMessagesOf
+import dev.tachyonmcp.transport.netty.NettyIoEngine
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 
@@ -31,6 +32,7 @@ fun createServer(port: Int = 0): ServerHandle = TachyonServer(port = port) {
     network {
         allowedOrigins.add("*")
         allowNullOrigin = true
+        ioEngine = NettyIoEngine.AUTO // io_uring > epoll > kqueue > NIO; native jars optional
     }
     tool(name = "ping", description = "Simple ping") {
         ToolResult.text("pong")

--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
-<div>
-</div>
-
 [![Maven Central](https://img.shields.io/maven-central/v/dev.tachyonmcp/tachyon-server)](https://repo1.maven.org/maven2/dev/tachyonmcp/tachyon-server/)
 [![Java 21+](https://img.shields.io/badge/Java-21+-orange.svg?logo=jvm)](http://java.com)
 [![Build](https://github.com/kpavlov/tachyon/actions/workflows/build.yml/badge.svg?branch=main)](https://github.com/kpavlov/tachyon/actions/workflows/build.yml)
@@ -10,6 +7,14 @@
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/kpavlov/tachyon)
 
 **Tachyon MCP** is a Java 21 [Model Context Protocol](https://modelcontextprotocol.io) (MCP) server built on [Netty](https://netty.io). Implements the **2025-11-25** Streamable HTTP transport, protocol extensions, and stateless mode.
+
+## Why Tachyon?
+
+1. **MCP Spec Compliant** — All official conformance tests green on the current **2025-11-25** spec; tools, resources, prompts, tasks, elicitation, sampling, and extensions (SEP-1686, SEP-2133) in one artifact.
+2. **Your handlers outlive the spec** — MCP moves fast; Tachyon's stable domain types (`ToolHandler`, `ResourceHandler`, `PromptHandler`, Task support) absorb protocol changes in an internal mapper layer, so version bumps don't touch your code.
+3. **Write blocking code, get async runtime** — handlers run on Java 21 virtual threads off the Netty event loop; plain synchronous logic scales without thread pools, reactive chains, or `CompletableFuture` gymnastics. Coroutine-first Kotlin DSL included.
+4. **Serverless-ready** — one-line stateless mode (`.stateless(true)`) drops session state for AWS Lambda and friends; full session mode gives SSE resumability, Last-Event-ID replay, TTL + janitor.
+5. **Production-grade transport** — Netty core with backpressure watermarks, graceful shutdown, DNS-rebinding protection, and auto-detected native transports (io_uring / epoll / kqueue) when you want the extra speed.
 
 **TL;DR**
 
@@ -27,11 +32,11 @@
 
     ```java
     import dev.tachyonmcp.server.TachyonServer;
+    import dev.tachyonmcp.runtime.InteractionContext;
     import dev.tachyonmcp.server.features.tools.AbstractSyncToolHandler;
     import dev.tachyonmcp.server.features.tools.ToolArgs;
     import dev.tachyonmcp.server.features.tools.ToolDescriptor;
     import dev.tachyonmcp.server.features.tools.ToolResult;
-    import dev.tachyonmcp.server.session.McpContext;
     import tools.jackson.databind.node.JsonNodeFactory;
 
     void main() {
@@ -48,7 +53,7 @@
                     .build()) {
 
                 @Override
-                public ToolResult handle(McpContext ctx, ToolArgs args) {
+                public ToolResult handle(InteractionContext ctx, ToolArgs args) {
                     return ToolResult.text("☀️ 22°C");
                 }
             })
@@ -63,6 +68,7 @@
 | Guide | Description |
 |---|---|
 | [Quickstart](docs/quickstart.md) | Build a working server in 5 minutes |
+| [Configuration](docs/configuration.md) | Network, I/O engine (native transports), sessions, CORS |
 | [Tools](docs/tools.md) | Sync/async handlers, input schema, `ToolResult` |
 | [Resources](docs/resources.md) | Static URIs, dynamic handlers, URI templates |
 | [Tasks](docs/tasks.md) | Long-running operations, state machine, `TasksExtension` |
@@ -79,7 +85,7 @@ npx skills add kpavlov/tachyon --skill tachyon-mcp
 ```
 
 The skill includes compilable Java and Kotlin example sources under `.agents/skills/tachyon-mcp/resources/`.
-They are linked into `e2e/src/skill/` and compiled during `mvn test` to keep them valid.
+They are compiled as extra source roots of the `e2e` module during `mvn test` to keep them valid.
 
 Check out [Skills CLI](https://github.com/vercel-labs/skills) for more options.
 

--- a/conformance/pom.xml
+++ b/conformance/pom.xml
@@ -27,20 +27,21 @@
             <artifactId>tachyon-server</artifactId>
         </dependency>
 
+        <!-- Netty transport Java classes (for reflection-based transport detection) -->
         <dependency>
             <groupId>io.netty</groupId>
-            <artifactId>netty-transport-classes-io_uring</artifactId>
+            <artifactId>netty-transport-classes-epoll</artifactId>
             <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
-            <artifactId>netty-transport-classes-epoll</artifactId>
-            <scope>test</scope>
+            <artifactId>netty-transport-classes-kqueue</artifactId>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
-            <artifactId>netty-transport-classes-kqueue</artifactId>
-            <scope>test</scope>
+            <artifactId>netty-transport-classes-io_uring</artifactId>
+            <scope>runtime</scope>
         </dependency>
 
         <!-- Test -->
@@ -125,5 +126,65 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <!-- Native Netty transports; disable with -Dnetty.native.enabled=false -->
+        <profile>
+            <id>netty-native-mac</id>
+            <activation>
+                <os>
+                    <family>mac</family>
+                </os>
+                <property>
+                    <name>netty.native.enabled</name>
+                    <value>!false</value>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-transport-native-kqueue</artifactId>
+                    <version>${netty.version}</version>
+                    <classifier>${os.detected.classifier}</classifier>
+                    <scope>runtime</scope>
+                </dependency>
+                <dependency>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-resolver-dns-native-macos</artifactId>
+                    <version>${netty.version}</version>
+                    <classifier>${os.detected.classifier}</classifier>
+                    <scope>runtime</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>netty-native-linux</id>
+            <activation>
+                <os>
+                    <name>linux</name>
+                </os>
+                <property>
+                    <name>netty.native.enabled</name>
+                    <value>!false</value>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-transport-native-epoll</artifactId>
+                    <version>${netty.version}</version>
+                    <classifier>${os.detected.classifier}</classifier>
+                    <scope>runtime</scope>
+                </dependency>
+                <dependency>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-transport-native-io_uring</artifactId>
+                    <version>${netty.version}</version>
+                    <classifier>${os.detected.classifier}</classifier>
+                    <scope>runtime</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 </project>
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,147 @@
+# Configuration — Tachyon MCP Server
+
+All configuration flows through `TachyonServer.builder()` (Java) or the `TachyonServer { }` DSL (Kotlin). Four scopes: `info`, `capabilities`, `network`, `session`.
+
+```java
+TachyonServer.builder()
+    .info(i -> i.name("my-server").version("1.0"))
+    .network(n -> n.port(8080).ioEngine(NettyIoEngine.AUTO))
+    .session(s -> s.sessionTtl(Duration.ofMinutes(5)))
+    .start();
+```
+
+```kotlin
+TachyonServer {
+    info { name = "my-server"; version = "1.0" }
+    network { port = 8080 }
+    session { sessionTtl = 5.minutes }
+}.start()
+```
+
+## Network
+
+Configured via `network { }` / `NetworkConfig.Builder`.
+
+| Option | Default | Description |
+|---|---|---|
+| `host` | `127.0.0.1` | Bind address |
+| `port` | — | Listen port; `0` picks a free port. Must be set before `start()` |
+| `address` | — | Full `SocketAddress`; mutually exclusive with `host`/`port` |
+| `endpointPath` | `/mcp` | HTTP endpoint path |
+| `readerIdleTimeout` | `60s` | Close connections with no inbound traffic for this long |
+| `writerIdleTimeout` | `5m` | SSE heartbeat interval (outbound idle) |
+| `maxContentLength` | `1 MB` | Max aggregated HTTP request body |
+| `ioEngine` | `AUTO` | Netty I/O transport, see below |
+
+`.port(int)` is also available as a top-level `ServerBuilder` shortcut.
+
+### CORS
+
+| Option | Default | Description |
+|---|---|---|
+| `allowedOrigins` | — | Allowed `Origin` values; unset disables CORS handling |
+| `allowNullOrigin` | `false` | Allow `Origin: null` |
+| `allowPrivateNetworks` | `false` | Allow private-network CORS preflight |
+| `allowedHeaders` | — | Extra allowed request headers |
+
+## I/O engine
+
+`NettyIoEngine` selects the Netty transport:
+
+| Engine | OS | Runtime dependency |
+|---|---|---|
+| `AUTO` (default) | any | picks best available, in order below |
+| `IO_URING` | Linux 5.9+ | `netty-transport-native-io_uring` |
+| `EPOLL` | Linux | `netty-transport-native-epoll` |
+| `KQUEUE` | macOS / BSD | `netty-transport-native-kqueue` |
+| `NIO` | any | none (bundled) |
+
+`AUTO` detection order: io_uring → epoll → kqueue → NIO. Detection happens once and is cached; the chosen engine is logged at startup:
+
+```text
+Netty I/O engine: KQUEUE
+```
+
+Native transports are optional runtime dependencies — `tachyon-server` itself depends only on the portable NIO transport. To enable a native transport, add the matching jar with your platform classifier (via [os-maven-plugin](https://github.com/trustin/os-maven-plugin)):
+
+```xml
+<build>
+    <extensions>
+        <extension>
+            <groupId>kr.motd.maven</groupId>
+            <artifactId>os-maven-plugin</artifactId>
+            <version>1.7.1</version>
+        </extension>
+    </extensions>
+</build>
+
+<profiles>
+    <profile>
+        <id>netty-native-linux</id>
+        <activation>
+            <os><name>linux</name></os>
+        </activation>
+        <dependencies>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-transport-native-epoll</artifactId>
+                <version>${netty.version}</version>
+                <classifier>${os.detected.classifier}</classifier>
+                <scope>runtime</scope>
+            </dependency>
+        </dependencies>
+    </profile>
+    <profile>
+        <id>netty-native-mac</id>
+        <activation>
+            <os><family>mac</family></os>
+        </activation>
+        <dependencies>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-transport-native-kqueue</artifactId>
+                <version>${netty.version}</version>
+                <classifier>${os.detected.classifier}</classifier>
+                <scope>runtime</scope>
+            </dependency>
+        </dependencies>
+    </profile>
+</profiles>
+```
+
+See [examples/weather/pom.xml](../examples/weather/pom.xml) for a complete working setup.
+
+Requesting an explicit engine whose transport is not on the classpath (or not supported by the OS) throws `UnsupportedOperationException` at startup, with Netty's unavailability cause in the message:
+
+```java
+network(n -> n.ioEngine(NettyIoEngine.EPOLL)) // fails fast on macOS
+```
+
+```kotlin
+network { ioEngine = NettyIoEngine.EPOLL }
+```
+
+## Session
+
+Configured via `session { }` / `SessionConfig.Builder`.
+
+| Option | Default | Description |
+|---|---|---|
+| `stateless` | `false` | No session creation, no TTL tracking |
+| `sessionTtl` | `30s` | Idle sessions are evicted after this duration |
+| `shutdownGracePeriod` | `5s` | Time in-flight handlers get to drain on `close()`; `ZERO` interrupts immediately |
+| `sessionLogRouter` | in-memory | Custom event log router |
+| `sessionStore` | in-memory | Custom session store |
+
+## Identity and capabilities
+
+`info { }` sets the `serverInfo` returned by `initialize` (name, version, title, etc.); `.name(String)` is a top-level shortcut. `capabilities { }` toggles advertised MCP capabilities. See [quickstart](quickstart.md) for a full example.
+
+## Advanced
+
+| Option | Description |
+|---|---|
+| `executor(ExecutorService)` | Handler executor; default runs handlers on virtual threads |
+| `threadFactory(ThreadFactory)` | Thread factory for the default executor |
+| `pipelineCustomizer(Consumer<ChannelPipeline>)` | Hook to mutate the Netty pipeline after MCP handlers are installed |
+| `jsonSchemaValidator(...)` | Custom JSON Schema validator for tool inputs |

--- a/e2e/pom.xml
+++ b/e2e/pom.xml
@@ -43,6 +43,7 @@
             <version>${kotlinx-coroutines.version}</version>
             <scope>test</scope>
         </dependency>
+        <!-- Netty transport Java classes (for reflection-based transport detection) -->
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-transport-classes-epoll</artifactId>
@@ -51,6 +52,11 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-transport-classes-kqueue</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport-classes-io_uring</artifactId>
             <scope>runtime</scope>
         </dependency>
 
@@ -166,7 +172,7 @@
                         </goals>
                         <configuration>
                             <sources>
-                                <source>src/skill/java</source>
+                                <source>${project.basedir}/../.agents/skills/tachyon-mcp/resources/java</source>
                                 <source>${project.basedir}/../.agents/skills/tachyon-mcp/resources/kotlin</source>
                             </sources>
                         </configuration>
@@ -175,4 +181,64 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <!-- Native Netty transports; disable with -Dnetty.native.enabled=false -->
+        <profile>
+            <id>netty-native-mac</id>
+            <activation>
+                <os>
+                    <family>mac</family>
+                </os>
+                <property>
+                    <name>netty.native.enabled</name>
+                    <value>!false</value>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-transport-native-kqueue</artifactId>
+                    <version>${netty.version}</version>
+                    <classifier>${os.detected.classifier}</classifier>
+                    <scope>runtime</scope>
+                </dependency>
+                <dependency>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-resolver-dns-native-macos</artifactId>
+                    <version>${netty.version}</version>
+                    <classifier>${os.detected.classifier}</classifier>
+                    <scope>runtime</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>netty-native-linux</id>
+            <activation>
+                <os>
+                    <name>linux</name>
+                </os>
+                <property>
+                    <name>netty.native.enabled</name>
+                    <value>!false</value>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-transport-native-epoll</artifactId>
+                    <version>${netty.version}</version>
+                    <classifier>${os.detected.classifier}</classifier>
+                    <scope>runtime</scope>
+                </dependency>
+                <dependency>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-transport-native-io_uring</artifactId>
+                    <version>${netty.version}</version>
+                    <classifier>${os.detected.classifier}</classifier>
+                    <scope>runtime</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 </project>

--- a/e2e/src/skill/README.md
+++ b/e2e/src/skill/README.md
@@ -1,1 +1,0 @@
-Skill resources linked here to verify they can compile

--- a/e2e/src/skill/java
+++ b/e2e/src/skill/java
@@ -1,1 +1,0 @@
-../../../.agents/skills/tachyon-mcp/resources/java

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/NativeTransportDetectionTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/NativeTransportDetectionTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2026 Konstantin Pavlov.
+ */
+
+package dev.tachyonmcp.e2e;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
+
+import dev.tachyonmcp.transport.netty.NettyIoEngine;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+/**
+ * Guards the {@code netty-native-*} Maven profiles: if they stop putting native transport jars
+ * on the runtime classpath, detection silently falls back to NIO and these tests fail.
+ *
+ * @author Konstantin Pavlov
+ */
+class NativeTransportDetectionTest {
+
+    @Test
+    @EnabledOnOs(OS.MAC)
+    void kqueueDetectedOnMac() {
+        assumeNativeEnabled();
+
+        assertThat(NettyIoEngine.detect()).isEqualTo(NettyIoEngine.KQUEUE);
+        assertThat(NettyIoEngine.KQUEUE.channel().getSimpleName()).isEqualTo("KQueueServerSocketChannel");
+    }
+
+    @Test
+    @EnabledOnOs(OS.LINUX)
+    void nativeTransportDetectedOnLinux() {
+        assumeNativeEnabled();
+
+        assertThat(NettyIoEngine.detect()).isIn(NettyIoEngine.IO_URING, NettyIoEngine.EPOLL);
+    }
+
+    private static void assumeNativeEnabled() {
+        assumeFalse("false".equals(System.getProperty("netty.native.enabled")));
+    }
+}

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/SseHeartbeatTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/SseHeartbeatTest.java
@@ -9,6 +9,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import dev.tachyonmcp.server.Server;
 import dev.tachyonmcp.server.TachyonServer;
 import dev.tachyonmcp.transport.netty.McpChannelInitializer;
+import dev.tachyonmcp.transport.netty.NettyIoEngine;
 import dev.tachyonmcp.transport.netty.NettyServer;
 import dev.tachyonmcp.transport.netty.NettyServerConfig;
 import java.net.Socket;
@@ -49,6 +50,7 @@ class SseHeartbeatTest {
                 Duration.ofMinutes(5),
                 McpChannelInitializer.DEFAULT_MAX_CONTENT_LENGTH,
                 NettyServerConfig.buildCorsConfig(null, false, false, null),
+                NettyIoEngine.AUTO,
                 null);
         nettyServer = new NettyServer(server, config);
         port = nettyServer.port();
@@ -77,10 +79,10 @@ class SseHeartbeatTest {
         try (var client = HttpClient.newHttpClient()) {
             // language=JSON
             var body = """
-                    {"jsonrpc":"2.0","id":0,"method":"initialize",
-                     "params":{"protocolVersion":"2025-11-25","capabilities":{},
-                               "clientInfo":{"name":"test","version":"1.0"}}}
-                    """;
+                {"jsonrpc":"2.0","id":0,"method":"initialize",
+                 "params":{"protocolVersion":"2025-11-25","capabilities":{},
+                           "clientInfo":{"name":"test","version":"1.0"}}}
+                """;
             var response = client.send(
                     HttpRequest.newBuilder()
                             .uri(URI.create("http://localhost:" + port + "/mcp"))
@@ -107,7 +109,9 @@ class SseHeartbeatTest {
         }
     }
 
-    /** Opens a raw SSE GET and accumulates everything received over {@code durationMs}. */
+    /**
+     * Opens a raw SSE GET and accumulates everything received over {@code durationMs}.
+     */
     private String readRawSse(String sessionId, long durationMs) throws Exception {
         try (var socket = new Socket("localhost", port)) {
             var req = ("GET /mcp HTTP/1.1\r\n"

--- a/examples/echo-kotlin/pom.xml
+++ b/examples/echo-kotlin/pom.xml
@@ -23,6 +23,7 @@
         <json-unit.version>5.1.2</json-unit.version>
         <jackson.version>3.2.0</jackson.version>
         <slf4j.version>2.0.18</slf4j.version>
+        <netty.version>4.2.15.Final</netty.version>
     </properties>
 
     <dependencyManagement>
@@ -91,6 +92,13 @@
     <build>
         <sourceDirectory>${project.basedir}/src/main/kotlin</sourceDirectory>
         <testSourceDirectory>${project.basedir}/src/test/kotlin</testSourceDirectory>
+        <extensions>
+            <extension>
+                <groupId>kr.motd.maven</groupId>
+                <artifactId>os-maven-plugin</artifactId>
+                <version>1.7.1</version>
+            </extension>
+        </extensions>
         <plugins>
             <plugin>
                 <groupId>org.jetbrains.kotlin</groupId>
@@ -127,4 +135,49 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <!-- Optional native Netty transports (kqueue/epoll/io_uring); AUTO picks them up at runtime -->
+        <profile>
+            <id>netty-native-mac</id>
+            <activation>
+                <os>
+                    <family>mac</family>
+                </os>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-transport-native-kqueue</artifactId>
+                    <version>${netty.version}</version>
+                    <classifier>${os.detected.classifier}</classifier>
+                    <scope>runtime</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>netty-native-linux</id>
+            <activation>
+                <os>
+                    <name>linux</name>
+                </os>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-transport-native-epoll</artifactId>
+                    <version>${netty.version}</version>
+                    <classifier>${os.detected.classifier}</classifier>
+                    <scope>runtime</scope>
+                </dependency>
+                <dependency>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-transport-native-io_uring</artifactId>
+                    <version>${netty.version}</version>
+                    <classifier>${os.detected.classifier}</classifier>
+                    <scope>runtime</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 </project>

--- a/examples/weather/pom.xml
+++ b/examples/weather/pom.xml
@@ -20,6 +20,7 @@
 <!--        <tachyon-server.version>1.0.0-beta.3</tachyon-server.version>-->
         <tachyon-server.version>1.0.0-SNAPSHOT</tachyon-server.version>
         <assertj.version>3.27.7</assertj.version>
+        <netty.version>4.2.15.Final</netty.version>
     </properties>
 
     <dependencyManagement>
@@ -92,6 +93,13 @@
     </dependencies>
 
     <build>
+        <extensions>
+            <extension>
+                <groupId>kr.motd.maven</groupId>
+                <artifactId>os-maven-plugin</artifactId>
+                <version>1.7.1</version>
+            </extension>
+        </extensions>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -119,4 +127,49 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <!-- Optional native Netty transports (kqueue/epoll/io_uring); AUTO picks them up at runtime -->
+        <profile>
+            <id>netty-native-mac</id>
+            <activation>
+                <os>
+                    <family>mac</family>
+                </os>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-transport-native-kqueue</artifactId>
+                    <version>${netty.version}</version>
+                    <classifier>${os.detected.classifier}</classifier>
+                    <scope>runtime</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>netty-native-linux</id>
+            <activation>
+                <os>
+                    <name>linux</name>
+                </os>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-transport-native-epoll</artifactId>
+                    <version>${netty.version}</version>
+                    <classifier>${os.detected.classifier}</classifier>
+                    <scope>runtime</scope>
+                </dependency>
+                <dependency>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-transport-native-io_uring</artifactId>
+                    <version>${netty.version}</version>
+                    <classifier>${os.detected.classifier}</classifier>
+                    <scope>runtime</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 </project>

--- a/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/NetworkScope.kt
+++ b/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/NetworkScope.kt
@@ -3,6 +3,7 @@
 package dev.tachyonmcp.server
 
 import dev.tachyonmcp.server.config.NetworkConfig
+import dev.tachyonmcp.transport.netty.NettyIoEngine
 import kotlin.time.Duration
 import kotlin.time.toJavaDuration
 
@@ -18,6 +19,7 @@ public class NetworkScope
         public var readerIdleTimeout: Duration? = null
         public var writerIdleTimeout: Duration? = null
         public var maxContentLength: Int? = null
+        public var ioEngine: NettyIoEngine? = null
         public val allowedOrigins: MutableList<String> = mutableListOf()
         public val allowedHeaders: MutableList<String> = mutableListOf()
 
@@ -32,5 +34,6 @@ public class NetworkScope
             readerIdleTimeout?.let { builder.readerIdleTimeout(it.toJavaDuration()) }
             writerIdleTimeout?.let { builder.writerIdleTimeout(it.toJavaDuration()) }
             maxContentLength?.let(builder::maxContentLength)
+            ioEngine?.let(builder::ioEngine)
         }
     }

--- a/tachyon-server/pom.xml
+++ b/tachyon-server/pom.xml
@@ -34,18 +34,7 @@
             <groupId>io.netty</groupId>
             <artifactId>netty-handler</artifactId>
         </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-transport-classes-epoll</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-transport-classes-kqueue</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-transport-classes-io_uring</artifactId>
-        </dependency>
+
         <dependency>
             <groupId>tools.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
@@ -205,22 +194,4 @@
             </plugin>
         </plugins>
     </build>
-
-    <profiles>
-        <profile>
-            <id>mac</id>
-            <activation>
-                <os>
-                    <family>mac</family>
-                </os>
-            </activation>
-            <dependencies>
-                <dependency>
-                    <groupId>io.netty</groupId>
-                    <artifactId>netty-resolver-dns-native-macos</artifactId>
-                    <scope>runtime</scope>
-                </dependency>
-            </dependencies>
-        </profile>
-    </profiles>
 </project>

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/ServerBuilder.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/ServerBuilder.java
@@ -238,6 +238,7 @@ public final class ServerBuilder {
                         networkConfig.allowNullOrigin(),
                         networkConfig.allowPrivateNetworks(),
                         networkConfig.allowedHeaders()),
+                networkConfig.ioEngine(),
                 pipelineCustomizer);
         var netty = new NettyServer(server, nettyConfig);
         return new ServerHandle(server, netty.port(), netty);

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/config/NetworkConfig.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/config/NetworkConfig.java
@@ -5,10 +5,12 @@
 package dev.tachyonmcp.server.config;
 
 import dev.tachyonmcp.transport.netty.McpChannelInitializer;
+import dev.tachyonmcp.transport.netty.NettyIoEngine;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.time.Duration;
 import java.util.List;
+import java.util.Objects;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -24,6 +26,7 @@ import org.jspecify.annotations.Nullable;
  * @param allowNullOrigin    whether to allow {@code Origin: null}
  * @param allowPrivateNetworks whether to allow private network CORS
  * @param allowedHeaders     additional allowed CORS headers
+ * @param ioEngine           Netty I/O engine; defaults to {@link NettyIoEngine#AUTO}
  */
 public record NetworkConfig(
         String host,
@@ -35,7 +38,8 @@ public record NetworkConfig(
         @Nullable List<String> allowedOrigins,
         boolean allowNullOrigin,
         boolean allowPrivateNetworks,
-        @Nullable List<String> allowedHeaders) {
+        @Nullable List<String> allowedHeaders,
+        NettyIoEngine ioEngine) {
 
     public static final NetworkConfig DEFAULT = new NetworkConfig(
             "127.0.0.1",
@@ -47,7 +51,8 @@ public record NetworkConfig(
             null,
             false,
             false,
-            null);
+            null,
+            NettyIoEngine.AUTO);
 
     public static Builder builder() {
         return new Builder();
@@ -65,6 +70,7 @@ public record NetworkConfig(
         private boolean allowNullOrigin;
         private boolean allowPrivateNetworks;
         private @Nullable List<String> allowedHeaders;
+        private NettyIoEngine ioEngine = NettyIoEngine.AUTO;
         private boolean hostPortExplicitlySet;
         private boolean addressExplicitlySet;
 
@@ -154,6 +160,12 @@ public record NetworkConfig(
             return this;
         }
 
+        /** Sets the Netty I/O engine; defaults to {@link NettyIoEngine#AUTO}. */
+        public Builder ioEngine(NettyIoEngine ioEngine) {
+            this.ioEngine = Objects.requireNonNull(ioEngine, "ioEngine");
+            return this;
+        }
+
         /** Builds the {@link NetworkConfig}. */
         public NetworkConfig build() {
             return new NetworkConfig(
@@ -166,7 +178,8 @@ public record NetworkConfig(
                     allowedOrigins,
                     allowNullOrigin,
                     allowPrivateNetworks,
-                    allowedHeaders);
+                    allowedHeaders,
+                    ioEngine);
         }
     }
 }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/NettyIoEngine.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/NettyIoEngine.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2026 Konstantin Pavlov.
+ */
+
+package dev.tachyonmcp.transport.netty;
+
+import io.netty.channel.IoHandlerFactory;
+import io.netty.channel.nio.NioIoHandler;
+import io.netty.channel.socket.ServerSocketChannel;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A Netty I/O transport engine — pairs an {@link IoHandlerFactory} with a
+ * {@link ServerSocketChannel} class.
+ *
+ * <p>Native transports ({@link #IO_URING}, {@link #EPOLL}, {@link #KQUEUE}) are resolved via
+ * Netty's own {@code isAvailable()} detectors (reflective) so that the
+ * {@code netty-transport-classes-*} JARs are needed only at runtime.
+ *
+ * <p>Use {@link #detect()} for the best available transport, or set an explicit engine.
+ */
+public enum NettyIoEngine {
+    IO_URING(resolve(
+            "io.netty.channel.uring.IoUring",
+            "io.netty.channel.uring.IoUringIoHandler",
+            "io.netty.channel.uring.IoUringServerSocketChannel")),
+    EPOLL(resolve(
+            "io.netty.channel.epoll.Epoll",
+            "io.netty.channel.epoll.EpollIoHandler",
+            "io.netty.channel.epoll.EpollServerSocketChannel")),
+    KQUEUE(resolve(
+            "io.netty.channel.kqueue.KQueue",
+            "io.netty.channel.kqueue.KQueueIoHandler",
+            "io.netty.channel.kqueue.KQueueServerSocketChannel")),
+    NIO(new Resolution(new Resolved(NioIoHandler.newFactory(), NioServerSocketChannel.class), null)),
+    AUTO(new Resolution(null, "AUTO is resolved via detect()"));
+
+    private final @Nullable Resolved resolved;
+    private final @Nullable String unavailabilityReason;
+
+    NettyIoEngine(Resolution resolution) {
+        this.resolved = resolution.resolved;
+        this.unavailabilityReason = resolution.reason;
+    }
+
+    /**
+     * Returns the {@link IoHandlerFactory} for this transport.
+     *
+     * @throws UnsupportedOperationException if the transport classes are unavailable
+     */
+    public IoHandlerFactory ioHandler() {
+        if (this == AUTO) return detect().ioHandler();
+        return require().ioHandler;
+    }
+
+    /**
+     * Returns the {@link ServerSocketChannel} class for this transport.
+     *
+     * @throws UnsupportedOperationException if the transport classes are unavailable
+     */
+    public Class<? extends ServerSocketChannel> channel() {
+        if (this == AUTO) return detect().channel();
+        return require().channel;
+    }
+
+    private Resolved require() {
+        if (resolved == null) {
+            throw new UnsupportedOperationException(name() + " transport not available: " + unavailabilityReason);
+        }
+        return resolved;
+    }
+
+    // -----------------------------------------------------------------------
+    // Detection
+    // -----------------------------------------------------------------------
+
+    private static volatile NettyIoEngine detected;
+
+    /**
+     * Detects the best available transport in priority order:
+     * io_uring &gt; epoll &gt; kqueue &gt; NIO.
+     *
+     * <p>The result is cached after the first call.
+     */
+    public static NettyIoEngine detect() {
+        NettyIoEngine result = detected;
+        if (result != null) {
+            return result;
+        }
+        synchronized (NettyIoEngine.class) {
+            result = detected;
+            if (result != null) {
+                return result;
+            }
+            for (var e : values()) {
+                if (e != AUTO && e.resolved != null) {
+                    detected = e;
+                    return e;
+                }
+            }
+            detected = NIO;
+            return NIO;
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Reflection-based transport resolver
+    // -----------------------------------------------------------------------
+
+    private record Resolved(IoHandlerFactory ioHandler, Class<? extends ServerSocketChannel> channel) {}
+
+    private record Resolution(
+            @Nullable Resolved resolved, @Nullable String reason) {}
+
+    private static Resolution resolve(String availClass, String factoryClass, String channelClass) {
+        try {
+            Class<?> avail = Class.forName(availClass);
+            if (!(boolean) avail.getMethod("isAvailable").invoke(null)) {
+                var cause = avail.getMethod("unavailabilityCause").invoke(null);
+                LoggerFactory.getLogger(NettyIoEngine.class).debug("{} unavailable: {}", availClass, cause);
+                return new Resolution(null, String.valueOf(cause));
+            }
+            IoHandlerFactory factory = (IoHandlerFactory)
+                    Class.forName(factoryClass).getMethod("newFactory").invoke(null);
+            @SuppressWarnings("unchecked")
+            Class<? extends ServerSocketChannel> channel =
+                    (Class<? extends ServerSocketChannel>) Class.forName(channelClass);
+            return new Resolution(new Resolved(factory, channel), null);
+        } catch (ReflectiveOperationException | LinkageError e) {
+            LoggerFactory.getLogger(NettyIoEngine.class).debug("{} unavailable", availClass, e);
+            return new Resolution(null, e.toString());
+        }
+    }
+}

--- a/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/NettyServer.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/NettyServer.java
@@ -7,20 +7,11 @@ package dev.tachyonmcp.transport.netty;
 import dev.tachyonmcp.server.Server;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.buffer.PooledByteBufAllocator;
-import io.netty.channel.*;
-import io.netty.channel.epoll.Epoll;
-import io.netty.channel.epoll.EpollIoHandler;
-import io.netty.channel.epoll.EpollServerSocketChannel;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.MultiThreadIoEventLoopGroup;
+import io.netty.channel.WriteBufferWaterMark;
 import io.netty.channel.group.DefaultChannelGroup;
-import io.netty.channel.kqueue.KQueue;
-import io.netty.channel.kqueue.KQueueIoHandler;
-import io.netty.channel.kqueue.KQueueServerSocketChannel;
-import io.netty.channel.nio.NioIoHandler;
-import io.netty.channel.socket.ServerSocketChannel;
-import io.netty.channel.socket.nio.NioServerSocketChannel;
-import io.netty.channel.uring.IoUring;
-import io.netty.channel.uring.IoUringIoHandler;
-import io.netty.channel.uring.IoUringServerSocketChannel;
 import io.netty.util.concurrent.DefaultThreadFactory;
 import io.netty.util.concurrent.GlobalEventExecutor;
 import java.io.Closeable;
@@ -30,9 +21,9 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Netty-based MCP server with Streamable HTTP transport. Detects the best
- * available I/O handler (io_uring, epoll, kqueue, NIO) and binds a
- * {@link ServerBootstrap} with the MCP pipeline defined by
- * {@link McpChannelInitializer}.
+ * available I/O transport (io_uring, epoll, kqueue, NIO) via
+ * {@link NettyIoEngine#detect()} and binds a {@link ServerBootstrap} with the
+ * MCP pipeline defined by {@link McpChannelInitializer}.
  */
 public final class NettyServer implements Closeable {
 
@@ -58,20 +49,23 @@ public final class NettyServer implements Closeable {
     }
 
     public NettyServer(Server server, NettyServerConfig config) {
-        var transport = Transport.detect();
-        logger.info("Netty transport: {}", transport.channel.getSimpleName());
+        var engine = config.ioEngine();
+        if (engine == NettyIoEngine.AUTO) {
+            engine = NettyIoEngine.detect();
+        }
+        logger.info("Netty I/O engine: {}", engine);
 
         // Event loops run on PLATFORM threads. Netty I/O loops never voluntarily
         // yield (they spin in epoll_wait / io_uring_enter / Selector.select), and
         // native transports pin via JNI — so virtual threads provide no benefit
         // here and add scheduling cost. Virtual threads are used only for
         // application-level work (see Server#executor()).
-        eventLoopGroup = new MultiThreadIoEventLoopGroup(new DefaultThreadFactory("netty-io"), transport.ioHandler);
+        eventLoopGroup = new MultiThreadIoEventLoopGroup(new DefaultThreadFactory("netty-io"), engine.ioHandler());
 
         var bootstrap = new ServerBootstrap();
         bootstrap
                 .group(eventLoopGroup)
-                .channel(transport.channel)
+                .channel(engine.channel())
                 .option(ChannelOption.SO_BACKLOG, 1024)
                 .option(ChannelOption.SO_REUSEADDR, true)
                 .childOption(ChannelOption.ALLOCATOR, PooledByteBufAllocator.DEFAULT)
@@ -96,29 +90,6 @@ public final class NettyServer implements Closeable {
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new RuntimeException("Failed to start Netty server on " + config.host() + ":" + config.port(), e);
-        }
-    }
-
-    private record Transport(IoHandlerFactory ioHandler, Class<? extends ServerSocketChannel> channel) {
-        static Transport detect() {
-            if (isIoUringAvailable()) {
-                return new Transport(IoUringIoHandler.newFactory(), IoUringServerSocketChannel.class);
-            }
-            if (Epoll.isAvailable()) {
-                return new Transport(EpollIoHandler.newFactory(), EpollServerSocketChannel.class);
-            }
-            if (KQueue.isAvailable()) {
-                return new Transport(KQueueIoHandler.newFactory(), KQueueServerSocketChannel.class);
-            }
-            return new Transport(NioIoHandler.newFactory(), NioServerSocketChannel.class);
-        }
-    }
-
-    private static boolean isIoUringAvailable() {
-        try {
-            return IoUring.isAvailable();
-        } catch (NoClassDefFoundError e) {
-            return false;
         }
     }
 

--- a/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/NettyServerConfig.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/NettyServerConfig.java
@@ -21,6 +21,7 @@ public record NettyServerConfig(
         Duration writerIdleTimeout,
         int maxContentLength,
         @Nullable CorsConfig corsConfig,
+        NettyIoEngine ioEngine,
         @Nullable Consumer<ChannelPipeline> pipelineCustomizer) {
 
     /** Builds a CORS configuration from the given parameters. */
@@ -53,6 +54,7 @@ public record NettyServerConfig(
                 Duration.ofMinutes(5),
                 McpChannelInitializer.DEFAULT_MAX_CONTENT_LENGTH,
                 buildCorsConfig(null, false, false, null),
+                NettyIoEngine.AUTO,
                 null);
     }
 
@@ -65,6 +67,7 @@ public record NettyServerConfig(
                 Duration.ofMinutes(5),
                 McpChannelInitializer.DEFAULT_MAX_CONTENT_LENGTH,
                 buildCorsConfig(null, false, false, null),
+                NettyIoEngine.AUTO,
                 null);
     }
 }

--- a/tachyon-server/src/test/java/dev/tachyonmcp/transport/netty/NettyIoEngineTest.java
+++ b/tachyon-server/src/test/java/dev/tachyonmcp/transport/netty/NettyIoEngineTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2026 Konstantin Pavlov.
+ */
+
+package dev.tachyonmcp.transport.netty;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class NettyIoEngineTest {
+
+    @Test
+    void detectReturnsAvailableEngine() {
+        var engine = NettyIoEngine.detect();
+
+        assertThat(engine).isNotNull();
+        assertThat(engine.ioHandler()).isNotNull();
+        assertThat(engine.channel()).isNotNull();
+    }
+
+    @Test
+    void nioIsAlwaysAvailable() {
+        assertThat(NettyIoEngine.NIO.ioHandler()).isNotNull();
+        assertThat(NettyIoEngine.NIO.channel()).isEqualTo(NioServerSocketChannel.class);
+    }
+
+    @Test
+    void detectIsCached() {
+        var a = NettyIoEngine.detect();
+        var b = NettyIoEngine.detect();
+
+        assertThat(a).isSameAs(b);
+    }
+
+    @Test
+    void autoDelegatesToDetect() {
+        var autoEngine = NettyIoEngine.detect();
+
+        assertThat(NettyIoEngine.AUTO.ioHandler()).isEqualTo(autoEngine.ioHandler());
+        assertThat(NettyIoEngine.AUTO.channel()).isEqualTo(autoEngine.channel());
+    }
+
+    @Test
+    void detectFallsBackToNioWithoutTransportJars() {
+        assertThat(NettyIoEngine.detect()).isEqualTo(NettyIoEngine.NIO);
+    }
+
+    @Test
+    void nativeEnginesThrowWithReasonWithoutTransportJars() {
+        for (var engine : List.of(NettyIoEngine.IO_URING, NettyIoEngine.EPOLL, NettyIoEngine.KQUEUE)) {
+            assertThatThrownBy(engine::ioHandler)
+                    .isInstanceOf(UnsupportedOperationException.class)
+                    .hasMessageContaining(engine.name())
+                    .hasMessageContaining("not available");
+            assertThatThrownBy(engine::channel).isInstanceOf(UnsupportedOperationException.class);
+        }
+    }
+}


### PR DESCRIPTION
## New Features

- Added configuration for choosing the server’s Netty I/O engine, including automatic detection and explicit engine selection.
- Added support for native Netty transports on supported macOS and Linux environments. 

## Bug Fixes

- Automatic transport selection now falls back to a safe default when native support is unavailable.
- Improved behavior when an unavailable engine is selected, with clearer failure handling.


## Documentation

- Expanded setup and configuration docs, including network settings, session options, and native transport requirements.
- Walkthrough
- Introduces a NettyIoEngine enum for selecting/detecting Netty transport implementations (epoll/kqueue/io_uring/NIO/AUTO), wires it through NetworkConfig, NettyServerConfig, ServerBuilder, NettyServer, and the Kotlin DSL, updates Maven build files with OS-conditional native transport profiles, adds tests, and documents the feature.