### PR TITLE
feat: Kotlin DSL outputSchema and structured tool results

### DIFF
--- a/.agents/skills/tachyon-mcp/resources/java/ConfigReference.java
+++ b/.agents/skills/tachyon-mcp/resources/java/ConfigReference.java
@@ -2,12 +2,12 @@
  * Copyright (c) 2026 Konstantin Pavlov.
  */
 
-import dev.tachyonmcp.server.config.CapabilitiesConfig;
-import dev.tachyonmcp.server.config.Mode;
-import dev.tachyonmcp.server.config.NetworkConfig;
-import dev.tachyonmcp.server.config.RuntimeConfig;
-import dev.tachyonmcp.server.config.SessionConfig;
+import dev.tachyonmcp.server.config.*;
+import dev.tachyonmcp.server.session.InMemorySessionLogRouter;
+import dev.tachyonmcp.server.session.InMemorySessionStore;
+import dev.tachyonmcp.server.session.SessionIdGenerator;
 import dev.tachyonmcp.transport.netty.NettyIoEngine;
+
 import java.time.Duration;
 
 /**
@@ -16,65 +16,78 @@ import java.time.Duration;
  */
 final class ConfigReference {
 
-    /** Capabilities — which MCP features to advertise. */
+    /**
+     * Capabilities — which MCP features to advertise.
+     */
     static CapabilitiesConfig capabilities() {
         return CapabilitiesConfig.builder()
-                .toolsMode(Mode.AUTO) // ON when tools registered
-                .toolsListChanged(false)
-                .resourcesMode(Mode.AUTO) // ON when resources registered
-                .resourcesSubscribe(false)
-                .resourcesListChanged(false)
-                .promptsMode(Mode.AUTO) // ON when prompts registered
-                .promptsListChanged(false)
-                .tasksList(false)
-                .tasksCancel(false)
-                .tasksRequests(false)
-                .completions(false)
-                .logging(false)
-                .build();
+            .toolsMode(Mode.AUTO) // ON when tools registered
+            .toolsListChanged(false)
+            .resourcesMode(Mode.AUTO) // ON when resources registered
+            .resourcesSubscribe(false)
+            .resourcesListChanged(false)
+            .promptsMode(Mode.AUTO) // ON when prompts registered
+            .promptsListChanged(false)
+            .tasksList(false)
+            .tasksCancel(false)
+            .tasksRequests(false)
+            .completions(false)
+            .logging(false)
+            .build();
     }
 
-    /** Convenience defaults. */
+    /**
+     * Convenience defaults.
+     */
     static CapabilitiesConfig convenienceDefaults() {
         return CapabilitiesConfig.builder()
-                .tools(true) // Mode.ON, listChanged=true
-                .resources(true, true) // Mode.ON, subscribe=true, listChanged=true
-                .prompts() // Mode.ON, listChanged=false
-                .tasks() // list=true, cancel=false, requests=false
-                .completions() // true
-                .logging() // true
-                .build();
+            .tools(true) // Mode.ON, listChanged=true
+            .resources(true, true) // Mode.ON, subscribe=true, listChanged=true
+            .prompts() // Mode.ON, listChanged=false
+            .tasks() // list=true, cancel=false, requests=false
+            .completions() // true
+            .logging() // true
+            .build();
     }
 
-    /** Network — binding and transport config. */
+    /**
+     * Network — binding and transport config.
+     */
     static NetworkConfig network() {
         return NetworkConfig.builder()
-                .host("127.0.0.1")
-                .port(8080)
-                .endpointPath("/mcp")
-                .readerIdleTimeout(Duration.ofSeconds(30))
-                .writerIdleTimeout(Duration.ofMinutes(2))
-                .maxContentLength(65536) // 64KB
-                .allowedOrigins("https://app.example.com")
-                .allowNullOrigin(false)
-                .allowPrivateNetworks(true)
-                .allowedHeaders("X-Custom-Header")
-                .ioEngine(NettyIoEngine.AUTO) // io_uring > epoll > kqueue > NIO; native jars optional
-                .build();
+            .host("127.0.0.1")
+            .port(8080)
+            .endpointPath("/mcp")
+            .readerIdleTimeout(Duration.ofSeconds(30))
+            .writerIdleTimeout(Duration.ofMinutes(2))
+            .maxContentLength(65536) // 64KB
+            .allowedOrigins("https://app.example.com")
+            .allowNullOrigin(false)
+            .allowPrivateNetworks(true)
+            .allowedHeaders("X-Custom-Header")
+            .ioEngine(NettyIoEngine.AUTO) // io_uring > epoll > kqueue > NIO; native jars optional
+            .build();
     }
 
-    /** Session — connection lifecycle. */
+    /**
+     * Session — connection lifecycle.
+     */
     static SessionConfig session() {
         return SessionConfig.builder()
-                .enabled(true) // stateless by default; enable server-side sessions explicitly
-                .sessionTtl(Duration.ofMinutes(10))
-                .build();
+            .enabled(true) // stateless by default; enable server-side sessions explicitly
+            .sessionIdGenerator(SessionIdGenerator.DEFAULT)
+            .sessionLogRouter(new InMemorySessionLogRouter())
+            .sessionStore(new InMemorySessionStore())
+            .sessionTtl(Duration.ofMinutes(10))
+            .build();
     }
 
-    /** Runtime — handler-execution lifecycle. */
+    /**
+     * Runtime — handler-execution lifecycle.
+     */
     static RuntimeConfig runtime() {
         return RuntimeConfig.builder()
-                .shutdownGracePeriod(Duration.ofSeconds(5)) // drain in-flight handlers on close; ZERO = interrupt now
-                .build();
+            .shutdownGracePeriod(Duration.ofSeconds(5)) // drain in-flight handlers on close; ZERO = interrupt now
+            .build();
     }
 }

--- a/docs/kotlin.md
+++ b/docs/kotlin.md
@@ -85,6 +85,71 @@ tool(name = "reverse", description = "Reverse a string") {
 
 For class-based handlers, extend `AbstractSyncToolHandler` or `AbstractAsyncToolHandler` from `tachyon-server` — they work unchanged from Kotlin.
 
+## Tool schemas
+
+`inputSchema` / `outputSchema` accept three shapes on every registration overload
+(`tool(...)` in the DSL, `Server.registerTool(...)` post-build, `toolDescriptor { }`):
+
+```kotlin
+// Jackson JsonNode
+tool("a", inputSchema = jacksonNode) { /* ... */ }
+
+// Raw JSON string — parsed by Tachyon
+tool(
+    "b",
+    inputSchema = """{"type":"object","properties":{"msg":{"type":"string"}}}""",
+    outputSchema = """{"type":"object","properties":{"echo":{"type":"string"}}}""",
+) { /* ... */ }
+
+// kotlinx.serialization JsonObject — requires kotlinx-serialization-json (optional)
+tool("c", inputSchema = buildJsonObject { put("type", "object") }) { /* ... */ }
+```
+
+Schema roots are validated at registration time: a schema whose root does not declare
+`"type": "object"` fails fast with `IllegalArgumentException` instead of surfacing later
+in the MCP client. Tool descriptions longer than 2048 characters log a warning —
+clients may truncate them.
+
+## kotlinx.serialization integration
+
+`kotlinx-serialization-json` is an **optional** dependency of `tachyon-server-kotlin`.
+Add it to use `JsonObject` schemas, `args.decode<T>()`, and `structured(value)`:
+
+```xml
+<dependency>
+    <groupId>org.jetbrains.kotlinx</groupId>
+    <artifactId>kotlinx-serialization-json</artifactId>
+</dependency>
+```
+
+```kotlin
+@Serializable data class EchoArgs(val message: String, val loud: Boolean = false)
+
+@Serializable data class EchoReply(val echo: String)
+
+tool(
+    "echo",
+    inputSchema = """{"type":"object","properties":{"message":{"type":"string"}}}""",
+    outputSchema = """{"type":"object","properties":{"echo":{"type":"string"}}}""",
+) {
+    val input = args.decode<EchoArgs>() // typed decode, unknown keys ignored
+    structured(EchoReply(input.message)) // structuredContent + JSON text fallback
+}
+```
+
+`decode` ignores unknown keys by default; pass a custom `Json` instance for strict decoding.
+`structured(value)` requires the value to encode to a JSON object and pairs with the
+declared `outputSchema`.
+
+## ToolArgs accessors
+
+| Call | Behaviour |
+|---|---|
+| `args.string("k")` / `intValue` / `boolValue` / `doubleValue` | Required — throws when missing |
+| `args.stringOrNull("k")` / `intOrNull` / `booleanOrNull` / `doubleOrNull` | Returns `null` when missing |
+| `args.stringOr("k", "d")` / `int("k", 0)` / `boolean("k", true)` / `double("k", 0.0)` | Falls back to default |
+| `args.decode<T>()` | kotlinx decode into a `@Serializable` class |
+
 ## Scope reference
 
 | Scope | Builder method | Properties |
@@ -132,6 +197,9 @@ TachyonServer(port = 8080) {
 | `ToolResult.empty()` | No content |
 
 `structuredContent` requires a JSON object shape. Tachyon rejects primitives and arrays at runtime.
+
+With kotlinx-serialization on the classpath, prefer `structured(value)` inside a tool lambda —
+it encodes any `@Serializable` value and emits both `structuredContent` and the JSON text fallback.
 
 ## Testing
 

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/ToolCapabilitiesTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/ToolCapabilitiesTest.java
@@ -207,6 +207,29 @@ class ToolCapabilitiesTest extends AbstractMcpE2eTest {
         }
     }
 
+    // region: Structured content in tools/call
+
+    @Test
+    void shouldReturnStructuredContentAndTextFallback() throws Exception {
+        startServer(it -> it.tool(new StructuredToolHandler()));
+
+        try (var client = createTestClient()) {
+            var sessionId = client.initialize();
+            var response = client.sendRequest(sessionId, """
+                {"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"structured","arguments":{"message":"hi"}}}
+                """);
+
+            assertThat(response.statusCode()).isEqualTo(200);
+            assertThatJson(response.body()).inPath("$.result.content[0].text").isEqualTo("Echo: hi");
+            assertThatJson(response.body())
+                    .inPath("$.result.structuredContent")
+                    .isObject()
+                    .containsKey("echo");
+        }
+    }
+
+    // endregion
+
     @Test
     void shouldRegisterWithFullDescriptor() throws Exception {
         var annotations = ToolAnnotations.of(null, true, false, null, null);
@@ -343,6 +366,30 @@ class ToolCapabilitiesTest extends AbstractMcpE2eTest {
         @Override
         public ToolResult handle(InteractionContext context, ToolArgs arguments) {
             return ToolResult.text("ok");
+        }
+    }
+
+    private static class StructuredToolHandler implements SyncToolHandler {
+        @Override
+        public String name() {
+            return "structured";
+        }
+
+        @Override
+        public String description() {
+            return "Returns structured content";
+        }
+
+        @Override
+        public JsonNode inputSchema() {
+            return INPUT_SCHEMA;
+        }
+
+        @Override
+        public ToolResult handle(InteractionContext context, ToolArgs arguments) {
+            var msg = arguments.string("message");
+            var echo = JsonNodeFactory.instance.objectNode().put("echo", msg);
+            return ToolResult.of(echo, "Echo: " + msg);
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,7 @@
             -Dio.netty.leakDetection.level=PARANOID
         </argLine>
         <kotlinx-coroutines.version>1.11.0</kotlinx-coroutines.version>
+        <kotlinx-serialization-json.version>1.8.1</kotlinx-serialization-json.version>
     </properties>
 
     <dependencyManagement>

--- a/tachyon-server-kotlin/README.md
+++ b/tachyon-server-kotlin/README.md
@@ -14,6 +14,9 @@ Kotlin coroutine-first DSL for [Tachyon MCP](../README.md). Wraps the Java `Serv
 
 Requires `tachyon-server` on the classpath (included transitively).
 
+Optionally add `org.jetbrains.kotlinx:kotlinx-serialization-json` to unlock `JsonObject`
+schemas, `args.decode<T>()`, and `structured(value)` tool results.
+
 ## Documentation
 
 Full reference: [docs/kotlin.md](../docs/kotlin.md)

--- a/tachyon-server-kotlin/detekt.yml
+++ b/tachyon-server-kotlin/detekt.yml
@@ -18,7 +18,9 @@ config:
 complexity:
   TooManyFunctions:
     active: true
-    excludes: [ '**/*Builder.kt', '**/*Test.kt' ]
+    excludes:
+      - '**/*Builder.kt'
+      - '**/*Test.kt'
 #    allowedFunctionsPerFile: 15
 #    allowedFunctionsPerClass: 15
 #    allowedFunctionsPerInterface: 11

--- a/tachyon-server-kotlin/detekt.yml
+++ b/tachyon-server-kotlin/detekt.yml
@@ -18,7 +18,7 @@ config:
 complexity:
   TooManyFunctions:
     active: true
-    excludes: [ '**/*Builder.kt' ]
+    excludes: [ '**/*Builder.kt', '**/*Test.kt' ]
 #    allowedFunctionsPerFile: 15
 #    allowedFunctionsPerClass: 15
 #    allowedFunctionsPerInterface: 11

--- a/tachyon-server-kotlin/pom.xml
+++ b/tachyon-server-kotlin/pom.xml
@@ -37,6 +37,14 @@
             <artifactId>slf4j-api</artifactId>
         </dependency>
 
+        <!-- Optional: kotlinx-serialization-json for KotlinxExtensions -->
+        <dependency>
+            <groupId>org.jetbrains.kotlinx</groupId>
+            <artifactId>kotlinx-serialization-json</artifactId>
+            <version>${kotlinx-serialization-json.version}</version>
+            <optional>true</optional>
+        </dependency>
+
         <!-- Test -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>
@@ -83,7 +91,17 @@
                         <arg>-Xexplicit-api=strict</arg>
                         <arg>-Werror</arg>
                     </args>
+                    <compilerPlugins>
+                        <plugin>kotlinx-serialization</plugin>
+                    </compilerPlugins>
                 </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.jetbrains.kotlin</groupId>
+                        <artifactId>kotlin-maven-serialization</artifactId>
+                        <version>${kotlin.version}</version>
+                    </dependency>
+                </dependencies>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/JsonInterop.kt
+++ b/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/JsonInterop.kt
@@ -2,6 +2,7 @@
 
 package dev.tachyonmcp.server
 
+import dev.tachyonmcp.server.features.tools.DefaultToolDescriptor
 import tools.jackson.databind.JsonNode
 import tools.jackson.databind.ObjectMapper
 import tools.jackson.databind.json.JsonMapper
@@ -10,4 +11,17 @@ import tools.jackson.databind.json.JsonMapper
 internal val sharedMapper: ObjectMapper = JsonMapper.builder().build()
 
 @PublishedApi
-internal fun String.toJsonNode(): JsonNode = sharedMapper.readTree(this)
+@Suppress("TooGenericExceptionCaught")
+internal fun String.toJsonNode(): JsonNode =
+    try {
+        sharedMapper.readTree(this)
+    } catch (e: Exception) {
+        throw IllegalArgumentException("Failed to parse JSON schema: '$this'", e)
+    }
+
+@PublishedApi
+internal fun DefaultToolDescriptor.Builder.schemas(
+    inputSchema: String,
+    outputSchema: String?,
+): DefaultToolDescriptor.Builder =
+    inputSchema(inputSchema.toJsonNode()).outputSchema(outputSchema?.toJsonNode())

--- a/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/JsonInterop.kt
+++ b/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/JsonInterop.kt
@@ -1,0 +1,13 @@
+// Copyright (c) 2026 Konstantin Pavlov.
+
+package dev.tachyonmcp.server
+
+import tools.jackson.databind.JsonNode
+import tools.jackson.databind.ObjectMapper
+import tools.jackson.databind.json.JsonMapper
+
+@PublishedApi
+internal val sharedMapper: ObjectMapper = JsonMapper.builder().build()
+
+@PublishedApi
+internal fun String.toJsonNode(): JsonNode = sharedMapper.readTree(this)

--- a/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/KotlinxExtensions.kt
+++ b/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/KotlinxExtensions.kt
@@ -8,6 +8,8 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import tools.jackson.databind.JsonNode
 
+private fun JsonObject.toJacksonNode(): JsonNode = toString().toJsonNode()
+
 /**
  * Registers a tool using a [JsonObject] input schema.
  * Requires kotlinx-serialization-json on the classpath.
@@ -23,8 +25,8 @@ public fun Server.registerTool(
     registerTool(
         name = name,
         description = description,
-        inputSchema = inputSchema.toString().toJsonNode(),
-        outputSchema = outputSchema?.toString()?.toJsonNode(),
+        inputSchema = inputSchema.toJacksonNode(),
+        outputSchema = outputSchema?.toJacksonNode(),
         block = block,
     )
 
@@ -42,8 +44,8 @@ public fun ServerBuilder.tool(
     this.tool(
         name = name,
         description = description,
-        inputSchema = inputSchema.toString().toJsonNode(),
-        outputSchema = outputSchema?.toString()?.toJsonNode(),
+        inputSchema = inputSchema.toJacksonNode(),
+        outputSchema = outputSchema?.toJacksonNode(),
         handler = handler,
     )
 
@@ -61,19 +63,19 @@ public fun TachyonServerBuilder.tool(
     this.tool(
         name = name,
         description = description,
-        inputSchema = inputSchema.toString().toJsonNode(),
-        outputSchema = outputSchema?.toString()?.toJsonNode(),
+        inputSchema = inputSchema.toJacksonNode(),
+        outputSchema = outputSchema?.toJacksonNode(),
         handler = handler,
     )
 
 /** Sets the input schema from a [JsonObject]. Requires kotlinx-serialization-json on the classpath. */
 public fun ToolDescriptorScope.inputSchema(json: JsonObject) {
-    inputSchema = json.toString().toJsonNode()
+    inputSchema = json.toJacksonNode()
 }
 
 /** Sets the output schema from a [JsonObject]. Requires kotlinx-serialization-json on the classpath. */
 public fun ToolDescriptorScope.outputSchema(json: JsonObject) {
-    outputSchema = json.toString().toJsonNode()
+    outputSchema = json.toJacksonNode()
 }
 
 /**

--- a/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/KotlinxExtensions.kt
+++ b/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/KotlinxExtensions.kt
@@ -1,0 +1,108 @@
+// Copyright (c) 2026 Konstantin Pavlov.
+
+package dev.tachyonmcp.server
+
+import dev.tachyonmcp.server.features.tools.ToolArgs
+import dev.tachyonmcp.server.features.tools.ToolResult
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import tools.jackson.databind.JsonNode
+
+/**
+ * Registers a tool using a [JsonObject] input schema.
+ * Requires kotlinx-serialization-json on the classpath.
+ */
+@JvmSynthetic
+public fun Server.registerTool(
+    name: String,
+    description: String? = null,
+    inputSchema: JsonObject,
+    outputSchema: JsonObject? = null,
+    block: suspend ToolScope.() -> ToolResult,
+): Server =
+    registerTool(
+        name = name,
+        description = description,
+        inputSchema = inputSchema.toString().toJsonNode(),
+        outputSchema = outputSchema?.toString()?.toJsonNode(),
+        block = block,
+    )
+
+/**
+ * Registers a tool using a [JsonObject] input schema.
+ * Requires kotlinx-serialization-json on the classpath.
+ */
+public fun ServerBuilder.tool(
+    name: String,
+    description: String? = null,
+    inputSchema: JsonObject,
+    outputSchema: JsonObject? = null,
+    handler: suspend ToolScope.() -> ToolResult,
+): ServerBuilder =
+    this.tool(
+        name = name,
+        description = description,
+        inputSchema = inputSchema.toString().toJsonNode(),
+        outputSchema = outputSchema?.toString()?.toJsonNode(),
+        handler = handler,
+    )
+
+/**
+ * Registers a tool using a [JsonObject] input schema.
+ * Requires kotlinx-serialization-json on the classpath.
+ */
+public fun TachyonServerBuilder.tool(
+    name: String,
+    description: String? = null,
+    inputSchema: JsonObject,
+    outputSchema: JsonObject? = null,
+    handler: suspend ToolScope.() -> ToolResult,
+): TachyonServerBuilder =
+    this.tool(
+        name = name,
+        description = description,
+        inputSchema = inputSchema.toString().toJsonNode(),
+        outputSchema = outputSchema?.toString()?.toJsonNode(),
+        handler = handler,
+    )
+
+/** Sets the input schema from a [JsonObject]. Requires kotlinx-serialization-json on the classpath. */
+public fun ToolDescriptorScope.inputSchema(json: JsonObject) {
+    inputSchema = json.toString().toJsonNode()
+}
+
+/** Sets the output schema from a [JsonObject]. Requires kotlinx-serialization-json on the classpath. */
+public fun ToolDescriptorScope.outputSchema(json: JsonObject) {
+    outputSchema = json.toString().toJsonNode()
+}
+
+/**
+ * Produces a [ToolResult] with a structured value encoded via kotlinx-serialization.
+ * The serialized JSON string serves as the text fallback.
+ * The value must encode to a JSON object, as required by the MCP `structuredContent` field.
+ * Requires kotlinx-serialization-json on the classpath.
+ */
+public inline fun <reified T> ToolScope.structured(
+    value: T,
+    json: Json = Json.Default,
+): ToolResult {
+    val text = json.encodeToString(value)
+    val node: JsonNode = text.toJsonNode()
+    require(node.isObject) {
+        "structuredContent must be a JSON object, got ${node.nodeType}: $text"
+    }
+    return ToolResult.of(node, text)
+}
+
+@PublishedApi
+internal val defaultArgsJson: Json = Json { ignoreUnknownKeys = true }
+
+/**
+ * Decodes tool arguments into a [T] using kotlinx-serialization.
+ * Unknown keys are ignored by default; pass a custom [json] for strict decoding.
+ * Requires kotlinx-serialization-json on the classpath.
+ */
+public inline fun <reified T> ToolArgs.decode(json: Json = defaultArgsJson): T {
+    val text = asMap().let { sharedMapper.writeValueAsString(it) }
+    return json.decodeFromString(text)
+}

--- a/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/McpServerExtensions.kt
+++ b/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/McpServerExtensions.kt
@@ -17,12 +17,29 @@ public fun Server.registerTool(
     name: String,
     description: String? = null,
     inputSchema: JsonNode? = null,
+    outputSchema: JsonNode? = null,
     block: suspend ToolScope.() -> ToolResult,
 ): Server =
     registerTool(configure = {
         name(name)
         description(description)
         inputSchema(inputSchema)
+        outputSchema(outputSchema)
+    }, block = block)
+
+@JvmSynthetic
+public fun Server.registerTool(
+    name: String,
+    description: String? = null,
+    inputSchema: String,
+    outputSchema: String? = null,
+    block: suspend ToolScope.() -> ToolResult,
+): Server =
+    registerTool(configure = {
+        name(name)
+        description(description)
+        inputSchema(inputSchema.toJsonNode())
+        outputSchema(outputSchema?.toJsonNode())
     }, block = block)
 
 @JvmSynthetic

--- a/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/McpServerExtensions.kt
+++ b/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/McpServerExtensions.kt
@@ -38,8 +38,7 @@ public fun Server.registerTool(
     registerTool(configure = {
         name(name)
         description(description)
-        inputSchema(inputSchema.toJsonNode())
-        outputSchema(outputSchema?.toJsonNode())
+        schemas(inputSchema, outputSchema)
     }, block = block)
 
 @JvmSynthetic

--- a/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/TachyonServerBuilder.kt
+++ b/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/TachyonServerBuilder.kt
@@ -67,6 +67,7 @@ public class TachyonServerBuilder
             name: String,
             description: String? = null,
             inputSchema: JsonNode? = null,
+            outputSchema: JsonNode? = null,
             handler: suspend ToolScope.() -> ToolResult,
         ): TachyonServerBuilder =
             this.also {
@@ -76,6 +77,28 @@ public class TachyonServerBuilder
                             .builder(name)
                             .description(description)
                             .inputSchema(inputSchema)
+                            .outputSchema(outputSchema)
+                            .build(),
+                        handler,
+                    ),
+                )
+            }
+
+        public fun tool(
+            name: String,
+            description: String? = null,
+            inputSchema: String,
+            outputSchema: String? = null,
+            handler: suspend ToolScope.() -> ToolResult,
+        ): TachyonServerBuilder =
+            this.also {
+                delegate.tool(
+                    asyncHandler(
+                        ToolDescriptor
+                            .builder(name)
+                            .description(description)
+                            .inputSchema(inputSchema.toJsonNode())
+                            .outputSchema(outputSchema?.toJsonNode())
                             .build(),
                         handler,
                     ),

--- a/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/TachyonServerBuilder.kt
+++ b/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/TachyonServerBuilder.kt
@@ -97,8 +97,7 @@ public class TachyonServerBuilder
                         ToolDescriptor
                             .builder(name)
                             .description(description)
-                            .inputSchema(inputSchema.toJsonNode())
-                            .outputSchema(outputSchema?.toJsonNode())
+                            .schemas(inputSchema, outputSchema)
                             .build(),
                         handler,
                     ),

--- a/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/ToolArgsExtensions.kt
+++ b/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/ToolArgsExtensions.kt
@@ -1,0 +1,28 @@
+// Copyright (c) 2026 Konstantin Pavlov.
+
+package dev.tachyonmcp.server
+
+import dev.tachyonmcp.server.features.tools.ToolArgs
+
+public fun ToolArgs.stringOrNull(key: String): String? = if (has(key)) string(key) else null
+
+public fun ToolArgs.intOrNull(key: String): Int? = if (has(key)) intValue(key) else null
+
+public fun ToolArgs.booleanOrNull(key: String): Boolean? = if (has(key)) boolValue(key) else null
+
+public fun ToolArgs.doubleOrNull(key: String): Double? = if (has(key)) doubleValue(key) else null
+
+public fun ToolArgs.boolean(
+    key: String,
+    default: Boolean,
+): Boolean = boolOr(key, default)
+
+public fun ToolArgs.int(
+    key: String,
+    default: Int,
+): Int = intOr(key, default)
+
+public fun ToolArgs.double(
+    key: String,
+    default: Double,
+): Double = doubleOr(key, default)

--- a/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/ToolDescriptorScope.kt
+++ b/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/ToolDescriptorScope.kt
@@ -19,6 +19,14 @@ public class ToolDescriptorScope
         public var taskSupport: TaskSupport? = null
         public var annotations: ToolAnnotations? = null
 
+        public fun inputSchema(json: String) {
+            inputSchema = json.toJsonNode()
+        }
+
+        public fun outputSchema(json: String) {
+            outputSchema = json.toJsonNode()
+        }
+
         @PublishedApi
         internal fun build(): ToolDescriptor {
             val n = requireNotNull(name) { "ToolDescriptor.name is required" }

--- a/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/ToolScope.kt
+++ b/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/ToolScope.kt
@@ -20,6 +20,7 @@ public fun ServerBuilder.tool(
     name: String,
     description: String? = null,
     inputSchema: JsonNode? = null,
+    outputSchema: JsonNode? = null,
     handler: suspend ToolScope.() -> ToolResult,
 ): ServerBuilder =
     tool(
@@ -28,6 +29,26 @@ public fun ServerBuilder.tool(
                 .builder(name)
                 .description(description)
                 .inputSchema(inputSchema)
+                .outputSchema(outputSchema)
+                .build(),
+            handler,
+        ),
+    )
+
+public fun ServerBuilder.tool(
+    name: String,
+    description: String? = null,
+    inputSchema: String,
+    outputSchema: String? = null,
+    handler: suspend ToolScope.() -> ToolResult,
+): ServerBuilder =
+    tool(
+        asyncHandler(
+            ToolDescriptor
+                .builder(name)
+                .description(description)
+                .inputSchema(inputSchema.toJsonNode())
+                .outputSchema(outputSchema?.toJsonNode())
                 .build(),
             handler,
         ),

--- a/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/ToolScope.kt
+++ b/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/ToolScope.kt
@@ -47,8 +47,7 @@ public fun ServerBuilder.tool(
             ToolDescriptor
                 .builder(name)
                 .description(description)
-                .inputSchema(inputSchema.toJsonNode())
-                .outputSchema(outputSchema?.toJsonNode())
+                .schemas(inputSchema, outputSchema)
                 .build(),
             handler,
         ),

--- a/tachyon-server-kotlin/src/test/kotlin/dev/tachyonmcp/server/KotlinApiTest.kt
+++ b/tachyon-server-kotlin/src/test/kotlin/dev/tachyonmcp/server/KotlinApiTest.kt
@@ -1,0 +1,277 @@
+// Copyright (c) 2026 Konstantin Pavlov.
+
+package dev.tachyonmcp.server
+
+import dev.tachyonmcp.server.domain.TextContent
+import dev.tachyonmcp.server.features.tools.ToolArgs
+import dev.tachyonmcp.server.features.tools.ToolResult
+import dev.tachyonmcp.server.session.DefaultMcpContext
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import org.junit.jupiter.api.Test
+import tools.jackson.databind.JsonNode
+import tools.jackson.databind.node.JsonNodeFactory
+
+internal class KotlinApiTest {
+    // region: Overload resolution — all shapes compile
+    // These tests verify overloads compile for all schema types
+
+    @Test
+    fun `JsonNode overload compiles and registers tool`() {
+        val schema: JsonNode = JsonNodeFactory.instance.objectNode().put("type", "object")
+        TachyonServer(port = 0) {
+            name("test")
+            tool("t1", inputSchema = schema) { ToolResult.text("ok") }
+        }.use { handle ->
+            handle.server().getTool("t1") shouldNotBe null
+        }
+    }
+
+    @Test
+    fun `JsonNode overload with outputSchema compiles`() {
+        val schema: JsonNode = JsonNodeFactory.instance.objectNode().put("type", "object")
+        TachyonServer(port = 0) {
+            name("test")
+            tool("t2", inputSchema = schema, outputSchema = schema) { ToolResult.text("ok") }
+        }.use { handle ->
+            handle.server().getTool("t2") shouldNotBe null
+        }
+    }
+
+    @Test
+    fun `String overload compiles and registers tool`() {
+        val json = """{"type":"object"}"""
+        TachyonServer(port = 0) {
+            name("test")
+            tool("t3", inputSchema = json) { ToolResult.text("ok") }
+        }.use { handle ->
+            handle.server().getTool("t3") shouldNotBe null
+        }
+    }
+
+    @Test
+    fun `String overload with outputSchema compiles`() {
+        val json = """{"type":"object"}"""
+        TachyonServer(port = 0) {
+            name("test")
+            tool("t4", inputSchema = json, outputSchema = json) { ToolResult.text("ok") }
+        }.use { handle ->
+            handle.server().getTool("t4") shouldNotBe null
+        }
+    }
+
+    @Test
+    fun `JsonObject overload compiles and registers tool`() {
+        val schema = buildJsonObject { put("type", "object") }
+        TachyonServer(port = 0) {
+            name("test")
+            tool("t5", inputSchema = schema) { ToolResult.text("ok") }
+        }.use { handle ->
+            handle.server().getTool("t5") shouldNotBe null
+        }
+    }
+
+    @Test
+    fun `JsonObject overload with outputSchema compiles`() {
+        val schema = buildJsonObject { put("type", "object") }
+        TachyonServer(port = 0) {
+            name("test")
+            tool("t6", inputSchema = schema, outputSchema = schema) { ToolResult.text("ok") }
+        }.use { handle ->
+            handle.server().getTool("t6") shouldNotBe null
+        }
+    }
+
+    // endregion
+
+    // region: String.toJsonNode parse
+
+    @Test
+    fun `toJsonNode parses valid JSON`() {
+        val node = """{"type":"object"}""".toJsonNode()
+        node.isObject shouldBe true
+        @Suppress("DEPRECATION")
+        val type = node.get("type").asText()
+        type shouldBe "object"
+    }
+
+    @Test
+    fun `toJsonNode parses array JSON`() {
+        val node = """[1,2,3]""".toJsonNode()
+        node.isArray shouldBe true
+        node.size() shouldBe 3
+    }
+
+    // endregion
+
+    // region: ToolArgs orNull sugar
+
+    @Test
+    fun `stringOrNull returns value when present`() {
+        val args = ToolArgs.of(mapOf("k" to JsonNodeFactory.instance.stringNode("v")))
+        args.stringOrNull("k") shouldBe "v"
+    }
+
+    @Test
+    fun `stringOrNull returns null when missing`() {
+        val args = ToolArgs.of(mapOf())
+        args.stringOrNull("k") shouldBe null
+    }
+
+    @Test
+    fun `intOrNull returns value when present`() {
+        val args = ToolArgs.of(mapOf("k" to JsonNodeFactory.instance.numberNode(42)))
+        args.intOrNull("k") shouldBe 42
+    }
+
+    @Test
+    fun `intOrNull returns null when missing`() {
+        val args = ToolArgs.of(mapOf())
+        args.intOrNull("k") shouldBe null
+    }
+
+    @Test
+    fun `booleanOrNull returns value when present`() {
+        val args = ToolArgs.of(mapOf("k" to JsonNodeFactory.instance.booleanNode(true)))
+        args.booleanOrNull("k") shouldBe true
+    }
+
+    @Test
+    fun `booleanOrNull returns null when missing`() {
+        val args = ToolArgs.of(mapOf())
+        args.booleanOrNull("k") shouldBe null
+    }
+
+    @Test
+    fun `doubleOrNull returns value when present`() {
+        val args = ToolArgs.of(mapOf("k" to JsonNodeFactory.instance.numberNode(3.14)))
+        args.doubleOrNull("k") shouldBe 3.14
+    }
+
+    @Test
+    fun `doubleOrNull returns null when missing`() {
+        val args = ToolArgs.of(mapOf())
+        args.doubleOrNull("k") shouldBe null
+    }
+
+    // endregion
+
+    // region: ToolArgs boolean/int/double with defaults
+
+    @Test
+    fun `boolean with default returns value`() {
+        val args = ToolArgs.of(mapOf("k" to JsonNodeFactory.instance.booleanNode(true)))
+        args.boolean("k", false) shouldBe true
+    }
+
+    @Test
+    fun `boolean with default returns default`() {
+        val args = ToolArgs.of(mapOf())
+        args.boolean("k", true) shouldBe true
+    }
+
+    @Test
+    fun `int with default returns value`() {
+        val args = ToolArgs.of(mapOf("k" to JsonNodeFactory.instance.numberNode(42)))
+        args.int("k", 0) shouldBe 42
+    }
+
+    @Test
+    fun `double with default returns value`() {
+        val args = ToolArgs.of(mapOf("k" to JsonNodeFactory.instance.numberNode(3.14)))
+        args.double("k", 0.0) shouldBe 3.14
+    }
+
+    // endregion
+
+    // region: Kotlinx — decode<T> and structured
+
+    @Serializable
+    data class GreetingArgs(
+        val name: String,
+        val age: Int = 0,
+    )
+
+    @Test
+    fun `decode round-trip with kotlinx`() {
+        val raw =
+            mapOf(
+                "name" to JsonNodeFactory.instance.stringNode("Alice"),
+                "age" to JsonNodeFactory.instance.numberNode(30),
+            )
+        val args = ToolArgs.of(raw)
+        val decoded = args.decode<GreetingArgs>()
+        decoded shouldBe GreetingArgs("Alice", 30)
+    }
+
+    @Test
+    fun `decode uses default values`() {
+        val raw = mapOf("name" to JsonNodeFactory.instance.stringNode("Bob"))
+        val args = ToolArgs.of(raw)
+        val decoded = args.decode<GreetingArgs>()
+        decoded shouldBe GreetingArgs("Bob", 0)
+    }
+
+    @Test
+    fun `decode ignores unknown keys by default`() {
+        val raw =
+            mapOf(
+                "name" to JsonNodeFactory.instance.stringNode("Eve"),
+                "unexpected" to JsonNodeFactory.instance.stringNode("extra"),
+            )
+        val args = ToolArgs.of(raw)
+        val decoded = args.decode<GreetingArgs>()
+        decoded shouldBe GreetingArgs("Eve", 0)
+    }
+
+    @Test
+    fun `structured produces ToolResult with json node and text fallback`() {
+        val value = GreetingArgs("Charlie", 25)
+        TachyonServer.builder().build().use { server ->
+            val ctx = DefaultMcpContext.stateless(server)
+            val scope = ToolScope(ctx, ToolArgs.of(null))
+            val result = scope.structured(value)
+            result.shouldBeInstanceOf<ToolResult.Success>()
+            val success = result as ToolResult.Success
+            success.structured() shouldNotBe null
+            success.structured().get().shouldBeInstanceOf<JsonNode>()
+            (success.content().first() as TextContent).text() shouldBe
+                """{"name":"Charlie","age":25}"""
+        }
+    }
+
+    @Test
+    fun `structured uses custom Json instance`() {
+        val value = GreetingArgs("Dave", 50)
+        val customJson = Json { prettyPrint = true }
+        TachyonServer.builder().build().use { server ->
+            val ctx = DefaultMcpContext.stateless(server)
+            val scope = ToolScope(ctx, ToolArgs.of(null))
+            val result = scope.structured(value, customJson)
+            result.shouldBeInstanceOf<ToolResult.Success>()
+            val success = result as ToolResult.Success
+            success.structured() shouldNotBe null
+            (success.content().first() as TextContent).text() shouldContain "\"name\""
+        }
+    }
+
+    @Test
+    fun `structured rejects non-object payloads`() {
+        TachyonServer.builder().build().use { server ->
+            val ctx = DefaultMcpContext.stateless(server)
+            val scope = ToolScope(ctx, ToolArgs.of(null))
+            shouldThrow<IllegalArgumentException> {
+                scope.structured(listOf(1, 2, 3))
+            }.message shouldContain "must be a JSON object"
+        }
+    }
+
+    // endregion
+}

--- a/tachyon-server-kotlin/src/test/kotlin/dev/tachyonmcp/server/TachyonServerTest.kt
+++ b/tachyon-server-kotlin/src/test/kotlin/dev/tachyonmcp/server/TachyonServerTest.kt
@@ -194,6 +194,45 @@ internal class TachyonServerTest {
     }
 
     @Test
+    fun `tool with outputSchema appears in tools list`() {
+        val schema = """{"type":"object"}"""
+        val outputSchema = """{"type":"object","properties":{"result":{"type":"string"}}}"""
+        TachyonServer(port = 0) {
+            name("output-test")
+            session { enabled = true }
+            tool(
+                "with-output",
+                "Has output schema",
+                inputSchema = schema,
+                outputSchema = outputSchema,
+            ) {
+                ToolResult.text("done")
+            }
+        }.use { handle ->
+            McpProbe(handle.port()).use { probe ->
+                probe.initialize()
+                val response = probe.request(2, "tools/list")
+                response.body() shouldContain "with-output"
+                response.body() shouldContain "outputSchema"
+            }
+        }
+    }
+
+    @Test
+    fun `tool with string overload schema`() {
+        val schema = """{"type":"object"}"""
+        TachyonServer(port = 0) {
+            name("string-schema-test")
+            session { enabled = true }
+            tool("string-schema", inputSchema = schema) {
+                ToolResult.text("ok")
+            }
+        }.use { handle ->
+            handle.server().getTool("string-schema") shouldNotBe null
+        }
+    }
+
+    @Test
     fun `sync tool body compiles and works with suspend signature`() {
         TachyonServer(port = 0) {
             name("sync-test")

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tools/ToolArgs.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tools/ToolArgs.java
@@ -2,6 +2,7 @@
 
 package dev.tachyonmcp.server.features.tools;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 import org.jspecify.annotations.Nullable;
@@ -27,6 +28,11 @@ public final class ToolArgs {
         return raw.containsKey(key);
     }
 
+    /** Returns an unmodifiable view of the raw argument map. */
+    public Map<String, JsonNode> asMap() {
+        return Collections.unmodifiableMap(raw);
+    }
+
     public String string(String key) {
         return node(key).asString();
     }
@@ -49,6 +55,18 @@ public final class ToolArgs {
 
     public String stringOr(String key, String fallback) {
         return has(key) ? raw.get(key).asString() : fallback;
+    }
+
+    public int intOr(String key, int fallback) {
+        return has(key) ? raw.get(key).asInt() : fallback;
+    }
+
+    public boolean boolOr(String key, boolean fallback) {
+        return has(key) ? raw.get(key).asBoolean() : fallback;
+    }
+
+    public double doubleOr(String key, double fallback) {
+        return has(key) ? raw.get(key).asDouble() : fallback;
     }
 
     public JsonNode node(String key) {

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tools/ToolRegistry.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tools/ToolRegistry.java
@@ -41,6 +41,12 @@ public class ToolRegistry {
 
     private static final int DEFAULT_PAGE_SIZE = 50;
 
+    /**
+     * Maximum description length before a warning is logged. MCP clients may truncate
+     * descriptions beyond this length.
+     */
+    public static final int MAX_DESCRIPTION_LENGTH = 2048;
+
     /** Creates a tool registry with the given schema validator. */
     public ToolRegistry(JsonSchemaValidator validator) {
         this.validator = validator;
@@ -63,8 +69,34 @@ public class ToolRegistry {
         Objects.requireNonNull(descriptor, "ToolDescriptor must not be null");
         var name = descriptor.name();
         validateName(name);
+        validateSchemaRoot("inputSchema", name, descriptor.inputSchema());
+        validateSchemaRoot("outputSchema", name, descriptor.outputSchema());
+        var desc = descriptor.description();
+        if (desc != null && desc.length() > MAX_DESCRIPTION_LENGTH) {
+            logger.warn(
+                    "Tool '{}' description exceeds {} characters ({}), may be truncated by clients",
+                    name,
+                    MAX_DESCRIPTION_LENGTH,
+                    desc.length());
+        }
         handlers.put(name, handler);
         fireOnChange();
+    }
+
+    private static void validateSchemaRoot(String schemaKind, String toolName, @Nullable JsonNode schema) {
+        if (schema == null) return;
+        final String detail;
+        if (!schema.isObject()) {
+            detail = "got: " + schema.getNodeType();
+        } else if (!schema.has("type")) {
+            detail = "missing \"type\"";
+        } else if (!"object".equals(schema.get("type").asString())) {
+            detail = "got: " + schema.get("type");
+        } else {
+            return;
+        }
+        throw new IllegalArgumentException(
+                "Tool '" + toolName + "' " + schemaKind + " root must declare \"type\": \"object\", " + detail);
     }
 
     static void validateName(String name) {
@@ -205,7 +237,7 @@ public class ToolRegistry {
         }
 
         @Override
-        public Object handle(DispatchContext context, Object params) throws Exception {
+        public Object handle(DispatchContext context, Object params) {
             return handleAsync(context, params).toCompletableFuture().join();
         }
 
@@ -252,7 +284,7 @@ public class ToolRegistry {
                         return context.responseMapper().callToolResult(toolResult);
                     })
                     .exceptionally(e -> {
-                        var cause = CompletionException.class.isInstance(e) && e.getCause() != null ? e.getCause() : e;
+                        var cause = e instanceof CompletionException && e.getCause() != null ? e.getCause() : e;
                         if (cause instanceof InvalidArgumentException ia) {
                             return invalidRequest("invalid argument '" + ia.argName() + "': " + ia.getMessage());
                         }
@@ -326,17 +358,28 @@ public class ToolRegistry {
             if (schema == null) return;
             var inner = result instanceof ToolResult.WithMeta wm ? wm.inner() : result;
             if (!(inner instanceof ToolResult.Success s)) return;
-            if (!(s.structuredValue() instanceof java.util.Map<?, ?> map)) return;
-            var contentNode = JsonNodeFactory.instance.objectNode();
-            for (var entry : map.entrySet()) {
-                if (entry.getKey() instanceof String k && entry.getValue() instanceof JsonNode v) {
-                    contentNode.set(k, v);
-                }
-            }
+            var contentNode = structuredValueAsObjectNode(s.structuredValue());
+            if (contentNode == null) return;
             var errors = validator.validate(schema, contentNode);
             if (!errors.isEmpty()) {
                 logger.debug("Tool output failed schema validation (advisory only): {}", joinMessages(errors));
             }
+        }
+
+        private static @Nullable JsonNode structuredValueAsObjectNode(@Nullable Object structuredValue) {
+            if (structuredValue instanceof JsonNode node) {
+                return node.isObject() ? node : null;
+            }
+            if (structuredValue instanceof java.util.Map<?, ?> map) {
+                var contentNode = JsonNodeFactory.instance.objectNode();
+                for (var entry : map.entrySet()) {
+                    if (entry.getKey() instanceof String k && entry.getValue() instanceof JsonNode v) {
+                        contentNode.set(k, v);
+                    }
+                }
+                return contentNode;
+            }
+            return null;
         }
 
         private static String joinMessages(List<SchemaValidationError> errors) {

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tools/ToolRegistry.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tools/ToolRegistry.java
@@ -373,8 +373,13 @@ public class ToolRegistry {
             if (structuredValue instanceof java.util.Map<?, ?> map) {
                 var contentNode = JsonNodeFactory.instance.objectNode();
                 for (var entry : map.entrySet()) {
-                    if (entry.getKey() instanceof String k && entry.getValue() instanceof JsonNode v) {
-                        contentNode.set(k, v);
+                    if (entry.getKey() instanceof String k) {
+                        var v = entry.getValue();
+                        if (v instanceof JsonNode jn) {
+                            contentNode.set(k, jn);
+                        } else if (v != null) {
+                            contentNode.set(k, ProtocolCodecUtil.parseJsonNode(JsonRpcCodec.writeValueAsString(v)));
+                        }
                     }
                 }
                 return contentNode;

--- a/tachyon-server/src/test/java/dev/tachyonmcp/server/features/tools/ToolArgsTest.java
+++ b/tachyon-server/src/test/java/dev/tachyonmcp/server/features/tools/ToolArgsTest.java
@@ -8,6 +8,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.util.Map;
 import java.util.Objects;
 import org.junit.jupiter.api.Test;
+import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.node.JsonNodeFactory;
 
 class ToolArgsTest {
@@ -131,5 +132,49 @@ class ToolArgsTest {
     void rawReturnsNodeWithText() {
         var args = ToolArgs.of(Map.of("k", JSON.stringNode("v")));
         assertThat(Objects.requireNonNull(args.raw("k")).asString()).isEqualTo("v");
+    }
+
+    @Test
+    void asMapReturnsUnmodifiableView() {
+        java.util.Map<String, JsonNode> raw = new java.util.HashMap<>(Map.of("k", JSON.stringNode("v")));
+        var args = ToolArgs.of(raw);
+        assertThat(args.asMap()).containsOnlyKeys("k");
+        assertThat(args.asMap()).isUnmodifiable();
+    }
+
+    @Test
+    void boolOrReturnsValueWhenPresent() {
+        var args = ToolArgs.of(Map.of("k", JSON.booleanNode(true)));
+        assertThat(args.boolOr("k", false)).isTrue();
+    }
+
+    @Test
+    void boolOrReturnsFallbackWhenMissing() {
+        var args = ToolArgs.of(Map.of());
+        assertThat(args.boolOr("k", true)).isTrue();
+    }
+
+    @Test
+    void intOrReturnsValueWhenPresent() {
+        var args = ToolArgs.of(Map.of("k", JSON.numberNode(42)));
+        assertThat(args.intOr("k", 0)).isEqualTo(42);
+    }
+
+    @Test
+    void intOrReturnsFallbackWhenMissing() {
+        var args = ToolArgs.of(Map.of());
+        assertThat(args.intOr("k", 99)).isEqualTo(99);
+    }
+
+    @Test
+    void doubleOrReturnsValueWhenPresent() {
+        var args = ToolArgs.of(Map.of("k", JSON.numberNode(3.14)));
+        assertThat(args.doubleOr("k", 0.0)).isEqualTo(3.14);
+    }
+
+    @Test
+    void doubleOrReturnsFallbackWhenMissing() {
+        var args = ToolArgs.of(Map.of());
+        assertThat(args.doubleOr("k", 1.5)).isEqualTo(1.5);
     }
 }

--- a/tachyon-server/src/test/java/dev/tachyonmcp/server/features/tools/ToolRegistryTest.java
+++ b/tachyon-server/src/test/java/dev/tachyonmcp/server/features/tools/ToolRegistryTest.java
@@ -41,6 +41,7 @@ import tools.jackson.databind.JsonNode;
 
 class ToolRegistryTest {
 
+    // language=json
     private static final JsonNode TEST_SCHEMA = parseJson("""
         {"type":"object","properties":{"message":{"type":"string"}},"required":["message"]}
         """);
@@ -66,6 +67,7 @@ class ToolRegistryTest {
         registry.register(new TestTool("minimal-tool", null, null));
 
         // full: all possible fields set
+        // language=json
         var outputSchema = parseJson("""
             {"type":"object","properties":{"result":{"type":"string"}}}
             """);
@@ -170,7 +172,7 @@ class ToolRegistryTest {
             var callHandler = handlers.get("tools/call");
             var params = Map.of("name", "echo", "arguments", Map.of("message", "hello"));
 
-            var ctx = DefaultMcpContext.create(Protocols.versions().get(0), server);
+            var ctx = DefaultMcpContext.create(Protocols.versions().getFirst(), server);
             ctx.setSession(session);
             var result = callHandler.handle(ctx, params);
             assertThat(result).isInstanceOf(CallToolResult.class);
@@ -541,7 +543,7 @@ class ToolRegistryTest {
             var session = server.createSession("s-async-thread");
             session.activate();
             var callHandler = handlers.get("tools/call");
-            var ctx = DefaultMcpContext.create(Protocols.versions().get(0), server);
+            var ctx = DefaultMcpContext.create(Protocols.versions().getFirst(), server);
             ctx.setSession(session);
             var params = Map.of("name", "async-thread", "arguments", Map.of());
             var stage = callHandler.handleAsync(ctx, params);
@@ -577,7 +579,7 @@ class ToolRegistryTest {
             var session = server.createSession("s-inv-arg");
             session.activate();
             var callHandler = handlers.get("tools/call");
-            var ctx = DefaultMcpContext.create(Protocols.versions().get(0), server);
+            var ctx = DefaultMcpContext.create(Protocols.versions().getFirst(), server);
             ctx.setSession(session);
             var params = Map.of("name", "invalid-arg-async", "arguments", Map.of());
             var result = callHandler.handle(ctx, params);
@@ -677,6 +679,77 @@ class ToolRegistryTest {
                     }
                 });
         assertThat(registry.get("valid-output")).isNotNull();
+    }
+
+    // endregion
+
+    // region: Structured value conversion for output validation
+
+    @Test
+    void shouldConvertPlainJavaMapEntriesBeforeOutputValidation() throws Exception {
+        // language=json
+        var outputSchema = parseJson("""
+            {"type":"object","properties":{"message":{"type":"string"},"count":{"type":"integer"}},"required":["message","count"]}
+            """);
+        var registryVal = new ToolRegistry(new dev.tachyonmcp.server.NetworkntJsonSchemaValidator());
+        var handlers = new HashMap<String, RpcMethodHandler>();
+        registryVal.registerHandlers(handlers);
+        var handler =
+                new AbstractSyncToolHandler(ToolDescriptor.builder("structured-out")
+                        .description("test")
+                        .outputSchema(outputSchema)
+                        .build()) {
+                    @Override
+                    public ToolResult handle(InteractionContext context, ToolArgs args) {
+                        // Map with plain Java values, not JsonNode
+                        return ToolResult.of(Map.of("message", "hello", "count", 42), "text fallback");
+                    }
+                };
+        registryVal.register(handler);
+
+        try (var server = TachyonServer.builder().build()) {
+            var session = server.createSession("s-struct-out");
+            session.activate();
+            var callHandler = handlers.get("tools/call");
+            var ctx = DefaultMcpContext.create(Protocols.versions().getFirst(), server);
+            ctx.setSession(session);
+            var params = Map.of("name", "structured-out", "arguments", Map.of());
+            var result = callHandler.handle(ctx, params);
+            assertThat(result).isInstanceOf(CallToolResult.class);
+            // structuredContent should contain both "message" and "count"
+            assertThat(((CallToolResult) result).structuredContent()).isNotNull();
+            assertThat(((CallToolResult) result).structuredContent()).containsKeys("message", "count");
+        }
+    }
+
+    @Test
+    void shouldConvertMixedJavaAndJsonNodeEntries() throws Exception {
+        var registryVal = new ToolRegistry(new dev.tachyonmcp.server.NetworkntJsonSchemaValidator());
+        var handlers = new HashMap<String, RpcMethodHandler>();
+        registryVal.registerHandlers(handlers);
+        var handler = new AbstractSyncToolHandler(
+                ToolDescriptor.builder("mixed-out").description("test").build()) {
+            @Override
+            public ToolResult handle(InteractionContext context, ToolArgs args) {
+                var jsonNodeVal = tools.jackson.databind.node.JsonNodeFactory.instance.stringNode("json-val");
+                // Mixed map: one JsonNode value, one plain String value
+                return ToolResult.of(Map.of("jsonField", jsonNodeVal, "plainField", "plain-val"), "fallback");
+            }
+        };
+        registryVal.register(handler);
+
+        try (var server = TachyonServer.builder().build()) {
+            var session = server.createSession("s-mixed");
+            session.activate();
+            var callHandler = handlers.get("tools/call");
+            var ctx = DefaultMcpContext.create(Protocols.versions().getFirst(), server);
+            ctx.setSession(session);
+            var params = Map.of("name", "mixed-out", "arguments", Map.of());
+            var result = callHandler.handle(ctx, params);
+            assertThat(result).isInstanceOf(CallToolResult.class);
+            assertThat(((CallToolResult) result).structuredContent()).isNotNull();
+            assertThat(((CallToolResult) result).structuredContent()).containsOnlyKeys("jsonField", "plainField");
+        }
     }
 
     // endregion

--- a/tachyon-server/src/test/java/dev/tachyonmcp/server/features/tools/ToolRegistryTest.java
+++ b/tachyon-server/src/test/java/dev/tachyonmcp/server/features/tools/ToolRegistryTest.java
@@ -597,6 +597,90 @@ class ToolRegistryTest {
         assertThat(callCount).hasValue(1);
     }
 
+    // region: Schema root check
+
+    @Test
+    void shouldAcceptNullInputSchema() {
+        registry.register(new TestTool("null-input", null, null));
+        assertThat(registry.get("null-input")).isNotNull();
+    }
+
+    @Test
+    void shouldAcceptValidInputSchemaWithTypeObject() {
+        registry.register(new TestTool("valid-input", null, TEST_SCHEMA));
+        assertThat(registry.get("valid-input")).isNotNull();
+    }
+
+    @Test
+    void shouldRejectInputSchemaWithWrongRootType() {
+        var schema = parseJson("""
+            {"type":"string"}
+            """);
+        assertThatThrownBy(() -> registry.register(new TestTool("bad", null, schema)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("inputSchema")
+                .hasMessageContaining("\"type\": \"object\"");
+    }
+
+    @Test
+    void shouldRejectInputSchemaWithoutType() {
+        var schema = parseJson("""
+            {"properties":{}}
+            """);
+        assertThatThrownBy(() -> registry.register(new TestTool("no-type", null, schema)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("inputSchema")
+                .hasMessageContaining("\"type\": \"object\"")
+                .hasMessageContaining("missing \"type\"");
+    }
+
+    @Test
+    void shouldRejectInputSchemaThatIsNotAnObject() {
+        var schema = parseJson("\"just a string\"");
+        assertThatThrownBy(() -> registry.register(new TestTool("not-obj", null, schema)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("inputSchema")
+                .hasMessageContaining("\"type\": \"object\"");
+    }
+
+    @Test
+    void shouldRejectOutputSchemaWithWrongRootType() {
+        var outputSchema = parseJson("""
+            {"type":"string"}
+            """);
+        assertThatThrownBy(() -> registry.register(
+                        new AbstractSyncToolHandler(ToolDescriptor.builder("bad-output")
+                                .outputSchema(outputSchema)
+                                .build()) {
+                            @Override
+                            public ToolResult handle(InteractionContext context, ToolArgs args) {
+                                return ToolResult.text("x");
+                            }
+                        }))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("outputSchema")
+                .hasMessageContaining("\"type\": \"object\"");
+    }
+
+    @Test
+    void shouldAcceptValidOutputSchema() {
+        var outputSchema = parseJson("""
+            {"type":"object","properties":{"result":{"type":"string"}}}
+            """);
+        registry.register(
+                new AbstractSyncToolHandler(ToolDescriptor.builder("valid-output")
+                        .outputSchema(outputSchema)
+                        .build()) {
+                    @Override
+                    public ToolResult handle(InteractionContext context, ToolArgs args) {
+                        return ToolResult.text("ok");
+                    }
+                });
+        assertThat(registry.get("valid-output")).isNotNull();
+    }
+
+    // endregion
+
     private static class TestTool extends AbstractSyncToolHandler {
 
         TestTool(String name, @Nullable String description, @Nullable JsonNode schema) {

--- a/tachyon-server/src/test/java/dev/tachyonmcp/transport/netty/McpOperationHandlerRequestTest.java
+++ b/tachyon-server/src/test/java/dev/tachyonmcp/transport/netty/McpOperationHandlerRequestTest.java
@@ -45,8 +45,7 @@ class McpOperationHandlerRequestTest {
 
     private static final ToolDescriptor PROGRESS_DESCRIPTOR = ToolDescriptor.builder("progress_tool")
             .description("emits progress notifications")
-            .inputSchema(
-                    JsonNodeFactory.instance.objectNode().put("type", "object").putObject("properties"))
+            .inputSchema(JsonNodeFactory.instance.objectNode().put("type", "object"))
             .build();
 
     /** Emits two progress notifications (which upgrade the POST response to SSE), then returns a result. */
@@ -164,10 +163,7 @@ class McpOperationHandlerRequestTest {
     void idleOnUpgradedPostSseStreamSendsHeartbeat() throws InterruptedException {
         var descriptor = ToolDescriptor.builder("stalled_tool")
                 .description("upgrades to SSE then never completes")
-                .inputSchema(JsonNodeFactory.instance
-                        .objectNode()
-                        .put("type", "object")
-                        .putObject("properties"))
+                .inputSchema(JsonNodeFactory.instance.objectNode().put("type", "object"))
                 .build();
         var upgraded = new CountDownLatch(1);
         var neverComplete = new CompletableFuture<ToolResult>();

--- a/tachyon-server/src/test/java/dev/tachyonmcp/transport/netty/NotificationDeliveryTest.java
+++ b/tachyon-server/src/test/java/dev/tachyonmcp/transport/netty/NotificationDeliveryTest.java
@@ -30,8 +30,7 @@ class NotificationDeliveryTest {
 
     private static final ToolDescriptor TOOL_DESCRIPTOR = ToolDescriptor.builder("test_tool")
             .description("Test tool")
-            .inputSchema(
-                    JsonNodeFactory.instance.objectNode().put("type", "object").putObject("properties"))
+            .inputSchema(JsonNodeFactory.instance.objectNode().put("type", "object"))
             .build();
 
     /** Emits 3 progress events and 3 log events per invocation (plus 2 automatic lifecycle logs from ToolsCallHandler). */


### PR DESCRIPTION
## Summary

This PR adds `outputSchema` support and kotlinx-serialization based structured tool results to the Kotlin server DSL, introduces schema-root validation and description-length warnings in `ToolRegistry`, adds `ToolArgs` accessor utilities in Java and Kotlin, and updates related docs, build config, and tests.

* **New Features**
  * Added Kotlin-friendly tool registration and argument helpers, including typed schema support and structured tool outputs.
  * Added support for specifying output schemas for tools and returning structured JSON alongside text fallbacks.

* **Bug Fixes**
  * Improved schema validation for tool registration to catch invalid input and output schemas earlier.
  * Added safer typed argument accessors with default and nullable variants.

* **Documentation**
  * Expanded Kotlin docs and README guidance for schema handling and serialization integration.

