### PR TITLE
feat: Add X-Accel-Buffering:no to SSE Streams

### DIFF
--- a/e2e/src/test/java/dev/tachyonmcp/e2e/SseHeartbeatTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/SseHeartbeatTest.java
@@ -70,6 +70,7 @@ class SseHeartbeatTest {
         var raw = readRawSse(sessionId, READER_IDLE.toMillis() * 5);
 
         assertThat(raw).as("stream must open as text/event-stream").contains("text/event-stream");
+        assertThat(raw).contains("X-Accel-Buffering: no");
         assertThat(countOccurrences(raw, ":\r\n"))
                 .as("reader-idle must drive repeated SSE comment heartbeats (proves timer rescheduling)")
                 .isGreaterThanOrEqualTo(2);

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/SsePollingTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/SsePollingTest.java
@@ -7,6 +7,7 @@ package dev.tachyonmcp.e2e;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.net.Socket;
+import java.net.SocketTimeoutException;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -30,6 +31,7 @@ class SsePollingTest extends AbstractMcpE2eTest {
         var sessionId = initializeSession();
         var raw = readRawSse(sessionId, 1024, 2000);
         assertThat(raw).contains("retry: 3000");
+        assertThat(raw).contains("X-Accel-Buffering: no");
     }
 
     @Test
@@ -95,7 +97,7 @@ class SsePollingTest extends AbstractMcpE2eTest {
         }
     }
 
-    /** Reads raw SSE bytes up to {@code bufSize} bytes or until {@code timeoutMs}. */
+    /** Reads raw SSE bytes until {@code timeoutMs}. */
     private String readRawSse(String sessionId, int bufSize, int timeoutMs) throws Exception {
         try (var socket = new Socket("localhost", port)) {
             var req = ("GET /mcp HTTP/1.1\r\n"
@@ -106,20 +108,23 @@ class SsePollingTest extends AbstractMcpE2eTest {
                     .getBytes(StandardCharsets.UTF_8);
             socket.getOutputStream().write(req);
             socket.getOutputStream().flush();
+            socket.setSoTimeout(50);
 
+            var sb = new StringBuilder();
             var buf = new byte[bufSize];
-            var total = 0;
             var deadline = System.currentTimeMillis() + timeoutMs;
-            while (total < buf.length && System.currentTimeMillis() < deadline) {
-                if (socket.getInputStream().available() > 0) {
-                    var n = socket.getInputStream().read(buf, total, buf.length - total);
-                    if (n > 0) total += n;
-                } else {
-                    Thread.sleep(5);
+            while (System.currentTimeMillis() < deadline) {
+                try {
+                    var n = socket.getInputStream().read(buf);
+                    if (n < 0) break;
+                    if (n > 0) sb.append(new String(buf, 0, n, StandardCharsets.UTF_8));
+                } catch (SocketTimeoutException e) {
+                    // No data this poll; keep reading until the deadline.
                 }
             }
-            assertThat(total).isGreaterThan(0);
-            return new String(buf, 0, total, StandardCharsets.UTF_8);
+            var raw = sb.toString();
+            assertThat(raw).as("must have received data").isNotEmpty();
+            return raw;
         }
     }
 

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/SseRetryTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/SseRetryTest.java
@@ -7,6 +7,7 @@ package dev.tachyonmcp.e2e;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.net.Socket;
+import java.net.SocketTimeoutException;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -45,24 +46,23 @@ class SseRetryTest extends AbstractMcpE2eTest {
                     .getBytes(StandardCharsets.UTF_8);
             socket.getOutputStream().write(req);
             socket.getOutputStream().flush();
+            socket.setSoTimeout(50);
 
+            var sb = new StringBuilder();
             var buf = new byte[512];
-            var total = 0;
             var deadline = System.currentTimeMillis() + 5000;
-            while (total < buf.length && System.currentTimeMillis() < deadline) {
-                if (socket.getInputStream().available() > 0) {
-                    var n = socket.getInputStream().read(buf, total, buf.length - total);
-                    if (n > 0) {
-                        total += n;
-                    }
-                } else {
-                    Thread.sleep(20);
+            while (System.currentTimeMillis() < deadline) {
+                try {
+                    var n = socket.getInputStream().read(buf);
+                    if (n < 0) break;
+                    if (n > 0) sb.append(new String(buf, 0, n, StandardCharsets.UTF_8));
+                } catch (SocketTimeoutException e) {
+                    // No data this poll; keep reading until the deadline.
                 }
             }
-            assertThat(total).isGreaterThan(0);
-
-            var raw = new String(buf, 0, total, StandardCharsets.UTF_8);
+            var raw = sb.toString();
             assertThat(raw).contains("retry: 3000");
+            assertThat(raw).contains("X-Accel-Buffering: no");
         }
     }
 }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/http/HttpHelpers.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/http/HttpHelpers.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2026 Konstantin Pavlov.
+ */
+
+package dev.tachyonmcp.transport.netty.http;
+
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpHeaderValues;
+import io.netty.handler.codec.http.HttpResponse;
+import org.jspecify.annotations.Nullable;
+
+public final class HttpHelpers {
+
+    /**
+     * Add {@code X-Accel-Buffering: no} to SSE HTTP responses. This instructs reverse proxies (such as
+     * nginx) to disable response buffering, ensuring that SSE events are delivered to clients
+     * immediately rather than being held in a buffer.
+     *
+     * @see <a
+     * href="https://modelcontextprotocol.io/specification/draft/basic/transports/streamable-http#receiving-messages">
+     * MCP Streamable HTTP Protocol</a>
+     */
+    private static final String X_ACCEL_BUFFERING = "X-Accel-Buffering";
+
+    private HttpHelpers() {}
+
+    /**
+     * Set required HTTP headers for SSE stream response
+     */
+    public static void setSseStreamHeaders(HttpResponse response, @Nullable String origin) {
+        response.headers()
+                .set(HttpHeaderNames.CONTENT_TYPE, "text/event-stream")
+                .set(HttpHeaderNames.TRANSFER_ENCODING, HttpHeaderValues.CHUNKED)
+                .set(HttpHeaderNames.CACHE_CONTROL, "no-cache")
+                .set(HttpHeaderNames.CONNECTION, "keep-alive")
+                .set(X_ACCEL_BUFFERING, "no");
+        if (origin != null) {
+            response.headers().set(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN, origin);
+        }
+    }
+}

--- a/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/sse/PostSseStream.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/sse/PostSseStream.java
@@ -8,6 +8,7 @@ import static dev.tachyonmcp.transport.netty.sse.SseManager.SSE_RETRY_DELAY_MS;
 
 import dev.tachyonmcp.runtime.SseEvent;
 import dev.tachyonmcp.server.OutboundSseStream;
+import dev.tachyonmcp.transport.netty.http.HttpHelpers;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
 import io.netty.channel.Channel;
@@ -88,14 +89,7 @@ public final class PostSseStream implements OutboundSseStream {
         started = true;
 
         var response = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK);
-        response.headers()
-                .set(HttpHeaderNames.CONTENT_TYPE, "text/event-stream")
-                .set(HttpHeaderNames.TRANSFER_ENCODING, HttpHeaderValues.CHUNKED)
-                .set(HttpHeaderNames.CACHE_CONTROL, "no-cache")
-                .set(HttpHeaderNames.CONNECTION, HttpHeaderValues.CLOSE);
-        if (origin != null) {
-            response.headers().set(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN, origin);
-        }
+        HttpHelpers.setSseStreamHeaders(response, origin);
         channel.write(response);
         channel.write(
                 new DefaultHttpContent(ByteBufUtil.writeUtf8(channel.alloc(), "retry: " + SSE_RETRY_DELAY_MS + "\n")));

--- a/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/sse/SseManager.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/sse/SseManager.java
@@ -8,6 +8,7 @@ import dev.tachyonmcp.runtime.Session;
 import dev.tachyonmcp.runtime.SseConnection;
 import dev.tachyonmcp.runtime.SseEvent;
 import dev.tachyonmcp.server.Server;
+import dev.tachyonmcp.transport.netty.http.HttpHelpers;
 import io.netty.buffer.ByteBufUtil;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.*;
@@ -63,14 +64,7 @@ public class SseManager {
 
     private void writeOpeningFrames(ChannelHandlerContext ctx, @Nullable String origin, NettySseConnection connection) {
         var response = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK);
-        response.headers()
-                .set(HttpHeaderNames.CONTENT_TYPE, "text/event-stream")
-                .set(HttpHeaderNames.TRANSFER_ENCODING, HttpHeaderValues.CHUNKED)
-                .set(HttpHeaderNames.CACHE_CONTROL, "no-cache")
-                .set(HttpHeaderNames.CONNECTION, "keep-alive");
-        if (origin != null) {
-            response.headers().set(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN, origin);
-        }
+        HttpHelpers.setSseStreamHeaders(response, origin);
         ctx.write(response);
         ctx.writeAndFlush(
                 new DefaultHttpContent(ByteBufUtil.writeUtf8(ctx.alloc(), "retry: " + SSE_RETRY_DELAY_MS + "\n")));


### PR DESCRIPTION
Adds {@code X-Accel-Buffering: no} to every SSE ({@code text/event-stream}) response. This instructs reverse proxies (such as nginx) to disable response buffering, ensuring that SSE events are delivered to clients immediately rather than being held in a buffer.

[MCP Streamable HTTP Protocol](https://modelcontextprotocol.io/specification/draft/basic/transports/streamable-http#receiving-messages)