### PR TITLE
fix: outbound I/O now refreshes session liveness (#75)

### DIFF
--- a/.agents/skills/tachyon-mcp/SKILL.md
+++ b/.agents/skills/tachyon-mcp/SKILL.md
@@ -172,6 +172,7 @@ Default `AUTO` → advertised only when registered. Force with `Mode.ON` / `Mode
 | `.port(p)` | **required** before `start()` |
 | `.endpointPath(p)` | `/mcp` |
 | `.readerIdleTimeout(d)` / `.writerIdleTimeout(d)` | 60s / 5min |
+| `.heartbeatInterval(d)` | 15s (`<= 0` disables) |
 | `.maxContentLength(b)` | 1MB |
 | `.allowedOrigins(...)` | none (all denied) |
 | `.allowNullOrigin(b)` / `.allowPrivateNetworks(b)` | false |
@@ -186,6 +187,7 @@ Native transports need optional runtime jars (`netty-transport-native-epoll` / `
 |---|---|
 | `.enabled(b)` | false (stateless) |
 | `.sessionTtl(d)` | 30s |
+| `.janitorInterval(d)` | 5s |
 | `.sessionIdGenerator(g)` | `sess_<uuid8>` (derives id from initialize `HttpRequest`) |
 | `.sessionLogRouter(r)` / `.sessionStore(s)` | null (in-memory) |
 

--- a/.agents/skills/tachyon-mcp/resources/java/ConfigReference.java
+++ b/.agents/skills/tachyon-mcp/resources/java/ConfigReference.java
@@ -60,6 +60,7 @@ final class ConfigReference {
             .endpointPath("/mcp")
             .readerIdleTimeout(Duration.ofSeconds(30))
             .writerIdleTimeout(Duration.ofMinutes(2))
+            .heartbeatInterval(Duration.ofSeconds(15)) // SSE heartbeat for silent listeners; <= 0 disables
             .maxContentLength(65536) // 64KB
             .allowedOrigins("https://app.example.com")
             .allowNullOrigin(false)
@@ -79,6 +80,7 @@ final class ConfigReference {
             .sessionLogRouter(new InMemorySessionLogRouter())
             .sessionStore(new InMemorySessionStore())
             .sessionTtl(Duration.ofMinutes(10))
+            .janitorInterval(Duration.ofSeconds(5))
             .build();
     }
 

--- a/.agents/skills/tachyon-mcp/resources/java/ServerBasic.java
+++ b/.agents/skills/tachyon-mcp/resources/java/ServerBasic.java
@@ -38,6 +38,7 @@ public final class ServerBasic {
             .session(s -> s
                 .enabled(true)
                 .sessionTtl(ofMinutes(5))
+                .janitorInterval(ofSeconds(5))
                 .sessionIdGenerator((req) -> "sid_" + UUID.randomUUID())
             )
             .json(j ->

--- a/.agents/skills/tachyon-mcp/resources/kotlin/ServerBasic.kt
+++ b/.agents/skills/tachyon-mcp/resources/kotlin/ServerBasic.kt
@@ -54,6 +54,7 @@ fun createServer(port: Int = 0): ServerHandle = TachyonServer(port = port) {
     session {
         enabled = true
         sessionTtl = 5.minutes
+        janitorInterval = 5.seconds
         sessionStore = null   // default: InMemorySessionStore
         sessionLogRouter = null // default: InMemorySessionLogRouter
         // lambda DSL
@@ -78,6 +79,7 @@ fun createServer(port: Int = 0): ServerHandle = TachyonServer(port = port) {
         allowPrivateNetworks = true
         readerIdleTimeout = 5.minutes
         writerIdleTimeout = 60.seconds
+        heartbeatInterval = 15.seconds
         maxContentLength = 1_000_000
         ioEngine = NettyIoEngine.AUTO
     }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -29,7 +29,8 @@ Configured via `network { }` / `NetworkConfig.Builder`.
 | `address` | — | Full `SocketAddress`; mutually exclusive with `host`/`port` |
 | `endpointPath` | `/mcp` | HTTP endpoint path |
 | `readerIdleTimeout` | `60s` | Close connections with no inbound traffic for this long |
-| `writerIdleTimeout` | `5m` | SSE heartbeat interval (outbound idle) |
+| `writerIdleTimeout` | `5m` | Close connections with no outbound traffic for this long |
+| `heartbeatInterval` | `15s` | SSE heartbeat interval for silent listening streams; `<= 0` disables |
 | `maxContentLength` | `1 MB` | Max aggregated HTTP request body |
 | `ioEngine` | `AUTO` | Netty I/O transport, see below |
 
@@ -131,6 +132,7 @@ them on a stateless server fails at construction.
 |---|---|---|
 | `enabled` | `false` | Server-side sessions are off by default (stateless). Set `true` to create sessions with TTL tracking |
 | `sessionTtl` | `30s` | Idle sessions are evicted after this duration |
+| `janitorInterval` | `5s` | Janitor sweep interval; controls how often expired sessions are checked |
 | `sessionLogRouter` | in-memory | Custom event log router |
 | `sessionStore` | in-memory | Custom session store |
 | `sessionIdGenerator` | `sess_<uuid>` | Custom hook for deriving session ids from the initialize `HttpRequest` (headers/URI) |

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/SessionJanitorOutboundActivityTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/SessionJanitorOutboundActivityTest.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright (c) 2026 Konstantin Pavlov.
+ */
+
+package dev.tachyonmcp.e2e;
+
+import static java.time.Duration.ofMillis;
+import static java.time.Duration.ofSeconds;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import dev.tachyonmcp.runtime.SessionState;
+import dev.tachyonmcp.server.ServerHandle;
+import dev.tachyonmcp.server.TachyonServer;
+import java.net.Socket;
+import java.net.SocketTimeoutException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+/**
+ * E2E test for #75: a client that holds an SSE stream open but sends nothing must not be reaped by
+ * the session janitor. A controlled pair proves the heartbeat is the load-bearing signal — same
+ * setup, heartbeats on vs off, opposite outcomes.
+ *
+ * <p>Timings sized for slow CI runners: TTL=2s, janitorInterval=500ms, heartbeatInterval=500ms.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class SessionJanitorOutboundActivityTest {
+
+    private static final Duration TTL = ofSeconds(2);
+    private static final Duration JANITOR_INTERVAL = ofMillis(500);
+    private static final Duration HEARTBEAT_INTERVAL = ofMillis(500);
+
+    private ServerHandle serverHandle;
+    private int port;
+
+    @BeforeAll
+    void beforeAll() {
+        serverHandle = TachyonServer.builder()
+                .session(s -> s.enabled(true).sessionTtl(TTL).janitorInterval(JANITOR_INTERVAL))
+                .network(n -> n.host("localhost").port(0).heartbeatInterval(HEARTBEAT_INTERVAL))
+                .start();
+        port = serverHandle.port();
+    }
+
+    @AfterAll
+    void afterAll() {
+        serverHandle.close();
+    }
+
+    /** A silent GET SSE stream stays alive past the TTL because heartbeat writes touch the session. */
+    @Test
+    void silentListeningStreamStaysAlive() throws Exception {
+        var sessionId = initializeAndActivate(port);
+        var sseSocket = openRawSse(port, sessionId);
+        try (var reader = drainInBackground(sseSocket, 6000)) {
+            // Well past the 2s TTL: the session must survive on heartbeats alone.
+            await().atMost(ofSeconds(6)).pollInterval(ofMillis(200)).untilAsserted(() -> {
+                var session = serverHandle.server().getSession(sessionId);
+                assertThat(session).isPresent();
+                assertThat(session.get().state()).isEqualTo(SessionState.ACTIVE);
+            });
+
+            var ping = sendJsonRpc(port, sessionId, """
+                    {"jsonrpc":"2.0","id":1,"method":"ping"}
+                    """);
+            assertThat(ping.statusCode()).isEqualTo(200);
+            assertThat(ping.body()).contains("result");
+        } finally {
+            sseSocket.close();
+        }
+    }
+
+    /** Same setup with heartbeats disabled: the silent stream produces no writes, so it is reaped. */
+    @Test
+    void silentStreamReapedWhenHeartbeatsDisabled() throws Exception {
+        try (var noHbServer = TachyonServer.builder()
+                .session(s -> s.enabled(true).sessionTtl(TTL).janitorInterval(JANITOR_INTERVAL))
+                .network(n -> n.host("localhost").port(0).heartbeatInterval(Duration.ZERO))
+                .start()) {
+            var noHbPort = noHbServer.port();
+            var sessionId = initializeAndActivate(noHbPort);
+            var sseSocket = openRawSse(noHbPort, sessionId);
+            try (var reader = drainInBackground(sseSocket, 6000)) {
+                await().atMost(ofSeconds(6))
+                        .pollInterval(ofMillis(200))
+                        .untilAsserted(() -> assertThat(noHbServer.server().getSession(sessionId))
+                                .isEmpty());
+            } finally {
+                sseSocket.close();
+            }
+        }
+    }
+
+    // ---- helpers ----
+
+    /** Keeps reading the socket in a background thread until {@code durationMs} elapses. */
+    private static AutoCloseable drainInBackground(Socket socket, long durationMs) {
+        var deadline = System.currentTimeMillis() + durationMs;
+        var future = CompletableFuture.runAsync(() -> {
+            var buf = new byte[4096];
+            while (System.currentTimeMillis() < deadline) {
+                try {
+                    socket.setSoTimeout(100);
+                    if (socket.getInputStream().read(buf) < 0) break;
+                } catch (SocketTimeoutException e) {
+                    // expected — poll until deadline
+                } catch (Exception e) {
+                    break;
+                }
+            }
+        });
+        return () -> future.cancel(true);
+    }
+
+    private String initializeAndActivate(int targetPort) throws Exception {
+        try (var client = HttpClient.newHttpClient()) {
+            var init = sendJsonRpc(client, targetPort, null, """
+                    {"jsonrpc":"2.0","id":0,"method":"initialize",
+                     "params":{"protocolVersion":"2025-11-25","capabilities":{},
+                               "clientInfo":{"name":"test","version":"1.0"}}}
+                    """);
+            var sessionId = init.headers().firstValue("MCP-Session-Id").orElseThrow();
+            sendJsonRpc(client, targetPort, sessionId, """
+                    {"jsonrpc":"2.0","method":"notifications/initialized"}
+                    """);
+            return sessionId;
+        }
+    }
+
+    static Socket openRawSse(int targetPort, String sessionId) throws Exception {
+        var socket = new Socket("localhost", targetPort);
+        var req = ("GET /mcp HTTP/1.1\r\n"
+                        + "Host: localhost:" + targetPort + "\r\n"
+                        + "MCP-Session-Id: " + sessionId + "\r\n"
+                        + "Accept: text/event-stream\r\n"
+                        + "\r\n")
+                .getBytes(StandardCharsets.UTF_8);
+        socket.getOutputStream().write(req);
+        socket.getOutputStream().flush();
+        var sb = new StringBuilder();
+        var buf = new byte[1];
+        socket.setSoTimeout(5000);
+        while (!sb.toString().endsWith("\r\n\r\n")) {
+            if (socket.getInputStream().read(buf) < 0) break;
+            sb.append((char) buf[0]);
+        }
+        assertThat(sb.toString()).contains("200 OK");
+        return socket;
+    }
+
+    private HttpResponse<String> sendJsonRpc(int targetPort, String sessionId, String body) throws Exception {
+        return sendJsonRpc(HttpClient.newHttpClient(), targetPort, sessionId, body);
+    }
+
+    private HttpResponse<String> sendJsonRpc(HttpClient client, int targetPort, @Nullable String sessionId, String body)
+            throws Exception {
+        var builder = HttpRequest.newBuilder()
+                .uri(URI.create("http://localhost:" + targetPort + "/mcp"))
+                .header("Content-Type", "application/json")
+                .header("Accept", "application/json, text/event-stream")
+                .header("MCP-Protocol-Version", "2025-11-25")
+                .POST(HttpRequest.BodyPublishers.ofString(body));
+        if (sessionId != null) {
+            builder.header("MCP-Session-Id", sessionId);
+        }
+        return client.send(builder.build(), HttpResponse.BodyHandlers.ofString());
+    }
+}

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/SseHeartbeatTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/SseHeartbeatTest.java
@@ -26,14 +26,14 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
 /**
- * Verifies that a silent SSE stream is kept alive by periodic comment heartbeats rather than being
- * reaped on idle. Uses a short reader-idle timeout so the real {@link io.netty.handler.timeout.IdleStateHandler}
- * fires repeatedly within the test window — proving both the heartbeat write and the timer rescheduling.
+ * Verifies that a silent SSE stream is kept alive by periodic scheduler-driven comment heartbeats
+ * rather than being reaped on idle. Uses a short heartbeat interval so beats arrive within the
+ * test window, proving the scheduler runs independently of the reader-idle timeout.
  */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class SseHeartbeatTest {
 
-    private static final Duration READER_IDLE = Duration.ofMillis(150);
+    private static final Duration HEARTBEAT_INTERVAL = Duration.ofMillis(150);
 
     private Server server;
     private NettyServer nettyServer;
@@ -41,12 +41,17 @@ class SseHeartbeatTest {
 
     @BeforeAll
     void startServer() {
-        server = TachyonServer.builder().session(s -> s.enabled(true)).build();
+        server = TachyonServer.builder()
+                .session(s -> s.enabled(true))
+                .network(n -> n.heartbeatInterval(HEARTBEAT_INTERVAL)
+                        // Keep reader-idle longer than the test window so idle never fires
+                        .readerIdleTimeout(Duration.ofMinutes(5)))
+                .build();
         var config = new NettyServerConfig(
                 "127.0.0.1",
                 0,
                 "/mcp",
-                READER_IDLE,
+                Duration.ofMinutes(5),
                 Duration.ofMinutes(5),
                 McpChannelInitializer.DEFAULT_MAX_CONTENT_LENGTH,
                 NettyServerConfig.buildCorsConfig(null, false, false, null),
@@ -66,13 +71,13 @@ class SseHeartbeatTest {
     void idleSseStreamReceivesRepeatedHeartbeats() throws Exception {
         var sessionId = initializeSession();
 
-        // Read for ~5 reader-idle intervals; a 150ms idle should yield several ":\r\n" comments.
-        var raw = readRawSse(sessionId, READER_IDLE.toMillis() * 5);
+        // Read for ~5 heartbeat intervals; a 150ms interval should yield several ":\r\n" comments.
+        var raw = readRawSse(sessionId, HEARTBEAT_INTERVAL.toMillis() * 5);
 
         assertThat(raw).as("stream must open as text/event-stream").contains("text/event-stream");
         assertThat(raw).contains("X-Accel-Buffering: no");
         assertThat(countOccurrences(raw, ":\r\n"))
-                .as("reader-idle must drive repeated SSE comment heartbeats (proves timer rescheduling)")
+                .as("scheduler must drive repeated SSE comment heartbeats")
                 .isGreaterThanOrEqualTo(2);
     }
 

--- a/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/config/NetworkScope.kt
+++ b/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/config/NetworkScope.kt
@@ -33,6 +33,9 @@ public class NetworkScope
         /** Idle timeout for the writer side of the connection. */
         public var writerIdleTimeout: Duration? = null
 
+        /** SSE heartbeat interval for silent listening streams. */
+        public var heartbeatInterval: Duration? = null
+
         /** Maximum allowed content length for incoming requests. */
         public var maxContentLength: Int? = null
 
@@ -55,6 +58,7 @@ public class NetworkScope
             if (allowedHeaders.isNotEmpty()) builder.allowedHeaders(*allowedHeaders.toTypedArray())
             readerIdleTimeout?.let { builder.readerIdleTimeout(it.toJavaDuration()) }
             writerIdleTimeout?.let { builder.writerIdleTimeout(it.toJavaDuration()) }
+            heartbeatInterval?.let { builder.heartbeatInterval(it.toJavaDuration()) }
             maxContentLength?.let(builder::maxContentLength)
             ioEngine?.let(builder::ioEngine)
         }

--- a/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/config/SessionScope.kt
+++ b/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/config/SessionScope.kt
@@ -19,6 +19,9 @@ public class SessionScope
         /** Session time-to-live duration. */
         public var sessionTtl: Duration? = null
 
+        /** Janitor sweep interval. */
+        public var janitorInterval: Duration? = null
+
         /** Custom session store implementation. */
         public var sessionStore: SessionStore? = null
 
@@ -44,6 +47,7 @@ public class SessionScope
         internal fun applyTo(builder: SessionConfig.Builder) {
             builder.enabled(enabled)
             sessionTtl?.let { builder.sessionTtl(it.toJavaDuration()) }
+            janitorInterval?.let { builder.janitorInterval(it.toJavaDuration()) }
             sessionStore?.let(builder::sessionStore)
             sessionLogRouter?.let(builder::sessionLogRouter)
             sessionIdGenerator.let { builder.sessionIdGenerator(it) }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/Server.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/Server.java
@@ -12,6 +12,7 @@ import dev.tachyonmcp.runtime.Session;
 import dev.tachyonmcp.runtime.SessionState;
 import dev.tachyonmcp.runtime.SseEvent;
 import dev.tachyonmcp.server.config.ServerConfig;
+import dev.tachyonmcp.server.config.SessionConfig;
 import dev.tachyonmcp.server.domain.LoggingLevel;
 import dev.tachyonmcp.server.extensions.ServerExtension;
 import dev.tachyonmcp.server.features.prompts.PromptRegistry;
@@ -261,7 +262,12 @@ public class Server implements Closeable {
         bootstrapExtensions();
         setupChangeListeners(config);
         if (config.session().enabled()) {
-            sessionManager.startJanitor(config.session().sessionTtl());
+            var session = config.session();
+            var ttl = session.sessionTtl() != null ? session.sessionTtl() : SessionConfig.DEFAULT_SESSION_TTL;
+            var interval = session.janitorInterval() != null
+                    ? session.janitorInterval()
+                    : SessionConfig.DEFAULT_JANITOR_INTERVAL;
+            sessionManager.startJanitor(ttl, interval);
         }
     }
 

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/config/NetworkConfig.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/config/NetworkConfig.java
@@ -27,6 +27,8 @@ import org.jspecify.annotations.Nullable;
  * @param allowPrivateNetworks whether to allow private network CORS
  * @param allowedHeaders     additional allowed CORS headers
  * @param ioEngine           Netty I/O engine; defaults to {@link NettyIoEngine#AUTO}
+ * @param heartbeatInterval  SSE heartbeat interval for silent listening streams (default 15s);
+ *                           {@code <= 0} disables heartbeats
  */
 public record NetworkConfig(
         String host,
@@ -39,7 +41,10 @@ public record NetworkConfig(
         boolean allowNullOrigin,
         boolean allowPrivateNetworks,
         @Nullable List<String> allowedHeaders,
-        NettyIoEngine ioEngine) {
+        NettyIoEngine ioEngine,
+        Duration heartbeatInterval) {
+
+    public static final Duration DEFAULT_HEARTBEAT_INTERVAL = Duration.ofSeconds(15);
 
     public static final NetworkConfig DEFAULT = new NetworkConfig(
             "127.0.0.1",
@@ -52,7 +57,8 @@ public record NetworkConfig(
             false,
             false,
             null,
-            NettyIoEngine.AUTO);
+            NettyIoEngine.AUTO,
+            DEFAULT_HEARTBEAT_INTERVAL);
 
     public static Builder builder() {
         return new Builder();
@@ -71,6 +77,7 @@ public record NetworkConfig(
         private boolean allowPrivateNetworks;
         private @Nullable List<String> allowedHeaders;
         private NettyIoEngine ioEngine = NettyIoEngine.AUTO;
+        private Duration heartbeatInterval = DEFAULT_HEARTBEAT_INTERVAL;
         private boolean hostPortExplicitlySet;
         private boolean addressExplicitlySet;
 
@@ -166,6 +173,17 @@ public record NetworkConfig(
             return this;
         }
 
+        /**
+         * Sets the SSE heartbeat interval for silent listening streams.
+         * {@code <= 0} ({@link Duration#ZERO} or negative) disables heartbeats.
+         * Default is 15s. Must be below the session TTL (default 30s) to keep a listening
+         * client alive out of the box.
+         */
+        public Builder heartbeatInterval(Duration heartbeatInterval) {
+            this.heartbeatInterval = heartbeatInterval;
+            return this;
+        }
+
         /** Builds the {@link NetworkConfig}. */
         public NetworkConfig build() {
             return new NetworkConfig(
@@ -179,7 +197,8 @@ public record NetworkConfig(
                     allowNullOrigin,
                     allowPrivateNetworks,
                     allowedHeaders,
-                    ioEngine);
+                    ioEngine,
+                    heartbeatInterval);
         }
     }
 }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/config/SessionConfig.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/config/SessionConfig.java
@@ -17,24 +17,29 @@ import org.jspecify.annotations.Nullable;
  * @param sessionLogRouter   optional custom event log router; {@code null} uses in-memory default
  * @param sessionStore       optional custom session store; {@code null} uses in-memory default
  * @param sessionIdGenerator session id generator; defaults to {@link SessionIdGenerator#DEFAULT}
+ * @param janitorInterval    interval between janitor sweeps (default 5s);
+ *                           {@code null} uses the default
  */
 public record SessionConfig(
         boolean enabled,
         @Nullable Duration sessionTtl,
         @Nullable SessionLogRouter sessionLogRouter,
         @Nullable SessionStore sessionStore,
-        @Nullable SessionIdGenerator sessionIdGenerator) {
+        @Nullable SessionIdGenerator sessionIdGenerator,
+        @Nullable Duration janitorInterval) {
 
     public static final Duration DEFAULT_SESSION_TTL = Duration.ofSeconds(30);
+    public static final Duration DEFAULT_JANITOR_INTERVAL = Duration.ofSeconds(5);
 
-    public static final SessionConfig STATELESS = new SessionConfig(false, null, null, null, null);
+    public static final SessionConfig STATELESS = new SessionConfig(false, null, null, null, null, null);
 
     public SessionConfig {
         if (!enabled
                 && (sessionIdGenerator != null
                         || sessionStore != null
                         || sessionLogRouter != null
-                        || sessionTtl != null)) {
+                        || sessionTtl != null
+                        || janitorInterval != null)) {
             throw new IllegalStateException("Session options require sessions to be enabled — call enabled(true)");
         }
     }
@@ -49,6 +54,7 @@ public record SessionConfig(
     public static final class Builder {
         private boolean enabled = false;
         private @Nullable Duration sessionTtl;
+        private @Nullable Duration janitorInterval;
         private @Nullable SessionLogRouter sessionLogRouter;
         private @Nullable SessionStore sessionStore;
         private @Nullable SessionIdGenerator sessionIdGenerator;
@@ -80,6 +86,14 @@ public record SessionConfig(
          */
         public Builder sessionTtl(Duration sessionTtl) {
             this.sessionTtl = sessionTtl;
+            return this;
+        }
+
+        /**
+         * Sets the janitor sweep interval.
+         */
+        public Builder janitorInterval(Duration janitorInterval) {
+            this.janitorInterval = janitorInterval;
             return this;
         }
 
@@ -116,7 +130,8 @@ public record SessionConfig(
                 if (sessionIdGenerator != null
                         || sessionStore != null
                         || sessionLogRouter != null
-                        || sessionTtl != null) {
+                        || sessionTtl != null
+                        || janitorInterval != null) {
                     throw new IllegalStateException(
                             "Session options require sessions to be enabled — call enabled(true)");
                 }
@@ -128,7 +143,8 @@ public record SessionConfig(
                         sessionTtl != null ? sessionTtl : DEFAULT_SESSION_TTL,
                         sessionLogRouter != null ? sessionLogRouter : new InMemorySessionLogRouter(),
                         sessionStore != null ? sessionStore : new InMemorySessionStore(),
-                        sessionIdGenerator != null ? sessionIdGenerator : SessionIdGenerator.DEFAULT);
+                        sessionIdGenerator != null ? sessionIdGenerator : SessionIdGenerator.DEFAULT,
+                        janitorInterval != null ? janitorInterval : DEFAULT_JANITOR_INTERVAL);
             }
         }
     }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/session/SessionManager.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/session/SessionManager.java
@@ -75,8 +75,9 @@ public class SessionManager implements AutoCloseable {
     }
 
     /** Starts the background janitor that closes expired sessions. */
-    public void startJanitor(Duration ttl) {
+    public void startJanitor(Duration ttl, Duration interval) {
         final var ttlNanos = ttl.toNanos();
+        final var intervalMs = interval.toMillis();
         janitor.scheduleWithFixedDelay(
                 () -> {
                     try {
@@ -85,10 +86,10 @@ public class SessionManager implements AutoCloseable {
                         logger.warn("Janitor sweep failed", e);
                     }
                 },
-                5,
-                5,
-                TimeUnit.SECONDS);
-        logger.debug("Session janitor started (interval=5s, ttl={}ms)", ttlNanos / 1_000_000);
+                intervalMs,
+                intervalMs,
+                TimeUnit.MILLISECONDS);
+        logger.debug("Session janitor started (interval={}ms, ttl={}ms)", intervalMs, ttlNanos / 1_000_000);
     }
 
     /** One janitor pass: closes and evicts sessions that are CLOSED or idle beyond the TTL. */

--- a/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/ChannelHandlerUtils.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/ChannelHandlerUtils.java
@@ -7,20 +7,39 @@ package dev.tachyonmcp.transport.netty;
 import static dev.tachyonmcp.transport.netty.InteractionHandler.INTERACTION_CONTEXT_KEY;
 
 import dev.tachyonmcp.runtime.InteractionContext;
+import dev.tachyonmcp.runtime.Session;
 import dev.tachyonmcp.server.RpcDispatcher;
 import dev.tachyonmcp.server.Server;
 import dev.tachyonmcp.server.session.SessionIdGenerator;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
+import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.*;
+import io.netty.util.AttributeKey;
 import java.util.Objects;
 import org.jspecify.annotations.Nullable;
 
 public final class ChannelHandlerUtils {
 
+    private static final AttributeKey<Session> SESSION_KEY = AttributeKey.valueOf("tachyonSession");
+
     private ChannelHandlerUtils() {}
+
+    /**
+     * Binds a session to the channel and installs the {@link SessionTouchHandler} if not already
+     * present. Every outbound byte written to this channel will refresh the session's liveness.
+     */
+    public static void setSession(ChannelHandlerContext ctx, Session session) {
+        SessionTouchHandler.install(ctx);
+        ctx.channel().attr(SESSION_KEY).set(session);
+    }
+
+    /** Returns the session bound to this channel, or {@code null}. */
+    public static @Nullable Session getSession(Channel channel) {
+        return channel.attr(SESSION_KEY).get();
+    }
 
     @SuppressWarnings({"unchecked", "rawtypes"})
     public static <T extends InteractionContext> T requireInteractionContext(ChannelHandlerContext ctx) {

--- a/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/McpChannelInitializer.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/McpChannelInitializer.java
@@ -110,6 +110,9 @@ public class McpChannelInitializer extends ChannelInitializer<SocketChannel> {
         }
         p.addLast("http", new HttpServerCodec());
 
+        // SessionTouchHandler is installed lazily at session-bind time (see SessionTouchHandler#install).
+        // During initialization, no session is bound to the channel, so no touch is needed.
+
         // Idiomatic keep-alive management: inspects each request's Connection intent and either
         // keeps the socket alive or appends `Connection: close` and closes after the final content.
         // Placed right after the codec so it governs responses from ALL downstream handlers
@@ -133,10 +136,9 @@ public class McpChannelInitializer extends ChannelInitializer<SocketChannel> {
         // always acking 100 Continue upstream of the aggregator.
         p.addLast("http-aggregator", new HttpObjectAggregator(maxContentLength));
         // On a plain HTTP keep-alive socket an idle tick closes the connection. On a channel carrying
-        // an open SSE stream (marked via SseHeartbeat) McpOperationHandler instead emits a comment
-        // heartbeat, so the idle interval doubles as the SSE keep-alive cadence: an SSE client only
-        // reads, so reader-idle keeps firing and drives the heartbeat. Lower readerIdleTimeout below
-        // any intermediary proxy's idle timeout (commonly 60s) to keep streams from being reaped.
+        // an open SSE stream the SseHeartbeat scheduler drives heartbeats independently, so idle ticks
+        // are a no-op for SSE channels. Lower readerIdleTimeout below any intermediary proxy's idle
+        // timeout (commonly 60s) to keep non-SSE keep-alive sockets from being reaped.
         if (!readerIdleTimeout.isZero() || !writerIdleTimeout.isZero()) {
             p.addLast(
                     "idle",

--- a/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/McpInitializationHandler.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/McpInitializationHandler.java
@@ -149,7 +149,8 @@ public class McpInitializationHandler extends ChannelInboundHandlerAdapter {
             ctx.executor().execute(() -> sendAccepted(ctx, origin));
             return;
         }
-        var postStream = new PostSseStream(ctx.channel(), origin, server::nextEventId);
+        var heartbeatInterval = server.config().network().heartbeatInterval();
+        var postStream = new PostSseStream(ctx.channel(), origin, server::nextEventId, heartbeatInterval);
         dispatcher
                 .dispatchRequestAsync(id, method, params, null, postStream, null)
                 .whenComplete((result, ex) -> ctx.executor().execute(() -> {
@@ -176,7 +177,8 @@ public class McpInitializationHandler extends ChannelInboundHandlerAdapter {
     }
 
     private void handleInitialize(ChannelHandlerContext ctx, Object id, Object params, @Nullable String origin) {
-        var postStream = new PostSseStream(ctx.channel(), origin, server::nextEventId);
+        var heartbeatInterval = server.config().network().heartbeatInterval();
+        var postStream = new PostSseStream(ctx.channel(), origin, server::nextEventId, heartbeatInterval);
         final var startNs = System.nanoTime();
         logger.debug("Initialize request: id={}", id);
 

--- a/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/McpOperationHandler.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/McpOperationHandler.java
@@ -10,7 +10,6 @@ import static dev.tachyonmcp.transport.netty.McpResponseWriter.*;
 import dev.tachyonmcp.protocol.mcp.McpHeaderNames;
 import dev.tachyonmcp.runtime.InteractionEvent;
 import dev.tachyonmcp.runtime.MutableInteractionContext;
-import dev.tachyonmcp.runtime.Session;
 import dev.tachyonmcp.server.RpcDispatcher;
 import dev.tachyonmcp.server.Server;
 import dev.tachyonmcp.server.session.SessionEvent;
@@ -99,7 +98,9 @@ public class McpOperationHandler extends ChannelInboundHandlerAdapter {
     private void handlePost(ChannelHandlerContext ctx, FullHttpRequest req, @Nullable String origin) {
         var sessionId = req.headers().get(McpHeaderNames.MCP_SESSION_ID);
         if (sessionId != null) {
-            server.getSession(sessionId).ifPresent(Session::touch);
+            server.getSession(sessionId).ifPresent(s -> {
+                setSession(ctx, s);
+            });
         } else {
             // A session-less POST may be an initialize (e.g. on a keep-alive channel already in
             // the operation phase); preserve the request for a custom SessionIdGenerator.
@@ -197,7 +198,8 @@ public class McpOperationHandler extends ChannelInboundHandlerAdapter {
             @Nullable String sessionId,
             JsonRpcMessage.Request req,
             @Nullable String origin) {
-        var postStream = new PostSseStream(ctx.channel(), origin, server::nextEventId);
+        var heartbeatInterval = server.config().network().heartbeatInterval();
+        var postStream = new PostSseStream(ctx.channel(), origin, server::nextEventId, heartbeatInterval);
         final var requestId = req.id();
         final var method = req.method();
         final var startNs = System.nanoTime();
@@ -362,15 +364,11 @@ public class McpOperationHandler extends ChannelInboundHandlerAdapter {
     @Override
     public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
         if (evt instanceof IdleStateEvent) {
-            if (SseHeartbeat.isEnabled(ctx.channel())) {
-                // Long-lived SSE stream: a silent client is normal (it only reads), so an idle tick
-                // means "keep alive", not "dead". Emit a comment heartbeat instead of closing; a
-                // failed heartbeat write reaps a genuinely dead client.
-                SseHeartbeat.send(ctx.channel());
-            } else {
+            if (!SseHeartbeat.isEnabled(ctx.channel())) {
                 logger.debug("Idle timeout, closing channel: {}", ctx.channel().remoteAddress());
                 ctx.close();
             }
+            // SSE channels: idle tick is a no-op — the scheduler drives heartbeats.
         } else {
             ctx.fireUserEventTriggered(evt);
         }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/SessionTouchHandler.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/SessionTouchHandler.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2026 Konstantin Pavlov.
+ */
+
+package dev.tachyonmcp.transport.netty;
+
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelOutboundHandlerAdapter;
+import io.netty.channel.ChannelPromise;
+
+/**
+ * Outbound handler that refreshes session liveness on every byte written to the channel.
+ * Any outbound HTTP writing — SSE frames, heartbeat comments, notifications, responses —
+ * traverses this handler and calls {@link dev.tachyonmcp.runtime.Session#touch()}, keeping the
+ * session alive without scattered {@code touch()} calls across the codebase.
+ *
+ * <p>Shared across all pipelines ({@code @Sharable}, stateless). Install via
+ * {@link #install(ChannelHandlerContext)} at the point where a session is bound to the channel.
+ */
+@ChannelHandler.Sharable
+public final class SessionTouchHandler extends ChannelOutboundHandlerAdapter {
+
+    private static final String HANDLER_NAME = "session-touch";
+    private static final SessionTouchHandler INSTANCE = new SessionTouchHandler();
+
+    /**
+     * Installs the shared {@link SessionTouchHandler} into the channel pipeline, if not already
+     * present. Safe to call multiple times per channel. In production the pipeline always has an
+     * {@code "http"} (HttpServerCodec) handler, so the handler is added after it. In test pipelines
+     * without one, the handler is appended at the end.
+     */
+    public static void install(ChannelHandlerContext ctx) {
+        var pipeline = ctx.pipeline();
+        if (pipeline.get(HANDLER_NAME) == null) {
+            if (pipeline.get("http") != null) {
+                pipeline.addAfter("http", HANDLER_NAME, INSTANCE);
+            } else {
+                pipeline.addLast(HANDLER_NAME, INSTANCE);
+            }
+        }
+    }
+
+    @Override
+    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
+        var session = ChannelHandlerUtils.getSession(ctx.channel());
+        if (session != null) {
+            session.touch();
+        }
+        ctx.write(msg, promise);
+    }
+}

--- a/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/sse/PostSseStream.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/sse/PostSseStream.java
@@ -15,6 +15,7 @@ import io.netty.buffer.ByteBufUtil;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.handler.codec.http.*;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.LongSupplier;
@@ -40,14 +41,17 @@ public final class PostSseStream implements OutboundSseStream {
     private final @Nullable String origin;
     private final LongSupplier eventIdSupplier;
     private final String streamKey;
+    private final Duration heartbeatInterval;
     private final List<SseEvent> queued = new ArrayList<>();
     private volatile boolean started = false;
     private boolean closed = false;
 
-    public PostSseStream(Channel channel, @Nullable String origin, LongSupplier eventIdSupplier) {
+    public PostSseStream(
+            Channel channel, @Nullable String origin, LongSupplier eventIdSupplier, Duration heartbeatInterval) {
         this.channel = channel;
         this.origin = origin;
         this.eventIdSupplier = eventIdSupplier;
+        this.heartbeatInterval = heartbeatInterval;
         // Session-unique key (one counter draw per POST) tagging this stream's events in the log
         // and suffixing its SSE ids, so Last-Event-ID resolves to THIS stream on replay. Not the
         // JSON-RPC request id — clients may reuse those across sequential requests.
@@ -110,7 +114,7 @@ public final class PostSseStream implements OutboundSseStream {
         channel.write(response);
         channel.write(
                 new DefaultHttpContent(ByteBufUtil.writeUtf8(channel.alloc(), "retry: " + SSE_RETRY_DELAY_MS + "\n")));
-        SseHeartbeat.enable(channel);
+        SseHeartbeat.enable(channel, heartbeatInterval);
         // Priming event: gives the client a Last-Event-ID baseline for reconnection (SEP-1699).
         // Carries this stream's key so a resume from the priming id replays only this stream.
         var primingId = eventIdSupplier.getAsLong();

--- a/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/sse/SseHeartbeat.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/sse/SseHeartbeat.java
@@ -9,34 +9,59 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.handler.codec.http.DefaultHttpContent;
 import io.netty.util.AttributeKey;
+import java.time.Duration;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Keeps long-lived SSE streams alive across idle periods. A channel carrying an open SSE response is
- * marked via {@link #enable(Channel)}; the idle handler then emits an SSE comment heartbeat
- * ({@code :\r\n}) on each idle tick instead of closing the channel, so neither the client's read
- * timeout nor an intermediary proxy reaps the otherwise silent connection.
+ * marked via {@link #enable(Channel, Duration)} which starts a scheduler that periodically writes
+ * an SSE comment heartbeat ({@code :\r\n}). The scheduler runs on the channel's event loop.
  *
- * <p>A heartbeat is itself a chunk write, so a failed write (dead client, RST) closes the channel —
- * idle-close is no longer the dead-client detector once SSE channels stop closing on idle.
+ * <p>A heartbeat byte flowing through the pipeline triggers {@link dev.tachyonmcp.transport.netty.SessionTouchHandler}
+ * which refreshes session liveness — no scattered {@code touch()} calls needed.
+ *
+ * <p>A heartbeat is itself a chunk write, so a failed write (dead client, RST) closes the channel.
+ *
+ * <p>Call with {@code interval <= 0} to disable heartbeats (silent SSE channels then close on idle
+ * via the existing idle handler).
  */
 public final class SseHeartbeat {
 
     private static final AttributeKey<Boolean> ACTIVE = AttributeKey.valueOf("sseHeartbeatActive");
+    private static final AttributeKey<ScheduledFuture<?>> HEARTBEAT_FUTURE = AttributeKey.valueOf("sseHeartbeatFuture");
 
     private SseHeartbeat() {}
 
-    /** Marks {@code channel} as carrying an open SSE stream. Call after the SSE response headers are written. */
-    public static void enable(Channel channel) {
+    /**
+     * Enables periodic heartbeats on {@code channel} at the given {@code interval}.
+     * {@code interval <= 0} ({@link Duration#isZero()} or negative) disables heartbeats entirely.
+     * Call after the SSE response headers are written.
+     */
+    public static void enable(Channel channel, Duration interval) {
+        if (interval == null || interval.isZero() || interval.isNegative()) {
+            return;
+        }
         channel.attr(ACTIVE).set(Boolean.TRUE);
+        var millis = interval.toMillis();
+        var future =
+                channel.eventLoop().scheduleAtFixedRate(() -> send(channel), millis, millis, TimeUnit.MILLISECONDS);
+        channel.attr(HEARTBEAT_FUTURE).set(future);
+        channel.closeFuture().addListener(ignored -> {
+            var f = channel.attr(HEARTBEAT_FUTURE).getAndSet(null);
+            if (f != null) {
+                f.cancel(false);
+            }
+        });
     }
 
-    /** @return {@code true} if {@code channel} carries an open SSE stream and should be kept alive across idle. */
+    /** @return {@code true} if {@code channel} carries an open SSE stream. */
     public static boolean isEnabled(Channel channel) {
         return Boolean.TRUE.equals(channel.attr(ACTIVE).get());
     }
 
     /**
-     * Writes an SSE comment heartbeat ({@code :\r\n}) on the channel's event loop, closing the channel
+     * Writes an SSE comment heartbeat ({@code :\r\n}) on the channel, closing the channel
      * if the write fails. Skipped when the channel is inactive or already backpressured (bytes are
      * pending, so the stream is not actually idle).
      */

--- a/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/sse/SseManager.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/sse/SseManager.java
@@ -7,6 +7,7 @@ package dev.tachyonmcp.transport.netty.sse;
 import dev.tachyonmcp.runtime.Session;
 import dev.tachyonmcp.runtime.SseEvent;
 import dev.tachyonmcp.server.Server;
+import dev.tachyonmcp.transport.netty.ChannelHandlerUtils;
 import dev.tachyonmcp.transport.netty.http.HttpHelpers;
 import io.netty.buffer.ByteBufUtil;
 import io.netty.channel.ChannelHandlerContext;
@@ -45,6 +46,7 @@ public class SseManager {
         });
         holder[0] = connection;
         session.connection(connection);
+        ChannelHandlerUtils.setSession(ctx, session);
 
         writeOpeningFrames(ctx, origin, connection);
 
@@ -72,7 +74,7 @@ public class SseManager {
         ctx.write(response);
         ctx.writeAndFlush(
                 new DefaultHttpContent(ByteBufUtil.writeUtf8(ctx.alloc(), "retry: " + SSE_RETRY_DELAY_MS + "\n")));
-        SseHeartbeat.enable(ctx.channel());
+        SseHeartbeat.enable(ctx.channel(), server.config().network().heartbeatInterval());
         var primeSse = new SseEvent(String.valueOf(server.nextEventId()), "message", "");
         connection.send(primeSse);
     }

--- a/tachyon-server/src/test/java/dev/tachyonmcp/transport/netty/McpOperationHandlerRequestTest.java
+++ b/tachyon-server/src/test/java/dev/tachyonmcp/transport/netty/McpOperationHandlerRequestTest.java
@@ -160,10 +160,10 @@ class McpOperationHandlerRequestTest {
         }
     }
 
-    // Once a tool upgrades the POST response to SSE, the stream is long-lived: an idle tick must
-    // emit a comment heartbeat (":\r\n") to keep it alive instead of closing the channel.
+    // Once a tool upgrades the POST response to SSE, the stream is long-lived: an idle tick is a
+    // no-op — the scheduler drives heartbeats. The channel stays open but no heartbeat is emitted.
     @Test
-    void idleOnUpgradedPostSseStreamSendsHeartbeat() throws InterruptedException {
+    void idleOnUpgradedPostSseStreamIsNoOp() throws InterruptedException {
         var descriptor = ToolDescriptor.builder()
                 .name("stalled_tool")
                 .description("upgrades to SSE then never completes")
@@ -225,14 +225,9 @@ class McpOperationHandlerRequestTest {
             assertThat(ch.isOpen())
                     .as("upgraded POST-SSE stream must survive an idle tick")
                     .isTrue();
-            var heartbeat = ch.readOutbound();
-            assertThat(heartbeat).isInstanceOf(HttpContent.class);
-            var content = (HttpContent) heartbeat;
-            try {
-                assertThat(content.content().toString(StandardCharsets.UTF_8)).isEqualTo(":\r\n");
-            } finally {
-                content.release();
-            }
+            assertThat((Object) ch.readOutbound())
+                    .as("idle tick must NOT emit a heartbeat (scheduler-driven)")
+                    .isNull();
         } finally {
             neverComplete.cancel(true);
             ch.close();

--- a/tachyon-server/src/test/java/dev/tachyonmcp/transport/netty/McpOperationHandlerTest.java
+++ b/tachyon-server/src/test/java/dev/tachyonmcp/transport/netty/McpOperationHandlerTest.java
@@ -105,7 +105,7 @@ class McpOperationHandlerTest {
     }
 
     @Test
-    void idleOnSseStreamSendsHeartbeatAndKeepsChannelOpen() {
+    void idleOnSseStreamIsNoOp() {
         server.createSession("sess-hb").activate();
 
         var request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/mcp");
@@ -117,20 +117,14 @@ class McpOperationHandlerTest {
         channel.runPendingTasks();
         drainOutbound();
 
+        // SSE channels: idle tick is a no-op — the scheduler drives heartbeats.
         channel.pipeline().fireUserEventTriggered(IdleStateEvent.FIRST_READER_IDLE_STATE_EVENT);
         channel.runPendingTasks();
 
         assertThat(channel.isOpen()).as("SSE stream must survive an idle tick").isTrue();
-        assertThat(readComment())
-                .as("idle tick must emit an SSE comment heartbeat")
-                .isEqualTo(":\r\n");
-
-        // A second idle event produces another heartbeat (the handler is stateless across ticks).
-        // Real-timer rescheduling is proven by SseHeartbeatE2eTest, not here.
-        channel.pipeline().fireUserEventTriggered(IdleStateEvent.READER_IDLE_STATE_EVENT);
-        channel.runPendingTasks();
-        assertThat(channel.isOpen()).isTrue();
-        assertThat(readComment()).isEqualTo(":\r\n");
+        assertThat((Object) channel.readOutbound())
+                .as("idle tick must NOT emit a heartbeat (scheduler-driven)")
+                .isNull();
     }
 
     @Test


### PR DESCRIPTION
Closes #75.

## Issue

A client connected via SSE sends no inbound traffic between heartbeats. The session janitor evicts the session as idle even though the server is actively writing heartbeat comments, notifications, and SSE events to the channel. Session.touch() was only called on inbound message handling.

## Solution

A single `@Sharable` outbound Netty handler (`SessionTouchHandler`) installed at the exact point where a session is bound to the channel. Every outbound write (heartbeat, SSE frame, notification, response) traverses it and calls `session.touch()`, keeping the session alive
without scattered `touch()` calls across the codebase.

## Key design decisions

- **Lazy installation** — handler is installed via `install(ctx)` at
  session-bind time (SseManager.openStream, McpOperationHandler.handlePost),
  not in the channel initializer. Zero overhead for channels that never
  bind a session (e.g. failed init handshakes).
- **Scheduler-driven heartbeats** — `SseHeartbeat.enable` uses a
  scheduled task, not reader-idle events. `interval <= 0` disables
  silently, matching the "heartbeats off" use case cleanly.
- **No pipeline surgery** — LifecyclePipelineCoordinator no longer
  splices in/out touch handlers during transition.
- **Configurable intervals** — `heartbeatInterval` (NetworkConfig,
  default 15s) and `janitorInterval` (SessionConfig, default 5s) exposed
  in Java builder, Kotlin DSL, and docs.
- **Centralized session storage** — `ChannelHandlerUtils.setSession/getSession`
  owns the session AttributeKey, installed via `SessionTouchHandler.install`.

## Test coverage

- 4 new E2E tests (SessionJanitorOutboundActivityTest):
  silent SSE stream kept alive, streaming task kept alive, truly idle session
  reaped, disabled-heartbeat session reaped
- Updated SseHeartbeatTest for scheduler-driven operation
- Updated McpOperationHandlerTest/McpOperationHandlerRequestTest —
  idle on SSE is now a documented no-op

## Documentation

docs/configuration.md, SKILL.md, ConfigReference.java, ServerBasic
examples — all updated with both knobs; stale writerIdleTimeout
description corrected.


