### PR TITLE
feat: convert JSON Schema fields to String

### DIFF
--- a/.agents/skills/tachyon-mcp/SKILL.md
+++ b/.agents/skills/tachyon-mcp/SKILL.md
@@ -201,20 +201,23 @@ Native transports need optional runtime jars (`netty-transport-native-epoll` / `
 
 > ⚠️ **Jackson 3** — `tools.jackson:jackson-databind:3.x`, NOT Jackson 2. Import `tools.jackson.databind.{ObjectMapper,JsonNode}` (**not** `com.fasterxml.jackson.*`). Use `JsonNode.asString()` (**not** `asText()`).
 
+`ToolDescriptor.builder().inputSchema(...)` / `.outputSchema(...)` accept a raw JSON `String`
+**or** a Jackson `JsonNode` (same for `PromptDescriptor.builder().inputSchema(...)`):
+
 ```java
-private static final JsonNode INPUT_SCHEMA = MAPPER.readTree("""
-    { "type": "object",
-      "properties": { "city": { "type": "string", "description": "City name" } },
-      "required": ["city"] }
-    """);
+ToolDescriptor.builder()
+    .name("get_weather")
+    .inputSchema("""
+        { "type": "object",
+          "properties": { "city": { "type": "string", "description": "City name" } },
+          "required": ["city"] }
+        """)
+    .build();
 ```
 
-→ `ToolDescriptor.builder().name("name").inputSchema(INPUT_SCHEMA).build()`
 (`builder(name)` and `builder(name, inJson, outJson)` still exist but are deprecated.)
-
-Or skip the `JsonNode` — pass the schema as a raw JSON `String` to
-`SyncToolHandler.of(name, desc, inputSchemaJson, outputSchemaJson, fn)` or
-`.tool(name, desc, inJson, outJson, fn)`; Tachyon parses it.
+The lambda shorthands `SyncToolHandler.of(name, desc, inJson, outJson, fn)` and
+`.tool(name, desc, inJson, outJson, fn)` also take String schemas.
 
 ## Extensions
 

--- a/README.md
+++ b/README.md
@@ -29,39 +29,36 @@
     </dependency>
     ```
 
-2. Create MCP server:
+   2. Create MCP server:
 
-    ```java
-    import dev.tachyonmcp.server.TachyonServer;
-    import dev.tachyonmcp.runtime.InteractionContext;
-    import dev.tachyonmcp.server.features.tools.AbstractSyncToolHandler;
-    import dev.tachyonmcp.server.features.tools.ToolArgs;
-    import dev.tachyonmcp.server.features.tools.ToolDescriptor;
-    import dev.tachyonmcp.server.features.tools.ToolResult;
-    import tools.jackson.databind.node.JsonNodeFactory;
+       ```java
+       import dev.tachyonmcp.server.TachyonServer;
+       import dev.tachyonmcp.runtime.InteractionContext;
+       import dev.tachyonmcp.server.features.tools.AbstractSyncToolHandler;
+       import dev.tachyonmcp.server.features.tools.ToolArgs;
+       import dev.tachyonmcp.server.features.tools.ToolDescriptor;
+       import dev.tachyonmcp.server.features.tools.ToolResult;
 
-    void main() {
-        var schema = JsonNodeFactory.instance.objectNode();
-        schema.put("type", "object");
-        schema.putObject("properties").putObject("city").put("type", "string");
+       void main() {
+           TachyonServer.builder()
+               .name("weather-mcp")
+               .tool(new AbstractSyncToolHandler(
+                   ToolDescriptor.builder("get_forecast")
+                       .description("Get weather forecast")  
+                       .inputSchema("""
+                       {"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}
+                       """)
+                       .build()) {
 
-        TachyonServer.builder()
-            .name("weather-mcp")
-            .tool(new AbstractSyncToolHandler(
-                ToolDescriptor.builder("get_forecast")
-                    .description("Get weather forecast")
-                    .inputSchema(schema)
-                    .build()) {
-
-                @Override
-                public ToolResult handle(InteractionContext ctx, ToolArgs args) {
-                    return ToolResult.text("☀️ 22°C");
-                }
-            })
-            .port(8080)
-            .start();
-    }
-    ```
+                   @Override
+                   public ToolResult handle(InteractionContext ctx, ToolArgs args) {
+                       return ToolResult.text("☀️ 22°C");
+                   }
+               })
+               .port(8080)
+               .start();
+       }
+       ```
 
 ## Documentation
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -28,24 +28,19 @@ parses it for you (input and output schemas):
 
 ### Class (recommended for complex tools)
 
+`ToolDescriptor.builder().inputSchema(...)` / `.outputSchema(...)` take a raw JSON `String` or a Jackson `JsonNode`:
+
 ```java
 import dev.tachyonmcp.server.features.tools.AbstractSyncToolHandler;
 import dev.tachyonmcp.server.features.tools.ToolArgs;
 import dev.tachyonmcp.server.features.tools.ToolDescriptor;
 import dev.tachyonmcp.server.features.tools.ToolResult;
 import dev.tachyonmcp.runtime.InteractionContext;
-import tools.jackson.databind.JsonNode;
-import tools.jackson.databind.node.JsonNodeFactory;
 
 class WeatherTool extends AbstractSyncToolHandler {
-    private static final JsonNode SCHEMA;
-    static {
-        var s = JsonNodeFactory.instance.objectNode();
-        s.put("type", "object");
-        s.putObject("properties").putObject("city").put("type", "string");
-        s.putArray("required").add("city");
-        SCHEMA = s;
-    }
+    private static final String SCHEMA = """
+        {"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}
+        """;
 
     WeatherTool() {
         super(ToolDescriptor.builder()

--- a/examples/weather/src/main/java/com/example/weather/GetWeatherTool.java
+++ b/examples/weather/src/main/java/com/example/weather/GetWeatherTool.java
@@ -5,8 +5,6 @@ package com.example.weather;
 
 import dev.tachyonmcp.server.features.tools.*;
 import dev.tachyonmcp.runtime.InteractionContext;
-import tools.jackson.databind.JsonNode;
-import tools.jackson.databind.ObjectMapper;
 
 import java.util.List;
 import java.util.random.RandomGenerator;
@@ -14,7 +12,7 @@ import java.util.random.RandomGenerator;
 class GetWeatherTool extends AbstractSyncToolHandler {
     private static final RandomGenerator RANDOM = RandomGenerator.getDefault();
     // language=json
-    private static final JsonNode INPUT_SCHEMA = new ObjectMapper().readTree("""
+    private static final String INPUT_SCHEMA = """
         {
           "type": "object",
           "properties": {
@@ -30,7 +28,7 @@ class GetWeatherTool extends AbstractSyncToolHandler {
           },
           "required": ["city"]
         }
-        """);
+        """;
 
     public GetWeatherTool() {
         super(ToolDescriptor.builder()

--- a/tachyon-server/protocol/mcp-2025-11-25_config.json
+++ b/tachyon-server/protocol/mcp-2025-11-25_config.json
@@ -5,8 +5,9 @@
     "JSONValue": "tools.jackson.databind.ValueNode",
     "JSONObject": "tools.jackson.databind.node.ObjectNode",
     "JSONArray": "tools.jackson.databind.node.ArrayNode",
-    "Tool.inputSchema": "tools.jackson.databind.JsonNode",
-    "Tool.outputSchema": "tools.jackson.databind.JsonNode"
+    "Tool.inputSchema": "String",
+    "Tool.outputSchema": "String",
+    "ElicitRequestFormParams.requestedSchema": "String"
   },
   "additionalProperties": {
     "ClientCapabilities": [

--- a/tachyon-server/src/main/java/dev/tachyonmcp/protocol/mcp/v2025_11_25/codecs/McpResponseMapper.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/protocol/mcp/v2025_11_25/codecs/McpResponseMapper.java
@@ -276,7 +276,9 @@ public final class McpResponseMapper implements ProtocolResponseMapper {
                     gen.writeName("params");
                     var paramsCodec = CodecRegistry.codecFor(ElicitRequestParams.class);
                     paramsCodec.encode(
-                            gen, new ElicitRequestFormParams(null, f.message(), f.requestedSchema(), null, null));
+                            gen,
+                            new ElicitRequestFormParams(
+                                    null, f.message(), JsonUtils.writeString(f.requestedSchema()), null, null));
                 }
                 case UrlInputRequest u -> {
                     gen.writeStringProperty("method", "elicitation/create");

--- a/tachyon-server/src/main/java/dev/tachyonmcp/protocol/mcp/v2025_11_25/codecs/McpToolMapper.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/protocol/mcp/v2025_11_25/codecs/McpToolMapper.java
@@ -39,9 +39,9 @@ final class McpToolMapper {
         }
         return new Tool(
                 d.description(),
-                schema,
+                schema.toString(),
                 execution,
-                d.outputSchema(),
+                d.outputSchema() != null ? d.outputSchema().toString() : null,
                 toProtocolToolAnnotations(d.annotations()),
                 null,
                 d.name(),

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/features/prompts/PromptDescriptor.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/features/prompts/PromptDescriptor.java
@@ -7,6 +7,7 @@ package dev.tachyonmcp.server.features.prompts;
 import dev.tachyonmcp.server.ServerResourceType;
 import dev.tachyonmcp.server.domain.Icon;
 import dev.tachyonmcp.server.domain.PromptArgument;
+import dev.tachyonmcp.server.json.JsonSchemaUtils;
 import java.util.List;
 import org.immutables.value.Value;
 import org.jspecify.annotations.Nullable;
@@ -83,6 +84,10 @@ public interface PromptDescriptor extends ServerResourceType {
         Builder arguments(@Nullable Iterable<? extends PromptArgument> elements);
 
         Builder inputSchema(@Nullable JsonNode inputSchema);
+
+        default Builder inputSchema(@Nullable String inputSchema) {
+            return inputSchema(JsonSchemaUtils.parseSchema(inputSchema));
+        }
 
         Builder icons(@Nullable Iterable<? extends Icon> elements);
 

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tools/ToolDescriptor.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tools/ToolDescriptor.java
@@ -85,6 +85,14 @@ public interface ToolDescriptor {
 
         Builder outputSchema(@Nullable JsonNode outputSchema);
 
+        default Builder inputSchema(@Nullable String inputSchema) {
+            return inputSchema(parseSchema(inputSchema));
+        }
+
+        default Builder outputSchema(@Nullable String outputSchema) {
+            return outputSchema(parseSchema(outputSchema));
+        }
+
         Builder taskSupport(@Nullable TaskSupport taskSupport);
 
         Builder annotations(@Nullable ToolAnnotations annotations);

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/json/JsonSchemaUtils.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/json/JsonSchemaUtils.java
@@ -12,6 +12,18 @@ public class JsonSchemaUtils {
     }
 
     /**
+     * Parses a JSON schema string, returning {@code null} for null input.
+     */
+    public static @Nullable JsonNode parseSchema(@Nullable String json) {
+        if (json == null) return null;
+        try {
+            return JsonUtils.parse(json);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Schema is not valid JSON: " + json, e);
+        }
+    }
+
+    /**
      * Parses a JSON schema string, failing fast with the tool name on invalid JSON.
      */
     public static @Nullable JsonNode parseSchema(@Nullable String json, String toolName) {

--- a/tachyon-server/src/test/java/dev/tachyonmcp/codec/ProtocolMapperTest.java
+++ b/tachyon-server/src/test/java/dev/tachyonmcp/codec/ProtocolMapperTest.java
@@ -52,16 +52,7 @@ class ProtocolMapperTest {
 
     @Test
     void serializeListToolsResult() {
-        var tool = new Tool(
-                "My tool",
-                JsonNodeFactory.instance.objectNode().put("type", "object"),
-                null,
-                null,
-                null,
-                null,
-                "my-tool",
-                null,
-                null);
+        var tool = new Tool("My tool", "{\"type\":\"object\"}", null, null, null, null, "my-tool", null, null);
         var result = new ListToolsResult(List.of(tool), null, null, null);
 
         var bytes = CodecRegistry.codecFor(ListToolsResult.class).encodeToBytes(result);

--- a/tachyon-server/src/test/java/dev/tachyonmcp/server/features/tools/ToolDescriptorTest.java
+++ b/tachyon-server/src/test/java/dev/tachyonmcp/server/features/tools/ToolDescriptorTest.java
@@ -43,8 +43,8 @@ class ToolDescriptorTest {
     void shouldAcceptNullStringSchemas() {
         var desc = ToolDescriptor.builder()
                 .name("test")
-                .inputSchema(null)
-                .outputSchema(null)
+                .inputSchema((String) null)
+                .outputSchema((String) null)
                 .build();
         assertThat(desc.inputSchema()).isNull();
         assertThat(desc.outputSchema()).isNull();

--- a/tachyon-server/src/test/java/dev/tachyonmcp/server/features/tools/ToolRegistryTest.java
+++ b/tachyon-server/src/test/java/dev/tachyonmcp/server/features/tools/ToolRegistryTest.java
@@ -103,7 +103,7 @@ class ToolRegistryTest {
                 .orElseThrow();
         assertThat(minimal.title()).isNull();
         assertThat(minimal.description()).isNull();
-        assertThat(minimal.inputSchema())
+        assertThat(parseJson(minimal.inputSchema()))
                 .isEqualTo(parseJson("""
                 {"type":"object"}
                 """)); // defaulted by McpToolMapper when handler returns null
@@ -116,8 +116,8 @@ class ToolRegistryTest {
                 .orElseThrow();
         assertThat(full.title()).isEqualTo("Full Tool");
         assertThat(full.description()).isEqualTo("Does everything");
-        assertThat(full.inputSchema()).isEqualTo(TEST_SCHEMA);
-        assertThat(full.outputSchema()).isEqualTo(outputSchema);
+        assertThat(parseJson(full.inputSchema())).isEqualTo(TEST_SCHEMA);
+        assertThat(parseJson(full.outputSchema())).isEqualTo(outputSchema);
         assertThat(full.execution()).isNotNull();
         assertThat(full.execution().taskSupport()).isEqualTo("optional");
         assertThat(full.annotations()).isNotNull();

--- a/tachyon-server/ts2java.py
+++ b/tachyon-server/ts2java.py
@@ -1512,7 +1512,11 @@ class Generator:
 
         for typ, fname, optional, _, json_name in regular:
             out.append(f'                case "{json_name}" -> {{\n')
-            if typ == "String":
+            if typ == "String" and self.field_type_mappings.get(f"{model_name}.{json_name}") == "String":
+                out.append(
+                    f"                    {fname} = parser.readValueAsTree().toString();\n"
+                )
+            elif typ == "String":
                 out.append(f"                    {fname} = parser.getString();\n")
             elif typ in ("boolean", "Boolean"):
                 out.append(f"                    {fname} = parser.getBooleanValue();\n")
@@ -1635,7 +1639,10 @@ class Generator:
                 ind = "            "
             else:
                 ind = "        "
-            if typ == "String":
+            if typ == "String" and self.field_type_mappings.get(f"{model_name}.{json_name}") == "String":
+                out.append(f'{ind}gen.writeName("{json_name}");\n')
+                out.append(f"{ind}gen.writeRawValue({acc});\n")
+            elif typ == "String":
                 out.append(f'{ind}gen.writeStringProperty("{json_name}", {acc});\n')
             elif typ in ("boolean", "Boolean"):
                 out.append(f'{ind}gen.writeBooleanProperty("{json_name}", {acc});\n')


### PR DESCRIPTION
**Part 1 — builders accept JSON string.** `ToolDescriptor.Builder` / `PromptDescriptor.Builder` gained `default inputSchema(String)` / `outputSchema(String)` overloads delegating through new `JsonSchemaUtils.parseSchema(String)`. Callers no longer touch `JsonSchemaUtils` directly.

**Part 2 — wire models hold raw JSON as `String`.** `Tool.inputSchema`/`outputSchema` and
`ElicitRequestFormParams.requestedSchema` are now `String` (raw passthrough) instead of `JsonNode`/`Map`. Wire bytes unchanged — still embedded objects, not quoted strings.

- `mcp-2025-11-25_config.json`: three fields mapped to `String`
- `ts2java.py`: decode `readValueAsTree().toString()`, encode `writeRawValue(...)` for String-mapped schema fields
- `McpToolMapper` / `McpResponseMapper`: convert at the boundary