### PR TITLE
fix: : Config consolidation + immutability hardening (#77)

### DIFF
--- a/.agents/skills/tachyon-mcp/SKILL.md
+++ b/.agents/skills/tachyon-mcp/SKILL.md
@@ -2,7 +2,7 @@
 name: tachyon-mcp
 description: Build MCP (Model Context Protocol) servers using the [Tachyon MCP](https://github.com/kpavlov/tachyon).
 compatibility: Designed for Claude Code on JDK 21+ projects
-version: 1.0.0-beta.6
+version: 1.0.0-beta.7
 metadata:
     author: Konstantin Pavlov
 ---

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/Server.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/Server.java
@@ -12,7 +12,6 @@ import dev.tachyonmcp.runtime.Session;
 import dev.tachyonmcp.runtime.SessionState;
 import dev.tachyonmcp.runtime.SseEvent;
 import dev.tachyonmcp.server.config.ServerConfig;
-import dev.tachyonmcp.server.config.SessionConfig;
 import dev.tachyonmcp.server.domain.LoggingLevel;
 import dev.tachyonmcp.server.extensions.ServerExtension;
 import dev.tachyonmcp.server.features.prompts.PromptRegistry;
@@ -263,11 +262,9 @@ public class Server implements Closeable {
         setupChangeListeners(config);
         if (config.session().enabled()) {
             var session = config.session();
-            var ttl = session.sessionTtl() != null ? session.sessionTtl() : SessionConfig.DEFAULT_SESSION_TTL;
-            var interval = session.janitorInterval() != null
-                    ? session.janitorInterval()
-                    : SessionConfig.DEFAULT_JANITOR_INTERVAL;
-            sessionManager.startJanitor(ttl, interval);
+            assert session.sessionTtl() != null : "compact ctor fills ttl when enabled";
+            assert session.janitorInterval() != null : "compact ctor fills janitor when enabled";
+            sessionManager.startJanitor(session.sessionTtl(), session.janitorInterval());
         }
     }
 

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/config/NetworkConfig.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/config/NetworkConfig.java
@@ -44,14 +44,28 @@ public record NetworkConfig(
         NettyIoEngine ioEngine,
         Duration heartbeatInterval) {
 
+    public NetworkConfig {
+        if (allowedOrigins != null) {
+            allowedOrigins = List.copyOf(allowedOrigins);
+        }
+        if (allowedHeaders != null) {
+            allowedHeaders = List.copyOf(allowedHeaders);
+        }
+    }
+
+    public static final String DEFAULT_HOST = "127.0.0.1";
+    public static final int UNSET_PORT = -1;
+    public static final String DEFAULT_ENDPOINT_PATH = "/mcp";
+    public static final Duration DEFAULT_READER_IDLE_TIMEOUT = Duration.ofSeconds(60);
+    public static final Duration DEFAULT_WRITER_IDLE_TIMEOUT = Duration.ofMinutes(5);
     public static final Duration DEFAULT_HEARTBEAT_INTERVAL = Duration.ofSeconds(15);
 
     public static final NetworkConfig DEFAULT = new NetworkConfig(
-            "127.0.0.1",
-            -1,
-            "/mcp",
-            Duration.ofSeconds(60),
-            Duration.ofMinutes(5),
+            DEFAULT_HOST,
+            UNSET_PORT,
+            DEFAULT_ENDPOINT_PATH,
+            DEFAULT_READER_IDLE_TIMEOUT,
+            DEFAULT_WRITER_IDLE_TIMEOUT,
             McpChannelInitializer.DEFAULT_MAX_CONTENT_LENGTH,
             null,
             false,
@@ -66,11 +80,11 @@ public record NetworkConfig(
 
     /** Builder for {@link NetworkConfig}. */
     public static final class Builder {
-        private String host = "127.0.0.1";
-        private int port = -1;
-        private String endpointPath = "/mcp";
-        private Duration readerIdleTimeout = Duration.ofSeconds(60);
-        private Duration writerIdleTimeout = Duration.ofMinutes(5);
+        private String host = DEFAULT_HOST;
+        private int port = UNSET_PORT;
+        private String endpointPath = DEFAULT_ENDPOINT_PATH;
+        private Duration readerIdleTimeout = DEFAULT_READER_IDLE_TIMEOUT;
+        private Duration writerIdleTimeout = DEFAULT_WRITER_IDLE_TIMEOUT;
         private int maxContentLength = McpChannelInitializer.DEFAULT_MAX_CONTENT_LENGTH;
         private @Nullable List<String> allowedOrigins;
         private boolean allowNullOrigin;

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/config/ServerIdentity.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/config/ServerIdentity.java
@@ -37,6 +37,9 @@ public record ServerIdentity(
     public ServerIdentity {
         Objects.requireNonNull(name, "name cannot be null");
         Objects.requireNonNull(version, "version cannot be null");
+        if (icons != null) {
+            icons = List.copyOf(icons);
+        }
     }
 
     public static ServerIdentityBuilder builder() {

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/config/SessionConfig.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/config/SessionConfig.java
@@ -34,13 +34,18 @@ public record SessionConfig(
     public static final SessionConfig STATELESS = new SessionConfig(false, null, null, null, null, null);
 
     public SessionConfig {
-        if (!enabled
-                && (sessionIdGenerator != null
-                        || sessionStore != null
-                        || sessionLogRouter != null
-                        || sessionTtl != null
-                        || janitorInterval != null)) {
-            throw new IllegalStateException("Session options require sessions to be enabled — call enabled(true)");
+        if (!enabled) {
+            if (sessionIdGenerator != null
+                    || sessionStore != null
+                    || sessionLogRouter != null
+                    || sessionTtl != null
+                    || janitorInterval != null) {
+                throw new IllegalStateException("Session options require sessions to be enabled — call enabled(true)");
+            }
+        } else {
+            if (sessionTtl == null) sessionTtl = DEFAULT_SESSION_TTL;
+            if (janitorInterval == null) janitorInterval = DEFAULT_JANITOR_INTERVAL;
+            if (sessionIdGenerator == null) sessionIdGenerator = SessionIdGenerator.DEFAULT;
         }
     }
 
@@ -140,11 +145,11 @@ public record SessionConfig(
             } else {
                 return new SessionConfig(
                         enabled,
-                        sessionTtl != null ? sessionTtl : DEFAULT_SESSION_TTL,
+                        sessionTtl,
                         sessionLogRouter != null ? sessionLogRouter : new InMemorySessionLogRouter(),
                         sessionStore != null ? sessionStore : new InMemorySessionStore(),
-                        sessionIdGenerator != null ? sessionIdGenerator : SessionIdGenerator.DEFAULT,
-                        janitorInterval != null ? janitorInterval : DEFAULT_JANITOR_INTERVAL);
+                        sessionIdGenerator,
+                        janitorInterval);
             }
         }
     }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/NettyServerConfig.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/NettyServerConfig.java
@@ -4,6 +4,7 @@
 
 package dev.tachyonmcp.transport.netty;
 
+import dev.tachyonmcp.server.config.NetworkConfig;
 import io.netty.channel.ChannelPipeline;
 import io.netty.handler.codec.http.cors.CorsConfig;
 import io.netty.handler.codec.http.cors.CorsConfigBuilder;
@@ -46,25 +47,16 @@ public record NettyServerConfig(
     }
 
     static NettyServerConfig defaults(int port) {
-        return new NettyServerConfig(
-                "127.0.0.1",
-                port,
-                "/mcp",
-                Duration.ofSeconds(60),
-                Duration.ofMinutes(5),
-                McpChannelInitializer.DEFAULT_MAX_CONTENT_LENGTH,
-                buildCorsConfig(null, false, false, null),
-                NettyIoEngine.AUTO,
-                null);
+        return defaults(NetworkConfig.DEFAULT_HOST, port);
     }
 
     static NettyServerConfig defaults(String host, int port) {
         return new NettyServerConfig(
                 host,
                 port,
-                "/mcp",
-                Duration.ofSeconds(60),
-                Duration.ofMinutes(5),
+                NetworkConfig.DEFAULT_ENDPOINT_PATH,
+                NetworkConfig.DEFAULT_READER_IDLE_TIMEOUT,
+                NetworkConfig.DEFAULT_WRITER_IDLE_TIMEOUT,
                 McpChannelInitializer.DEFAULT_MAX_CONTENT_LENGTH,
                 buildCorsConfig(null, false, false, null),
                 NettyIoEngine.AUTO,

--- a/tachyon-server/src/test/java/dev/tachyonmcp/server/config/NetworkConfigTest.java
+++ b/tachyon-server/src/test/java/dev/tachyonmcp/server/config/NetworkConfigTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2026 Konstantin Pavlov.
+ */
+
+package dev.tachyonmcp.server.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import dev.tachyonmcp.transport.netty.McpChannelInitializer;
+import dev.tachyonmcp.transport.netty.NettyIoEngine;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies {@link NetworkConfig} defaults, builder validation, and immutability of collection
+ * fields — a built config must never expose a mutable collection to callers.
+ *
+ * @author Konstantin Pavlov
+ */
+class NetworkConfigTest {
+
+    @Test
+    void usesDefaults() {
+        var config = NetworkConfig.builder().build();
+
+        assertThat(config.host()).isEqualTo("127.0.0.1");
+        assertThat(config.port()).isEqualTo(-1);
+        assertThat(config.endpointPath()).isEqualTo("/mcp");
+        assertThat(config.readerIdleTimeout()).isEqualTo(Duration.ofSeconds(60));
+        assertThat(config.writerIdleTimeout()).isEqualTo(Duration.ofMinutes(5));
+        assertThat(config.maxContentLength()).isEqualTo(McpChannelInitializer.DEFAULT_MAX_CONTENT_LENGTH);
+        assertThat(config.allowedOrigins()).isNull();
+        assertThat(config.allowNullOrigin()).isFalse();
+        assertThat(config.allowPrivateNetworks()).isFalse();
+        assertThat(config.allowedHeaders()).isNull();
+        assertThat(config.ioEngine()).isEqualTo(NettyIoEngine.AUTO);
+        assertThat(config.heartbeatInterval()).isEqualTo(Duration.ofSeconds(15));
+    }
+
+    @Test
+    void allowedOriginsViaBuilderIsUnmodifiable() {
+        var config = NetworkConfig.builder()
+                .allowedOrigins("http://localhost", "http://127.0.0.1")
+                .build();
+
+        assertThat(config.allowedOrigins()).containsExactly("http://localhost", "http://127.0.0.1");
+        assertThatThrownBy(() -> config.allowedOrigins().add("http://evil.com"))
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void allowedHeadersViaBuilderIsUnmodifiable() {
+        var config = NetworkConfig.builder().allowedHeaders("X-Custom").build();
+
+        assertThat(config.allowedHeaders()).containsExactly("X-Custom");
+        assertThatThrownBy(() -> config.allowedHeaders().add("X-Evil"))
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void directConstructionWithMutableListIsDefended() {
+        var origins = new ArrayList<>(List.of("http://example.com"));
+        var headers = new ArrayList<>(List.of("X-Foo"));
+        var config = new NetworkConfig(
+                "127.0.0.1",
+                8080,
+                "/mcp",
+                Duration.ofSeconds(60),
+                Duration.ofMinutes(5),
+                McpChannelInitializer.DEFAULT_MAX_CONTENT_LENGTH,
+                origins,
+                false,
+                false,
+                headers,
+                NettyIoEngine.AUTO,
+                Duration.ofSeconds(15));
+
+        // Mutating the original lists must not affect the config
+        origins.add("http://evil.com");
+        headers.add("X-Evil");
+
+        assertThat(config.allowedOrigins()).containsExactly("http://example.com");
+        assertThat(config.allowedHeaders()).containsExactly("X-Foo");
+    }
+
+    @Test
+    void rejectsNonPositiveMaxContentLength() {
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> NetworkConfig.builder().maxContentLength(0))
+                .withMessage("maxContentLength must be positive");
+
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> NetworkConfig.builder().maxContentLength(-1))
+                .withMessage("maxContentLength must be positive");
+    }
+
+    @Test
+    void buildsDistinctConfigs() {
+        var config1 = NetworkConfig.builder().port(8080).build();
+        var config2 = NetworkConfig.builder().port(9090).build();
+
+        assertThat(config1).isNotSameAs(config2);
+        assertThat(config1.port()).isEqualTo(8080);
+        assertThat(config2.port()).isEqualTo(9090);
+    }
+}

--- a/tachyon-server/src/test/java/dev/tachyonmcp/server/config/RuntimeConfigTest.java
+++ b/tachyon-server/src/test/java/dev/tachyonmcp/server/config/RuntimeConfigTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026 Konstantin Pavlov.
+ */
+
+package dev.tachyonmcp.server.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies {@link RuntimeConfig} defaults and builder null rejection.
+ *
+ * @author Konstantin Pavlov
+ */
+class RuntimeConfigTest {
+
+    @Test
+    void usesDefaults() {
+        var config = RuntimeConfig.builder().build();
+
+        assertThat(config.shutdownGracePeriod()).isEqualTo(Duration.ofSeconds(5));
+        assertThat(config.requestTimeout()).isEqualTo(Duration.ofSeconds(60));
+    }
+
+    @Test
+    void buildsWithCustomValues() {
+        var config = RuntimeConfig.builder()
+                .shutdownGracePeriod(Duration.ofSeconds(10))
+                .requestTimeout(Duration.ofSeconds(30))
+                .build();
+
+        assertThat(config.shutdownGracePeriod()).isEqualTo(Duration.ofSeconds(10));
+        assertThat(config.requestTimeout()).isEqualTo(Duration.ofSeconds(30));
+    }
+
+    @Test
+    void rejectsNullShutdownGracePeriod() {
+        assertThatNullPointerException()
+                .isThrownBy(() -> RuntimeConfig.builder().shutdownGracePeriod(null));
+    }
+
+    @Test
+    void rejectsNullRequestTimeout() {
+        assertThatNullPointerException()
+                .isThrownBy(() -> RuntimeConfig.builder().requestTimeout(null));
+    }
+}

--- a/tachyon-server/src/test/java/dev/tachyonmcp/server/config/SessionConfigTest.java
+++ b/tachyon-server/src/test/java/dev/tachyonmcp/server/config/SessionConfigTest.java
@@ -15,8 +15,9 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Verifies {@link SessionConfig} defaults (stateless, default id generator) and the fail-fast
- * rejection of session options configured while sessions are disabled — {@code enabled} cannot be
- * flipped after construction, so the contradiction is definitive.
+ * rejection of session options configured while sessions are disabled — compact constructor
+ * resolves value defaults ({@code sessionTtl}, {@code janitorInterval},
+ * {@code sessionIdGenerator}) when {@code enabled=true}.
  *
  * @author Konstantin Pavlov
  */
@@ -30,6 +31,28 @@ class SessionConfigTest {
         assertThat(config.sessionIdGenerator()).isNull();
         assertThat(config.sessionStore()).isNull();
         assertThat(config.sessionLogRouter()).isNull();
+    }
+
+    @Test
+    void resolvesDefaultTtlWhenEnabled() {
+        var config = SessionConfig.builder().enabled(true).build();
+
+        assertThat(config.enabled()).isTrue();
+        assertThat(config.sessionTtl()).isEqualTo(SessionConfig.DEFAULT_SESSION_TTL);
+    }
+
+    @Test
+    void resolvesDefaultJanitorIntervalWhenEnabled() {
+        var config = SessionConfig.builder().enabled(true).build();
+
+        assertThat(config.janitorInterval()).isEqualTo(SessionConfig.DEFAULT_JANITOR_INTERVAL);
+    }
+
+    @Test
+    void resolvesDefaultSessionIdGeneratorWhenEnabled() {
+        var config = SessionConfig.builder().enabled(true).build();
+
+        assertThat(config.sessionIdGenerator()).isSameAs(SessionIdGenerator.DEFAULT);
     }
 
     @Test

--- a/tachyon-server/src/test/java/dev/tachyonmcp/server/json/JsonConfigTest.java
+++ b/tachyon-server/src/test/java/dev/tachyonmcp/server/json/JsonConfigTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2026 Konstantin Pavlov.
+ */
+
+package dev.tachyonmcp.server.json;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Type;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies {@link JsonConfig} builder behavior: defaults, custom values, and convenience methods.
+ *
+ * @author Konstantin Pavlov
+ */
+class JsonConfigTest {
+
+    @Test
+    void allNullByDefault() {
+        var config = JsonConfig.builder().build();
+
+        assertThat(config.serializer()).isNull();
+        assertThat(config.deserializer()).isNull();
+        assertThat(config.inputValidator()).isNull();
+        assertThat(config.outputValidator()).isNull();
+    }
+
+    @Test
+    void buildsWithCustomValues() {
+        var ser = new PayloadSerializer() {
+            @Override
+            public <T> String serialize(T value) {
+                return "{}";
+            }
+        };
+        var deser = new PayloadDeserializer() {
+            @Override
+            public <T> T deserialize(String json, Type targetType) {
+                return null;
+            }
+        };
+        var validator = (JsonSchemaValidator) (schema, arguments) -> List.of();
+
+        var config = JsonConfig.builder()
+                .serializer(ser)
+                .deserializer(deser)
+                .inputSchemaValidator(validator)
+                .outputSchemaValidator(validator)
+                .build();
+
+        assertThat(config.serializer()).isSameAs(ser);
+        assertThat(config.deserializer()).isSameAs(deser);
+        assertThat(config.inputValidator()).isSameAs(validator);
+        assertThat(config.outputValidator()).isSameAs(validator);
+    }
+
+    @Test
+    void serdeSetsBothSerializerAndDeserializer() {
+        var serde = new PayloadSerde() {
+            @Override
+            public <T> String serialize(T value) {
+                return "{}";
+            }
+
+            @Override
+            public <T> T deserialize(String json, Type targetType) {
+                return null;
+            }
+        };
+
+        var config = JsonConfig.builder().serde(serde).build();
+
+        assertThat(config.serializer()).isSameAs(serde);
+        assertThat(config.deserializer()).isSameAs(serde);
+    }
+
+    @Test
+    void schemaValidatorSetsBothInputAndOutput() {
+        var validator = (JsonSchemaValidator) (schema, arguments) -> List.of();
+
+        var config = JsonConfig.builder().schemaValidator(validator).build();
+
+        assertThat(config.inputValidator()).isSameAs(validator);
+        assertThat(config.outputValidator()).isSameAs(validator);
+    }
+}


### PR DESCRIPTION
## Summary

Core: Config defaults now live on the record class, build() returns effective values. No third copy.
- SessionConfig — compact constructor resolves sessionTtl/janitorInterval/sessionIdGenerator defaults when enabled=true. Builder passes raw nullable values; no fallback logic duplication.
- NetworkConfig — named constants (DEFAULT_HOST, UNSET_PORT, DEFAULT_ENDPOINT_PATH, etc.) replace triplicate literals. Used in both DEFAULT instance and Builder field initializers. Compact constructor defensively copies allowedOrigins/allowedHeaders via List.copyOf().
- ServerIdentity — compact constructor defensively copies icons via List.copyOf().
- Server — removes SessionConfig.DEFAULT_* re-resolution; adds assert to document non-null contract from compact constructor.
- Tests: NetworkConfigTest (6 tests — defaults, unmodifiable collections, direct-construction defense, validation), RuntimeConfigTest (4 tests — defaults, null rejection), JsonConfigTest (4 tests — defaults, serde/validator convenience), SessionConfigTest (+3 tests — default resolution when enabled).