### PR TITLE
chore: enable assertions in tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
 
         <!-- Test configuration -->
         <surefire.forkCount>1C</surefire.forkCount>
-        <argLine>--add-exports java.base/jdk.internal.ref=ALL-UNNAMED --add-exports java.base/sun.nio.ch=ALL-UNNAMED
+        <argLine>-ea --add-exports java.base/jdk.internal.ref=ALL-UNNAMED --add-exports java.base/sun.nio.ch=ALL-UNNAMED
             --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.lang.reflect=ALL-UNNAMED --add-opens
             java.base/java.io=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens
             java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.base/java.nio.channels.spi=ALL-UNNAMED

--- a/reports/pom.xml
+++ b/reports/pom.xml
@@ -35,6 +35,16 @@
             <artifactId>tachyon-server-kotlin</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>dev.tachyonmcp</groupId>
+            <artifactId>e2e</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>dev.tachyonmcp</groupId>
+            <artifactId>conformance</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
## Summary

- Enabled Java assertions during test runs to help catch issues earlier.
- Added additional test-related dependencies to expand validation coverage for the reports module.