### PR TITLE
refactor: simplify handler dispatch to blocking-on-VT pattern

### DIFF
--- a/.agents/skills/tachyon-mcp/SKILL.md
+++ b/.agents/skills/tachyon-mcp/SKILL.md
@@ -17,6 +17,7 @@ Make **Java 21+** MCP server. Tachyon lib. Transport = Streamable HTTP (Netty).
 - `.build()` → `Server` only, no transport.
 - `ServerHandle`: `.server()`, `.port()`.
 - `InteractionContext` → session + notifications + server ctx. Every handler gets it (`dev.tachyonmcp.runtime.InteractionContext`).
+- ⚡ **Virtual threads**: All handlers (`ToolHandler`, `ResourceHandler`, `PromptHandler`) run on a virtual thread per request. Blocking for I/O is fine — never use `synchronized` (pins carrier thread). Use `ReentrantLock` instead. CPU-bound work → offload to `context.server().executor()`. See `RpcMethodHandler.java` javadoc.
 
 ## Quickstart
 

--- a/README.md
+++ b/README.md
@@ -9,15 +9,19 @@
 
 **Tachyon MCP** is a Java 21 [Model Context Protocol](https://modelcontextprotocol.io) (MCP) server built on [Netty](https://netty.io). Implements the **2025-11-25** Streamable HTTP transport, protocol extensions, and stateless mode.
 
-## Why Tachyon?
+## 💫 Why Tachyon?
 
-1. **MCP Spec Compliant** — All official conformance tests green on the current **2025-11-25** spec; tools, resources, prompts, tasks, elicitation, sampling, and extensions (SEP-1686, SEP-2133) in one artifact.
-2. **Your handlers outlive the spec** — MCP moves fast; Tachyon's stable domain types (`ToolHandler`, `ResourceHandler`, `PromptHandler`, Task support) absorb protocol changes in an internal mapper layer, so version bumps don't touch your code.
-3. **Write blocking code, get async runtime** — handlers run on Java 21 virtual threads off the Netty event loop; plain synchronous logic scales without thread pools, reactive chains, or `CompletableFuture` gymnastics. Coroutine-first Kotlin DSL included.
-4. **Serverless-ready** — stateless by default, so each request is independent for AWS Lambda and friends; opt into full session mode (`.session(s -> s.enabled(true))`) for SSE resumability, Last-Event-ID replay, TTL + janitor, and a customizable session-id generator.
-5. **Production-grade transport** — Netty core with backpressure watermarks, graceful shutdown, DNS-rebinding protection, and auto-detected native transports (io_uring / epoll / kqueue) when you want the extra speed.
+✅ **MCP spec compliant** -- Passes all official conformance tests for the **2025-11-25** specification, including tools, resources, prompts, tasks, elicitation, sampling, and extensions (SEP-1686, SEP-2133).
 
-**TL;DR**
+🛡️ **Stable APIs across spec changes** -- MCP evolves quickly. Stable domain APIs (`ToolHandler`, `ResourceHandler`, `PromptHandler`, task support) isolate protocol changes behind an internal mapping layer, so upgrades rarely affect application code.
+
+🧵 **Synchronous code, asynchronous runtime** -- Write blocking handlers while Java 21 virtual threads run them off the Netty event loop. No thread pools, reactive pipelines, or `CompletableFuture` boilerplate. Includes a coroutine-first Kotlin DSL.
+
+☁️ **Serverless by default** -- Stateless request handling works out of the box for AWS Lambda and similar platforms. Enable sessions (`.session(s -> s.enabled(true))`) for SSE resumability, `Last-Event-ID` replay, TTL cleanup, and customizable session IDs.
+
+🚄 **Production-ready transport** — Built on Netty with backpressure, graceful shutdown, DNS rebinding protection, and automatic native transport support (`io_uring`, `epoll`, `kqueue`) where available.
+
+## TL;DR
 
 1. Add dependency:
 
@@ -25,40 +29,40 @@
     <dependency>
         <groupId>dev.tachyonmcp</groupId>
         <artifactId>tachyon-server</artifactId>
-        <version>1.0.0-beta.6</version>
+        <version>1.0.0-beta.7</version>
     </dependency>
     ```
 
-   2. Create MCP server:
+2. Create MCP server:
 
-       ```java
-       import dev.tachyonmcp.server.TachyonServer;
-       import dev.tachyonmcp.runtime.InteractionContext;
-       import dev.tachyonmcp.server.features.tools.AbstractSyncToolHandler;
-       import dev.tachyonmcp.server.features.tools.ToolArgs;
-       import dev.tachyonmcp.server.features.tools.ToolDescriptor;
-       import dev.tachyonmcp.server.features.tools.ToolResult;
+    ```java
+    import dev.tachyonmcp.server.TachyonServer;
+    import dev.tachyonmcp.runtime.InteractionContext;
+    import dev.tachyonmcp.server.features.tools.AbstractSyncToolHandler;
+    import dev.tachyonmcp.server.features.tools.ToolArgs;
+    import dev.tachyonmcp.server.features.tools.ToolDescriptor;
+    import dev.tachyonmcp.server.features.tools.ToolResult;
 
-       void main() {
-           TachyonServer.builder()
-               .name("weather-mcp")
-               .tool(new AbstractSyncToolHandler(
-                   ToolDescriptor.builder("get_forecast")
-                       .description("Get weather forecast")  
-                       .inputSchema("""
-                       {"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}
-                       """)
-                       .build()) {
+    void main() {
+        TachyonServer.builder()
+            .name("weather-mcp")
+            .tool(new AbstractSyncToolHandler(
+                ToolDescriptor.builder("get_forecast")
+                    .description("Get weather forecast")  
+                    .inputSchema("""
+                    {"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}
+                    """)
+                    .build()) {
 
-                   @Override
-                   public ToolResult handle(InteractionContext ctx, ToolArgs args) {
-                       return ToolResult.text("☀️ 22°C");
-                   }
-               })
-               .port(8080)
-               .start();
-       }
-       ```
+                @Override
+                public ToolResult handle(InteractionContext ctx, ToolArgs args) {
+                    return ToolResult.text("☀️ 22°C");
+                }
+            })
+            .port(8080)
+            .start();
+    }
+    ```
 
 ## Documentation
 

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/ToolErrorTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/ToolErrorTest.java
@@ -27,14 +27,16 @@ class ToolErrorTest extends AbstractMcpE2eTest {
         try (var client = createTestClient()) {
             var sessionId = client.initialize();
             var body = """
-                    {"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"boom","arguments":{}}}
-                    """;
+                {"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"boom","arguments":{}}}
+                """;
             var response = client.sendRequest(sessionId, body);
 
             assertThat(response.statusCode()).isEqualTo(200);
             assertThat(response.body()).contains("notifications/before-boom");
-            assertThat(response.body()).contains("-32603");
-            assertThat(response.body()).contains("Internal error");
+            // language=json
+            assertThat(response.body()).contains("""
+                {"jsonrpc":"2.0","id":1,"error":{"code":-32603,"message":"Tool handler failed"}}
+                """.trim());
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
             --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.lang.reflect=ALL-UNNAMED --add-opens
             java.base/java.io=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens
             java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.base/java.nio.channels.spi=ALL-UNNAMED
-            -Dio.netty.leakDetection.level=PARANOID
+            -Dio.netty.leakDetection.level=PARANOID -Djdk.tracePinnedThreads=short
         </argLine>
         <kotlinx-coroutines.version>1.11.0</kotlinx-coroutines.version>
         <kotlinx-serialization-json.version>1.11.0</kotlinx-serialization-json.version>

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/RpcDispatcher.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/RpcDispatcher.java
@@ -396,31 +396,15 @@ public class RpcDispatcher {
             return CompletableFuture.completedFuture(
                     errorResult(id, JsonRpcErrors.METHOD_NOT_FOUND, "Method not found: initialize"));
         }
-        if (server.isStateless()) {
-            return CompletableFuture.supplyAsync(
-                            () -> {
-                                try {
-                                    return handler.handleAsync(ic, rawParams);
-                                } catch (Exception e) {
-                                    return CompletableFuture.failedFuture(e);
-                                }
-                            },
-                            executor)
-                    .thenCompose(Function.identity())
-                    .handle((result, ex) -> {
-                        if (ex != null) {
-                            logger.warn("Initialize handler exception (stateless)", ex);
-                            return errorResult(id, JsonRpcErrors.INTERNAL_ERROR, "Internal error");
-                        }
-                        return handleSuccessOrJsonRpcError(id, "initialize", result, null);
-                    });
-        }
+        // Stateful init creates the session before invoking the handler; stateless skips it. Both
+        // then share one async pipeline — the response sessionId falls out of ic.session() (null
+        // when stateless, since no session was set).
         return CompletableFuture.supplyAsync(
                         () -> {
                             try {
-                                var sessionId = generateSessionId(channelContext);
-                                var session = server.createSession(sessionId);
-                                ic.setSession(session);
+                                if (!server.isStateless()) {
+                                    ic.setSession(server.createSession(generateSessionId(channelContext)));
+                                }
                                 return handler.handleAsync(ic, rawParams);
                             } catch (Exception e) {
                                 return CompletableFuture.failedFuture(e);

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/RpcMethodHandler.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/RpcMethodHandler.java
@@ -11,6 +11,18 @@ import java.util.concurrent.CompletionStage;
 /**
  * Handles a single JSON-RPC method. Internal/advanced SPI — receives the rich
  * {@link DispatchContext} (server, response mapper, outbound stream).
+ *
+ * <p>{@link #handle} runs on a <b>virtual thread</b> per request. Handler code may block for I/O
+ * — that is the intended VT contract — but must <b>never</b> use {@code synchronized}, call native
+ * methods, or otherwise pin the carrier thread.
+ * Use {@link java.util.concurrent.locks.ReentrantLock} over {@code synchronized} for mutual
+ * exclusion. For CPU-bound work or third-party code that may synchronize, offload to
+ * {@code context.server().executor()} and join the result:
+ * <pre>{@code
+ * var future = CompletableFuture.supplyAsync(
+ *         () -> heavyWork(), context.server().executor());
+ * return HandlerFutures.joinInterruptibly(future);
+ * }</pre>
  */
 public interface RpcMethodHandler {
 

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/features/ChangeSupport.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/features/ChangeSupport.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026 Konstantin Pavlov.
+ */
+
+package dev.tachyonmcp.server.features;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Change-notification for registries: a list of listeners run when contents change. Composed by
+ * registries that don't share the {@link Registry} base, so the listener boilerplate lives once.
+ *
+ * @author Konstantin Pavlov
+ */
+public final class ChangeSupport {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ChangeSupport.class);
+
+    private final List<Runnable> listeners = new CopyOnWriteArrayList<>();
+
+    /**
+     * Registers a callback invoked when the registry contents change.
+     */
+    public void onChange(Runnable callback) {
+        listeners.add(callback);
+    }
+
+    /**
+     * Runs every registered listener.
+     */
+    public void fireOnChange() {
+        for (var listener : listeners) {
+            try {
+                listener.run();
+            } catch (RuntimeException e) {
+                // log and continue so other listeners still receive the notification
+                LOGGER.debug("Can't notify listener: {}", listener, e);
+            }
+        }
+    }
+}

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/features/HandlerFutures.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/features/HandlerFutures.java
@@ -4,12 +4,9 @@
 
 package dev.tachyonmcp.server.features;
 
-import dev.tachyonmcp.server.session.DispatchContext;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
-import java.util.function.BiFunction;
-import org.jspecify.annotations.Nullable;
 
 /**
  * Static utilities for common CompletionStage patterns.
@@ -38,34 +35,5 @@ public final class HandlerFutures {
             }
             throw new CompletionException(cause);
         }
-    }
-
-    /**
-     * Wraps a CompletionStage with an isDone fast-path and CompletionException unwrapping:
-     * if already complete, runs the transformer inline (Runnable::run); otherwise hops to the
-     * server executor. The transformer receives the unwrapped result and any exception cause
-     * (CompletionException already unwrapped).
-     *
-     * <p>TOCTOU note: a stage completing after the isDone check merely takes the executor hop
-     * — benign, not a race.
-     */
-    public static CompletionStage<Object> completeOn(
-            CompletionStage<?> stage,
-            DispatchContext ctx,
-            BiFunction<@Nullable Object, @Nullable Throwable, Object> transformer) {
-        var done = stage.toCompletableFuture().isDone();
-        var executor = done
-                ? (java.util.concurrent.Executor) Runnable::run
-                : ctx.server().executor();
-        return stage.handleAsync(
-                (result, e) -> {
-                    if (e != null) {
-                        var cause = e instanceof CompletionException ce && ce.getCause() != null ? ce.getCause() : e;
-                        return transformer.apply(null, cause);
-                    } else {
-                        return transformer.apply(result, null);
-                    }
-                },
-                executor);
     }
 }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/features/ListRequests.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/features/ListRequests.java
@@ -4,13 +4,33 @@
 
 package dev.tachyonmcp.server.features;
 
+import dev.tachyonmcp.protocol.mcp.v2025_11_25.codecs.ProtocolCodecUtil;
+import dev.tachyonmcp.transport.jsonrpc.JsonRpcCodec;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import org.jspecify.annotations.Nullable;
+import tools.jackson.databind.JsonNode;
 
 /** Shared parsing of limit/cursor from JSON-RPC request params. */
 public final class ListRequests {
 
     private ListRequests() {}
+
+    /**
+     * Parses the {@code inputResponses} value of a request into a name→node map, re-encoding each
+     * raw value through the codec. Returns {@code null} when absent or empty. Pass
+     * {@code map.get("inputResponses")}.
+     */
+    public static @Nullable Map<String, JsonNode> extractInputResponses(@Nullable Object raw) {
+        if (!(raw instanceof Map<?, ?> rawMap) || rawMap.isEmpty()) return null;
+        var result = new LinkedHashMap<String, JsonNode>();
+        for (var entry : rawMap.entrySet()) {
+            if (entry.getKey() instanceof String k) {
+                result.put(k, ProtocolCodecUtil.parseJsonNode(JsonRpcCodec.writeValueAsString(entry.getValue())));
+            }
+        }
+        return result.isEmpty() ? null : result;
+    }
 
     /** Extracts the limit parameter from a Map or typed request object. */
     public static int parseLimit(Object params) {

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/features/Pagination.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/features/Pagination.java
@@ -12,7 +12,8 @@ import org.jspecify.annotations.Nullable;
 /** Static pagination utility shared by registries. */
 public final class Pagination {
 
-    private static final int DEFAULT_PAGE_SIZE = 50;
+    /** Default page size used when a request omits (or non-positively sizes) its limit. */
+    public static final int DEFAULT_PAGE_SIZE = 50;
 
     private Pagination() {}
 

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/features/Registry.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/features/Registry.java
@@ -8,10 +8,8 @@ import dev.tachyonmcp.server.RpcMethodHandler;
 import dev.tachyonmcp.server.ServerResourceType;
 import java.util.Collection;
 import java.util.Comparator;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Predicate;
 import org.jspecify.annotations.Nullable;
 
@@ -20,19 +18,11 @@ public abstract class Registry<R extends ServerResourceType> {
 
     private final ConcurrentHashMap<String, R> items = new ConcurrentHashMap<>();
 
-    private static final int DEFAULT_PAGE_SIZE = 50;
-
-    private final List<Runnable> onChangeListeners = new CopyOnWriteArrayList<>();
+    private final ChangeSupport changes = new ChangeSupport();
 
     /** Registers a callback invoked when the registry contents change. */
-    public void onChange(@Nullable Runnable callback) {
-        if (callback != null) {
-            onChangeListeners.add(callback);
-        }
-    }
-
-    void addChangeListener(Runnable listener) {
-        onChangeListeners.add(listener);
+    public void onChange(Runnable callback) {
+        changes.onChange(callback);
     }
 
     /** Adds or replaces an item by name. */
@@ -50,9 +40,7 @@ public abstract class Registry<R extends ServerResourceType> {
     }
 
     protected void fireOnChange() {
-        for (var listener : onChangeListeners) {
-            listener.run();
-        }
+        changes.fireOnChange();
     }
 
     /** Returns the item by name, or {@code null} if not found. */
@@ -66,11 +54,11 @@ public abstract class Registry<R extends ServerResourceType> {
     }
 
     public PaginatedResult<R> list(int limit, @Nullable String cursor) {
-        return list(limit, cursor, DEFAULT_PAGE_SIZE, r -> true);
+        return list(limit, cursor, Pagination.DEFAULT_PAGE_SIZE, r -> true);
     }
 
     public PaginatedResult<R> list(int limit, @Nullable String cursor, Predicate<R> filter) {
-        return list(limit, cursor, DEFAULT_PAGE_SIZE, filter);
+        return list(limit, cursor, Pagination.DEFAULT_PAGE_SIZE, filter);
     }
 
     public PaginatedResult<R> list(int limit, @Nullable String cursor, int defaultLimit) {

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/features/prompts/PromptHandler.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/features/prompts/PromptHandler.java
@@ -8,7 +8,13 @@ import dev.tachyonmcp.server.domain.PromptMessage;
 import java.util.List;
 import org.jspecify.annotations.Nullable;
 
-/** Generates prompt messages from optional arguments. */
+/**
+ * Generates prompt messages from optional arguments.
+ *
+ * <p>{@link #getMessages} runs on a virtual thread — blocking for I/O is the intended contract.
+ * Never use {@code synchronized} or call native methods (pins the carrier thread).
+ * Use {@link java.util.concurrent.locks.ReentrantLock} instead.
+ */
 @FunctionalInterface
 public interface PromptHandler {
 

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/features/prompts/PromptRegistry.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/features/prompts/PromptRegistry.java
@@ -16,12 +16,8 @@ import dev.tachyonmcp.server.json.JsonSchemaValidator;
 import dev.tachyonmcp.server.session.DispatchContext;
 import dev.tachyonmcp.transport.jsonrpc.JsonRpcCodec;
 import dev.tachyonmcp.transport.jsonrpc.JsonRpcErrors;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
-import java.util.concurrent.CompletionStage;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -85,29 +81,14 @@ public class PromptRegistry extends Registry<PromptEntry> {
         }
 
         @Override
-        public Object handle(DispatchContext context, Object params) {
-            try {
-                return HandlerFutures.joinInterruptibly(handleAsync(context, params));
-            } catch (RuntimeException | Error e) {
-                throw e;
-            } catch (Exception e) {
-                throw new CompletionException(e);
-            }
-        }
-
-        @Override
-        public CompletionStage<Object> handleAsync(DispatchContext context, Object params) {
+        public Object handle(DispatchContext context, Object params) throws Exception {
             var name = extractParamName(params);
-            if (name == null) {
-                return CompletableFuture.completedFuture(JsonRpcErrors.invalidRequest("Missing prompt name"));
-            }
+            if (name == null) return JsonRpcErrors.invalidRequest("Missing prompt name");
             var entry = registry.get(name);
-            if (entry == null) {
-                return CompletableFuture.completedFuture(JsonRpcErrors.invalidRequest("Prompt not found"));
-            }
+            if (entry == null) return JsonRpcErrors.invalidRequest("Prompt not found");
             var extId = entry.descriptor().extensionId();
             if (extId != null && !context.isExtensionEnabled(extId)) {
-                return CompletableFuture.completedFuture(JsonRpcErrors.invalidRequest("Prompt not found"));
+                return JsonRpcErrors.invalidRequest("Prompt not found");
             }
             var inputSchema = entry.descriptor().inputSchema();
             if (inputSchema != null) {
@@ -115,10 +96,10 @@ public class PromptRegistry extends Registry<PromptEntry> {
                 try {
                     argsMap = extractArgumentsMap(params);
                 } catch (RuntimeException e) {
-                    return CompletableFuture.completedFuture(JsonRpcErrors.invalidParams("Invalid arguments"));
+                    return JsonRpcErrors.invalidParams("Invalid arguments");
                 }
                 var error = JsonSchemaUtils.validateArguments(validator, inputSchema, argsMap);
-                if (error != null) return CompletableFuture.completedFuture(JsonRpcErrors.invalidParams(error));
+                if (error != null) return JsonRpcErrors.invalidParams(error);
             }
 
             var request = new PromptRequest(
@@ -126,28 +107,23 @@ public class PromptRegistry extends Registry<PromptEntry> {
                     extractInputResponsesFromParams(params),
                     extractRequestStateFromParams(params));
 
-            CompletionStage<? extends PromptHandlerResult> stage;
+            // Runs on the dispatcher's virtual thread; blocking to join the handler is the SPI contract.
+            PromptHandlerResult result;
             try {
-                stage = entry.handler().handleAsync(context, request);
+                result = HandlerFutures.joinInterruptibly(entry.handler().handleAsync(context, request));
             } catch (Exception e) {
                 logger.error("Prompt handler error for '{}'", name, e);
-                return CompletableFuture.completedFuture(JsonRpcErrors.internalError("Prompt handler failed"));
+                return JsonRpcErrors.internalError("Prompt handler failed");
             }
-            return HandlerFutures.completeOn(stage, context, (result, e) -> {
-                if (e != null) {
-                    logger.error("Prompt handler error for '{}'", name, e);
-                    return JsonRpcErrors.internalError("Prompt handler failed");
+            return switch (result) {
+                case PromptHandlerResult.Messages m -> {
+                    var messages = m.messages() != null ? m.messages() : List.<PromptMessage>of();
+                    yield context.responseMapper()
+                            .getPromptResult(entry.descriptor().description(), messages);
                 }
-                return switch ((PromptHandlerResult) result) {
-                    case PromptHandlerResult.Messages m -> {
-                        var messages = m.messages() != null ? m.messages() : List.<PromptMessage>of();
-                        yield context.responseMapper()
-                                .getPromptResult(entry.descriptor().description(), messages);
-                    }
-                    case PromptHandlerResult.InputRequired ir ->
-                        context.responseMapper().inputRequiredResult(ir.inputRequests(), ir.requestState());
-                };
-            });
+                case PromptHandlerResult.InputRequired ir ->
+                    context.responseMapper().inputRequiredResult(ir.inputRequests(), ir.requestState());
+            };
         }
 
         private static @Nullable String extractArguments(Object params) {
@@ -182,16 +158,9 @@ public class PromptRegistry extends Registry<PromptEntry> {
         }
 
         private static @Nullable Map<String, JsonNode> extractInputResponsesFromParams(Object params) {
-            if (!(params instanceof Map<?, ?> map)) return null;
-            var raw = map.get("inputResponses");
-            if (!(raw instanceof Map<?, ?> rawMap) || rawMap.isEmpty()) return null;
-            var result = new LinkedHashMap<String, JsonNode>();
-            for (var entry : rawMap.entrySet()) {
-                if (entry.getKey() instanceof String k) {
-                    result.put(k, ProtocolCodecUtil.parseJsonNode(JsonRpcCodec.writeValueAsString(entry.getValue())));
-                }
-            }
-            return result.isEmpty() ? null : result;
+            return params instanceof Map<?, ?> map
+                    ? ListRequests.extractInputResponses(map.get("inputResponses"))
+                    : null;
         }
 
         private static @Nullable String extractRequestStateFromParams(Object params) {

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/features/resources/ResourceHandler.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/features/resources/ResourceHandler.java
@@ -10,7 +10,13 @@ import dev.tachyonmcp.server.domain.ResourceContents;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
-/** Reads a resource's contents. One handler per resource. */
+/**
+ * Reads a resource's contents. One handler per resource.
+ *
+ * <p>{@link #read} runs on a virtual thread — blocking for I/O is the intended contract.
+ * Never use {@code synchronized} or call native methods (pins the carrier thread).
+ * Use {@link java.util.concurrent.locks.ReentrantLock} instead.
+ */
 @FunctionalInterface
 public interface ResourceHandler {
 

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/features/resources/ResourceRegistry.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/features/resources/ResourceRegistry.java
@@ -11,25 +11,32 @@ import dev.tachyonmcp.server.RpcMethodHandler;
 import dev.tachyonmcp.server.Server;
 import dev.tachyonmcp.server.domain.ReadResourceRequest;
 import dev.tachyonmcp.server.domain.ResourceContents;
+import dev.tachyonmcp.server.features.ChangeSupport;
 import dev.tachyonmcp.server.features.HandlerFutures;
 import dev.tachyonmcp.server.features.ListRequests;
 import dev.tachyonmcp.server.features.PaginatedResult;
 import dev.tachyonmcp.server.features.Pagination;
 import dev.tachyonmcp.server.session.DispatchContext;
 import dev.tachyonmcp.transport.jsonrpc.JsonRpcErrors;
-import java.util.*;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.Callable;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.function.Predicate;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** Registry for resources, templates, and subscriptions. */
+/**
+ * Registry for resources, templates, and subscriptions.
+ */
 public class ResourceRegistry {
 
     private final ConcurrentHashMap<String, ResourceEntry> byName = new ConcurrentHashMap<>();
@@ -38,25 +45,21 @@ public class ResourceRegistry {
     final ConcurrentHashMap<String, Set<String>> subscriptions = new ConcurrentHashMap<>();
     private final Server server;
 
-    private final List<Runnable> onChangeListeners = new CopyOnWriteArrayList<>();
+    private final ChangeSupport changes = new ChangeSupport();
 
-    private static final int DEFAULT_PAGE_SIZE = 50;
-
-    /** Creates a resource registry bound to the given server (for broadcasting subscription notifications). */
+    /**
+     * Creates a resource registry bound to the given server (for broadcasting subscription notifications).
+     */
     public ResourceRegistry(Server server) {
         this.server = server;
     }
 
-    public void onChange(@Nullable Runnable callback) {
-        if (callback != null) {
-            onChangeListeners.add(callback);
-        }
+    public void onChange(Runnable callback) {
+        changes.onChange(callback);
     }
 
     private void fireOnChange() {
-        for (var listener : onChangeListeners) {
-            listener.run();
-        }
+        changes.fireOnChange();
     }
 
     public ResourceRegistry add(ResourceDescriptor descriptor, ResourceHandler handler) {
@@ -79,7 +82,9 @@ public class ResourceRegistry {
         return this;
     }
 
-    /** Returns the resource descriptor by name. */
+    /**
+     * Returns the resource descriptor by name.
+     */
     public @Nullable ResourceDescriptor get(String name) {
         var entry = byName.get(name);
         return entry != null ? entry.descriptor() : null;
@@ -90,12 +95,12 @@ public class ResourceRegistry {
     }
 
     public PaginatedResult<ResourceDescriptor> list(int limit, @Nullable String cursor) {
-        return list(limit, cursor, DEFAULT_PAGE_SIZE, descriptor -> true);
+        return list(limit, cursor, Pagination.DEFAULT_PAGE_SIZE, descriptor -> true);
     }
 
     public PaginatedResult<ResourceDescriptor> list(
             int limit, @Nullable String cursor, Predicate<ResourceDescriptor> filter) {
-        return list(limit, cursor, DEFAULT_PAGE_SIZE, filter);
+        return list(limit, cursor, Pagination.DEFAULT_PAGE_SIZE, filter);
     }
 
     public PaginatedResult<ResourceDescriptor> list(int limit, @Nullable String cursor, int defaultLimit) {
@@ -163,7 +168,9 @@ public class ResourceRegistry {
         registry.put("resources/unsubscribe", new ResourcesUnsubscribeHandler(this));
     }
 
-    /** Returns whether the given session is subscribed to the resource URI. */
+    /**
+     * Returns whether the given session is subscribed to the resource URI.
+     */
     public boolean isSubscribed(String uri, String sessionId) {
         var subs = subscriptions.get(uri);
         return subs != null && subs.contains(sessionId);
@@ -184,7 +191,9 @@ public class ResourceRegistry {
         });
     }
 
-    /** Removes the session's subscription to the URI, pruning the map entry when it empties. */
+    /**
+     * Removes the session's subscription to the URI, pruning the map entry when it empties.
+     */
     void unsubscribe(String uri, String sessionId) {
         subscriptions.computeIfPresent(uri, (k, set) -> {
             set.remove(sessionId);
@@ -192,7 +201,9 @@ public class ResourceRegistry {
         });
     }
 
-    /** Notifies all subscribed sessions that a resource has been updated. */
+    /**
+     * Notifies all subscribed sessions that a resource has been updated.
+     */
     public void notifyResourceUpdated(String uri) {
         var subscribedSessionIds = subscriptions.get(uri);
         if (subscribedSessionIds == null || subscribedSessionIds.isEmpty()) {
@@ -254,67 +265,37 @@ public class ResourceRegistry {
             return "resources/read";
         }
 
+        /**
+         * Runs on the dispatcher's virtual thread; blocking to join the handler is the SPI contract.
+         */
         @Override
-        public Object handle(DispatchContext context, Object params) {
-            try {
-                return HandlerFutures.joinInterruptibly(handleAsync(context, params));
-            } catch (RuntimeException | Error e) {
-                throw e;
-            } catch (Exception e) {
-                throw new CompletionException(e);
-            }
-        }
-
-        @Override
-        public CompletionStage<Object> handleAsync(DispatchContext context, Object params) {
+        public Object handle(DispatchContext context, Object params) throws Exception {
             var readParams = toReadParams(params);
-            if (readParams == null) {
-                return CompletableFuture.completedFuture(JsonRpcErrors.invalidRequest("Missing resource URI"));
-            }
+            if (readParams == null) return JsonRpcErrors.invalidRequest("Missing resource URI");
             var uri = readParams.uri();
             var entry = registry.getByUri(uri);
             if (entry != null) {
                 var extId = entry.descriptor().extensionId();
                 if (extId != null && !context.isExtensionEnabled(extId)) {
-                    return CompletableFuture.completedFuture(JsonRpcErrors.resourceNotFound("Resource not found"));
+                    return JsonRpcErrors.resourceNotFound("Resource not found");
                 }
+                return readResult(context, uri, () -> entry.handler().readAsync(context, readParams));
             }
-            if (entry == null) {
-                var match = registry.matchTemplate(uri);
-                if (match != null) {
-                    try {
-                        var stage = match.entry().handler().readAsync(context, uri, match.params());
-                        return completeReadStage(stage, context, "Resource template handler", uri);
-                    } catch (Exception e) {
-                        logger.error("Resource template handler error for '{}'", uri, e);
-                        return CompletableFuture.completedFuture(
-                                JsonRpcErrors.internalError("Resource handler failed"));
-                    }
-                }
-                return CompletableFuture.completedFuture(JsonRpcErrors.resourceNotFound("Resource not found"));
-            }
-            CompletionStage<? extends ResourceContents> stage;
-            try {
-                stage = entry.handler().readAsync(context, readParams);
-            } catch (Exception e) {
-                logger.error("Resource handler error for '{}'", uri, e);
-                return CompletableFuture.completedFuture(JsonRpcErrors.internalError("Resource handler failed"));
-            }
-            return completeReadStage(stage, context, "Resource handler", uri);
+            var match = registry.matchTemplate(uri);
+            if (match == null) return JsonRpcErrors.resourceNotFound("Resource not found");
+            return readResult(context, uri, () -> match.entry().handler().readAsync(context, uri, match.params()));
         }
 
-        private CompletionStage<Object> completeReadStage(
-                CompletionStage<? extends ResourceContents> stage,
-                DispatchContext context,
-                String logLabel,
-                String uri) {
-            return HandlerFutures.completeOn(stage, context, (result, e) -> {
-                if (e != null) {
-                    logger.error("{} error for '{}'", logLabel, uri, e);
-                    return JsonRpcErrors.internalError("Resource handler failed");
-                }
-                return context.responseMapper().readResourceResult(List.of((ResourceContents) result));
-            });
+        private Object readResult(
+                DispatchContext context, String uri, Callable<CompletionStage<? extends ResourceContents>> invoker) {
+            ResourceContents contents;
+            try {
+                contents = HandlerFutures.joinInterruptibly(invoker.call());
+            } catch (Exception e) {
+                logger.error("Resource handler error for '{}'", uri, e);
+                return JsonRpcErrors.internalError("Resource handler failed");
+            }
+            return context.responseMapper().readResourceResult(List.of(contents));
         }
 
         private static @Nullable ReadResourceRequest toReadParams(Object params) {

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tools/SyncToolHandler.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tools/SyncToolHandler.java
@@ -13,6 +13,9 @@ import tools.jackson.databind.JsonNode;
 
 /**
  * Convenient base for synchronous (blocking) tool handlers.
+ *
+ * <p>See {@link ToolHandler} for the virtual-thread contract — {@link #handle} runs on a VT,
+ * never use {@code synchronized}, use {@link java.util.concurrent.locks.ReentrantLock} instead.
  */
 public interface SyncToolHandler extends ToolHandler {
 

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tools/ToolHandler.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tools/ToolHandler.java
@@ -8,6 +8,12 @@ import java.util.concurrent.CompletionStage;
 
 /**
  * Handles tool execution. One handler per tool.
+ *
+ * <p>{@link #handle} runs on a virtual thread — blocking for I/O is the intended contract.
+ * Never use {@code synchronized} or call native methods (pins the carrier thread).
+ * Use {@link java.util.concurrent.locks.ReentrantLock} instead. For CPU-bound work or
+ * third-party code that may synchronize, offload to
+ * {@code context.server().executor()}.
  */
 public interface ToolHandler {
 
@@ -18,8 +24,6 @@ public interface ToolHandler {
 
     /**
      * Executes the tool with the given context and request.
-     * Runs on the server executor which must be thread-per-task (e.g. virtual threads).
-     * Blocking is expected and fine; bounded pools deadlock with this contract.
      */
     ToolResult handle(InteractionContext context, ToolRequest request) throws Exception;
 

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tools/ToolRegistry.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tools/ToolRegistry.java
@@ -4,6 +4,7 @@
 
 package dev.tachyonmcp.server.features.tools;
 
+import static dev.tachyonmcp.transport.jsonrpc.JsonRpcErrors.internalError;
 import static dev.tachyonmcp.transport.jsonrpc.JsonRpcErrors.invalidParams;
 import static dev.tachyonmcp.transport.jsonrpc.JsonRpcErrors.invalidRequest;
 import static dev.tachyonmcp.transport.jsonrpc.JsonRpcErrors.methodNotFound;
@@ -13,6 +14,7 @@ import dev.tachyonmcp.protocol.mcp.v2025_11_25.models.CallToolRequestParams;
 import dev.tachyonmcp.protocol.mcp.v2025_11_25.models.TaskMetadata;
 import dev.tachyonmcp.server.OutboundSseStreamMessageRouter;
 import dev.tachyonmcp.server.RpcMethodHandler;
+import dev.tachyonmcp.server.features.ChangeSupport;
 import dev.tachyonmcp.server.features.HandlerFutures;
 import dev.tachyonmcp.server.features.ListRequests;
 import dev.tachyonmcp.server.features.PaginatedResult;
@@ -25,14 +27,10 @@ import dev.tachyonmcp.server.json.*;
 import dev.tachyonmcp.server.session.DispatchContext;
 import dev.tachyonmcp.transport.jsonrpc.JsonRpcCodec;
 import java.util.*;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
-import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -52,9 +50,7 @@ public class ToolRegistry {
     private final PayloadSerializer payloadSerializer;
     private final PayloadDeserializer payloadDeserializer;
 
-    private final List<Runnable> onChangeListeners = new CopyOnWriteArrayList<>();
-
-    private static final int DEFAULT_PAGE_SIZE = 50;
+    private final ChangeSupport changes = new ChangeSupport();
 
     /**
      * Maximum description length before a warning is logged. MCP clients may truncate
@@ -76,16 +72,12 @@ public class ToolRegistry {
         this.payloadDeserializer = payloadDeserializer;
     }
 
-    public void onChange(@Nullable Runnable callback) {
-        if (callback != null) {
-            onChangeListeners.add(callback);
-        }
+    public void onChange(Runnable callback) {
+        changes.onChange(callback);
     }
 
     private void fireOnChange() {
-        for (var listener : onChangeListeners) {
-            listener.run();
-        }
+        changes.fireOnChange();
     }
 
     /**
@@ -181,11 +173,11 @@ public class ToolRegistry {
     }
 
     public PaginatedResult<ToolDescriptor> list(int limit, @Nullable String cursor) {
-        return list(limit, cursor, DEFAULT_PAGE_SIZE, descriptor -> true);
+        return list(limit, cursor, Pagination.DEFAULT_PAGE_SIZE, descriptor -> true);
     }
 
     public PaginatedResult<ToolDescriptor> list(int limit, @Nullable String cursor, Predicate<ToolDescriptor> filter) {
-        return list(limit, cursor, DEFAULT_PAGE_SIZE, filter);
+        return list(limit, cursor, Pagination.DEFAULT_PAGE_SIZE, filter);
     }
 
     public PaginatedResult<ToolDescriptor> list(int limit, @Nullable String cursor, int defaultLimit) {
@@ -242,54 +234,39 @@ public class ToolRegistry {
         }
 
         /**
-         * Dispatch uses handleAsync; interruptible get on VT is safe.
+         * Runs on the dispatcher's virtual thread; blocking to join the handler is the SPI contract.
          */
         @Override
-        public Object handle(DispatchContext context, Object params) {
-            try {
-                return HandlerFutures.joinInterruptibly(handleAsync(context, params));
-            } catch (RuntimeException | Error e) {
-                throw e;
-            } catch (Exception e) {
-                throw new CompletionException(e);
-            }
-        }
-
-        @Override
-        public CompletionStage<Object> handleAsync(DispatchContext context, Object params) {
+        public Object handle(DispatchContext context, Object params) throws Exception {
             var parsed = parseCallParams(params);
-            if (parsed == null) return CompletableFuture.completedFuture(invalidRequest("Invalid params"));
-            if (parsed.name().isBlank()) return CompletableFuture.completedFuture(invalidRequest("Missing tool name"));
-            if (parsed.name().length() > 64)
-                return CompletableFuture.completedFuture(invalidRequest("Tool name exceeds maximum length (SEP-986)"));
+            if (parsed == null) return invalidRequest("Invalid params");
+            if (parsed.name().isBlank()) return invalidRequest("Missing tool name");
+            if (parsed.name().length() > 64) return invalidRequest("Tool name exceeds maximum length (SEP-986)");
 
             var handler = registry.get(parsed.name());
-            if (handler == null) return CompletableFuture.completedFuture(methodNotFound("Method not found"));
+            if (handler == null) return methodNotFound("Method not found");
             var extId = handler.descriptor().extensionId();
-            if (extId != null && !context.isExtensionEnabled(extId))
-                return CompletableFuture.completedFuture(methodNotFound("Method not found"));
+            if (extId != null && !context.isExtensionEnabled(extId)) return methodNotFound("Method not found");
 
             var validationError = validateInput(handler.descriptor().inputSchema(), parsed.args());
-            if (validationError != null) return CompletableFuture.completedFuture(invalidParams(validationError));
+            if (validationError != null) return invalidParams(validationError);
 
             var taskSupport = handler.descriptor().taskSupport();
             if (taskSupport == null) taskSupport = TaskSupport.FORBIDDEN;
             var taskMeta = parsed.task();
 
             if (taskSupport == TaskSupport.FORBIDDEN && taskMeta != null) {
-                return CompletableFuture.completedFuture(
-                        invalidRequest("Task augmentation not supported for this tool"));
+                return invalidRequest("Task augmentation not supported for this tool");
             }
             if (taskSupport == TaskSupport.REQUIRED && taskMeta == null) {
-                return CompletableFuture.completedFuture(invalidRequest("Task augmentation required for this tool"));
+                return invalidRequest("Task augmentation required for this tool");
             }
 
-            var progressToken = parseProgressToken(parsed.meta());
             var request = ToolRequest.builder()
                     .name(parsed.name())
                     .arguments(parsed.args() != null ? parsed.args() : Collections.emptyMap())
                     .meta(parsed.meta())
-                    .progressToken(progressToken)
+                    .progressToken(parseProgressToken(parsed.meta()))
                     .payloadDeserializer(payloadDeserializer)
                     .inputResponses(parsed.inputResponses())
                     .requestState(parsed.requestState())
@@ -298,71 +275,65 @@ public class ToolRegistry {
             // Task-augmented path: branch BEFORE invoking handler so the dispatch thread
             // returns CreateTaskResult immediately (even for sync/suspend handlers).
             if (taskMeta != null) {
-                sendLoggingIfEnabled(context, parsed.name(), "started");
-                var ttl = taskMeta.ttl() != null ? taskMeta.ttl() / 1000.0 : 0.0;
-                final var server = context.server();
-                var tasks = server.tasks();
-                var sessionId = OutboundSseStreamMessageRouter.currentSessionId();
-                var outboundStream = OutboundSseStreamMessageRouter.currentOutboundSseStream();
-                var descriptor = TaskDescriptor.builder(parsed.name())
-                        .description(handler.descriptor().description())
-                        .build();
-                var taskEntry = tasks.createTask(descriptor, ttl, sessionId);
-                var taskFuture = server.executor().submit(() -> {
-                    try {
-                        OutboundSseStreamMessageRouter.withDispatchContext(sessionId, outboundStream, () -> {
-                            var toolResult = HandlerFutures.joinInterruptibly(handler.handleAsync(context, request));
-                            sendLoggingIfEnabled(context, parsed.name(), "completed");
-                            validateOutput(handler.descriptor().outputSchema(), toolResult);
-                            var resultJson = JsonRpcCodec.writeValueAsString(
-                                    context.responseMapper().callToolResult(serializeStructured(toolResult)));
-                            tasks.completeTask(taskEntry.id(), resultJson);
-                            return null;
-                        });
-                    } catch (Exception e) {
-                        handleTaskError(context, taskEntry, e);
-                    }
-                    return null;
-                });
-                tasks.registerRunning(taskEntry.id(), taskFuture);
-                // The task may reach a terminal state before registerRunning: either the handler
-                // finished, or a tasks/cancel arrived in the window (which flips state but finds no
-                // future to interrupt). Drop the now-untracked future, and if the terminal state was
-                // a cancellation, interrupt the still-running handler ourselves.
-                if (!taskEntry.status().isActive()) {
-                    tasks.unregisterRunning(taskEntry.id());
-                    if (taskEntry.status() == TaskState.CANCELLED) {
-                        taskFuture.cancel(true);
-                    }
-                }
-                return CompletableFuture.completedFuture(
-                        context.responseMapper().createTaskResult(taskEntry));
+                return dispatchTaskAugmented(context, handler, request, parsed.name(), taskMeta);
             }
 
-            // Non-task path: existing sync/async dispatch
+            // Non-task path: run the handler on this virtual thread, blocking as the SPI allows.
             sendLoggingIfEnabled(context, parsed.name(), "started");
-            CompletionStage<? extends ToolResult> toolStage;
+            ToolResult toolResult;
             try {
-                toolStage = handler.handleAsync(context, request);
+                toolResult = HandlerFutures.joinInterruptibly(handler.handleAsync(context, request));
             } catch (InvalidArgumentException e) {
-                return CompletableFuture.completedFuture(
-                        invalidParams("invalid argument '" + e.argName() + "': " + e.getMessage()));
+                return invalidParams("invalid argument '" + e.argName() + "': " + e.getMessage());
             } catch (Exception e) {
-                return CompletableFuture.failedFuture(e);
+                logger.error("Tool handler error for '{}'", parsed.name(), e);
+                return internalError("Tool handler failed");
             }
+            sendLoggingIfEnabled(context, parsed.name(), "completed");
+            validateOutput(handler.descriptor().outputSchema(), toolResult);
+            return context.responseMapper().callToolResult(serializeStructured(toolResult));
+        }
 
-            return HandlerFutures.completeOn(toolStage, context, (result, e) -> {
-                if (e != null) {
-                    if (e instanceof InvalidArgumentException ia) {
-                        return invalidParams("invalid argument '" + ia.argName() + "': " + ia.getMessage());
-                    }
-                    throw new CompletionException(e);
+        private Object dispatchTaskAugmented(
+                DispatchContext context, ToolHandler handler, ToolRequest request, String name, TaskMetadata taskMeta) {
+            sendLoggingIfEnabled(context, name, "started");
+            var ttl = taskMeta.ttl() != null ? taskMeta.ttl() / 1000.0 : 0.0;
+            var server = context.server();
+            var tasks = server.tasks();
+            var sessionId = OutboundSseStreamMessageRouter.currentSessionId();
+            var outboundStream = OutboundSseStreamMessageRouter.currentOutboundSseStream();
+            var descriptor = TaskDescriptor.builder(name)
+                    .description(handler.descriptor().description())
+                    .build();
+            var taskEntry = tasks.createTask(descriptor, ttl, sessionId);
+            var taskFuture = server.executor().submit(() -> {
+                try {
+                    OutboundSseStreamMessageRouter.withDispatchContext(sessionId, outboundStream, () -> {
+                        var toolResult = HandlerFutures.joinInterruptibly(handler.handleAsync(context, request));
+                        sendLoggingIfEnabled(context, name, "completed");
+                        validateOutput(handler.descriptor().outputSchema(), toolResult);
+                        var resultJson = JsonRpcCodec.writeValueAsString(
+                                context.responseMapper().callToolResult(serializeStructured(toolResult)));
+                        tasks.completeTask(taskEntry.id(), resultJson);
+                        return null;
+                    });
+                } catch (Exception e) {
+                    handleTaskError(context, taskEntry, e);
                 }
-                sendLoggingIfEnabled(context, parsed.name(), "completed");
-                var toolResult = (ToolResult) result;
-                validateOutput(handler.descriptor().outputSchema(), toolResult);
-                return context.responseMapper().callToolResult(serializeStructured(toolResult));
+                return null;
             });
+            tasks.registerRunning(taskEntry.id(), taskFuture);
+            // The task may reach a terminal state before registerRunning: either the handler
+            // finished, or a tasks/cancel arrived in the window (which flips state but finds no
+            // future to interrupt). Drop the now-untracked future, and if the terminal state was
+            // a cancellation, interrupt the still-running handler ourselves.
+            if (!taskEntry.status().isActive()) {
+                tasks.unregisterRunning(taskEntry.id());
+                if (taskEntry.status() == TaskState.CANCELLED) {
+                    taskFuture.cancel(true);
+                }
+            }
+            return context.responseMapper().createTaskResult(taskEntry);
         }
 
         private static @Nullable Object parseProgressToken(@Nullable Map<String, JsonNode> meta) {
@@ -387,7 +358,7 @@ public class ToolRegistry {
                 var typed = ProtocolCodecUtil.decodeWithCodec(json, CallToolRequestParams.class);
                 var name = typed.name();
                 if (name == null) return null;
-                var inputResponses = extractInputResponsesFromMap(map.get("inputResponses"));
+                var inputResponses = ListRequests.extractInputResponses(map.get("inputResponses"));
                 var requestState = map.get("requestState") instanceof String s ? s : null;
                 return new CallParams(
                         name, typed.arguments(), typed._meta(), inputResponses, requestState, typed.task());
@@ -398,17 +369,6 @@ public class ToolRegistry {
                 return new CallParams(name, p.arguments(), p._meta(), p.inputResponses(), p.requestState(), p.task());
             }
             return null;
-        }
-
-        private static @Nullable Map<String, JsonNode> extractInputResponsesFromMap(@Nullable Object raw) {
-            if (!(raw instanceof Map<?, ?> rawMap) || rawMap.isEmpty()) return null;
-            var result = new java.util.LinkedHashMap<String, JsonNode>();
-            for (var entry : rawMap.entrySet()) {
-                if (entry.getKey() instanceof String k) {
-                    result.put(k, ProtocolCodecUtil.parseJsonNode(JsonRpcCodec.writeValueAsString(entry.getValue())));
-                }
-            }
-            return result.isEmpty() ? null : result;
         }
 
         private @Nullable String validateInput(@Nullable JsonNode schema, @Nullable Map<String, JsonNode> args) {
@@ -446,7 +406,8 @@ public class ToolRegistry {
             if (contentNode == null) return;
             var errors = outputValidator.validate(schema, contentNode);
             if (!errors.isEmpty()) {
-                logger.debug("Tool output failed schema validation (advisory only): {}", joinMessages(errors));
+                logger.debug(
+                        "Tool output failed schema validation (advisory only): {}", SchemaValidationError.join(errors));
             }
         }
 
@@ -473,10 +434,6 @@ public class ToolRegistry {
                 return contentNode;
             }
             return null;
-        }
-
-        private static String joinMessages(List<SchemaValidationError> errors) {
-            return errors.stream().map(SchemaValidationError::message).collect(Collectors.joining("; "));
         }
 
         private void handleTaskError(DispatchContext context, TaskEntry taskEntry, Exception e) {

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/json/JsonSchemaUtils.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/json/JsonSchemaUtils.java
@@ -4,7 +4,6 @@
 package dev.tachyonmcp.server.json;
 
 import java.util.Map;
-import java.util.stream.Collectors;
 import org.jspecify.annotations.Nullable;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.node.JsonNodeFactory;
@@ -47,8 +46,6 @@ public class JsonSchemaUtils {
         var node = JsonNodeFactory.instance.objectNode();
         if (args != null) node.setAll(args);
         var errors = validator.validate(schema, node);
-        return errors.isEmpty()
-                ? null
-                : errors.stream().map(SchemaValidationError::message).collect(Collectors.joining("; "));
+        return errors.isEmpty() ? null : SchemaValidationError.join(errors);
     }
 }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/json/SchemaValidationError.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/json/SchemaValidationError.java
@@ -4,6 +4,9 @@
 
 package dev.tachyonmcp.server.json;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 /**
  * A single schema validation error.
  *
@@ -11,4 +14,10 @@ package dev.tachyonmcp.server.json;
  * @param keyword the validation keyword that failed
  * @param message human-readable error description
  */
-public record SchemaValidationError(String path, String keyword, String message) {}
+public record SchemaValidationError(String path, String keyword, String message) {
+
+    /** Joins the messages of several errors into one {@code "; "}-separated string. */
+    public static String join(List<SchemaValidationError> errors) {
+        return errors.stream().map(SchemaValidationError::message).collect(Collectors.joining("; "));
+    }
+}

--- a/tachyon-server/src/test/java/dev/tachyonmcp/server/features/HandlerFuturesTest.java
+++ b/tachyon-server/src/test/java/dev/tachyonmcp/server/features/HandlerFuturesTest.java
@@ -7,15 +7,11 @@ package dev.tachyonmcp.server.features;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import dev.tachyonmcp.server.session.DefaultMcpContext;
-import dev.tachyonmcp.server.session.DispatchContext;
-import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.BiFunction;
 import org.junit.jupiter.api.Test;
 
 class HandlerFuturesTest {
@@ -42,30 +38,6 @@ class HandlerFuturesTest {
         assertThatThrownBy(() -> HandlerFutures.joinInterruptibly(future))
                 .isInstanceOf(CompletionException.class)
                 .hasCause(cause);
-    }
-
-    @Test
-    void shouldCompleteOnAlreadyCompleteStage() {
-        var future = CompletableFuture.completedFuture("done");
-        BiFunction<Object, Throwable, Object> transform = (result, e) -> "transformed:" + result;
-        var result = HandlerFutures.completeOn(future, noopContext(), transform);
-        assertThat(result).succeedsWithin(Duration.ofSeconds(1)).isEqualTo("transformed:done");
-    }
-
-    @Test
-    void shouldCompleteOnWithException() {
-        var future = CompletableFuture.failedFuture(new RuntimeException("boom"));
-        BiFunction<Object, Throwable, Object> transform = (result, e) -> "error:" + e.getMessage();
-        var result = HandlerFutures.completeOn(future, noopContext(), transform);
-        assertThat(result).succeedsWithin(Duration.ofSeconds(1)).isEqualTo("error:boom");
-    }
-
-    @Test
-    void shouldCompleteOnUnwrapsCompletionException() {
-        var future = CompletableFuture.failedFuture(new CompletionException(new RuntimeException("wrapped")));
-        BiFunction<Object, Throwable, Object> transform = (result, e) -> "error:" + e.getMessage();
-        var result = HandlerFutures.completeOn(future, noopContext(), transform);
-        assertThat(result).succeedsWithin(Duration.ofSeconds(1)).isEqualTo("error:wrapped");
     }
 
     @Test
@@ -98,9 +70,5 @@ class HandlerFuturesTest {
 
         assertThat(exRef.get()).isInstanceOf(InterruptedException.class);
         assertThat(t.isInterrupted()).isTrue();
-    }
-
-    private static DispatchContext noopContext() {
-        return DefaultMcpContext.noop();
     }
 }

--- a/tachyon-server/src/test/java/dev/tachyonmcp/server/features/tools/ToolRegistryTest.java
+++ b/tachyon-server/src/test/java/dev/tachyonmcp/server/features/tools/ToolRegistryTest.java
@@ -555,6 +555,50 @@ class ToolRegistryTest {
     }
 
     @Test
+    void syncToolHandlerReturnsResultThroughHandle() throws Exception {
+        var handlers = new HashMap<String, RpcMethodHandler>();
+        registry.registerHandlers(handlers);
+        registry.register(SyncToolHandler.of("sync-handle", "sync", TEST_SCHEMA, (ctx, args) -> {
+            var msg = args.string("message");
+            return ToolResult.text(msg);
+        }));
+
+        try (var server = TachyonServer.builder().build()) {
+            var session = server.createSession("s-sync-handle");
+            session.activate();
+            var callHandler = handlers.get("tools/call");
+            var ctx = DefaultMcpContext.create(Protocols.versions().getFirst(), server);
+            ctx.setSession(session);
+            var params = Map.of("name", "sync-handle", "arguments", Map.of("message", "hello-sync"));
+            var result = callHandler.handle(ctx, params);
+            assertThat(result).isInstanceOf(CallToolResult.class);
+            var content = ((CallToolResult) result).content();
+            assertThat(((TextContent) content.getFirst()).text()).isEqualTo("hello-sync");
+        }
+    }
+
+    @Test
+    void syncToolHandlerExceptionMapsToInternalError() throws Exception {
+        var handlers = new HashMap<String, RpcMethodHandler>();
+        registry.registerHandlers(handlers);
+        registry.register(SyncToolHandler.of("sync-fail", "sync", null, (ctx, args) -> {
+            throw new IllegalStateException("boom");
+        }));
+
+        try (var server = TachyonServer.builder().build()) {
+            var session = server.createSession("s-sync-fail");
+            session.activate();
+            var callHandler = handlers.get("tools/call");
+            var ctx = DefaultMcpContext.create(Protocols.versions().getFirst(), server);
+            ctx.setSession(session);
+            var params = Map.of("name", "sync-fail", "arguments", Map.of());
+            var result = callHandler.handle(ctx, params);
+            assertThat(result).isInstanceOf(JsonRpcError.class);
+            assertThat(((JsonRpcError) result).code()).isEqualTo(JsonRpcErrors.INTERNAL_ERROR);
+        }
+    }
+
+    @Test
     void shouldFireOnChangeWhenToolReRegistered() {
         registry.register(new TestTool("re-register", null, null));
 


### PR DESCRIPTION
This PR refactors async CompletionStage-based handler pipelines in ToolRegistry, ResourceRegistry, and PromptRegistry to synchronous virtual-thread joins via HandlerFutures.joinInterruptibly, removing completeOn. It introduces ChangeSupport, centralizes pagination defaults and input-response extraction, adds virtual-thread documentation, and updates tests/build config.
