### PR TITLE
test: Progress/Comment Keep-Alive + E2E Test

### DIFF
--- a/.agents/skills/tachyon-mcp/SKILL.md
+++ b/.agents/skills/tachyon-mcp/SKILL.md
@@ -23,8 +23,7 @@ Make **Java 21+** MCP server. Tachyon lib. Transport = Streamable HTTP (Netty).
 
 ```java
 var handle = TachyonServer.builder()
-    .name("my-server")
-    .version("1.0")
+    .info(b -> b.name("my-server").version("1.0"))
     .port(8080)
     .start();
 // handle.port() → real bound port (matters when port=0)
@@ -92,7 +91,7 @@ takes input + output schemas; there's a matching `.tool(name, desc, inJson, outJ
 Async — implement `AsyncToolHandler` (or extend `AbstractAsyncToolHandler`), return a
 `CompletionStage<ToolResult>`.
 
-`ToolResult` (not generic): `.text(t)` · `.error(msg)` (isError=true) · `.blocks(ContentBlock...)` · `.of(payload)` (structuredContent via Jackson) · `.of(payload, text)` · `.empty()`
+`ToolResult` (not generic): `.text(t)` · `.error(msg)` (isError=true) · `.blocks(ContentBlock...)` · `.of(payload)` (structuredContent via Jackson) · `.of(payload, text)` · `.raw(json, text)` (pre-serialized JSON) · `.inputRequired(reqs, state)` · `.empty()` · `.withMeta(map)` / `.withMeta(key, value)`
 
 Full: `resources/java/ToolHandlerExample.java`
 
@@ -182,7 +181,11 @@ Default `AUTO` → advertised only when registered. Force with `Mode.ON` / `Mode
 
 Native transports need optional runtime jars (`netty-transport-native-epoll` / `-kqueue` / `-io_uring` with `${os.detected.classifier}`); without them `AUTO` falls back to NIO. Explicit unavailable engine throws `UnsupportedOperationException`. See `docs/configuration.md`.
 
-⏳ **Keep-alive for long tools** — `readerIdleTimeout` (60s) closes any connection with no **inbound** bytes for that long, and a client waiting for a reply sends none — so a tool slower than 60s gets reaped mid-compute. Don't just raise the timeout. Emit an early `ctx.notifications().progress(token, ...)`: the POST upgrades to SSE and a scheduler sends `:\r\n` heartbeats every `heartbeatInterval` (15s), keeping the stream alive for the whole run. Rule: **long task ⇒ emit progress first**; keep `heartbeatInterval < readerIdleTimeout`; size `readerIdleTimeout` for dead-peer detection, not tool runtime.
+⏳ **Keep-alive for long tools** — `readerIdleTimeout` (60s) closes any connection with no **inbound** bytes for that long, and a client waiting for a reply sends none — so a tool slower than 60s gets reaped mid-compute. Set `readerIdleTimeout` to `Duration.ZERO` to disable closing idle inbound stream. Don't just raise the timeout. Emit an early server→client message: the POST upgrades to SSE and a scheduler sends `:\r\n` heartbeats every `heartbeatInterval` (15s), keeping the stream alive for the whole run. Two triggers (request-level `ToolHandler` only — `ToolArgs` carries neither):
+- `ctx.notifications().progress(token, ...)` — forward the client's `ToolRequest.progressToken()`; **null token throws**.
+- `ctx.notifications().comment(msg)` — token-free SSE comment (`: msg`); `comment()` = bare `:` heartbeat. Use when no progress token.
+
+Rule: **long task ⇒ emit progress or comment first**; keep `heartbeatInterval < readerIdleTimeout`; size `readerIdleTimeout` for dead-peer detection, not tool runtime.
 
 ### Session `session(cfg -> ...)`
 
@@ -199,6 +202,7 @@ Native transports need optional runtime jars (`netty-transport-native-epoll` / `
 | Method | Default |
 |---|---|
 | `.shutdownGracePeriod(d)` | 5s (drain in-flight handlers on close; `ZERO` = interrupt now) |
+| `.requestTimeout(d)` | 60s (timeout for pending requests sent to client) |
 
 ## JSON Schema
 
@@ -228,6 +232,7 @@ The lambda shorthands `SyncToolHandler.of(name, desc, inJson, outJson, fn)` and
 public interface ServerExtension extends Extension<MutableInteractionContext> {
     default JsonNode serverSettings() { return JsonNodeFactory.instance.objectNode(); }
     default Set<String> methods() { return Set.of(); }
+    default boolean requiresMetaEnvelope() { return true; }
     default void bootstrap(Server server) {}
     default void onConnectionInit(MutableInteractionContext context, Map<String, JsonNode> clientSettings) {}
 }
@@ -305,7 +310,8 @@ Post-build registration with `registerTool`:
 
 ```kotlin
 server.registerTool(
-    ToolDescriptor.builder("reverse-echo")
+    ToolDescriptor.builder()
+        .name("reverse-echo")
         .description("Echo reversed message")
         .inputSchema(schema)
         .build(),

--- a/.agents/skills/tachyon-mcp/SKILL.md
+++ b/.agents/skills/tachyon-mcp/SKILL.md
@@ -182,6 +182,8 @@ Default `AUTO` → advertised only when registered. Force with `Mode.ON` / `Mode
 
 Native transports need optional runtime jars (`netty-transport-native-epoll` / `-kqueue` / `-io_uring` with `${os.detected.classifier}`); without them `AUTO` falls back to NIO. Explicit unavailable engine throws `UnsupportedOperationException`. See `docs/configuration.md`.
 
+⏳ **Keep-alive for long tools** — `readerIdleTimeout` (60s) closes any connection with no **inbound** bytes for that long, and a client waiting for a reply sends none — so a tool slower than 60s gets reaped mid-compute. Don't just raise the timeout. Emit an early `ctx.notifications().progress(token, ...)`: the POST upgrades to SSE and a scheduler sends `:\r\n` heartbeats every `heartbeatInterval` (15s), keeping the stream alive for the whole run. Rule: **long task ⇒ emit progress first**; keep `heartbeatInterval < readerIdleTimeout`; size `readerIdleTimeout` for dead-peer detection, not tool runtime.
+
 ### Session `session(cfg -> ...)`
 
 | Method | Default |
@@ -317,7 +319,7 @@ server.registerTool(
 Load on demand (next to this skill):
 
 - [resources/java/ServerBasic.java](resources/java/ServerBasic.java) — full server, all features
-- `resources/java/ToolHandlerExample.java` — `ToolDescriptor`, `SyncToolHandler.of()`, `AbstractSyncToolHandler`
+- `resources/java/ToolHandlerExample.java` — `ToolDescriptor`, `SyncToolHandler.of()`, `AbstractSyncToolHandler`, long-running keep-alive (`ToolHandler` + `progress()`)
 - `resources/java/ResourceHandlerExample.java` — `ResourceDescriptor`, `ResourceTemplateEntry`, `ResourceHandler`
 - `resources/java/PromptHandlerExample.java` — `PromptDescriptor`, `PromptArgument`, `PromptHandler`
 - `resources/java/ConfigReference.java` — `CapabilitiesConfig.Builder`, `NetworkConfig.Builder`, `SessionConfig.Builder`

--- a/.agents/skills/tachyon-mcp/resources/java/ConfigReference.java
+++ b/.agents/skills/tachyon-mcp/resources/java/ConfigReference.java
@@ -58,9 +58,15 @@ final class ConfigReference {
             .host("127.0.0.1")
             .port(8080)
             .endpointPath("/mcp")
-            .readerIdleTimeout(Duration.ofSeconds(30))
+            // Closes a connection with no INBOUND bytes for this long. A client awaiting a reply
+            // sends none, so a tool slower than this is reaped mid-compute — keep long tools alive
+            // by emitting progress (upgrades POST → SSE), not by inflating this. Size for dead-peer
+            // detection. Must stay > heartbeatInterval.
+            .readerIdleTimeout(Duration.ofSeconds(60))
             .writerIdleTimeout(Duration.ofMinutes(2))
-            .heartbeatInterval(Duration.ofSeconds(15)) // SSE heartbeat for silent listeners; <= 0 disables
+            // Once a POST upgrades to SSE (handler emits progress), a scheduler sends `:` heartbeats
+            // at this interval so the stream never looks idle. Keep < readerIdleTimeout. <= 0 disables.
+            .heartbeatInterval(Duration.ofSeconds(15))
             .maxContentLength(65536) // 64KB
             .allowedOrigins("https://app.example.com")
             .allowNullOrigin(false)

--- a/.agents/skills/tachyon-mcp/resources/java/ServerBasic.java
+++ b/.agents/skills/tachyon-mcp/resources/java/ServerBasic.java
@@ -12,7 +12,6 @@ import dev.tachyonmcp.server.features.resources.ResourceTemplateEntry;
 import dev.tachyonmcp.server.features.tools.SyncToolHandler;
 import dev.tachyonmcp.server.features.tools.ToolResult;
 import dev.tachyonmcp.server.json.JacksonPayloadSerde;
-import dev.tachyonmcp.server.json.JsonSchemaValidator;
 import dev.tachyonmcp.server.json.NetworkntJsonSchemaValidator;
 
 import java.util.List;
@@ -42,14 +41,7 @@ public final class ServerBasic {
                 .sessionIdGenerator((req) -> "sid_" + UUID.randomUUID())
             )
             .json(j ->
-                j
-                    // json schema validator
-                    .schemaValidator(NetworkntJsonSchemaValidator.INSTANCE)
-                    .inputSchemaValidator(NetworkntJsonSchemaValidator.INSTANCE)
-                    .outputSchemaValidator(JsonSchemaValidator.NOOP)
-                    // serializer
-                    .serializer(JacksonPayloadSerde.INSTANCE)
-                    .deserializer(JacksonPayloadSerde.INSTANCE)
+                j.inputSchemaValidator(NetworkntJsonSchemaValidator.INSTANCE)
                     .serde(JacksonPayloadSerde.INSTANCE)
             )
             .runtime(r -> r.shutdownGracePeriod(ofSeconds(5)))

--- a/.agents/skills/tachyon-mcp/resources/java/ToolHandlerExample.java
+++ b/.agents/skills/tachyon-mcp/resources/java/ToolHandlerExample.java
@@ -7,6 +7,8 @@ import dev.tachyonmcp.server.features.tools.AbstractSyncToolHandler;
 import dev.tachyonmcp.server.features.tools.SyncToolHandler;
 import dev.tachyonmcp.server.features.tools.ToolArgs;
 import dev.tachyonmcp.server.features.tools.ToolDescriptor;
+import dev.tachyonmcp.server.features.tools.ToolHandler;
+import dev.tachyonmcp.server.features.tools.ToolRequest;
 import dev.tachyonmcp.server.features.tools.ToolResult;
 import org.jspecify.annotations.NonNull;
 import tools.jackson.databind.JsonNode;
@@ -16,6 +18,7 @@ import tools.jackson.databind.ObjectMapper;
  * Demonstrates the two tool-handler patterns:
  * 1. SyncToolHandler.of() — inline lambda
  * 2. AbstractSyncToolHandler — reusable class
+ * 3. LongRunningTool — keep-alive for tools slower than readerIdleTimeout
  */
 final class ToolHandlerExample {
 
@@ -71,6 +74,45 @@ final class ToolHandlerExample {
         public ToolResult handle(InteractionContext ctx, ToolArgs args) {
             var name = args.string("name");
             return ToolResult.text("Hello, " + name + "!");
+        }
+    }
+
+    /**
+     * Keep-alive for a long-running tool.
+     *
+     * <p>{@code readerIdleTimeout} (default 60s) closes a connection that receives no INBOUND
+     * bytes for its duration. A client awaiting a reply sends none, so a tool that computes
+     * longer than the timeout is reaped mid-flight. Do NOT just raise the timeout — instead emit
+     * an early {@code progress(...)}: it upgrades the POST response to SSE, after which a
+     * scheduler sends {@code :} heartbeats every {@code heartbeatInterval} (15s), keeping the
+     * connection alive for the whole run.
+     *
+     * <p>Forward the client's token from {@link ToolRequest#progressToken()} (the {@link ToolArgs}
+     * convenience overload does not carry it), so implement {@link ToolHandler} directly.
+     */
+    static final class LongRunningTool implements ToolHandler {
+        private static final int TOTAL = 10;
+
+        @Override
+        public ToolDescriptor descriptor() {
+            return ToolDescriptor.builder()
+                    .name("slow-task")
+                    .description("Long-running task that stays alive via SSE heartbeats")
+                    .build();
+        }
+
+        @Override
+        @NonNull
+        public ToolResult handle(InteractionContext ctx, ToolRequest request) throws Exception {
+            // Client _meta.progressToken; null if the client did not request progress. Emitting
+            // progress with a null token is a no-op and does NOT upgrade to SSE.
+            var token = request.progressToken();
+            ctx.notifications().progress(token, 0, TOTAL, "starting"); // upgrades POST -> SSE, arms heartbeat
+            for (int i = 0; i < TOTAL; i++) {
+                Thread.sleep(1_000); // blocking I/O is fine on the virtual thread
+                ctx.notifications().progress(token, i + 1, TOTAL, "step " + (i + 1));
+            }
+            return ToolResult.text("done");
         }
     }
 }

--- a/.agents/skills/tachyon-mcp/resources/java/ToolHandlerExample.java
+++ b/.agents/skills/tachyon-mcp/resources/java/ToolHandlerExample.java
@@ -24,16 +24,16 @@ final class ToolHandlerExample {
 
     private static final ObjectMapper MAPPER = new ObjectMapper();
     private static final JsonNode GREET_SCHEMA = MAPPER.createObjectNode()
-            .put("type", "object")
-            .set(
-                    "properties",
+        .put("type", "object")
+        .set(
+            "properties",
+            MAPPER.createObjectNode()
+                .set(
+                    "name",
                     MAPPER.createObjectNode()
-                            .set(
-                                    "name",
-                                    MAPPER.createObjectNode()
-                                            .put("type", "string")
-                                            .put("description", "Name to greet")))
-            .set("required", MAPPER.createArrayNode().add("name"));
+                        .put("type", "string")
+                        .put("description", "Name to greet")))
+        .set("required", MAPPER.createArrayNode().add("name"));
 
     /**
      * Lambda-style: use SyncToolHandler.of() inside a builder chain.
@@ -47,13 +47,13 @@ final class ToolHandlerExample {
      */
     static SyncToolHandler lambdaGreet() {
         return SyncToolHandler.of(
-                "greeting",
-                "Generates a personalized greeting",
-                GREET_SCHEMA,
-                (@NonNull InteractionContext ctx, ToolArgs args) -> {
-                    String name = args.string("name");
-                    return ToolResult.text("Hello, " + name + "!");
-                });
+            "greeting",
+            "Generates a personalized greeting",
+            GREET_SCHEMA,
+            (@NonNull InteractionContext ctx, ToolArgs args) -> {
+                String name = args.string("name");
+                return ToolResult.text("Hello, " + name + "!");
+            });
     }
 
     /**
@@ -61,12 +61,12 @@ final class ToolHandlerExample {
      */
     static final class GreetingTool extends AbstractSyncToolHandler {
         GreetingTool() {
-            super(ToolDescriptor.builder()
-                    .name("greeting")
-                    .title("Greeting")
-                    .description("Generates a personalized greeting")
-                    .inputSchema(GREET_SCHEMA)
-                    .build());
+            super(builder -> builder
+                .name("greeting")
+                .title("Greeting")
+                .description("Generates a personalized greeting")
+                .inputSchema(GREET_SCHEMA)
+            );
         }
 
         @Override
@@ -83,12 +83,19 @@ final class ToolHandlerExample {
      * <p>{@code readerIdleTimeout} (default 60s) closes a connection that receives no INBOUND
      * bytes for its duration. A client awaiting a reply sends none, so a tool that computes
      * longer than the timeout is reaped mid-flight. Do NOT just raise the timeout — instead emit
-     * an early {@code progress(...)}: it upgrades the POST response to SSE, after which a
+     * an early server→client message: it upgrades the POST response to SSE, after which a
      * scheduler sends {@code :} heartbeats every {@code heartbeatInterval} (15s), keeping the
      * connection alive for the whole run.
      *
-     * <p>Forward the client's token from {@link ToolRequest#progressToken()} (the {@link ToolArgs}
-     * convenience overload does not carry it), so implement {@link ToolHandler} directly.
+     * <p>Two triggers, both reachable only from the request-level {@link ToolHandler} (the
+     * {@link ToolArgs} convenience overload carries neither):
+     *
+     * <ul>
+     *   <li>{@code progress(token, ...)} — when the client requested progress, forward its
+     *       {@link ToolRequest#progressToken()}. A {@code null} token throws, so guard on it.
+     *   <li>{@code comment(msg)} — a token-free SSE comment ({@code : msg}); use it to keep alive
+     *       when no progress token is available.
+     * </ul>
      */
     static final class LongRunningTool implements ToolHandler {
         private static final int TOTAL = 10;
@@ -96,21 +103,24 @@ final class ToolHandlerExample {
         @Override
         public ToolDescriptor descriptor() {
             return ToolDescriptor.builder()
-                    .name("slow-task")
-                    .description("Long-running task that stays alive via SSE heartbeats")
-                    .build();
+                .name("slow-task")
+                .description("Long-running task that stays alive via SSE heartbeats")
+                .build();
         }
 
         @Override
         @NonNull
         public ToolResult handle(InteractionContext ctx, ToolRequest request) throws Exception {
-            // Client _meta.progressToken; null if the client did not request progress. Emitting
-            // progress with a null token is a no-op and does NOT upgrade to SSE.
-            var token = request.progressToken();
-            ctx.notifications().progress(token, 0, TOTAL, "starting"); // upgrades POST -> SSE, arms heartbeat
+            var token = request.progressToken(); // client _meta.progressToken; null if not requested
             for (int i = 0; i < TOTAL; i++) {
+                // First call upgrades the POST to SSE and arms the heartbeat. Token present ->
+                // progress notification; no token -> raw SSE comment (still keeps the stream alive).
+                if (token != null) {
+                    ctx.notifications().progress(token, i, TOTAL, "step " + i);
+                } else {
+                    ctx.notifications().comment("step " + i);
+                }
                 Thread.sleep(1_000); // blocking I/O is fine on the virtual thread
-                ctx.notifications().progress(token, i + 1, TOTAL, "step " + (i + 1));
             }
             return ToolResult.text("done");
         }

--- a/.agents/skills/tachyon-mcp/resources/kotlin/PromptHandlerExample.kt
+++ b/.agents/skills/tachyon-mcp/resources/kotlin/PromptHandlerExample.kt
@@ -11,7 +11,10 @@ import dev.tachyonmcp.server.features.prompts.promptMessagesOf
 
 /** Simplest — name + description. */
 fun simpleDescriptor(): PromptDescriptor =
-    PromptDescriptor(name = "rewrite-forecast", description = "Rewrites a weather forecast in a given style")
+    PromptDescriptor(
+        name = "rewrite-forecast",
+        description = "Rewrites a weather forecast in a given style"
+    )
 
 /** DSL — all properties. */
 fun argDescriptor(): PromptDescriptor =

--- a/.agents/skills/tachyon-mcp/resources/kotlin/ToolHandlerExample.kt
+++ b/.agents/skills/tachyon-mcp/resources/kotlin/ToolHandlerExample.kt
@@ -15,6 +15,7 @@ import dev.tachyonmcp.server.features.tools.ToolResult
 import dev.tachyonmcp.server.features.tools.decode
 import dev.tachyonmcp.server.features.tools.registerTool
 import dev.tachyonmcp.server.features.tools.toolDescriptor
+import kotlinx.coroutines.delay
 import kotlinx.serialization.Serializable
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CompletionStage
@@ -66,6 +67,25 @@ fun TachyonServerBuilder.registerTypedGreeting() {
 }
 
 /**
+ * Keep-alive for a long-running DSL tool.
+ *
+ * `readerIdleTimeout` (default 60s) closes a connection with no inbound bytes; a client awaiting a
+ * reply sends none, so a tool slower than the timeout is reaped mid-run. Emit an early SSE comment
+ * via `ctx.notifications().comment(...)` — it upgrades the POST to `text/event-stream` and arms the
+ * heartbeat, keeping the stream alive with no progress token. `comment(...)` is the natural fit for
+ * the DSL, whose [ToolScope] exposes `ctx` + `args` but not the request's progress token.
+ */
+fun TachyonServerBuilder.registerSlowTask() {
+    tool(name = "slow-task", description = "Long task kept alive via SSE comments") {
+        repeat(10) { i ->
+            ctx.notifications().comment("step $i") // upgrades POST -> SSE, keeps the connection alive
+            delay(1_000) // suspend handler — use delay(), not Thread.sleep
+        }
+        ToolResult.text("done")
+    }
+}
+
+/**
  * Class-based — extend AbstractSyncToolHandler.
  */
 class GreetingTool : AbstractSyncToolHandler(
@@ -102,6 +122,7 @@ fun buildWithPostRegistration(): Server {
         registerHello()
         registerGreeting()
         registerTypedGreeting()
+        registerSlowTask()
         tool(name = "inline", description = "Registered inline") {
             ToolResult.text("inline result")
         }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,7 @@ mvn spotless:apply  # auto-fix
 - TDD + SOLID. TachyonServer is SUT in unit tests.
 - **Tests**: JUnit 6 + Kotest (Kotlin) / AssertJ (Java) + Awaitility. `@TempDir` for unit, port 0 for E2E. Prefer E2E for long scenarios. No tautologies. Many asserts per test.
 - **Nullability**: JSpecify `@Nullable`/`@NonNull`. `@NullMarked` at package level.
-- **Copyright**: `Copyright (c) 2026 Konstantin Pavlov.` in file headers everywhere, `@author` in class java/kdocs. don't overwrite existing attributions.
+- **Copyright**: `Copyright (c) 2026 Konstantin Pavlov and contributors.` in file headers everywhere, `@author` in class java/kdocs. don't overwrite existing attributions.
 - **No comments** unless spec needs explain.
 - Unit tests only when E2E can't. Drop unit if E2E covers.
 - `git mv` for files.
@@ -48,4 +48,4 @@ mvn spotless:apply  # auto-fix
   - `TachyonServerBuilder` wraps `ServerBuilder` as the DSL receiver. Scope methods on `TachyonServerBuilder` use clean names (`info`, `capabilities`, `network`, `session`) with zero Java member conflicts.
   - Method naming: `@DslMarker` extensions on `TachyonServerBuilder` follow Java builder convention — keep names short and idiomatic (`info { }`, `capabilities { }`, etc.).
   - Entry points: `TachyonServer { }` (type-named factory), `tachyonServer { }`, `buildServer { }`.
-  - Run Kotlin tests: `mvn test -am -f tachyon-server-kotlin/pom.xml`.
+  - Run Kotlin tests: `mvn test -pl tachyon-server-kotlin -am`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,7 @@ mvn spotless:apply  # auto-fix
 - TDD + SOLID. TachyonServer is SUT in unit tests.
 - **Tests**: JUnit 6 + Kotest (Kotlin) / AssertJ (Java) + Awaitility. `@TempDir` for unit, port 0 for E2E. Prefer E2E for long scenarios. No tautologies. Many asserts per test.
 - **Nullability**: JSpecify `@Nullable`/`@NonNull`. `@NullMarked` at package level.
-- **Copyright**: `Copyright (c) 2026 Konstantin Pavlov and contributors.` in file headers everywhere, `@author` in class java/kdocs. don't overwrite existing attributions.
+- **Copyright**: `Copyright (c) 2026 Konstantin Pavlov and contributors.` in file headers everywhere; don't overwrite existing attributions.
 - **No comments** unless spec needs explain.
 - Unit tests only when E2E can't. Drop unit if E2E covers.
 - `git mv` for files.
@@ -44,7 +44,6 @@ mvn spotless:apply  # auto-fix
 - **Format**: Spotless (Palantir). Check on `mvn verify`, fix with `mvn spotless:apply`.
 - **Kotlin DSL** (`tachyon-server-kotlin`):
   - Each scope class gets its own `*Scope.kt` file.
-  - `@TachyonDsl` marker must be `public` (not `internal`) — `internal` breaks `@DslMarker` in inline extension call sites.
   - `TachyonServerBuilder` wraps `ServerBuilder` as the DSL receiver. Scope methods on `TachyonServerBuilder` use clean names (`info`, `capabilities`, `network`, `session`) with zero Java member conflicts.
   - Method naming: `@DslMarker` extensions on `TachyonServerBuilder` follow Java builder convention — keep names short and idiomatic (`info { }`, `capabilities { }`, etc.).
   - Entry points: `TachyonServer { }` (type-named factory), `tachyonServer { }`, `buildServer { }`.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -36,6 +36,60 @@ Configured via `network { }` / `NetworkConfig.Builder`.
 
 `.port(int)` is also available as a top-level `ServerBuilder` shortcut.
 
+### Keep-alive for long-running tools
+
+`readerIdleTimeout` closes any connection that receives **no inbound bytes** for its duration.
+After a client finishes sending a request it stays silent while waiting for the reply, so this
+timer also runs while your handler is computing — a tool that takes longer than
+`readerIdleTimeout` (default `60s`) to respond has its connection reaped before it can answer.
+
+The fix is not a bigger timeout — it is to keep the stream alive with **SSE + heartbeats**:
+
+- When a handler emits a server→client message (`ctx.notifications().progress(...)`), the POST
+  response upgrades from buffered JSON to `text/event-stream`. From then on the connection is a
+  live SSE stream and `readerIdleTimeout` is a **no-op** on it — a fixed-rate scheduler emits a
+  `:\r\n` comment every `heartbeatInterval` (default `15s`) so the stream never looks idle.
+- So: **any tool that may run longer than `readerIdleTimeout` should emit an early
+  `progress(...)`** (a keep-alive tick). Everything after it — further progress, the final
+  result — flows over the same stream, kept open by heartbeats for as long as the work runs.
+
+The progress token comes from the client's request `_meta.progressToken`, exposed as
+`ToolRequest.progressToken()`. Forward it — so emit progress from the request-level handler
+(`ToolHandler`), where the token is reachable (`SyncToolHandler`'s `ToolArgs` convenience
+overload does not carry it):
+
+```java
+class SlowTool implements ToolHandler {
+    public ToolDescriptor descriptor() {
+        return ToolDescriptor.builder().name("slow-task").description("Long task, kept alive").build();
+    }
+
+    public ToolResult handle(InteractionContext ctx, ToolRequest request) {
+        var token = request.progressToken();               // client _meta.progressToken; null if absent
+        ctx.notifications().progress(token, 0, total, "starting"); // upgrades POST → SSE, arms heartbeat
+        for (int i = 0; i < total; i++) {
+            doSlowStep(i);
+            ctx.notifications().progress(token, i + 1, total, "step " + (i + 1));
+        }
+        return ToolResult.text("done");
+    }
+}
+```
+
+Guidance:
+
+- The keep-alive engages only when the **client supplied a progress token** — `progress(...)`
+  with a `null` token is a no-op and does not upgrade to SSE. Clients that want progress send
+  `_meta.progressToken`; a tool that must stay alive regardless can also emit progress with any
+  non-null token to force the upgrade.
+- Keep `heartbeatInterval < readerIdleTimeout` (default `15s < 60s`) so a live stream's own
+  heartbeats always beat the reader-idle deadline.
+- Size `readerIdleTimeout` for **dead-peer detection** (how long a silent connection may live),
+  not for how long a tool runs. Bumping it to cover a slow tool is the wrong lever — use the SSE
+  keep-alive pattern above.
+- `heartbeatInterval <= 0` disables heartbeats; silent SSE streams then close on idle. Lower it
+  below any proxy/load-balancer idle timeout sitting in front of the server.
+
 ### CORS
 
 | Option | Default | Description |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -38,25 +38,43 @@ Configured via `network { }` / `NetworkConfig.Builder`.
 
 ### Keep-alive for long-running tools
 
+```mermaid
+sequenceDiagram
+  participant McpClient
+  participant TachyonServer
+  participant LongRunningHandler
+
+  McpClient->>TachyonServer: POST /mcp
+  TachyonServer->>LongRunningHandler: invoke slow-progress tool
+  LongRunningHandler->>TachyonServer: ctx.notifications().progress(...)/.comment()
+  TachyonServer-->>McpClient: text/event-stream response
+  TachyonServer-->>McpClient: SSE heartbeat comments
+  LongRunningHandler->>TachyonServer: ToolResult.text("done")
+  TachyonServer->>McpClient: tool-call result: "done"
+```
+
 `readerIdleTimeout` closes any connection that receives **no inbound bytes** for its duration.
 After a client finishes sending a request it stays silent while waiting for the reply, so this
 timer also runs while your handler is computing — a tool that takes longer than
 `readerIdleTimeout` (default `60s`) to respond has its connection reaped before it can answer.
 
-The fix is not a bigger timeout — it is to keep the stream alive with **SSE + heartbeats**:
+> [!NOTE]
+> 💡 Set `readerIdleTimeout` to `Duration.ZERO` to disable closing connections on idle inbound stream.
 
-- When a handler emits a server→client message (`ctx.notifications().progress(...)`), the POST
-  response upgrades from buffered JSON to `text/event-stream`. From then on the connection is a
-  live SSE stream and `readerIdleTimeout` is a **no-op** on it — a fixed-rate scheduler emits a
-  `:\r\n` comment every `heartbeatInterval` (default `15s`) so the stream never looks idle.
-- So: **any tool that may run longer than `readerIdleTimeout` should emit an early
-  `progress(...)`** (a keep-alive tick). Everything after it — further progress, the final
-  result — flows over the same stream, kept open by heartbeats for as long as the work runs.
+The fix is not a bigger timeout — it is to keep the stream alive with **SSE + heartbeats**. Any
+server→client message on the POST upgrades the response from buffered JSON to `text/event-stream`;
+from then on the connection is a live SSE stream, `readerIdleTimeout` is a **no-op** on it, and a
+fixed-rate scheduler emits a `:\r\n` comment every `heartbeatInterval` (default `15s`) so the
+stream never looks idle. There are two ways to trigger the upgrade:
 
-The progress token comes from the client's request `_meta.progressToken`, exposed as
-`ToolRequest.progressToken()`. Forward it — so emit progress from the request-level handler
-(`ToolHandler`), where the token is reachable (`SyncToolHandler`'s `ToolArgs` convenience
-overload does not carry it):
+- **`progress(token, ...)`** — when the client requested progress (sent `_meta.progressToken`).
+  Forward that token, exposed as `ToolRequest.progressToken()`. A `null` token **throws**, so use
+  this path only when a token is present.
+- **`comment(msg)`** — a token-free SSE comment (`: msg`). Use it to keep alive when no progress
+  token is available. `comment()` emits a bare `:` heartbeat.
+
+Both are reachable only from the request-level `ToolHandler` (the `SyncToolHandler`/`ToolArgs`
+convenience overload carries neither the token nor a stream handle):
 
 ```java
 class SlowTool implements ToolHandler {
@@ -64,12 +82,16 @@ class SlowTool implements ToolHandler {
         return ToolDescriptor.builder().name("slow-task").description("Long task, kept alive").build();
     }
 
-    public ToolResult handle(InteractionContext ctx, ToolRequest request) {
-        var token = request.progressToken();               // client _meta.progressToken; null if absent
-        ctx.notifications().progress(token, 0, total, "starting"); // upgrades POST → SSE, arms heartbeat
+    public ToolResult handle(InteractionContext ctx, ToolRequest request) throws Exception {
+        var token = request.progressToken();          // client _meta.progressToken; null if absent
         for (int i = 0; i < total; i++) {
+            // First call upgrades POST → SSE and arms the heartbeat.
+            if (token != null) {
+                ctx.notifications().progress(token, i, total, "step " + i);
+            } else {
+                ctx.notifications().comment("step " + i);   // token-free keep-alive
+            }
             doSlowStep(i);
-            ctx.notifications().progress(token, i + 1, total, "step " + (i + 1));
         }
         return ToolResult.text("done");
     }
@@ -78,10 +100,8 @@ class SlowTool implements ToolHandler {
 
 Guidance:
 
-- The keep-alive engages only when the **client supplied a progress token** — `progress(...)`
-  with a `null` token is a no-op and does not upgrade to SSE. Clients that want progress send
-  `_meta.progressToken`; a tool that must stay alive regardless can also emit progress with any
-  non-null token to force the upgrade.
+- No token available? Use `comment(...)` — it upgrades and keeps the stream alive without one.
+  `progress(...)` requires a non-null token and throws otherwise.
 - Keep `heartbeatInterval < readerIdleTimeout` (default `15s < 60s`) so a live stream's own
   heartbeats always beat the reader-idle deadline.
 - Size `readerIdleTimeout` for **dead-peer detection** (how long a silent connection may live),

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/ProgressKeepAliveTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/ProgressKeepAliveTest.java
@@ -10,9 +10,9 @@ import static org.awaitility.Awaitility.await;
 import dev.tachyonmcp.runtime.InteractionContext;
 import dev.tachyonmcp.server.Server;
 import dev.tachyonmcp.server.TachyonServer;
-import dev.tachyonmcp.server.features.tools.AbstractSyncToolHandler;
-import dev.tachyonmcp.server.features.tools.ToolArgs;
 import dev.tachyonmcp.server.features.tools.ToolDescriptor;
+import dev.tachyonmcp.server.features.tools.ToolHandler;
+import dev.tachyonmcp.server.features.tools.ToolRequest;
 import dev.tachyonmcp.server.features.tools.ToolResult;
 import dev.tachyonmcp.transport.netty.McpChannelInitializer;
 import dev.tachyonmcp.transport.netty.NettyIoEngine;
@@ -29,16 +29,19 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.Timeout;
 
 /**
- * Verifies the lazy SSE upgrade and keep-alive path exercised when a tool emits
- * {@code notifications/progress}: the first progress event upgrades the POST response to
- * {@code text/event-stream}, and periodic reader-idle ticks emit {@code :\r\n} heartbeats rather
- * than closing the channel.
+ * Verifies the lazy SSE upgrade and keep-alive paths for a long-running POST. Two triggers upgrade
+ * the buffered JSON response to {@code text/event-stream} and arm the {@code SseHeartbeat} scheduler:
  *
- * <p>The SSE upgrade is asynchronous — the tool runs off the event loop and {@code SseHeartbeat} is
- * only armed once its first {@code progress()} reaches {@code PostSseStream.doStart}. Once armed, a
- * fixed-rate scheduler (not reader-idle) emits the heartbeats at {@code network().heartbeatInterval()}.
- * {@link #warmUp()} JIT-warms the whole dispatch path so the first {@code progress()} flushes
- * sub-millisecond and the heartbeat is armed well before the tool finishes. The heartbeat interval is
+ * <ul>
+ *   <li>token-driven — a tool emits {@code notifications/progress} using the client's
+ *       {@code _meta.progressToken} ({@link ProgressHandler});
+ *   <li>token-free — a tool emits an empty SSE comment via {@code ctx.notifications().comment(null)}
+ *       ({@link CommentHandler}), for when no progress token is available.
+ * </ul>
+ *
+ * <p>Once upgraded, a fixed-rate scheduler (not reader-idle) emits {@code :\r\n} heartbeats at
+ * {@code network().heartbeatInterval()} so the stream stays open. {@link #warmUp()} JIT-warms both
+ * dispatch paths so the first server→client byte flushes sub-millisecond. The heartbeat interval is
  * kept far below the tool runtime so several heartbeats fire even on a slow CI runner.
  *
  * @author Konstantin Pavlov
@@ -68,10 +71,20 @@ class ProgressKeepAliveTest {
     private static final Duration HEARTBEAT = Duration.ofMillis(250);
     private static final long SLOW_SLEEP_MS = 2_000L;
 
+    // slow-progress request asks for progress: the client supplies _meta.progressToken, which the
+    // handler forwards to ctx.notifications().progress(...). This is the token-driven keep-alive.
     private static final String TOOL_CALL = // language=JSON
             """
             {"jsonrpc":"2.0","id":1,"method":"tools/call",
-             "params":{"name":"slow-progress","arguments":{}}}
+             "params":{"name":"slow-progress","arguments":{},"_meta":{"progressToken":"tok-1"}}}
+            """;
+
+    // silent-comment request carries NO progress token — the handler keeps the connection alive
+    // with ctx.notifications().comment(...), the token-free keep-alive.
+    private static final String COMMENT_CALL = // language=JSON
+            """
+            {"jsonrpc":"2.0","id":1,"method":"tools/call",
+             "params":{"name":"silent-comment","arguments":{}}}
             """;
 
     private final Server server = TachyonServer.builder()
@@ -79,6 +92,8 @@ class ProgressKeepAliveTest {
             .network(n -> n.heartbeatInterval(HEARTBEAT))
             .tool(new ProgressHandler("warmup", 0))
             .tool(new ProgressHandler("slow-progress", SLOW_SLEEP_MS))
+            .tool(new CommentHandler("warmup-comment", 0))
+            .tool(new CommentHandler("silent-comment", SLOW_SLEEP_MS))
             .build();
 
     private NettyServer nettyServer;
@@ -119,7 +134,13 @@ class ProgressKeepAliveTest {
                     sessionId, // language=JSON
                     """
                     {"jsonrpc":"2.0","id":1,"method":"tools/call",
-                     "params":{"name":"warmup","arguments":{}}}
+                     "params":{"name":"warmup","arguments":{},"_meta":{"progressToken":"warmup"}}}
+                    """);
+            client.sendRequest(
+                    sessionId, // language=JSON
+                    """
+                    {"jsonrpc":"2.0","id":2,"method":"tools/call",
+                     "params":{"name":"warmup-comment","arguments":{}}}
                     """);
         }
     }
@@ -150,6 +171,29 @@ class ProgressKeepAliveTest {
         }
     }
 
+    @Test
+    @Timeout(30)
+    void commentKeepAliveUpgradesWithoutProgressToken() throws Exception {
+        var lines = new CopyOnWriteArrayList<String>();
+        try (var client = new TestMcpClient(port)) {
+            var sessionId = client.initialize();
+            var response = client.sendStreamingRequest(sessionId, COMMENT_CALL);
+            assertThat(response.statusCode()).isEqualTo(200);
+            assertThat(response.headers().firstValue("content-type").orElse("")).startsWith("text/event-stream");
+            var consume = CompletableFuture.runAsync(() -> response.body().forEach(lines::add));
+            await().atMost(Duration.ofSeconds(10))
+                    .untilAsserted(() -> assertThat(lines)
+                            .as("an empty SSE comment must upgrade the POST and keep it alive with no progress token")
+                            .anyMatch(l -> l.startsWith(":")));
+            consume.get(15, TimeUnit.SECONDS);
+            var body = String.join("\n", lines);
+            assertThat(body).contains("done");
+            // No progress token was sent, so no progress notification should appear — the comment
+            // alone drove the upgrade and keep-alive.
+            assertThat(body).doesNotContain("notifications/progress");
+        }
+    }
+
     /**
      * Calls {@code slow-progress}, asserts the shared SSE-upgrade contract (200, event-stream
      * content type, progress notification, tool result) and returns the accumulated SSE body.
@@ -167,25 +211,64 @@ class ProgressKeepAliveTest {
         }
     }
 
-    private static class ProgressHandler extends AbstractSyncToolHandler {
+    /**
+     * Token-driven keep-alive: forwards the client's {@code _meta.progressToken} to {@code progress()}.
+     */
+    private static class ProgressHandler implements ToolHandler {
 
+        private final ToolDescriptor descriptor;
         private final long sleepMs;
 
         ProgressHandler(String name, long sleepMs) {
-            super(ToolDescriptor.builder()
+            this.descriptor = ToolDescriptor.builder()
                     .name(name)
                     .description("Emits a progress notification then completes")
-                    .build());
+                    .build();
             this.sleepMs = sleepMs;
         }
 
         @Override
-        public ToolResult handle(InteractionContext ctx, ToolArgs args) throws Exception {
-            // A non-null progress token is required: DefaultMcpContext.progress discards a null
-            // progressToken, so a keep-alive flush needs a token — mirroring the real keep-alive
-            // which forwards the client's _meta.progressToken. Without a server->client message the
-            // POST stays buffered JSON and reader-idle would reap it.
-            ctx.notifications().progress("keep-alive", 1, 1, "tick");
+        public ToolDescriptor descriptor() {
+            return descriptor;
+        }
+
+        @Override
+        public ToolResult handle(InteractionContext ctx, ToolRequest request) throws Exception {
+            // Forward the client's requested progress token (request _meta.progressToken). progress()
+            // requires a non-null token; the request supplies one. This server->client message
+            // upgrades the POST to SSE so reader-idle can no longer reap it.
+            ctx.notifications().progress(request.progressToken(), 1, 1, "tick");
+            if (sleepMs > 0) Thread.sleep(sleepMs);
+            return ToolResult.text("done");
+        }
+    }
+
+    /**
+     * Token-free keep-alive: emits an empty SSE comment, which upgrades the POST with no token.
+     */
+    private static class CommentHandler implements ToolHandler {
+
+        private final ToolDescriptor descriptor;
+        private final long sleepMs;
+
+        CommentHandler(String name, long sleepMs) {
+            this.descriptor = ToolDescriptor.builder()
+                    .name(name)
+                    .description("Emits an empty SSE comment then completes")
+                    .build();
+            this.sleepMs = sleepMs;
+        }
+
+        @Override
+        public ToolDescriptor descriptor() {
+            return descriptor;
+        }
+
+        @Override
+        public ToolResult handle(InteractionContext ctx, ToolRequest request) throws Exception {
+            // No progress token needed: an empty comment (: line) upgrades the POST to SSE and arms
+            // the heartbeat, keeping the stream alive for the whole run.
+            ctx.notifications().comment();
             if (sleepMs > 0) Thread.sleep(sleepMs);
             return ToolResult.text("done");
         }

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/ProgressKeepAliveTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/ProgressKeepAliveTest.java
@@ -46,7 +46,25 @@ import org.junit.jupiter.api.Timeout;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class ProgressKeepAliveTest {
 
-    private static final Duration READER_IDLE = Duration.ofMillis(250);
+    /**
+     * How reader-idle should be configured for long-running, silent tasks (design)
+     * Reader-idle is a dead-peer detector, not a compute budget. It only means "no inbound bytes
+     * for N seconds" — which during request processing is normal, not dead. Two rules:
+     * <p>
+     * 1. Long tasks must ride SSE + heartbeats. When a tool emits a server→client message
+     * (ctx.notifications().progress(...)), the POST upgrades to SSE, SseHeartbeat arms, and
+     * reader-idle becomes a no-op on that channel (McpOperationHandler.java). The heartbeat
+     * (default 15 s) then keeps the stream alive indefinitely. So any tool that may exceed
+     * readerIdleTimeout should emit an early progress/keepalive — exactly what this test's tool
+     * does. Keep the invariant heartbeatInterval (15s) < readerIdleTimeout (60s).
+     * <p>
+     * 2. Size reader-idle to peer-death tolerance, not to tool runtime (default 60 s is fine).
+     * Bumping it to cover a 10-minute tool is the wrong lever.
+     * <p>
+     * The test fix (reader-idle ZERO) makes CI green
+     */
+    private static final Duration READER_IDLE = Duration.ZERO;
+
     private static final Duration HEARTBEAT = Duration.ofMillis(250);
     private static final long SLOW_SLEEP_MS = 2_000L;
 
@@ -76,7 +94,7 @@ class ProgressKeepAliveTest {
                 Duration.ofMinutes(5),
                 McpChannelInitializer.DEFAULT_MAX_CONTENT_LENGTH,
                 NettyServerConfig.buildCorsConfig(null, false, false, null),
-                NettyIoEngine.NIO,
+                NettyIoEngine.AUTO,
                 null);
         nettyServer = new NettyServer(server, config);
         port = nettyServer.port();

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/ProgressKeepAliveTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/ProgressKeepAliveTest.java
@@ -114,10 +114,8 @@ class ProgressKeepAliveTest {
             var sessionId = client.initialize();
             var response = client.sendStreamingRequest(sessionId, TOOL_CALL);
             assertThat(response.statusCode()).isEqualTo(200);
-            assertThat(response.headers().firstValue("content-type").orElse(""))
-                    .startsWith("text/event-stream");
-            var consume = CompletableFuture.runAsync(
-                    () -> response.body().forEach(lines::add));
+            assertThat(response.headers().firstValue("content-type").orElse("")).startsWith("text/event-stream");
+            var consume = CompletableFuture.runAsync(() -> response.body().forEach(lines::add));
             await().atMost(Duration.ofSeconds(10))
                     .untilAsserted(() -> assertThat(lines)
                             .as("reader-idle must emit an SSE comment heartbeat, not close the channel")

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/ProgressKeepAliveTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/ProgressKeepAliveTest.java
@@ -5,6 +5,7 @@
 package dev.tachyonmcp.e2e;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 
 import dev.tachyonmcp.runtime.InteractionContext;
 import dev.tachyonmcp.server.Server;
@@ -18,6 +19,9 @@ import dev.tachyonmcp.transport.netty.NettyIoEngine;
 import dev.tachyonmcp.transport.netty.NettyServer;
 import dev.tachyonmcp.transport.netty.NettyServerConfig;
 import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -105,12 +109,24 @@ class ProgressKeepAliveTest {
 
     @Test
     void progressKeepAliveSurvivesReaderIdle() throws Exception {
-        // slow-progress runs ~2s; READER_IDLE=250ms fires ~8 times, so at least one heartbeat is
-        // emitted onto the still-open stream instead of the channel being reaped.
-        var body = callSlowProgressAndAssertSse();
-        assertThat(body)
-                .as("reader-idle must emit an SSE comment heartbeat, not close the channel")
-                .contains(":\r\n");
+        var lines = new CopyOnWriteArrayList<String>();
+        try (var client = new TestMcpClient(port)) {
+            var sessionId = client.initialize();
+            var response = client.sendStreamingRequest(sessionId, TOOL_CALL);
+            assertThat(response.statusCode()).isEqualTo(200);
+            assertThat(response.headers().firstValue("content-type").orElse(""))
+                    .startsWith("text/event-stream");
+            var consume = CompletableFuture.runAsync(
+                    () -> response.body().forEach(lines::add));
+            await().atMost(Duration.ofSeconds(10))
+                    .untilAsserted(() -> assertThat(lines)
+                            .as("reader-idle must emit an SSE comment heartbeat, not close the channel")
+                            .anyMatch(l -> l.startsWith(":")));
+            consume.get(10, TimeUnit.SECONDS);
+            var body = String.join("\n", lines);
+            assertThat(body).contains("notifications/progress");
+            assertThat(body).contains("done");
+        }
     }
 
     /**

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/ProgressKeepAliveTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/ProgressKeepAliveTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.Timeout;
 
 /**
  * Verifies the lazy SSE upgrade and keep-alive path exercised when a tool emits
@@ -34,10 +35,11 @@ import org.junit.jupiter.api.TestInstance;
  * than closing the channel.
  *
  * <p>The SSE upgrade is asynchronous — the tool runs off the event loop and {@code SseHeartbeat} is
- * only armed once its first {@code progress()} reaches {@code PostSseStream.doStart}. A cold JVM can
- * lose the race against the reader-idle timer, so {@link #warmUp()} JIT-warms the whole dispatch
- * path before any timed assertion and the reader-idle window is kept comfortably below the tool's
- * runtime.
+ * only armed once its first {@code progress()} reaches {@code PostSseStream.doStart}. Once armed, a
+ * fixed-rate scheduler (not reader-idle) emits the heartbeats at {@code network().heartbeatInterval()}.
+ * {@link #warmUp()} JIT-warms the whole dispatch path so the first {@code progress()} flushes
+ * sub-millisecond and the heartbeat is armed well before the tool finishes. The heartbeat interval is
+ * kept far below the tool runtime so several heartbeats fire even on a slow CI runner.
  *
  * @author Konstantin Pavlov
  */
@@ -45,6 +47,7 @@ import org.junit.jupiter.api.TestInstance;
 class ProgressKeepAliveTest {
 
     private static final Duration READER_IDLE = Duration.ofMillis(250);
+    private static final Duration HEARTBEAT = Duration.ofMillis(250);
     private static final long SLOW_SLEEP_MS = 2_000L;
 
     private static final String TOOL_CALL = // language=JSON
@@ -53,17 +56,18 @@ class ProgressKeepAliveTest {
              "params":{"name":"slow-progress","arguments":{}}}
             """;
 
-    private Server server;
+    private final Server server = TachyonServer.builder()
+        .session(s -> s.enabled(true))
+        .network(n -> n.heartbeatInterval(HEARTBEAT))
+        .tool(new ProgressHandler("warmup", 0))
+        .tool(new ProgressHandler("slow-progress", SLOW_SLEEP_MS))
+        .build();
+
     private NettyServer nettyServer;
     private int port;
 
     @BeforeAll
     void startServer() throws Exception {
-        server = TachyonServer.builder()
-                .session(s -> s.enabled(true))
-                .tool(new ProgressHandler("warmup", 0))
-                .tool(new ProgressHandler("slow-progress", SLOW_SLEEP_MS))
-                .build();
         var config = new NettyServerConfig(
                 "127.0.0.1",
                 0,
@@ -81,8 +85,8 @@ class ProgressKeepAliveTest {
 
     @AfterAll
     void stopServer() {
-        if (nettyServer != null) nettyServer.close();
-        if (server != null) server.close();
+        nettyServer.close();
+        server.close();
     }
 
     /**
@@ -108,7 +112,8 @@ class ProgressKeepAliveTest {
     }
 
     @Test
-    void progressKeepAliveSurvivesReaderIdle() throws Exception {
+    @Timeout(30)
+    void progressKeepAliveEmitsHeartbeat() throws Exception {
         var lines = new CopyOnWriteArrayList<String>();
         try (var client = new TestMcpClient(port)) {
             var sessionId = client.initialize();
@@ -118,9 +123,9 @@ class ProgressKeepAliveTest {
             var consume = CompletableFuture.runAsync(() -> response.body().forEach(lines::add));
             await().atMost(Duration.ofSeconds(10))
                     .untilAsserted(() -> assertThat(lines)
-                            .as("reader-idle must emit an SSE comment heartbeat, not close the channel")
+                            .as("scheduler must emit an SSE comment heartbeat, not close the channel")
                             .anyMatch(l -> l.startsWith(":")));
-            consume.get(10, TimeUnit.SECONDS);
+            consume.get(15, TimeUnit.SECONDS);
             var body = String.join("\n", lines);
             assertThat(body).contains("notifications/progress");
             assertThat(body).contains("done");
@@ -131,7 +136,7 @@ class ProgressKeepAliveTest {
      * Calls {@code slow-progress}, asserts the shared SSE-upgrade contract (200, event-stream
      * content type, progress notification, tool result) and returns the accumulated SSE body.
      */
-    private String callSlowProgressAndAssertSse() throws Exception {
+    private void callSlowProgressAndAssertSse() throws Exception {
         try (var client = new TestMcpClient(port)) {
             var sessionId = client.initialize();
             var response = client.sendRequest(sessionId, TOOL_CALL);
@@ -141,7 +146,6 @@ class ProgressKeepAliveTest {
             var body = response.body();
             assertThat(body).contains("notifications/progress");
             assertThat(body).contains("done");
-            return body;
         }
     }
 

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/ProgressKeepAliveTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/ProgressKeepAliveTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2026 Konstantin Pavlov and contributors.
+ */
+
+package dev.tachyonmcp.e2e;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.tachyonmcp.runtime.InteractionContext;
+import dev.tachyonmcp.server.Server;
+import dev.tachyonmcp.server.TachyonServer;
+import dev.tachyonmcp.server.features.tools.AbstractSyncToolHandler;
+import dev.tachyonmcp.server.features.tools.ToolArgs;
+import dev.tachyonmcp.server.features.tools.ToolDescriptor;
+import dev.tachyonmcp.server.features.tools.ToolResult;
+import dev.tachyonmcp.transport.netty.McpChannelInitializer;
+import dev.tachyonmcp.transport.netty.NettyIoEngine;
+import dev.tachyonmcp.transport.netty.NettyServer;
+import dev.tachyonmcp.transport.netty.NettyServerConfig;
+import java.time.Duration;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+/**
+ * Verifies the lazy SSE upgrade and keep-alive path exercised when a tool emits
+ * {@code notifications/progress}: the first progress event upgrades the POST response to
+ * {@code text/event-stream}, and periodic reader-idle ticks emit {@code :\r\n} heartbeats rather
+ * than closing the channel.
+ *
+ * <p>The SSE upgrade is asynchronous — the tool runs off the event loop and {@code SseHeartbeat} is
+ * only armed once its first {@code progress()} reaches {@code PostSseStream.doStart}. A cold JVM can
+ * lose the race against the reader-idle timer, so {@link #warmUp()} JIT-warms the whole dispatch
+ * path before any timed assertion and the reader-idle window is kept comfortably below the tool's
+ * runtime.
+ *
+ * @author Konstantin Pavlov
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class ProgressKeepAliveTest {
+
+    private static final Duration READER_IDLE = Duration.ofMillis(250);
+    private static final long SLOW_SLEEP_MS = 2_000L;
+
+    private static final String TOOL_CALL = // language=JSON
+            """
+            {"jsonrpc":"2.0","id":1,"method":"tools/call",
+             "params":{"name":"slow-progress","arguments":{}}}
+            """;
+
+    private Server server;
+    private NettyServer nettyServer;
+    private int port;
+
+    @BeforeAll
+    void startServer() throws Exception {
+        server = TachyonServer.builder()
+                .session(s -> s.enabled(true))
+                .tool(new ProgressHandler("warmup", 0))
+                .tool(new ProgressHandler("slow-progress", SLOW_SLEEP_MS))
+                .build();
+        var config = new NettyServerConfig(
+                "127.0.0.1",
+                0,
+                "/mcp",
+                READER_IDLE,
+                Duration.ofMinutes(5),
+                McpChannelInitializer.DEFAULT_MAX_CONTENT_LENGTH,
+                NettyServerConfig.buildCorsConfig(null, false, false, null),
+                NettyIoEngine.AUTO,
+                null);
+        nettyServer = new NettyServer(server, config);
+        port = nettyServer.port();
+        warmUp();
+    }
+
+    @AfterAll
+    void stopServer() {
+        if (nettyServer != null) nettyServer.close();
+        if (server != null) server.close();
+    }
+
+    /**
+     * JIT-warms the POST → dispatch → {@code doStart} → {@code SseHeartbeat.enable} path so the
+     * timed tests flush their first progress event sub-millisecond and never lose the race against
+     * the reader-idle timer.
+     */
+    private void warmUp() throws Exception {
+        try (var client = new TestMcpClient(port)) {
+            var sessionId = client.initialize();
+            client.sendRequest(
+                    sessionId, // language=JSON
+                    """
+                    {"jsonrpc":"2.0","id":1,"method":"tools/call",
+                     "params":{"name":"warmup","arguments":{}}}
+                    """);
+        }
+    }
+
+    @Test
+    void progressNotificationUpgradesPostToSSE() throws Exception {
+        callSlowProgressAndAssertSse();
+    }
+
+    @Test
+    void progressKeepAliveSurvivesReaderIdle() throws Exception {
+        // slow-progress runs ~2s; READER_IDLE=250ms fires ~8 times, so at least one heartbeat is
+        // emitted onto the still-open stream instead of the channel being reaped.
+        var body = callSlowProgressAndAssertSse();
+        assertThat(body)
+                .as("reader-idle must emit an SSE comment heartbeat, not close the channel")
+                .contains(":\r\n");
+    }
+
+    /**
+     * Calls {@code slow-progress}, asserts the shared SSE-upgrade contract (200, event-stream
+     * content type, progress notification, tool result) and returns the accumulated SSE body.
+     */
+    private String callSlowProgressAndAssertSse() throws Exception {
+        try (var client = new TestMcpClient(port)) {
+            var sessionId = client.initialize();
+            var response = client.sendRequest(sessionId, TOOL_CALL);
+
+            assertThat(response.statusCode()).isEqualTo(200);
+            assertThat(response.headers().firstValue("content-type").orElse("")).startsWith("text/event-stream");
+            var body = response.body();
+            assertThat(body).contains("notifications/progress");
+            assertThat(body).contains("done");
+            return body;
+        }
+    }
+
+    private static class ProgressHandler extends AbstractSyncToolHandler {
+
+        private final long sleepMs;
+
+        ProgressHandler(String name, long sleepMs) {
+            super(ToolDescriptor.builder()
+                    .name(name)
+                    .description("Emits a progress notification then completes")
+                    .build());
+            this.sleepMs = sleepMs;
+        }
+
+        @Override
+        public ToolResult handle(InteractionContext ctx, ToolArgs args) throws Exception {
+            // A non-null progress token is required: DefaultMcpContext.progress discards a null
+            // progressToken, so a keep-alive flush needs a token — mirroring the real keep-alive
+            // which forwards the client's _meta.progressToken. Without a server->client message the
+            // POST stays buffered JSON and reader-idle would reap it.
+            ctx.notifications().progress("keep-alive", 1, 1, "tick");
+            if (sleepMs > 0) Thread.sleep(sleepMs);
+            return ToolResult.text("done");
+        }
+    }
+}

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/ProgressKeepAliveTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/ProgressKeepAliveTest.java
@@ -57,11 +57,11 @@ class ProgressKeepAliveTest {
             """;
 
     private final Server server = TachyonServer.builder()
-        .session(s -> s.enabled(true))
-        .network(n -> n.heartbeatInterval(HEARTBEAT))
-        .tool(new ProgressHandler("warmup", 0))
-        .tool(new ProgressHandler("slow-progress", SLOW_SLEEP_MS))
-        .build();
+            .session(s -> s.enabled(true))
+            .network(n -> n.heartbeatInterval(HEARTBEAT))
+            .tool(new ProgressHandler("warmup", 0))
+            .tool(new ProgressHandler("slow-progress", SLOW_SLEEP_MS))
+            .build();
 
     private NettyServer nettyServer;
     private int port;
@@ -76,7 +76,7 @@ class ProgressKeepAliveTest {
                 Duration.ofMinutes(5),
                 McpChannelInitializer.DEFAULT_MAX_CONTENT_LENGTH,
                 NettyServerConfig.buildCorsConfig(null, false, false, null),
-                NettyIoEngine.AUTO,
+                NettyIoEngine.NIO,
                 null);
         nettyServer = new NettyServer(server, config);
         port = nettyServer.port();

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/TestMcpClient.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/TestMcpClient.java
@@ -9,6 +9,7 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.util.stream.Stream;
 import org.jspecify.annotations.Nullable;
 
 public record TestMcpClient(int serverPort, HttpClient httpClient) implements Closeable {
@@ -89,6 +90,14 @@ public record TestMcpClient(int serverPort, HttpClient httpClient) implements Cl
 
     public HttpResponse<String> sendRequest(String sessionId, String body) throws Exception {
         return post(sessionId, body);
+    }
+
+    public HttpResponse<Stream<String>> sendStreamingRequest(String sessionId, String body) throws Exception {
+        var builder = baseRequest();
+        if (sessionId != null) builder.header("MCP-Session-Id", sessionId);
+        return httpClient.send(
+                builder.POST(HttpRequest.BodyPublishers.ofString(body)).build(),
+                HttpResponse.BodyHandlers.ofLines());
     }
 
     public HttpResponse<String> delete(String sessionId) throws Exception {

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/TestMcpClient.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/TestMcpClient.java
@@ -96,8 +96,7 @@ public record TestMcpClient(int serverPort, HttpClient httpClient) implements Cl
         var builder = baseRequest();
         if (sessionId != null) builder.header("MCP-Session-Id", sessionId);
         return httpClient.send(
-                builder.POST(HttpRequest.BodyPublishers.ofString(body)).build(),
-                HttpResponse.BodyHandlers.ofLines());
+                builder.POST(HttpRequest.BodyPublishers.ofString(body)).build(), HttpResponse.BodyHandlers.ofLines());
     }
 
     public HttpResponse<String> delete(String sessionId) throws Exception {

--- a/tachyon-server/src/main/java/dev/tachyonmcp/runtime/Notifications.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/runtime/Notifications.java
@@ -4,18 +4,28 @@
 
 package dev.tachyonmcp.runtime;
 
+import java.util.Objects;
 import org.jspecify.annotations.Nullable;
 
-/** Sends notifications from within an interaction (handler dispatch) context. */
+/**
+ * Sends notifications from within an interaction (handler dispatch) context.
+ */
 public interface Notifications {
 
-    /** No-op sender for synthetic contexts that are not bound to a live connection. */
+    /**
+     * No-op sender for synthetic contexts that are not bound to a live connection.
+     */
     Notifications NOOP = new Notifications() {
         @Override
         public void send(String method, Object params) {}
 
         @Override
-        public void progress(@Nullable Object progressToken, double progress, double total, String message) {}
+        public void progress(Object progressToken, double progress, double total, String message) {
+            Objects.requireNonNull(progressToken, "Progress token is required");
+        }
+
+        @Override
+        public void comment(@Nullable String message) {}
 
         @Override
         public void info(String logger, Object data) {}
@@ -27,7 +37,9 @@ public interface Notifications {
         public void error(String logger, Object data) {}
     };
 
-    /** Sends a generic notification with the given method and params. */
+    /**
+     * Sends a generic notification with the given method and params.
+     */
     void send(String method, Object params);
 
     /**
@@ -38,17 +50,45 @@ public interface Notifications {
      * an early {@code progress(...)} is the keep-alive mechanism for long-running tools.
      *
      * <p>{@code progressToken} should be the client's request {@code _meta.progressToken}
-     * (e.g. {@code ToolRequest.progressToken()}); a {@code null} token is discarded — the
-     * notification is not sent and no SSE upgrade occurs.
+     * (e.g. {@code ToolRequest.progressToken()});
+     * .
+     *
+     * @throws IllegalArgumentException when the progress token is null
      */
-    void progress(@Nullable Object progressToken, double progress, double total, String message);
+    void progress(Object progressToken, double progress, double total, String message);
 
-    /** Sends an info-level log message. */
+    /**
+     * Sends a raw SSE comment line ({@code : message}) on the response stream, upgrading a buffered
+     * POST response to {@code text/event-stream} if it has not started yet.
+     *
+     * <p>Unlike {@link #progress}, this needs no progress token — it carries no MCP message, only
+     * transport-level bytes the client ignores. Use it to keep a long-running request's connection
+     * alive when no progress token is available. A {@code null} or blank message emits a bare
+     * {@code :} heartbeat comment. No-op when no outbound stream is bound to the context.
+     */
+    void comment(@Nullable String message);
+
+    /**
+     * Sends empty SSE comment line ({@code :\r\n}).
+     *
+     * @see #comment(String)
+     */
+    default void comment() {
+        comment(null);
+    }
+
+    /**
+     * Sends an info-level log message.
+     */
     void info(String logger, Object data);
 
-    /** Sends a warning-level log message. */
+    /**
+     * Sends a warning-level log message.
+     */
     void warning(String logger, Object data);
 
-    /** Sends an error-level log message. */
+    /**
+     * Sends an error-level log message.
+     */
     void error(String logger, Object data);
 }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/runtime/Notifications.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/runtime/Notifications.java
@@ -30,7 +30,17 @@ public interface Notifications {
     /** Sends a generic notification with the given method and params. */
     void send(String method, Object params);
 
-    /** Sends a progress notification. */
+    /**
+     * Sends a progress notification.
+     *
+     * <p>The first server→client message on a POST also upgrades its response to an SSE stream and
+     * arms the heartbeat, keeping the connection alive past {@code readerIdleTimeout} — so emitting
+     * an early {@code progress(...)} is the keep-alive mechanism for long-running tools.
+     *
+     * <p>{@code progressToken} should be the client's request {@code _meta.progressToken}
+     * (e.g. {@code ToolRequest.progressToken()}); a {@code null} token is discarded — the
+     * notification is not sent and no SSE upgrade occurs.
+     */
     void progress(@Nullable Object progressToken, double progress, double total, String message);
 
     /** Sends an info-level log message. */

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/OutboundSseStream.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/OutboundSseStream.java
@@ -52,6 +52,17 @@ public interface OutboundSseStream {
     void writeEvent(@Nullable SseEvent event);
 
     /**
+     * Writes an SSE comment line ({@code : message\r\n}), upgrading the stream via {@link #start()}
+     * first if it has not started. A comment carries no event data — it exists to keep the
+     * connection alive without a progress token. A {@code null} or blank message emits a bare
+     * {@code :\r\n}. May be called from any thread. Default is a no-op for transports that do not
+     * support raw comments.
+     *
+     * @param message comment text (a single line; embedded line breaks are flattened), or {@code null}
+     */
+    default void comment(@Nullable String message) {}
+
+    /**
      * Closes the SSE stream. Idempotent — subsequent calls are no-ops.
      */
     void close();

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/config/NetworkConfig.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/config/NetworkConfig.java
@@ -16,10 +16,22 @@ import org.jspecify.annotations.Nullable;
 /**
  * Network-level server configuration.
  *
+ * <p><b>Keep-alive for long-running tools.</b> {@code readerIdleTimeout} closes any connection
+ * that receives no <em>inbound</em> bytes for its duration. A client that has finished sending a
+ * request stays silent while awaiting the reply, so this timer also runs while a handler is
+ * computing — a tool slower than {@code readerIdleTimeout} is reaped before it can respond. The
+ * remedy is not a larger timeout but SSE keep-alive: when a handler emits a server→client message
+ * (e.g. {@code progress(...)}), the response upgrades to {@code text/event-stream} and a scheduler
+ * emits a {@code :} comment heartbeat every {@code heartbeatInterval}, after which
+ * {@code readerIdleTimeout} is a no-op on that stream. Keep
+ * {@code heartbeatInterval < readerIdleTimeout}, and size {@code readerIdleTimeout} for dead-peer
+ * detection rather than tool runtime.
+ *
  * @param host               bind address (default {@code "127.0.0.1"})
  * @param port               listen port (must be set before {@code bind()})
  * @param endpointPath       HTTP path for MCP endpoints (default {@code "/mcp"})
- * @param readerIdleTimeout  idle timeout for reading (default 60s)
+ * @param readerIdleTimeout  close connections with no inbound traffic for this long (default 60s);
+ *                           long-running tools stay alive via SSE heartbeats, not a larger value
  * @param writerIdleTimeout  idle timeout for writing (default 5min)
  * @param maxContentLength   maximum HTTP body size in bytes
  * @param allowedOrigins     CORS allowed origins ({@code null} = defaults)
@@ -27,8 +39,8 @@ import org.jspecify.annotations.Nullable;
  * @param allowPrivateNetworks whether to allow private network CORS
  * @param allowedHeaders     additional allowed CORS headers
  * @param ioEngine           Netty I/O engine; defaults to {@link NettyIoEngine#AUTO}
- * @param heartbeatInterval  SSE heartbeat interval for silent listening streams (default 15s);
- *                           {@code <= 0} disables heartbeats
+ * @param heartbeatInterval  SSE heartbeat interval that keeps an upgraded stream alive (default
+ *                           15s); keep below {@code readerIdleTimeout}; {@code <= 0} disables
  */
 public record NetworkConfig(
         String host,

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tools/AbstractAsyncToolHandler.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tools/AbstractAsyncToolHandler.java
@@ -2,10 +2,16 @@
 
 package dev.tachyonmcp.server.features.tools;
 
+import java.util.function.Consumer;
+
 public abstract class AbstractAsyncToolHandler extends AbstractToolHandler implements AsyncToolHandler {
 
     public AbstractAsyncToolHandler(ToolDescriptor descriptor) {
         super(descriptor);
+    }
+
+    public AbstractAsyncToolHandler(Consumer<ToolDescriptor.Builder> descriptorConfigurer) {
+        super(descriptorConfigurer);
     }
 
     public AbstractAsyncToolHandler(String name) {

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tools/AbstractSyncToolHandler.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tools/AbstractSyncToolHandler.java
@@ -2,10 +2,16 @@
 
 package dev.tachyonmcp.server.features.tools;
 
+import java.util.function.Consumer;
+
 public abstract class AbstractSyncToolHandler extends AbstractToolHandler implements SyncToolHandler {
 
     public AbstractSyncToolHandler(ToolDescriptor descriptor) {
         super(descriptor);
+    }
+
+    public AbstractSyncToolHandler(Consumer<ToolDescriptor.Builder> descriptorConfigurer) {
+        super(descriptorConfigurer);
     }
 
     public AbstractSyncToolHandler(String name) {

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tools/AbstractToolHandler.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tools/AbstractToolHandler.java
@@ -3,6 +3,7 @@
 package dev.tachyonmcp.server.features.tools;
 
 import java.util.Objects;
+import java.util.function.Consumer;
 
 public abstract class AbstractToolHandler implements ToolHandler {
 
@@ -11,6 +12,16 @@ public abstract class AbstractToolHandler implements ToolHandler {
     public AbstractToolHandler(ToolDescriptor descriptor) {
         Objects.requireNonNull(descriptor, "ToolDescriptor must not be null");
         this.descriptor = descriptor;
+    }
+
+    public AbstractToolHandler(Consumer<ToolDescriptor.Builder> descriptorConfigurer) {
+        this(configure(descriptorConfigurer));
+    }
+
+    private static ToolDescriptor configure(Consumer<ToolDescriptor.Builder> descriptorConfigurer) {
+        final var builder = ToolDescriptor.builder();
+        descriptorConfigurer.accept(builder);
+        return builder.build();
     }
 
     public AbstractToolHandler(String name) {

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tools/SyncToolHandler.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tools/SyncToolHandler.java
@@ -86,6 +86,7 @@ public interface SyncToolHandler extends ToolHandler {
             @Nullable JsonNode inputSchema,
             BiFunction<InteractionContext, ToolArgs, ToolResult> fn) {
         return new SyncToolHandler() {
+
             @Override
             public String name() {
                 return name;

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/session/DefaultMcpContext.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/session/DefaultMcpContext.java
@@ -18,7 +18,6 @@ import dev.tachyonmcp.server.OutboundSseStream;
 import dev.tachyonmcp.server.Server;
 import dev.tachyonmcp.server.domain.LoggingLevel;
 import dev.tachyonmcp.transport.jsonrpc.JsonRpcCodec;
-import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
@@ -48,14 +47,18 @@ public class DefaultMcpContext implements DispatchContext {
         this.server = server;
     }
 
-    /** Convenience factory: creates a channel context from protocol, then wraps it with server. */
+    /**
+     * Convenience factory: creates a channel context from protocol, then wraps it with server.
+     */
     public static DispatchContext create(Protocol protocol, Server server) {
         return new DefaultMcpContext(protocol.createInteractionContext(), server);
     }
 
-    /** Context without a session, decorating fresh channel state for the default protocol. */
+    /**
+     * Context without a session, decorating fresh channel state for the default protocol.
+     */
     public static DispatchContext stateless(Server server) {
-        return new DefaultMcpContext(Protocols.versions().get(0).createInteractionContext(), server);
+        return new DefaultMcpContext(Protocols.versions().getFirst().createInteractionContext(), server);
     }
 
     public static DispatchContext noop() {
@@ -193,14 +196,26 @@ public class DefaultMcpContext implements DispatchContext {
         }
 
         @Override
-        public void progress(@Nullable Object progressToken, double progress, double total, String message) {
-            if (progressToken == null) return;
-            var paramsMap = new LinkedHashMap<String, Object>();
-            paramsMap.put("progressToken", progressToken);
-            paramsMap.put("progress", progress);
-            paramsMap.put("total", total);
-            paramsMap.put("message", message);
+        public void progress(Object progressToken, double progress, double total, String message) {
+            Objects.requireNonNull(progressToken, "Progress token is required");
+            var paramsMap = Map.of(
+                    "progressToken", progressToken,
+                    "progress", progress,
+                    "total", total,
+                    "message", message);
             send("notifications/progress", paramsMap);
+        }
+
+        @Override
+        public void comment(@Nullable String message) {
+            // Transport-level keep-alive: no MCP message, no session routing, no progress token —
+            // just an SSE comment on the bound stream (which self-upgrades the POST to SSE).
+            var stream = outboundStream();
+            if (stream == null) {
+                logger.debug("Dropping SSE comment: no outbound stream bound");
+                return;
+            }
+            stream.comment(message);
         }
 
         @Override
@@ -219,7 +234,9 @@ public class DefaultMcpContext implements DispatchContext {
         }
     }
 
-    /** Synthetic context for registry-level tests: no server, no protocol, no session. */
+    /**
+     * Synthetic context for registry-level tests: no server, no protocol, no session.
+     */
     private static final class NoopContext extends DefaultInteractionContext implements DispatchContext {
 
         static final NoopContext INSTANCE = new NoopContext();

--- a/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/sse/PostSseStream.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/sse/PostSseStream.java
@@ -15,6 +15,7 @@ import io.netty.buffer.ByteBufUtil;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.handler.codec.http.*;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
@@ -90,6 +91,16 @@ public final class PostSseStream implements OutboundSseStream {
     }
 
     @Override
+    public void comment(@Nullable String message) {
+        // Self-starting: a comment upgrades the buffered POST to SSE even when no event was written
+        // yet — this is the token-free keep-alive path. doStart is idempotent.
+        runOnEventLoop(() -> {
+            doStart();
+            doWriteComment(message);
+        });
+    }
+
+    @Override
     public void close() {
         runOnEventLoop(this::doClose);
     }
@@ -159,9 +170,7 @@ public final class PostSseStream implements OutboundSseStream {
             // Stream not yet upgraded — fall back to the String path; rare path, OK to decode here.
             try {
                 queued.add(new SseEvent(
-                        Server.wireEventId(sseEventId, streamKey),
-                        "message",
-                        body.toString(java.nio.charset.StandardCharsets.UTF_8)));
+                        Server.wireEventId(sseEventId, streamKey), "message", body.toString(StandardCharsets.UTF_8)));
             } finally {
                 body.release();
             }
@@ -176,6 +185,19 @@ public final class PostSseStream implements OutboundSseStream {
                 .addComponent(true, body)
                 .addComponent(true, suffix);
         channel.writeAndFlush(new DefaultHttpContent(frame)).addListener((ChannelFutureListener) f -> {
+            if (!f.isSuccess()) channel.close();
+        });
+    }
+
+    private void doWriteComment(@Nullable String message) {
+        if (closed || !channel.isActive() || !started) return;
+        // SSE comment = a line starting with ':'. Flatten embedded line breaks so the message
+        // cannot inject extra SSE lines/events. Blank/null → bare ':' heartbeat.
+        String line = message == null || message.isBlank()
+                ? ":\r\n"
+                : ": " + message.replace('\r', ' ').replace('\n', ' ') + "\r\n";
+        var buf = ByteBufUtil.writeUtf8(channel.alloc(), line);
+        channel.writeAndFlush(new DefaultHttpContent(buf)).addListener((ChannelFutureListener) f -> {
             if (!f.isSuccess()) channel.close();
         });
     }


### PR DESCRIPTION
Updates keep-alive guidance for long-running tool calls, adds an example tool handler and e2e coverage for SSE upgrade and heartbeat behavior, and adjusts repository instructions and documentation around the same flow.


Verifies the lazy SSE upgrade and keep-alive path exercised when a tool emits `notifications/progress` or SSE comments: the first SSE message causes the POST response to upgrade to `text/event-stream`, and periodic reader-idle ticks emit `:\r\n` heartbeats rather than closing the channel.


```mermaid
sequenceDiagram
  participant McpClient
  participant TachyonServer
  participant ProgressHandler

  McpClient->>TachyonServer: POST /mcp
  TachyonServer->>ProgressHandler: invoke slow-progress tool
  ProgressHandler->>TachyonServer: ctx.notifications().progress(...)
  TachyonServer-->>McpClient: text/event-stream response
  TachyonServer-->>McpClient: SSE heartbeat comments
  ProgressHandler->>TachyonServer: ToolResult.text("done")
  TachyonServer->>McpClient: tool-call result: "done"
```
