### PR TITLE
feat: Capability configuration refactor

### DIFF
--- a/.agents/skills/tachyon-mcp/SKILL.md
+++ b/.agents/skills/tachyon-mcp/SKILL.md
@@ -166,16 +166,21 @@ Full: `resources/java/PromptHandlerExample.java`
 ## Config️
 
 ### Capabilities `capabilities(cfg -> ...)`
-Default `AUTO` → advertised only when registered. Force with `Mode.ON` / `Mode.OFF`.
+Each feature has its own config: `FeatureConfig` (tools/prompts — `mode`, `listChanged`, `pageSize`), `ResourcesConfig` (adds `subscribe`), `TasksConfig` (`enabled`, `list`, `cancel`, `requests`, `pageSize` — maps 1:1 to MCP `tasks.list`/`tasks.cancel`/`tasks.requests.tools.call`).
+Default `Mode.AUTO` → advertised only when registered. Force with `Mode.ON` / `Mode.OFF`. **`OFF` also blocks registration** — `register`/`add` on that registry becomes a no-op (logged at debug), not just hidden from `initialize`.
 
 | Method | Effect |
 |---|---|
-| `.tools()` / `.tools(listChanged)` / `.noTools()` | tools |
-| `.resources()` / `.resources(subscribe, listChanged)` / `.noResources()` | resources |
-| `.prompts()` / `.prompts(listChanged)` / `.noPrompts()` | prompts |
-| `.tasks()` / `.tasks(list, cancel, requests)` | tasks |
+| `.tools(FeatureConfig)` / `.resources(ResourcesConfig)` / `.prompts(FeatureConfig)` / `.tasks(TasksConfig)` | set the full nested config |
+| `.tools()` / `.tools(listChanged)` / `.noTools()` | shortcut: tools |
+| `.resources()` / `.resources(subscribe, listChanged)` / `.noResources()` | shortcut: resources |
+| `.prompts()` / `.prompts(listChanged)` / `.noPrompts()` | shortcut: prompts |
+| `.tasks()` / `.tasks(list, cancel, requests)` | shortcut: tasks (`enabled=true`) |
+| `.toolsMode(m)` / `.toolsListChanged(b)` / `.toolsPageSize(n)` (+ `resources*`/`prompts*`/`tasks*` siblings) | flat per-field setters; chain onto the shortcuts above, e.g. `c.tools().toolsPageSize(20)` |
 | `.completions()` | arg autocomplete |
 | `.logging()` | logging notifications |
+
+Kotlin DSL nests instead: `capabilities { tools { mode = Mode.ON; pageSize = 20 }; tasks { enabled = true; list = true } }`.
 
 ### Network `network(cfg -> ...)`
 | Method | Default |
@@ -281,9 +286,9 @@ val server = TachyonServer(port = 8080) {
         description = "Demo MCP server"
     }
     capabilities {
-        tools(true)
-        resources(true, true)
-        prompts(true)
+        tools { mode = Mode.ON; listChanged = true }
+        resources { mode = Mode.ON; subscribe = true; listChanged = true }
+        prompts { mode = Mode.ON; listChanged = true }
     }
     tool(name = "ping", description = "Simple ping") {
         ToolResult.text("pong")

--- a/.agents/skills/tachyon-mcp/resources/java/ConfigReference.java
+++ b/.agents/skills/tachyon-mcp/resources/java/ConfigReference.java
@@ -17,34 +17,45 @@ import java.time.Duration;
 final class ConfigReference {
 
     /**
-     * Capabilities — which MCP features to advertise.
+     * Capabilities — which MCP features to advertise. Each feature has its own config type:
+     * {@link FeatureConfig} (tools/prompts), {@link ResourcesConfig}, {@link TasksConfig}.
      */
     static CapabilitiesConfig capabilities() {
         return CapabilitiesConfig.builder()
-            .toolsMode(Mode.AUTO) // ON when tools registered
-            .toolsListChanged(false)
-            .resourcesMode(Mode.AUTO) // ON when resources registered
-            .resourcesSubscribe(false)
-            .resourcesListChanged(false)
-            .promptsMode(Mode.AUTO) // ON when prompts registered
-            .promptsListChanged(false)
-            .tasksList(false)
-            .tasksCancel(false)
-            .tasksRequests(false)
+            .tools(FeatureConfig.builder()
+                .mode(Mode.AUTO) // ON when tools registered
+                .listChanged(false)
+                .build())
+            .resources(ResourcesConfig.builder()
+                .mode(Mode.AUTO) // ON when resources registered
+                .subscribe(false)
+                .listChanged(false)
+                .build())
+            .prompts(FeatureConfig.builder()
+                .mode(Mode.AUTO) // ON when prompts registered
+                .listChanged(false)
+                .build())
+            .tasks(TasksConfig.builder()
+                .enabled(false) // also advertised when a registered tool supports task augmentation
+                .list(false)
+                .cancel(false)
+                .requests(false)
+                .build())
             .completions(false)
             .logging(false)
             .build();
     }
 
     /**
-     * Convenience defaults.
+     * Flat setters and convenience defaults still work — they delegate to the nested configs
+     * above and accumulate across chained calls (e.g. {@code c.tools().toolsPageSize(2)}).
      */
     static CapabilitiesConfig convenienceDefaults() {
         return CapabilitiesConfig.builder()
             .tools(true) // Mode.ON, listChanged=true
             .resources(true, true) // Mode.ON, subscribe=true, listChanged=true
             .prompts() // Mode.ON, listChanged=false
-            .tasks() // list=true, cancel=false, requests=false
+            .tasks() // enabled=true, list=true, cancel=false, requests=false
             .completions() // true
             .logging() // true
             .build();

--- a/.agents/skills/tachyon-mcp/resources/kotlin/ServerBasic.kt
+++ b/.agents/skills/tachyon-mcp/resources/kotlin/ServerBasic.kt
@@ -40,16 +40,25 @@ fun createServer(port: Int = NetworkConfig.UNSET_PORT): TachyonServer =
 
         // ── capabilities — all switches + helpers ─────────────────
         capabilities {
-            tools = Mode.ON
-            toolsListChanged = true
-            resources = Mode.ON
-            resourcesSubscribe = true
-            resourcesListChanged = true
-            prompts = Mode.ON
-            promptsListChanged = true
-            tasks = true
-            tasksCancel = true
-            tasksRequests = true
+            tools {
+                mode = Mode.ON
+                listChanged = true
+            }
+            resources {
+                mode = Mode.ON
+                subscribe = true
+                listChanged = true
+            }
+            prompts {
+                mode = Mode.ON
+                listChanged = true
+            }
+            tasks {
+                enabled = true
+                list = true
+                cancel = true
+                requests = true
+            }
             completions = true
             logging = true
         }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,3 @@
 @AGENTS.md
+
+You have a dumb Minion agent. Write detailed prompts for obvious tasks and ask User to delegate. 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -251,9 +251,61 @@ TachyonServer {
 }
 ```
 
-## Identity and capabilities
+## Identity
 
-`info { }` sets the `serverInfo` returned by `initialize` (name, version, title, etc.); `.name(String)` is a top-level shortcut. `capabilities { }` toggles advertised MCP capabilities. See [quickstart](quickstart.md) for a full example.
+`info { }` sets the `serverInfo` returned by `initialize` (name, version, title, etc.); `.name(String)` is a top-level shortcut. See [quickstart](quickstart.md) for a full example.
+
+## Capabilities
+
+Configured via `capabilities { }` / `CapabilitiesConfig.Builder`. Each MCP capability has its own
+config type, nested under `capabilities`: `tools` and `prompts` share `FeatureConfig`
+(`mode`, `listChanged`, `pageSize`); `resources` uses `ResourcesConfig` (adds `subscribe`); `tasks`
+uses `TasksConfig`, whose fields map 1:1 to the MCP `tasks` capability object (`tasks.list`,
+`tasks.cancel`, `tasks.requests.tools.call`).
+
+| Sub-config | Fields | Default |
+|---|---|---|
+| `tools` / `prompts` (`FeatureConfig`) | `mode`, `listChanged`, `pageSize` | `AUTO`, `false`, `50` |
+| `resources` (`ResourcesConfig`) | `mode`, `listChanged`, `pageSize`, `subscribe` | `AUTO`, `false`, `50`, `false` |
+| `tasks` (`TasksConfig`) | `enabled`, `list`, `cancel`, `requests`, `pageSize` | `false` × 4, `50` |
+| — | `completions`, `logging` | `false`, `false` |
+
+`mode`:
+- **`AUTO`** (default) — advertised only once a handler of that type is registered. No config needed for the common case.
+- **`ON`** — advertised from `initialize`, even with zero handlers registered yet (needed for dynamic registration + `list_changed` after startup).
+- **`OFF`** — never advertised, **and registration becomes a no-op**: `registerTool`/`resource().add(...)`/`prompt().add(...)` on that feature is silently skipped (logged at `debug`).
+
+`tasks.enabled` works the same as `mode == ON` for tools/resources/prompts, except the `tasks`
+capability is *also* advertised — regardless of `enabled` — whenever a registered tool declares
+task augmentation support (`ToolDescriptor.taskSupport()`).
+
+```java
+TachyonServer.builder()
+    .capabilities(c -> c
+        .tools(FeatureConfig.builder().mode(Mode.ON).listChanged(true).build())
+        .resources(ResourcesConfig.builder().mode(Mode.ON).subscribe(true).build())
+        .tasks(TasksConfig.builder().enabled(true).list(true).build())
+        .completions()
+        .logging())
+    .start();
+```
+
+```kotlin
+TachyonServer {
+    capabilities {
+        tools { mode = Mode.ON; listChanged = true }
+        resources { mode = Mode.ON; subscribe = true }
+        tasks { enabled = true; list = true }
+        completions = true
+        logging = true
+    }
+}
+```
+
+Java also keeps the pre-nesting flat setters and convenience shortcuts (`.tools()`,
+`.tools(listChanged)`, `.noTools()`, `.toolsPageSize(n)`, and the `resources`/`prompts`/`tasks`
+equivalents) — they mutate the same nested sub-config, so chaining still works:
+`c.tools().toolsPageSize(20)` sets `mode = ON` and `pageSize = 20` on the same `FeatureConfig`.
 
 ## Advanced
 

--- a/examples/echo-kotlin/src/main/kotlin/com/example/echo/EchoServer.kt
+++ b/examples/echo-kotlin/src/main/kotlin/com/example/echo/EchoServer.kt
@@ -23,7 +23,7 @@ fun createServer(port: Int = 0): TachyonServer {
                 enabled = true
             }
             capabilities {
-                tools = Mode.ON
+                tools { mode = Mode.ON }
             }
             tool(
                 name = "echo",

--- a/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/config/CapabilitiesScope.kt
+++ b/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/config/CapabilitiesScope.kt
@@ -3,41 +3,25 @@
 package dev.tachyonmcp.server.config
 
 import dev.tachyonmcp.server.TachyonDsl
-import dev.tachyonmcp.server.features.Pagination
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
 
 @TachyonDsl
 public class CapabilitiesScope
     @PublishedApi
     internal constructor() {
-        /** Tool capability mode: `ON`, `OFF`, or `AUTO`. */
-        public var tools: Mode = Mode.AUTO
+        @PublishedApi
+        internal var toolsConfig: FeatureConfig = FeatureConfig.DEFAULT
 
-        /** Whether to advertise tool list change notifications. */
-        public var toolsListChanged: Boolean = false
+        @PublishedApi
+        internal var resourcesConfig: ResourcesConfig = ResourcesConfig.DEFAULT
 
-        /** Resources capability mode: `ON`, `OFF`, or `AUTO`. */
-        public var resources: Mode = Mode.AUTO
+        @PublishedApi
+        internal var promptsConfig: FeatureConfig = FeatureConfig.DEFAULT
 
-        /** Whether to support resource subscriptions. */
-        public var resourcesSubscribe: Boolean = false
-
-        /** Whether to advertise resource list change notifications. */
-        public var resourcesListChanged: Boolean = false
-
-        /** Prompts capability mode: `ON`, `OFF`, or `AUTO`. */
-        public var prompts: Mode = Mode.AUTO
-
-        /** Whether to advertise prompt list change notifications. */
-        public var promptsListChanged: Boolean = false
-
-        /** Whether tasks capability is enabled. */
-        public var tasks: Boolean = false
-
-        /** Whether to support task cancellation. */
-        public var tasksCancel: Boolean = false
-
-        /** Whether to support task requests. */
-        public var tasksRequests: Boolean = false
+        @PublishedApi
+        internal var tasksConfig: TasksConfig = TasksConfig.DEFAULT
 
         /** Whether completions capability is enabled. */
         public var completions: Boolean = false
@@ -45,52 +29,37 @@ public class CapabilitiesScope
         /** Whether logging capability is enabled. */
         public var logging: Boolean = false
 
-        /** Default page size for tools/list when limit is omitted. */
-        public var toolsPageSize: Int = Pagination.DEFAULT_PAGE_SIZE
-
-        /** Default page size for resources/list when limit is omitted. */
-        public var resourcesPageSize: Int = Pagination.DEFAULT_PAGE_SIZE
-
-        /** Default page size for prompts/list when limit is omitted. */
-        public var promptsPageSize: Int = Pagination.DEFAULT_PAGE_SIZE
-
-        /** Default page size for tasks/list when limit is omitted. */
-        public var tasksPageSize: Int = Pagination.DEFAULT_PAGE_SIZE
-
-        public fun tools(listChanged: Boolean = false) {
-            tools = Mode.ON
-            toolsListChanged = listChanged
+        @OptIn(ExperimentalContracts::class)
+        public inline fun tools(configure: (@TachyonDsl FeatureScope).() -> Unit) {
+            contract { callsInPlace(configure, InvocationKind.EXACTLY_ONCE) }
+            toolsConfig = FeatureScope().apply(configure).toConfig()
         }
 
-        public fun resources(
-            subscribe: Boolean = false,
-            listChanged: Boolean = false,
-        ) {
-            resources = Mode.ON
-            resourcesSubscribe = subscribe
-            resourcesListChanged = listChanged
+        @OptIn(ExperimentalContracts::class)
+        public inline fun resources(configure: (@TachyonDsl ResourcesScope).() -> Unit) {
+            contract { callsInPlace(configure, InvocationKind.EXACTLY_ONCE) }
+            resourcesConfig = ResourcesScope().apply(configure).toConfig()
         }
 
-        public fun prompts(listChanged: Boolean = false) {
-            prompts = Mode.ON
-            promptsListChanged = listChanged
+        @OptIn(ExperimentalContracts::class)
+        public inline fun prompts(configure: (@TachyonDsl FeatureScope).() -> Unit) {
+            contract { callsInPlace(configure, InvocationKind.EXACTLY_ONCE) }
+            promptsConfig = FeatureScope().apply(configure).toConfig()
+        }
+
+        @OptIn(ExperimentalContracts::class)
+        public inline fun tasks(configure: (@TachyonDsl TasksScope).() -> Unit) {
+            contract { callsInPlace(configure, InvocationKind.EXACTLY_ONCE) }
+            tasksConfig = TasksScope().apply(configure).toConfig()
         }
 
         @PublishedApi
         internal fun applyTo(builder: CapabilitiesConfig.Builder) {
-            builder.toolsMode(tools)
-            builder.toolsListChanged(toolsListChanged)
-            builder.resourcesMode(resources)
-            builder.resourcesSubscribe(resourcesSubscribe)
-            builder.resourcesListChanged(resourcesListChanged)
-            builder.promptsMode(prompts)
-            builder.promptsListChanged(promptsListChanged)
-            if (tasks) builder.tasks(true, tasksCancel, tasksRequests)
+            builder.tools(toolsConfig)
+            builder.resources(resourcesConfig)
+            builder.prompts(promptsConfig)
+            builder.tasks(tasksConfig)
             if (completions) builder.completions()
             if (logging) builder.logging()
-            builder.toolsPageSize(toolsPageSize)
-            builder.resourcesPageSize(resourcesPageSize)
-            builder.promptsPageSize(promptsPageSize)
-            builder.tasksPageSize(tasksPageSize)
         }
     }

--- a/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/config/FeatureScope.kt
+++ b/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/config/FeatureScope.kt
@@ -1,0 +1,29 @@
+// Copyright (c) 2026 Konstantin Pavlov and contributors.
+
+package dev.tachyonmcp.server.config
+
+import dev.tachyonmcp.server.TachyonDsl
+import dev.tachyonmcp.server.features.Pagination
+
+@TachyonDsl
+public class FeatureScope
+    @PublishedApi
+    internal constructor() {
+        /** Enablement mode: `ON`, `OFF`, or `AUTO`. */
+        public var mode: Mode = Mode.AUTO
+
+        /** Whether to advertise list-changed notifications. */
+        public var listChanged: Boolean = false
+
+        /** Default page size when a list request omits its limit. */
+        public var pageSize: Int = Pagination.DEFAULT_PAGE_SIZE
+
+        @PublishedApi
+        internal fun toConfig(): FeatureConfig =
+            FeatureConfig
+                .builder()
+                .mode(mode)
+                .listChanged(listChanged)
+                .pageSize(pageSize)
+                .build()
+    }

--- a/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/config/ResourcesScope.kt
+++ b/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/config/ResourcesScope.kt
@@ -1,0 +1,33 @@
+// Copyright (c) 2026 Konstantin Pavlov and contributors.
+
+package dev.tachyonmcp.server.config
+
+import dev.tachyonmcp.server.TachyonDsl
+import dev.tachyonmcp.server.features.Pagination
+
+@TachyonDsl
+public class ResourcesScope
+    @PublishedApi
+    internal constructor() {
+        /** Enablement mode: `ON`, `OFF`, or `AUTO`. */
+        public var mode: Mode = Mode.AUTO
+
+        /** Whether to advertise list-changed notifications. */
+        public var listChanged: Boolean = false
+
+        /** Default page size when a list request omits its limit. */
+        public var pageSize: Int = Pagination.DEFAULT_PAGE_SIZE
+
+        /** Whether resource subscriptions (`resources/subscribe`) are supported. */
+        public var subscribe: Boolean = false
+
+        @PublishedApi
+        internal fun toConfig(): ResourcesConfig =
+            ResourcesConfig
+                .builder()
+                .mode(mode)
+                .listChanged(listChanged)
+                .pageSize(pageSize)
+                .subscribe(subscribe)
+                .build()
+    }

--- a/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/config/TasksScope.kt
+++ b/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/config/TasksScope.kt
@@ -1,0 +1,37 @@
+// Copyright (c) 2026 Konstantin Pavlov and contributors.
+
+package dev.tachyonmcp.server.config
+
+import dev.tachyonmcp.server.TachyonDsl
+import dev.tachyonmcp.server.features.Pagination
+
+@TachyonDsl
+public class TasksScope
+    @PublishedApi
+    internal constructor() {
+        /** Whether the `tasks` capability is advertised at all. */
+        public var enabled: Boolean = false
+
+        /** Whether `tasks/list` is exposed. */
+        public var list: Boolean = false
+
+        /** Whether `tasks/cancel` is supported. */
+        public var cancel: Boolean = false
+
+        /** Whether task-augmented `tools/call` requests are accepted (`tasks.requests.tools.call`). */
+        public var requests: Boolean = false
+
+        /** Default page size when a list request omits its limit. */
+        public var pageSize: Int = Pagination.DEFAULT_PAGE_SIZE
+
+        @PublishedApi
+        internal fun toConfig(): TasksConfig =
+            TasksConfig
+                .builder()
+                .enabled(enabled)
+                .list(list)
+                .cancel(cancel)
+                .requests(requests)
+                .pageSize(pageSize)
+                .build()
+    }

--- a/tachyon-server-kotlin/src/test/kotlin/dev/tachyonmcp/server/TachyonServerTest.kt
+++ b/tachyon-server-kotlin/src/test/kotlin/dev/tachyonmcp/server/TachyonServerTest.kt
@@ -44,20 +44,29 @@ internal class TachyonServerTest {
                 instructions = "ignore me"
             }
             capabilities {
-                tools = Mode.ON
-                toolsListChanged = true
-                toolsPageSize = 20
-                resources = Mode.ON
-                resourcesSubscribe = true
-                resourcesListChanged = true
-                resourcesPageSize = 21
-                prompts = Mode.ON
-                promptsListChanged = true
-                promptsPageSize = 22
-                tasks = true
-                tasksCancel = true
-                tasksRequests = true
-                tasksPageSize = 23
+                tools {
+                    mode = Mode.ON
+                    listChanged = true
+                    pageSize = 20
+                }
+                resources {
+                    mode = Mode.ON
+                    subscribe = true
+                    listChanged = true
+                    pageSize = 21
+                }
+                prompts {
+                    mode = Mode.ON
+                    listChanged = true
+                    pageSize = 22
+                }
+                tasks {
+                    enabled = true
+                    list = true
+                    cancel = true
+                    requests = true
+                    pageSize = 23
+                }
                 completions = true
                 logging = true
             }
@@ -115,20 +124,21 @@ internal class TachyonServerTest {
 
             // capabilities
             with(config.capabilities()) {
-                toolsMode() shouldBe Mode.ON
-                toolsListChanged() shouldBe true
-                toolsPageSize() shouldBe 20
-                resourcesMode() shouldBe Mode.ON
-                resourcesSubscribe() shouldBe true
-                resourcesListChanged() shouldBe true
-                resourcesPageSize() shouldBe 21
-                promptsMode() shouldBe Mode.ON
-                promptsListChanged() shouldBe true
-                promptsPageSize() shouldBe 22
-                tasksList() shouldBe true
-                tasksCancel() shouldBe true
-                tasksRequests() shouldBe true
-                tasksPageSize() shouldBe 23
+                tools().mode() shouldBe Mode.ON
+                tools().listChanged() shouldBe true
+                tools().pageSize() shouldBe 20
+                resources().mode() shouldBe Mode.ON
+                resources().subscribe() shouldBe true
+                resources().listChanged() shouldBe true
+                resources().pageSize() shouldBe 21
+                prompts().mode() shouldBe Mode.ON
+                prompts().listChanged() shouldBe true
+                prompts().pageSize() shouldBe 22
+                tasks().enabled() shouldBe true
+                tasks().list() shouldBe true
+                tasks().cancel() shouldBe true
+                tasks().requests() shouldBe true
+                tasks().pageSize() shouldBe 23
                 completions() shouldBe true
                 logging() shouldBe true
             }
@@ -176,7 +186,7 @@ internal class TachyonServerTest {
             buildServer {
                 name("kotlin-build")
                 capabilities {
-                    tools = Mode.AUTO
+                    tools { mode = Mode.AUTO }
                 }
                 tool("build", "Build test") { ToolResult.text("built") }
             }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/DefaultTachyonServer.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/DefaultTachyonServer.java
@@ -175,42 +175,44 @@ final class DefaultTachyonServer implements ServerEngine {
         var hasTaskAugmentedTools = toolRegistry.getAll().stream()
                 .anyMatch(h ->
                         h.descriptor().taskSupport() != null && h.descriptor().taskSupport() != TaskSupport.FORBIDDEN);
-        if (capabilitiesConfig.tasksList() || capabilitiesConfig.tasksRequests() || hasTaskAugmentedTools) {
+        var tasksConfig = capabilitiesConfig.tasks();
+        if (tasksConfig.enabled() || hasTaskAugmentedTools) {
             builder.tasks(new ServerCapabilities.Tasks(
-                    capabilitiesConfig.tasksList(),
-                    capabilitiesConfig.tasksCancel(),
-                    capabilitiesConfig.tasksRequests() || hasTaskAugmentedTools));
+                    tasksConfig.list(), tasksConfig.cancel(), tasksConfig.requests() || hasTaskAugmentedTools));
         }
 
-        switch (capabilitiesConfig.toolsMode()) {
-            case ON -> builder.tools(new ServerCapabilities.Tools(capabilitiesConfig.toolsListChanged()));
+        var toolsConfig = capabilitiesConfig.tools();
+        switch (toolsConfig.mode()) {
+            case ON -> builder.tools(new ServerCapabilities.Tools(toolsConfig.listChanged()));
             case OFF -> {}
             case AUTO -> {
                 if (!toolRegistry.isEmpty()) {
-                    builder.tools(new ServerCapabilities.Tools(capabilitiesConfig.toolsListChanged()));
+                    builder.tools(new ServerCapabilities.Tools(toolsConfig.listChanged()));
                 }
             }
         }
 
-        switch (capabilitiesConfig.resourcesMode()) {
+        var resourcesConfig = capabilitiesConfig.resources();
+        switch (resourcesConfig.mode()) {
             case ON ->
-                builder.resources(new ServerCapabilities.Resources(
-                        capabilitiesConfig.resourcesSubscribe(), capabilitiesConfig.resourcesListChanged()));
+                builder.resources(
+                        new ServerCapabilities.Resources(resourcesConfig.subscribe(), resourcesConfig.listChanged()));
             case OFF -> {}
             case AUTO -> {
                 if (!resourceRegistry.getAll().isEmpty()) {
                     builder.resources(new ServerCapabilities.Resources(
-                            capabilitiesConfig.resourcesSubscribe(), capabilitiesConfig.resourcesListChanged()));
+                            resourcesConfig.subscribe(), resourcesConfig.listChanged()));
                 }
             }
         }
 
-        switch (capabilitiesConfig.promptsMode()) {
-            case ON -> builder.prompts(new ServerCapabilities.Prompts(capabilitiesConfig.promptsListChanged()));
+        var promptsConfig = capabilitiesConfig.prompts();
+        switch (promptsConfig.mode()) {
+            case ON -> builder.prompts(new ServerCapabilities.Prompts(promptsConfig.listChanged()));
             case OFF -> {}
             case AUTO -> {
                 if (!promptRegistry.getAll().isEmpty()) {
-                    builder.prompts(new ServerCapabilities.Prompts(capabilitiesConfig.promptsListChanged()));
+                    builder.prompts(new ServerCapabilities.Prompts(promptsConfig.listChanged()));
                 }
             }
         }
@@ -245,10 +247,10 @@ final class DefaultTachyonServer implements ServerEngine {
                 payloadDeserializer != null ? payloadDeserializer : defaultSerde;
         var caps = config.capabilities();
         this.toolRegistry = new ToolRegistry(
-                inputValidator1, outputValidator1, payloadSerializer1, payloadDeserializer1, caps.toolsPageSize());
-        this.resourceRegistry = new ResourceRegistry(this, caps.resourcesPageSize());
-        this.taskRegistry = new TaskRegistry(this, caps.tasksPageSize());
-        this.promptRegistry = new PromptRegistry(inputValidator1, caps.promptsPageSize());
+                inputValidator1, outputValidator1, payloadSerializer1, payloadDeserializer1, caps.tools());
+        this.resourceRegistry = new ResourceRegistry(this, caps.resources());
+        this.taskRegistry = new TaskRegistry(this, caps.tasks());
+        this.promptRegistry = new PromptRegistry(inputValidator1, caps.prompts());
         registerDefaults();
         bootstrapExtensions();
         setupChangeListeners(config);
@@ -287,16 +289,17 @@ final class DefaultTachyonServer implements ServerEngine {
     }
 
     private void setupChangeListeners(ServerConfig config) {
-        if (config.capabilities().toolsListChanged()) {
+        var caps = config.capabilities();
+        if (caps.tools().listChanged()) {
             toolRegistry.onChange(() -> broadcastNotification("notifications/tools/list_changed"));
         }
-        if (config.capabilities().resourcesListChanged()) {
+        if (caps.resources().listChanged()) {
             resourceRegistry.onChange(() -> broadcastNotification("notifications/resources/list_changed"));
         }
-        if (config.capabilities().promptsListChanged()) {
+        if (caps.prompts().listChanged()) {
             promptRegistry.onChange(() -> broadcastNotification("notifications/prompts/list_changed"));
         }
-        if (config.capabilities().tasksList()) {
+        if (caps.tasks().list()) {
             taskRegistry.onChange(() -> broadcastNotification("notifications/tasks/list_changed"));
         }
         taskRegistry.startTtlJanitor();

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/config/CapabilitiesConfig.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/config/CapabilitiesConfig.java
@@ -20,7 +20,9 @@ public record CapabilitiesConfig(
         boolean completions,
         boolean logging) {
 
-    /** Default configuration with all capabilities auto-detected and change notifications off. */
+    /**
+     * Default configuration with all capabilities auto-detected and change notifications off.
+     */
     public static final CapabilitiesConfig DEFAULT = new CapabilitiesConfig(
             FeatureConfig.DEFAULT, ResourcesConfig.DEFAULT, FeatureConfig.DEFAULT, TasksConfig.DEFAULT, false, false);
 
@@ -28,7 +30,9 @@ public record CapabilitiesConfig(
         return new Builder();
     }
 
-    /** Builder for {@link CapabilitiesConfig}. */
+    /**
+     * Builder for {@link CapabilitiesConfig}.
+     */
     public static final class Builder {
 
         private FeatureConfig.Builder toolsBuilder = FeatureConfig.builder();
@@ -129,6 +133,11 @@ public record CapabilitiesConfig(
             return this;
         }
 
+        public Builder tasksEnabled(boolean tasksEnabled) {
+            tasksBuilder.enabled(tasksEnabled);
+            return this;
+        }
+
         public Builder tasksList(boolean tasksList) {
             tasksBuilder.list(tasksList);
             return this;
@@ -215,8 +224,16 @@ public record CapabilitiesConfig(
             return promptsMode(Mode.OFF);
         }
 
+        public Builder noTasks() {
+            return tasksEnabled(false);
+        }
+
         public Builder tasks() {
-            tasksBuilder.enabled(true).list(true).cancel(false).requests(false);
+            tasksBuilder
+                    .enabled(true)
+                    .list(TasksConfig.DEFAULT_TASK_LIST)
+                    .cancel(TasksConfig.DEFAULT_TASK_CANCEL)
+                    .requests(TasksConfig.DEFAULT_TASK_REQUESTS);
             return this;
         }
 

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/config/CapabilitiesConfig.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/config/CapabilitiesConfig.java
@@ -2,208 +2,227 @@
 
 package dev.tachyonmcp.server.config;
 
-import dev.tachyonmcp.server.features.Pagination;
-import org.immutables.value.Value;
-
 /**
  * Configuration of which MCP capabilities to enable and their behaviour.
+ *
+ * @param tools       tools capability configuration
+ * @param resources   resources capability configuration
+ * @param prompts     prompts capability configuration
+ * @param tasks       tasks capability configuration
+ * @param completions whether the completions capability is enabled (default {@code false})
+ * @param logging     whether the logging capability is enabled (default {@code false})
  */
-@Value.Immutable
-@Value.Style(visibility = Value.Style.ImplementationVisibility.PACKAGE, typeImmutable = "Default*")
-public interface CapabilitiesConfig {
-
-    @Value.Default
-    default Mode toolsMode() {
-        return Mode.AUTO;
-    }
-
-    @Value.Default
-    default boolean toolsListChanged() {
-        return false;
-    }
-
-    @Value.Default
-    default Mode resourcesMode() {
-        return Mode.AUTO;
-    }
-
-    @Value.Default
-    default boolean resourcesSubscribe() {
-        return false;
-    }
-
-    @Value.Default
-    default boolean resourcesListChanged() {
-        return false;
-    }
-
-    @Value.Default
-    default Mode promptsMode() {
-        return Mode.AUTO;
-    }
-
-    @Value.Default
-    default boolean promptsListChanged() {
-        return false;
-    }
-
-    @Value.Default
-    default boolean tasksList() {
-        return false;
-    }
-
-    @Value.Default
-    default boolean tasksCancel() {
-        return false;
-    }
-
-    @Value.Default
-    default boolean tasksRequests() {
-        return false;
-    }
-
-    @Value.Default
-    default boolean completions() {
-        return false;
-    }
-
-    @Value.Default
-    default boolean logging() {
-        return false;
-    }
-
-    @Value.Default
-    default int toolsPageSize() {
-        return Pagination.DEFAULT_PAGE_SIZE;
-    }
-
-    @Value.Default
-    default int resourcesPageSize() {
-        return Pagination.DEFAULT_PAGE_SIZE;
-    }
-
-    @Value.Default
-    default int promptsPageSize() {
-        return Pagination.DEFAULT_PAGE_SIZE;
-    }
-
-    @Value.Default
-    default int tasksPageSize() {
-        return Pagination.DEFAULT_PAGE_SIZE;
-    }
-
-    @Value.Check
-    default void check() {
-        if (toolsPageSize() <= 0) {
-            throw new IllegalArgumentException("toolsPageSize must be positive, got: " + toolsPageSize());
-        }
-        if (resourcesPageSize() <= 0) {
-            throw new IllegalArgumentException("resourcesPageSize must be positive, got: " + resourcesPageSize());
-        }
-        if (promptsPageSize() <= 0) {
-            throw new IllegalArgumentException("promptsPageSize must be positive, got: " + promptsPageSize());
-        }
-        if (tasksPageSize() <= 0) {
-            throw new IllegalArgumentException("tasksPageSize must be positive, got: " + tasksPageSize());
-        }
-    }
+public record CapabilitiesConfig(
+        FeatureConfig tools,
+        ResourcesConfig resources,
+        FeatureConfig prompts,
+        TasksConfig tasks,
+        boolean completions,
+        boolean logging) {
 
     /** Default configuration with all capabilities auto-detected and change notifications off. */
-    CapabilitiesConfig DEFAULT = builder().build();
+    public static final CapabilitiesConfig DEFAULT = new CapabilitiesConfig(
+            FeatureConfig.DEFAULT, ResourcesConfig.DEFAULT, FeatureConfig.DEFAULT, TasksConfig.DEFAULT, false, false);
 
-    static Builder builder() {
-        return DefaultCapabilitiesConfig.builder();
+    public static Builder builder() {
+        return new Builder();
     }
 
     /** Builder for {@link CapabilitiesConfig}. */
-    interface Builder {
+    public static final class Builder {
 
-        Builder toolsMode(Mode toolsMode);
+        private FeatureConfig.Builder toolsBuilder = FeatureConfig.builder();
+        private ResourcesConfig.Builder resourcesBuilder = ResourcesConfig.builder();
+        private FeatureConfig.Builder promptsBuilder = FeatureConfig.builder();
+        private TasksConfig.Builder tasksBuilder = TasksConfig.builder();
+        private boolean completions;
+        private boolean logging;
 
-        Builder toolsListChanged(boolean toolsListChanged);
+        private Builder() {}
 
-        Builder resourcesMode(Mode resourcesMode);
+        // === Nested config setters ===
 
-        Builder resourcesSubscribe(boolean resourcesSubscribe);
+        public Builder tools(FeatureConfig config) {
+            toolsBuilder = FeatureConfig.builder()
+                    .mode(config.mode())
+                    .listChanged(config.listChanged())
+                    .pageSize(config.pageSize());
+            return this;
+        }
 
-        Builder resourcesListChanged(boolean resourcesListChanged);
+        public Builder resources(ResourcesConfig config) {
+            resourcesBuilder = ResourcesConfig.builder()
+                    .mode(config.mode())
+                    .listChanged(config.listChanged())
+                    .pageSize(config.pageSize())
+                    .subscribe(config.subscribe());
+            return this;
+        }
 
-        Builder promptsMode(Mode promptsMode);
+        public Builder prompts(FeatureConfig config) {
+            promptsBuilder = FeatureConfig.builder()
+                    .mode(config.mode())
+                    .listChanged(config.listChanged())
+                    .pageSize(config.pageSize());
+            return this;
+        }
 
-        Builder promptsListChanged(boolean promptsListChanged);
+        public Builder tasks(TasksConfig config) {
+            tasksBuilder = TasksConfig.builder()
+                    .enabled(config.enabled())
+                    .list(config.list())
+                    .cancel(config.cancel())
+                    .requests(config.requests())
+                    .pageSize(config.pageSize());
+            return this;
+        }
 
-        Builder tasksList(boolean tasksList);
+        // === Flat field setters ===
 
-        Builder tasksCancel(boolean tasksCancel);
+        public Builder toolsMode(Mode toolsMode) {
+            toolsBuilder.mode(toolsMode);
+            return this;
+        }
 
-        Builder tasksRequests(boolean tasksRequests);
+        public Builder toolsListChanged(boolean toolsListChanged) {
+            toolsBuilder.listChanged(toolsListChanged);
+            return this;
+        }
 
-        Builder completions(boolean completions);
+        public Builder toolsPageSize(int toolsPageSize) {
+            toolsBuilder.pageSize(toolsPageSize);
+            return this;
+        }
 
-        Builder logging(boolean logging);
+        public Builder resourcesMode(Mode resourcesMode) {
+            resourcesBuilder.mode(resourcesMode);
+            return this;
+        }
 
-        Builder toolsPageSize(int toolsPageSize);
+        public Builder resourcesSubscribe(boolean resourcesSubscribe) {
+            resourcesBuilder.subscribe(resourcesSubscribe);
+            return this;
+        }
 
-        Builder resourcesPageSize(int resourcesPageSize);
+        public Builder resourcesListChanged(boolean resourcesListChanged) {
+            resourcesBuilder.listChanged(resourcesListChanged);
+            return this;
+        }
 
-        Builder promptsPageSize(int promptsPageSize);
+        public Builder resourcesPageSize(int resourcesPageSize) {
+            resourcesBuilder.pageSize(resourcesPageSize);
+            return this;
+        }
 
-        Builder tasksPageSize(int tasksPageSize);
+        public Builder promptsMode(Mode promptsMode) {
+            promptsBuilder.mode(promptsMode);
+            return this;
+        }
 
-        CapabilitiesConfig build();
+        public Builder promptsListChanged(boolean promptsListChanged) {
+            promptsBuilder.listChanged(promptsListChanged);
+            return this;
+        }
+
+        public Builder promptsPageSize(int promptsPageSize) {
+            promptsBuilder.pageSize(promptsPageSize);
+            return this;
+        }
+
+        public Builder tasksList(boolean tasksList) {
+            tasksBuilder.list(tasksList);
+            return this;
+        }
+
+        public Builder tasksCancel(boolean tasksCancel) {
+            tasksBuilder.cancel(tasksCancel);
+            return this;
+        }
+
+        public Builder tasksRequests(boolean tasksRequests) {
+            tasksBuilder.requests(tasksRequests);
+            return this;
+        }
+
+        public Builder tasksPageSize(int tasksPageSize) {
+            tasksBuilder.pageSize(tasksPageSize);
+            return this;
+        }
+
+        public Builder completions(boolean completions) {
+            this.completions = completions;
+            return this;
+        }
+
+        public Builder logging(boolean logging) {
+            this.logging = logging;
+            return this;
+        }
+
+        public CapabilitiesConfig build() {
+            return new CapabilitiesConfig(
+                    toolsBuilder.build(),
+                    resourcesBuilder.build(),
+                    promptsBuilder.build(),
+                    tasksBuilder.build(),
+                    completions,
+                    logging);
+        }
 
         // === Convenience defaults ===
 
-        default Builder completions() {
+        public Builder completions() {
             return completions(true);
         }
 
-        default Builder logging() {
+        public Builder logging() {
             return logging(true);
         }
 
-        default Builder tools() {
+        public Builder tools() {
             return toolsMode(Mode.ON).toolsListChanged(false);
         }
 
-        default Builder tools(boolean listChanged) {
+        public Builder tools(boolean listChanged) {
             return toolsMode(Mode.ON).toolsListChanged(listChanged);
         }
 
-        default Builder noTools() {
+        public Builder noTools() {
             return toolsMode(Mode.OFF);
         }
 
-        default Builder resources() {
+        public Builder resources() {
             return resourcesMode(Mode.ON).resourcesSubscribe(false).resourcesListChanged(false);
         }
 
-        default Builder resources(boolean subscribe, boolean listChanged) {
+        public Builder resources(boolean subscribe, boolean listChanged) {
             return resourcesMode(Mode.ON).resourcesSubscribe(subscribe).resourcesListChanged(listChanged);
         }
 
-        default Builder noResources() {
+        public Builder noResources() {
             return resourcesMode(Mode.OFF);
         }
 
-        default Builder prompts() {
+        public Builder prompts() {
             return promptsMode(Mode.ON).promptsListChanged(false);
         }
 
-        default Builder prompts(boolean listChanged) {
+        public Builder prompts(boolean listChanged) {
             return promptsMode(Mode.ON).promptsListChanged(listChanged);
         }
 
-        default Builder noPrompts() {
+        public Builder noPrompts() {
             return promptsMode(Mode.OFF);
         }
 
-        default Builder tasks() {
-            return tasksList(true).tasksCancel(false).tasksRequests(false);
+        public Builder tasks() {
+            tasksBuilder.enabled(true).list(true).cancel(false).requests(false);
+            return this;
         }
 
-        default Builder tasks(boolean list, boolean cancel, boolean requests) {
-            return tasksList(list).tasksCancel(cancel).tasksRequests(requests);
+        public Builder tasks(boolean list, boolean cancel, boolean requests) {
+            tasksBuilder.enabled(true).list(list).cancel(cancel).requests(requests);
+            return this;
         }
     }
 }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/config/FeatureConfig.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/config/FeatureConfig.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2026 Konstantin Pavlov and contributors.
+ */
+
+package dev.tachyonmcp.server.config;
+
+import dev.tachyonmcp.server.features.Pagination;
+
+/**
+ * Shared configuration for a single-list MCP capability (tools/prompts): enablement mode,
+ * list-changed notifications, and default page size.
+ *
+ * @param mode        enabled/disabled/auto-detected (default {@link Mode#AUTO})
+ * @param listChanged whether to advertise list-changed notifications (default {@code false})
+ * @param pageSize    default page size when a list request omits its limit
+ *                    (default {@link Pagination#DEFAULT_PAGE_SIZE})
+ */
+public record FeatureConfig(Mode mode, boolean listChanged, int pageSize) {
+
+    public static final FeatureConfig DEFAULT = new FeatureConfig(Mode.AUTO, false, Pagination.DEFAULT_PAGE_SIZE);
+
+    public FeatureConfig {
+        if (pageSize <= 0) {
+            throw new IllegalArgumentException("pageSize must be positive, got: " + pageSize);
+        }
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /** Builder for {@link FeatureConfig}. */
+    public static final class Builder {
+        private Mode mode = Mode.AUTO;
+        private boolean listChanged = false;
+        private int pageSize = Pagination.DEFAULT_PAGE_SIZE;
+
+        private Builder() {}
+
+        public Builder mode(Mode mode) {
+            this.mode = mode;
+            return this;
+        }
+
+        public Builder listChanged(boolean listChanged) {
+            this.listChanged = listChanged;
+            return this;
+        }
+
+        public Builder pageSize(int pageSize) {
+            this.pageSize = pageSize;
+            return this;
+        }
+
+        /** Enables the capability ({@code mode = ON}). */
+        public Builder on() {
+            return mode(Mode.ON);
+        }
+
+        /** Disables the capability ({@code mode = OFF}). */
+        public Builder off() {
+            return mode(Mode.OFF);
+        }
+
+        public FeatureConfig build() {
+            return new FeatureConfig(mode, listChanged, pageSize);
+        }
+    }
+}

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/config/FeatureConfig.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/config/FeatureConfig.java
@@ -17,7 +17,7 @@ import dev.tachyonmcp.server.features.Pagination;
  */
 public record FeatureConfig(Mode mode, boolean listChanged, int pageSize) {
 
-    public static final FeatureConfig DEFAULT = new FeatureConfig(Mode.AUTO, false, Pagination.DEFAULT_PAGE_SIZE);
+    static final FeatureConfig DEFAULT = new FeatureConfig(Mode.AUTO, false, Pagination.DEFAULT_PAGE_SIZE);
 
     public FeatureConfig {
         if (pageSize <= 0) {
@@ -31,9 +31,9 @@ public record FeatureConfig(Mode mode, boolean listChanged, int pageSize) {
 
     /** Builder for {@link FeatureConfig}. */
     public static final class Builder {
-        private Mode mode = Mode.AUTO;
-        private boolean listChanged = false;
-        private int pageSize = Pagination.DEFAULT_PAGE_SIZE;
+        private Mode mode = DEFAULT.mode;
+        private boolean listChanged = DEFAULT.listChanged;
+        private int pageSize = DEFAULT.pageSize;
 
         private Builder() {}
 

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/config/MonitoringConfig.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/config/MonitoringConfig.java
@@ -10,7 +10,7 @@ import java.util.Objects;
 public record MonitoringConfig(boolean slowRequestLogging, Duration slowRequestThreshold) {
 
     public static final Duration DEFAULT_SLOW_REQUEST_THRESHOLD = Duration.ofSeconds(10);
-    public static final MonitoringConfig DEFAULT = new MonitoringConfig(false, DEFAULT_SLOW_REQUEST_THRESHOLD);
+    static final MonitoringConfig DEFAULT = new MonitoringConfig(false, DEFAULT_SLOW_REQUEST_THRESHOLD);
 
     public static Builder builder() {
         return new Builder();
@@ -21,8 +21,8 @@ public record MonitoringConfig(boolean slowRequestLogging, Duration slowRequestT
     }
 
     public static final class Builder {
-        private boolean slowRequestLogging;
-        private Duration slowRequestThreshold = DEFAULT_SLOW_REQUEST_THRESHOLD;
+        private boolean slowRequestLogging = DEFAULT.slowRequestLogging;
+        private Duration slowRequestThreshold = DEFAULT.slowRequestThreshold;
 
         private Builder() {}
 

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/config/NetworkConfig.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/config/NetworkConfig.java
@@ -73,7 +73,7 @@ public record NetworkConfig(
     public static final Duration DEFAULT_HEARTBEAT_INTERVAL = Duration.ofSeconds(15);
     public static final int DEFAULT_MAX_CONTENT_LENGTH = 65535;
 
-    public static final NetworkConfig DEFAULT = new NetworkConfig(
+    static final NetworkConfig DEFAULT = new NetworkConfig(
             DEFAULT_HOST,
             UNSET_PORT,
             DEFAULT_ENDPOINT_PATH,
@@ -93,18 +93,18 @@ public record NetworkConfig(
 
     /** Builder for {@link NetworkConfig}. */
     public static final class Builder {
-        private String host = DEFAULT_HOST;
-        private int port = UNSET_PORT;
-        private String endpointPath = DEFAULT_ENDPOINT_PATH;
-        private Duration readerIdleTimeout = DEFAULT_READER_IDLE_TIMEOUT;
-        private Duration writerIdleTimeout = DEFAULT_WRITER_IDLE_TIMEOUT;
-        private int maxContentLength = McpChannelInitializer.DEFAULT_MAX_CONTENT_LENGTH;
-        private @Nullable List<String> allowedOrigins;
-        private boolean allowNullOrigin;
-        private boolean allowPrivateNetworks;
-        private @Nullable List<String> allowedHeaders;
-        private NettyIoEngine ioEngine = NettyIoEngine.AUTO;
-        private Duration heartbeatInterval = DEFAULT_HEARTBEAT_INTERVAL;
+        private String host = DEFAULT.host;
+        private int port = DEFAULT.port;
+        private String endpointPath = DEFAULT.endpointPath;
+        private Duration readerIdleTimeout = DEFAULT.readerIdleTimeout;
+        private Duration writerIdleTimeout = DEFAULT.writerIdleTimeout;
+        private int maxContentLength = DEFAULT.maxContentLength;
+        private @Nullable List<String> allowedOrigins = DEFAULT.allowedOrigins;
+        private boolean allowNullOrigin = DEFAULT.allowNullOrigin;
+        private boolean allowPrivateNetworks = DEFAULT.allowPrivateNetworks;
+        private @Nullable List<String> allowedHeaders = DEFAULT.allowedHeaders;
+        private NettyIoEngine ioEngine = DEFAULT.ioEngine;
+        private Duration heartbeatInterval = DEFAULT.heartbeatInterval;
         private boolean hostPortExplicitlySet;
         private boolean addressExplicitlySet;
 
@@ -151,13 +151,13 @@ public record NetworkConfig(
 
         /** Sets the reader idle timeout. */
         public Builder readerIdleTimeout(Duration timeout) {
-            this.readerIdleTimeout = timeout;
+            this.readerIdleTimeout = Objects.requireNonNull(timeout, "readerIdleTimeout cannot be null");
             return this;
         }
 
         /** Sets the writer idle timeout. */
         public Builder writerIdleTimeout(Duration timeout) {
-            this.writerIdleTimeout = timeout;
+            this.writerIdleTimeout = Objects.requireNonNull(timeout, "writerIdleTimeout cannot be null");
             return this;
         }
 
@@ -196,7 +196,7 @@ public record NetworkConfig(
 
         /** Sets the Netty I/O engine; defaults to {@link NettyIoEngine#AUTO}. */
         public Builder ioEngine(NettyIoEngine ioEngine) {
-            this.ioEngine = Objects.requireNonNull(ioEngine, "ioEngine");
+            this.ioEngine = Objects.requireNonNull(ioEngine, "ioEngine cannot be null");
             return this;
         }
 
@@ -207,7 +207,7 @@ public record NetworkConfig(
          * client alive out of the box.
          */
         public Builder heartbeatInterval(Duration heartbeatInterval) {
-            this.heartbeatInterval = heartbeatInterval;
+            this.heartbeatInterval = Objects.requireNonNull(heartbeatInterval, "heartbeatInterval  cannot be null");
             return this;
         }
 

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/config/ResourcesConfig.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/config/ResourcesConfig.java
@@ -18,8 +18,7 @@ import dev.tachyonmcp.server.features.Pagination;
  */
 public record ResourcesConfig(Mode mode, boolean listChanged, int pageSize, boolean subscribe) {
 
-    public static final ResourcesConfig DEFAULT =
-            new ResourcesConfig(Mode.AUTO, false, Pagination.DEFAULT_PAGE_SIZE, false);
+    static final ResourcesConfig DEFAULT = new ResourcesConfig(Mode.AUTO, false, Pagination.DEFAULT_PAGE_SIZE, false);
 
     public ResourcesConfig {
         if (pageSize <= 0) {
@@ -33,10 +32,10 @@ public record ResourcesConfig(Mode mode, boolean listChanged, int pageSize, bool
 
     /** Builder for {@link ResourcesConfig}. */
     public static final class Builder {
-        private Mode mode = Mode.AUTO;
-        private boolean listChanged = false;
-        private int pageSize = Pagination.DEFAULT_PAGE_SIZE;
-        private boolean subscribe = false;
+        private Mode mode = DEFAULT.mode;
+        private boolean listChanged = DEFAULT.listChanged;
+        private int pageSize = DEFAULT.pageSize;
+        private boolean subscribe = DEFAULT.subscribe;
 
         private Builder() {}
 

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/config/ResourcesConfig.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/config/ResourcesConfig.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2026 Konstantin Pavlov and contributors.
+ */
+
+package dev.tachyonmcp.server.config;
+
+import dev.tachyonmcp.server.features.Pagination;
+
+/**
+ * Configuration for the resources capability: the same knobs as {@link FeatureConfig} plus
+ * subscription support.
+ *
+ * @param mode        enabled/disabled/auto-detected (default {@link Mode#AUTO})
+ * @param listChanged whether to advertise list-changed notifications (default {@code false})
+ * @param pageSize    default page size when a list request omits its limit
+ * @param subscribe   whether resource subscriptions ({@code resources/subscribe}) are supported
+ *                    (default {@code false})
+ */
+public record ResourcesConfig(Mode mode, boolean listChanged, int pageSize, boolean subscribe) {
+
+    public static final ResourcesConfig DEFAULT =
+            new ResourcesConfig(Mode.AUTO, false, Pagination.DEFAULT_PAGE_SIZE, false);
+
+    public ResourcesConfig {
+        if (pageSize <= 0) {
+            throw new IllegalArgumentException("pageSize must be positive, got: " + pageSize);
+        }
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /** Builder for {@link ResourcesConfig}. */
+    public static final class Builder {
+        private Mode mode = Mode.AUTO;
+        private boolean listChanged = false;
+        private int pageSize = Pagination.DEFAULT_PAGE_SIZE;
+        private boolean subscribe = false;
+
+        private Builder() {}
+
+        public Builder mode(Mode mode) {
+            this.mode = mode;
+            return this;
+        }
+
+        public Builder listChanged(boolean listChanged) {
+            this.listChanged = listChanged;
+            return this;
+        }
+
+        public Builder pageSize(int pageSize) {
+            this.pageSize = pageSize;
+            return this;
+        }
+
+        public Builder subscribe(boolean subscribe) {
+            this.subscribe = subscribe;
+            return this;
+        }
+
+        /** Enables the capability ({@code mode = ON}). */
+        public Builder on() {
+            return mode(Mode.ON);
+        }
+
+        /** Disables the capability ({@code mode = OFF}). */
+        public Builder off() {
+            return mode(Mode.OFF);
+        }
+
+        public ResourcesConfig build() {
+            return new ResourcesConfig(mode, listChanged, pageSize, subscribe);
+        }
+    }
+}

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/config/RuntimeConfig.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/config/RuntimeConfig.java
@@ -19,8 +19,8 @@ import java.util.Objects;
  */
 public record RuntimeConfig(Duration shutdownGracePeriod, Duration requestTimeout) {
 
-    public static final Duration DEFAULT_REQUEST_TIMEOUT = Duration.ofSeconds(60);
-    public static final RuntimeConfig DEFAULT = new RuntimeConfig(Duration.ofSeconds(5), DEFAULT_REQUEST_TIMEOUT);
+    static final Duration DEFAULT_REQUEST_TIMEOUT = Duration.ofSeconds(60);
+    static final RuntimeConfig DEFAULT = new RuntimeConfig(Duration.ofSeconds(5), DEFAULT_REQUEST_TIMEOUT);
 
     public static Builder builder() {
         return new Builder();
@@ -30,8 +30,8 @@ public record RuntimeConfig(Duration shutdownGracePeriod, Duration requestTimeou
      * Builder for {@link RuntimeConfig}.
      */
     public static final class Builder {
-        private Duration shutdownGracePeriod = DEFAULT.shutdownGracePeriod();
-        private Duration requestTimeout = DEFAULT_REQUEST_TIMEOUT;
+        private Duration shutdownGracePeriod = DEFAULT.shutdownGracePeriod;
+        private Duration requestTimeout = DEFAULT.requestTimeout;
 
         private Builder() {
             Objects.requireNonNull(shutdownGracePeriod, "shutdownGracePeriod cannot be null");

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/config/ServerConfig.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/config/ServerConfig.java
@@ -25,7 +25,7 @@ public record ServerConfig(
         RuntimeConfig runtime,
         MonitoringConfig monitoring) {
 
-    public static final ServerConfig DEFAULT = new ServerConfig(
+    static final ServerConfig DEFAULT = new ServerConfig(
             ServerIdentity.DEFAULT,
             CapabilitiesConfig.DEFAULT,
             SessionConfig.STATELESS,

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/config/TasksConfig.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/config/TasksConfig.java
@@ -21,7 +21,12 @@ import dev.tachyonmcp.server.features.Pagination;
  */
 public record TasksConfig(boolean enabled, boolean list, boolean cancel, boolean requests, int pageSize) {
 
-    public static final TasksConfig DEFAULT = new TasksConfig(false, false, false, false, Pagination.DEFAULT_PAGE_SIZE);
+    static final boolean DEFAULT_TASKS_ENABLED = false;
+    static final boolean DEFAULT_TASK_LIST = false;
+    static final boolean DEFAULT_TASK_CANCEL = false;
+    static final boolean DEFAULT_TASK_REQUESTS = false;
+
+    static final TasksConfig DEFAULT = new TasksConfig(false, false, false, false, Pagination.DEFAULT_PAGE_SIZE);
 
     public TasksConfig {
         if (pageSize <= 0) {
@@ -33,13 +38,16 @@ public record TasksConfig(boolean enabled, boolean list, boolean cancel, boolean
         return new Builder();
     }
 
-    /** Builder for {@link TasksConfig}. */
+    /**
+     * Builder for {@link TasksConfig}.
+     */
     public static final class Builder {
-        private boolean enabled = false;
-        private boolean list = false;
-        private boolean cancel = false;
-        private boolean requests = false;
-        private int pageSize = Pagination.DEFAULT_PAGE_SIZE;
+
+        private boolean enabled = DEFAULT_TASKS_ENABLED;
+        private boolean list = DEFAULT.list;
+        private boolean cancel = DEFAULT.cancel;
+        private boolean requests = DEFAULT.requests;
+        private int pageSize = DEFAULT.pageSize;
 
         private Builder() {}
 
@@ -68,7 +76,9 @@ public record TasksConfig(boolean enabled, boolean list, boolean cancel, boolean
             return this;
         }
 
-        /** Enables the tasks capability with the list surface on. */
+        /**
+         * Enables the tasks capability with the list surface on.
+         */
         public Builder on() {
             return enabled(true).list(true);
         }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/config/TasksConfig.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/config/TasksConfig.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2026 Konstantin Pavlov and contributors.
+ */
+
+package dev.tachyonmcp.server.config;
+
+import dev.tachyonmcp.server.features.Pagination;
+
+/**
+ * Configuration for the tasks capability. Fields map 1:1 to the MCP {@code tasks} capability
+ * object ({@code tasks.list}, {@code tasks.cancel}, {@code tasks.requests.tools.call}).
+ *
+ * @param enabled  whether the {@code tasks} capability is advertised at all (default
+ *                 {@code false}); the capability is also advertised, regardless of this flag,
+ *                 when a registered tool supports task augmentation
+ * @param list     whether {@code tasks/list} is exposed (default {@code false})
+ * @param cancel   whether {@code tasks/cancel} is supported (default {@code false})
+ * @param requests whether task-augmented {@code tools/call} requests are accepted
+ *                 (default {@code false})
+ * @param pageSize default page size when a list request omits its limit
+ */
+public record TasksConfig(boolean enabled, boolean list, boolean cancel, boolean requests, int pageSize) {
+
+    public static final TasksConfig DEFAULT = new TasksConfig(false, false, false, false, Pagination.DEFAULT_PAGE_SIZE);
+
+    public TasksConfig {
+        if (pageSize <= 0) {
+            throw new IllegalArgumentException("pageSize must be positive, got: " + pageSize);
+        }
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /** Builder for {@link TasksConfig}. */
+    public static final class Builder {
+        private boolean enabled = false;
+        private boolean list = false;
+        private boolean cancel = false;
+        private boolean requests = false;
+        private int pageSize = Pagination.DEFAULT_PAGE_SIZE;
+
+        private Builder() {}
+
+        public Builder enabled(boolean enabled) {
+            this.enabled = enabled;
+            return this;
+        }
+
+        public Builder list(boolean list) {
+            this.list = list;
+            return this;
+        }
+
+        public Builder cancel(boolean cancel) {
+            this.cancel = cancel;
+            return this;
+        }
+
+        public Builder requests(boolean requests) {
+            this.requests = requests;
+            return this;
+        }
+
+        public Builder pageSize(int pageSize) {
+            this.pageSize = pageSize;
+            return this;
+        }
+
+        /** Enables the tasks capability with the list surface on. */
+        public Builder on() {
+            return enabled(true).list(true);
+        }
+
+        public TasksConfig build() {
+            return new TasksConfig(enabled, list, cancel, requests, pageSize);
+        }
+    }
+}

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/features/prompts/PromptRegistry.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/features/prompts/PromptRegistry.java
@@ -8,6 +8,8 @@ import dev.tachyonmcp.annotations.InternalApi;
 import dev.tachyonmcp.protocol.mcp.v2025_11_25.codecs.ProtocolCodecUtil;
 import dev.tachyonmcp.protocol.mcp.v2025_11_25.models.GetPromptRequestParams;
 import dev.tachyonmcp.server.RpcMethodHandler;
+import dev.tachyonmcp.server.config.FeatureConfig;
+import dev.tachyonmcp.server.config.Mode;
 import dev.tachyonmcp.server.domain.PromptMessage;
 import dev.tachyonmcp.server.features.HandlerFutures;
 import dev.tachyonmcp.server.features.ListRequests;
@@ -27,22 +29,31 @@ import tools.jackson.databind.JsonNode;
 @InternalApi
 public class PromptRegistry extends Registry<PromptEntry> {
 
-    private final JsonSchemaValidator validator;
+    private static final Logger logger = LoggerFactory.getLogger(PromptRegistry.class);
 
-    public PromptRegistry(JsonSchemaValidator validator, int pageSize) {
-        super(pageSize);
+    private final JsonSchemaValidator validator;
+    private final FeatureConfig config;
+
+    public PromptRegistry(JsonSchemaValidator validator, FeatureConfig config) {
+        super(config.pageSize());
         this.validator = validator;
+        this.config = config;
     }
 
     public void add(PromptDescriptor descriptor, List<PromptMessage> messages) {
-        super.add(PromptEntry.of(descriptor, args -> messages));
+        add(descriptor, (InputRequiredPromptHandler) (ctx, request) -> PromptHandlerResult.messages(messages));
     }
 
     public void add(PromptDescriptor descriptor, PromptHandler handler) {
-        super.add(PromptEntry.of(descriptor, handler));
+        add(descriptor, (InputRequiredPromptHandler)
+                (ctx, request) -> PromptHandlerResult.messages(handler.getMessages(request.arguments())));
     }
 
     public void add(PromptDescriptor descriptor, InputRequiredPromptHandler handler) {
+        if (config.mode() == Mode.OFF) {
+            logger.debug("Prompt '{}' not registered: prompts capability is OFF", descriptor.name());
+            return;
+        }
         super.add(new PromptEntry(descriptor, handler));
     }
 

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/features/resources/ResourceRegistry.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/features/resources/ResourceRegistry.java
@@ -9,6 +9,8 @@ import dev.tachyonmcp.protocol.mcp.v2025_11_25.models.ReadResourceRequestParams;
 import dev.tachyonmcp.protocol.mcp.v2025_11_25.models.SubscribeRequestParams;
 import dev.tachyonmcp.protocol.mcp.v2025_11_25.models.UnsubscribeRequestParams;
 import dev.tachyonmcp.server.RpcMethodHandler;
+import dev.tachyonmcp.server.config.Mode;
+import dev.tachyonmcp.server.config.ResourcesConfig;
 import dev.tachyonmcp.server.domain.ReadResourceRequest;
 import dev.tachyonmcp.server.domain.ResourceContents;
 import dev.tachyonmcp.server.features.ChangeSupport;
@@ -41,21 +43,23 @@ import org.slf4j.LoggerFactory;
 @InternalApi
 public class ResourceRegistry {
 
+    private static final Logger logger = LoggerFactory.getLogger(ResourceRegistry.class);
+
     private final ConcurrentHashMap<String, ResourceEntry> byName = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<String, ResourceEntry> byUri = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<String, ResourceTemplateEntry> templates = new ConcurrentHashMap<>();
     final ConcurrentHashMap<String, Set<String>> subscriptions = new ConcurrentHashMap<>();
     private final ServerEngine server;
-    private final int defaultPageSize;
+    private final ResourcesConfig config;
 
     private final ChangeSupport changes = new ChangeSupport();
 
     /**
      * Creates a resource registry bound to the given server (for broadcasting subscription notifications).
      */
-    public ResourceRegistry(ServerEngine server, int defaultPageSize) {
+    public ResourceRegistry(ServerEngine server, ResourcesConfig config) {
         this.server = server;
-        this.defaultPageSize = defaultPageSize;
+        this.config = config;
     }
 
     public void onChange(Runnable callback) {
@@ -67,6 +71,10 @@ public class ResourceRegistry {
     }
 
     public ResourceRegistry add(ResourceDescriptor descriptor, ResourceHandler handler) {
+        if (config.mode() == Mode.OFF) {
+            logger.debug("Resource '{}' not registered: resources capability is OFF", descriptor.name());
+            return this;
+        }
         var entry = new ResourceEntry(descriptor, handler);
         var previous = byName.put(descriptor.name(), entry);
         if (previous != null && !previous.descriptor().uri().equals(descriptor.uri())) {
@@ -99,7 +107,7 @@ public class ResourceRegistry {
     }
 
     public PaginatedResult<ResourceDescriptor> list(int limit, @Nullable String cursor) {
-        int lim = limit > 0 ? limit : defaultPageSize;
+        int lim = limit > 0 ? limit : config.pageSize();
         var all = byName.values().stream()
                 .map(ResourceEntry::descriptor)
                 .sorted(Comparator.comparing(ResourceDescriptor::name))
@@ -109,7 +117,7 @@ public class ResourceRegistry {
 
     public PaginatedResult<ResourceDescriptor> list(
             int limit, @Nullable String cursor, Predicate<ResourceDescriptor> filter) {
-        int lim = limit > 0 ? limit : defaultPageSize;
+        int lim = limit > 0 ? limit : config.pageSize();
         var all = byName.values().stream()
                 .map(ResourceEntry::descriptor)
                 .filter(filter)
@@ -124,6 +132,10 @@ public class ResourceRegistry {
     }
 
     public ResourceRegistry addTemplate(ResourceTemplateEntry template) {
+        if (config.mode() == Mode.OFF) {
+            logger.debug("Resource template '{}' not registered: resources capability is OFF", template.name());
+            return this;
+        }
         templates.put(template.name(), template);
         fireOnChange();
         return this;

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tasks/TaskRegistry.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tasks/TaskRegistry.java
@@ -10,6 +10,7 @@ import dev.tachyonmcp.protocol.ProtocolResponseMapper;
 import dev.tachyonmcp.protocol.mcp.v2025_11_25.McpProtocol;
 import dev.tachyonmcp.protocol.mcp.v2025_11_25.codecs.ProtocolCodecUtil;
 import dev.tachyonmcp.server.RpcMethodHandler;
+import dev.tachyonmcp.server.config.TasksConfig;
 import dev.tachyonmcp.server.features.ListRequests;
 import dev.tachyonmcp.server.features.PaginatedResult;
 import dev.tachyonmcp.server.features.Pagination;
@@ -49,8 +50,8 @@ public class TaskRegistry extends Registry<TaskEntry> {
     private volatile @Nullable ScheduledExecutorService ttlJanitor;
 
     /** Creates a task registry bound to the given server (for broadcasting status notifications). */
-    public TaskRegistry(ServerEngine server, int pageSize) {
-        super(pageSize);
+    public TaskRegistry(ServerEngine server, TasksConfig config) {
+        super(config.pageSize());
         this.server = server;
     }
 

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tools/ToolRegistry.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tools/ToolRegistry.java
@@ -15,6 +15,8 @@ import dev.tachyonmcp.protocol.mcp.v2025_11_25.models.CallToolRequestParams;
 import dev.tachyonmcp.protocol.mcp.v2025_11_25.models.TaskMetadata;
 import dev.tachyonmcp.server.OutboundSseStreamMessageRouter;
 import dev.tachyonmcp.server.RpcMethodHandler;
+import dev.tachyonmcp.server.config.FeatureConfig;
+import dev.tachyonmcp.server.config.Mode;
 import dev.tachyonmcp.server.features.ChangeSupport;
 import dev.tachyonmcp.server.features.HandlerFutures;
 import dev.tachyonmcp.server.features.ListRequests;
@@ -59,7 +61,7 @@ public class ToolRegistry {
     private final JsonSchemaValidator outputValidator;
     private final PayloadSerializer payloadSerializer;
     private final PayloadDeserializer payloadDeserializer;
-    private final int defaultPageSize;
+    private final FeatureConfig config;
 
     private final ChangeSupport changes = new ChangeSupport();
 
@@ -77,12 +79,12 @@ public class ToolRegistry {
             JsonSchemaValidator outputValidator,
             PayloadSerializer payloadSerializer,
             PayloadDeserializer payloadDeserializer,
-            int defaultPageSize) {
+            FeatureConfig config) {
         this.inputValidator = inputValidator;
         this.outputValidator = outputValidator;
         this.payloadSerializer = payloadSerializer;
         this.payloadDeserializer = payloadDeserializer;
-        this.defaultPageSize = defaultPageSize;
+        this.config = config;
     }
 
     public void onChange(Runnable callback) {
@@ -100,6 +102,10 @@ public class ToolRegistry {
         Objects.requireNonNull(handler, "ToolHandler must not be null");
         var descriptor = handler.descriptor();
         Objects.requireNonNull(descriptor, "ToolDescriptor must not be null");
+        if (config.mode() == Mode.OFF) {
+            logger.debug("Tool '{}' not registered: tools capability is OFF", descriptor.name());
+            return;
+        }
         var name = descriptor.name();
         validateName(name);
         validateSchemaRoot("inputSchema", name, descriptor.inputSchema());
@@ -186,7 +192,7 @@ public class ToolRegistry {
     }
 
     public PaginatedResult<ToolDescriptor> list(int limit, @Nullable String cursor) {
-        int lim = limit > 0 ? limit : defaultPageSize;
+        int lim = limit > 0 ? limit : config.pageSize();
         var all = handlers.values().stream()
                 .map(ToolHandler::descriptor)
                 .sorted(Comparator.comparing(ToolDescriptor::name))
@@ -195,7 +201,7 @@ public class ToolRegistry {
     }
 
     public PaginatedResult<ToolDescriptor> list(int limit, @Nullable String cursor, Predicate<ToolDescriptor> filter) {
-        int lim = limit > 0 ? limit : defaultPageSize;
+        int lim = limit > 0 ? limit : config.pageSize();
         var all = handlers.values().stream()
                 .map(ToolHandler::descriptor)
                 .filter(filter)

--- a/tachyon-server/src/test/java/dev/tachyonmcp/server/ServerShutdownGraceTest.java
+++ b/tachyon-server/src/test/java/dev/tachyonmcp/server/ServerShutdownGraceTest.java
@@ -30,7 +30,7 @@ class ServerShutdownGraceTest {
 
     @Test
     void defaultGracePeriodIsFiveSeconds() {
-        assertThat(RuntimeConfig.DEFAULT.shutdownGracePeriod()).isEqualTo(Duration.ofSeconds(5));
+        assertThat(RuntimeConfig.builder().build().shutdownGracePeriod()).isEqualTo(Duration.ofSeconds(5));
     }
 
     @Test

--- a/tachyon-server/src/test/java/dev/tachyonmcp/server/config/CapabilitiesConfigTest.java
+++ b/tachyon-server/src/test/java/dev/tachyonmcp/server/config/CapabilitiesConfigTest.java
@@ -64,24 +64,6 @@ class CapabilitiesConfigTest {
     }
 
     @Test
-    void featureConfigRejectsNonPositivePageSize() {
-        assertThatThrownBy(() -> FeatureConfig.builder().pageSize(0).build())
-                .isInstanceOf(IllegalArgumentException.class);
-    }
-
-    @Test
-    void resourcesConfigRejectsNonPositivePageSize() {
-        assertThatThrownBy(() -> ResourcesConfig.builder().pageSize(0).build())
-                .isInstanceOf(IllegalArgumentException.class);
-    }
-
-    @Test
-    void tasksConfigRejectsNonPositivePageSize() {
-        assertThatThrownBy(() -> TasksConfig.builder().pageSize(0).build())
-                .isInstanceOf(IllegalArgumentException.class);
-    }
-
-    @Test
     void chainedFlatSettersAccumulateOnSameSubConfig() {
         var config = CapabilitiesConfig.builder().tools().toolsPageSize(2).build();
 

--- a/tachyon-server/src/test/java/dev/tachyonmcp/server/config/CapabilitiesConfigTest.java
+++ b/tachyon-server/src/test/java/dev/tachyonmcp/server/config/CapabilitiesConfigTest.java
@@ -18,10 +18,10 @@ class CapabilitiesConfigTest {
     void defaultPageSizeIs50() {
         var config = CapabilitiesConfig.DEFAULT;
 
-        assertThat(config.toolsPageSize()).isEqualTo(Pagination.DEFAULT_PAGE_SIZE);
-        assertThat(config.resourcesPageSize()).isEqualTo(Pagination.DEFAULT_PAGE_SIZE);
-        assertThat(config.promptsPageSize()).isEqualTo(Pagination.DEFAULT_PAGE_SIZE);
-        assertThat(config.tasksPageSize()).isEqualTo(Pagination.DEFAULT_PAGE_SIZE);
+        assertThat(config.tools().pageSize()).isEqualTo(Pagination.DEFAULT_PAGE_SIZE);
+        assertThat(config.resources().pageSize()).isEqualTo(Pagination.DEFAULT_PAGE_SIZE);
+        assertThat(config.prompts().pageSize()).isEqualTo(Pagination.DEFAULT_PAGE_SIZE);
+        assertThat(config.tasks().pageSize()).isEqualTo(Pagination.DEFAULT_PAGE_SIZE);
     }
 
     @ParameterizedTest
@@ -60,6 +60,32 @@ class CapabilitiesConfigTest {
     void preservesPositiveToolsPageSize() {
         var config = CapabilitiesConfig.builder().toolsPageSize(10).build();
 
-        assertThat(config.toolsPageSize()).isEqualTo(10);
+        assertThat(config.tools().pageSize()).isEqualTo(10);
+    }
+
+    @Test
+    void featureConfigRejectsNonPositivePageSize() {
+        assertThatThrownBy(() -> FeatureConfig.builder().pageSize(0).build())
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void resourcesConfigRejectsNonPositivePageSize() {
+        assertThatThrownBy(() -> ResourcesConfig.builder().pageSize(0).build())
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void tasksConfigRejectsNonPositivePageSize() {
+        assertThatThrownBy(() -> TasksConfig.builder().pageSize(0).build())
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void chainedFlatSettersAccumulateOnSameSubConfig() {
+        var config = CapabilitiesConfig.builder().tools().toolsPageSize(2).build();
+
+        assertThat(config.tools().mode()).isEqualTo(Mode.ON);
+        assertThat(config.tools().pageSize()).isEqualTo(2);
     }
 }

--- a/tachyon-server/src/test/java/dev/tachyonmcp/server/config/MonitoringConfigTest.java
+++ b/tachyon-server/src/test/java/dev/tachyonmcp/server/config/MonitoringConfigTest.java
@@ -37,12 +37,6 @@ class MonitoringConfigTest {
     }
 
     @Test
-    void defaultValue() {
-        assertThat(MonitoringConfig.DEFAULT.slowRequestLogging()).isFalse();
-        assertThat(MonitoringConfig.DEFAULT.slowRequestThreshold()).isEqualTo(Duration.ofSeconds(10));
-    }
-
-    @Test
     void serverConfigDefaultMonitoringIsNonNull() {
         assertThat(ServerConfig.DEFAULT.monitoring()).isNotNull();
         assertThat(ServerConfig.DEFAULT.monitoring().slowRequestLogging()).isFalse();

--- a/tachyon-server/src/test/java/dev/tachyonmcp/server/config/NetworkConfigTest.java
+++ b/tachyon-server/src/test/java/dev/tachyonmcp/server/config/NetworkConfigTest.java
@@ -6,6 +6,7 @@ package dev.tachyonmcp.server.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import dev.tachyonmcp.transport.netty.McpChannelInitializer;
@@ -96,6 +97,18 @@ class NetworkConfigTest {
         assertThatIllegalArgumentException()
                 .isThrownBy(() -> NetworkConfig.builder().maxContentLength(-1))
                 .withMessage("maxContentLength must be positive");
+    }
+
+    @Test
+    void rejectsNullTimingArguments() {
+        assertThatNullPointerException()
+                .isThrownBy(() -> NetworkConfig.builder().readerIdleTimeout(null));
+        assertThatNullPointerException()
+                .isThrownBy(() -> NetworkConfig.builder().writerIdleTimeout(null));
+        assertThatNullPointerException()
+                .isThrownBy(() -> NetworkConfig.builder().heartbeatInterval(null));
+        assertThatNullPointerException()
+                .isThrownBy(() -> NetworkConfig.builder().ioEngine(null));
     }
 
     @Test

--- a/tachyon-server/src/test/java/dev/tachyonmcp/server/features/prompts/PromptRegistryTest.java
+++ b/tachyon-server/src/test/java/dev/tachyonmcp/server/features/prompts/PromptRegistryTest.java
@@ -9,10 +9,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import dev.tachyonmcp.protocol.mcp.v2025_11_25.models.GetPromptResult;
 import dev.tachyonmcp.protocol.mcp.v2025_11_25.models.ListPromptsResult;
 import dev.tachyonmcp.server.RpcMethodHandler;
+import dev.tachyonmcp.server.config.FeatureConfig;
 import dev.tachyonmcp.server.domain.Icon;
 import dev.tachyonmcp.server.domain.PromptArgument;
 import dev.tachyonmcp.server.domain.PromptMessage;
-import dev.tachyonmcp.server.features.Pagination;
 import dev.tachyonmcp.server.json.JsonSchemaValidator;
 import dev.tachyonmcp.server.session.DefaultDispatchContext;
 import dev.tachyonmcp.transport.jsonrpc.JsonRpcError;
@@ -26,8 +26,7 @@ import org.junit.jupiter.api.Test;
 
 class PromptRegistryTest {
 
-    private final PromptRegistry registry =
-            new PromptRegistry(JsonSchemaValidator.noop(), Pagination.DEFAULT_PAGE_SIZE);
+    private final PromptRegistry registry = new PromptRegistry(JsonSchemaValidator.noop(), FeatureConfig.DEFAULT);
     private final HashMap<String, RpcMethodHandler> handlers = new HashMap<>();
 
     private static PromptDescriptor prompt(String name) {
@@ -82,12 +81,21 @@ class PromptRegistryTest {
 
     @Test
     void listWithCustomPageSize() {
-        var reg = new PromptRegistry(JsonSchemaValidator.noop(), 1);
+        var reg = new PromptRegistry(
+                JsonSchemaValidator.noop(), FeatureConfig.builder().pageSize(1).build());
         reg.add(prompt("a"), List.of());
         reg.add(prompt("b"), List.of());
         var result = reg.list(0, null);
         assertThat(result.items()).hasSize(1);
         assertThat(result.nextCursor()).isEqualTo("a");
+    }
+
+    @Test
+    void addIsNoOpWhenPromptsCapabilityIsOff() {
+        var reg = new PromptRegistry(
+                JsonSchemaValidator.noop(), FeatureConfig.builder().off().build());
+        reg.add(prompt("a"), List.of());
+        assertThat(reg.getAll()).isEmpty();
     }
 
     @Test

--- a/tachyon-server/src/test/java/dev/tachyonmcp/server/features/prompts/PromptRegistryTest.java
+++ b/tachyon-server/src/test/java/dev/tachyonmcp/server/features/prompts/PromptRegistryTest.java
@@ -26,7 +26,8 @@ import org.junit.jupiter.api.Test;
 
 class PromptRegistryTest {
 
-    private final PromptRegistry registry = new PromptRegistry(JsonSchemaValidator.noop(), FeatureConfig.DEFAULT);
+    private final PromptRegistry registry = new PromptRegistry(
+            JsonSchemaValidator.noop(), FeatureConfig.builder().build());
     private final HashMap<String, RpcMethodHandler> handlers = new HashMap<>();
 
     private static PromptDescriptor prompt(String name) {

--- a/tachyon-server/src/test/java/dev/tachyonmcp/server/features/resources/ResourceRegistryTest.java
+++ b/tachyon-server/src/test/java/dev/tachyonmcp/server/features/resources/ResourceRegistryTest.java
@@ -40,7 +40,8 @@ import org.junit.jupiter.api.Test;
 class ResourceRegistryTest {
 
     private final ServerEngine server = newEngine(b -> {});
-    private final ResourceRegistry registry = new ResourceRegistry(server, ResourcesConfig.DEFAULT);
+    private final ResourceRegistry registry =
+            new ResourceRegistry(server, ResourcesConfig.builder().build());
     private final HashMap<String, RpcMethodHandler> handlers = new HashMap<>();
 
     private static ResourceDescriptor resource(String name) {

--- a/tachyon-server/src/test/java/dev/tachyonmcp/server/features/resources/ResourceRegistryTest.java
+++ b/tachyon-server/src/test/java/dev/tachyonmcp/server/features/resources/ResourceRegistryTest.java
@@ -17,11 +17,11 @@ import dev.tachyonmcp.runtime.Session;
 import dev.tachyonmcp.runtime.SseConnection;
 import dev.tachyonmcp.runtime.SseEvent;
 import dev.tachyonmcp.server.RpcMethodHandler;
+import dev.tachyonmcp.server.config.ResourcesConfig;
 import dev.tachyonmcp.server.domain.Annotations;
 import dev.tachyonmcp.server.domain.Icon;
 import dev.tachyonmcp.server.domain.Role;
 import dev.tachyonmcp.server.domain.TextResourceContents;
-import dev.tachyonmcp.server.features.Pagination;
 import dev.tachyonmcp.server.internal.ServerEngine;
 import dev.tachyonmcp.server.session.DefaultDispatchContext;
 import dev.tachyonmcp.server.session.DispatchContext;
@@ -40,7 +40,7 @@ import org.junit.jupiter.api.Test;
 class ResourceRegistryTest {
 
     private final ServerEngine server = newEngine(b -> {});
-    private final ResourceRegistry registry = new ResourceRegistry(server, Pagination.DEFAULT_PAGE_SIZE);
+    private final ResourceRegistry registry = new ResourceRegistry(server, ResourcesConfig.DEFAULT);
     private final HashMap<String, RpcMethodHandler> handlers = new HashMap<>();
 
     private static ResourceDescriptor resource(String name) {
@@ -101,12 +101,20 @@ class ResourceRegistryTest {
 
     @Test
     void listWithCustomPageSize() {
-        var reg = new ResourceRegistry(server, 1);
+        var reg = new ResourceRegistry(
+                server, ResourcesConfig.builder().pageSize(1).build());
         reg.add(resource("a"), (ctx, req) -> null);
         reg.add(resource("b"), (ctx, req) -> null);
         var result = reg.list(0, null);
         assertThat(result.items()).hasSize(1);
         assertThat(result.nextCursor()).isEqualTo("a");
+    }
+
+    @Test
+    void addIsNoOpWhenResourcesCapabilityIsOff() {
+        var reg = new ResourceRegistry(server, ResourcesConfig.builder().off().build());
+        reg.add(resource("a"), (ctx, req) -> null);
+        assertThat(reg.getAll()).isEmpty();
     }
 
     @Test

--- a/tachyon-server/src/test/java/dev/tachyonmcp/server/features/tasks/TaskRegistryTest.java
+++ b/tachyon-server/src/test/java/dev/tachyonmcp/server/features/tasks/TaskRegistryTest.java
@@ -12,7 +12,7 @@ import dev.tachyonmcp.protocol.mcp.v2025_11_25.models.GetTaskPayloadResult;
 import dev.tachyonmcp.protocol.mcp.v2025_11_25.models.GetTaskResult;
 import dev.tachyonmcp.protocol.mcp.v2025_11_25.models.ListTasksResult;
 import dev.tachyonmcp.server.RpcMethodHandler;
-import dev.tachyonmcp.server.features.Pagination;
+import dev.tachyonmcp.server.config.TasksConfig;
 import dev.tachyonmcp.server.internal.ServerEngine;
 import dev.tachyonmcp.server.session.DefaultDispatchContext;
 import dev.tachyonmcp.transport.jsonrpc.JsonRpcError;
@@ -27,7 +27,7 @@ import org.junit.jupiter.api.Test;
 class TaskRegistryTest {
 
     private final ServerEngine engine = newEngine(b -> {});
-    private final TaskRegistry registry = new TaskRegistry(engine, Pagination.DEFAULT_PAGE_SIZE);
+    private final TaskRegistry registry = new TaskRegistry(engine, TasksConfig.DEFAULT);
     private final HashMap<String, RpcMethodHandler> handlers = new HashMap<>();
 
     @AfterEach
@@ -85,7 +85,7 @@ class TaskRegistryTest {
     @Test
     void listWithCustomPageSize() {
         try (var engine = newEngine(b -> {})) {
-            var reg = new TaskRegistry(engine, 1);
+            var reg = new TaskRegistry(engine, TasksConfig.builder().pageSize(1).build());
             reg.add(new TaskEntry("a", "id-a", "A"));
             reg.add(new TaskEntry("b", "id-b", "B"));
             var result = reg.list(0, null);

--- a/tachyon-server/src/test/java/dev/tachyonmcp/server/features/tasks/TaskRegistryTest.java
+++ b/tachyon-server/src/test/java/dev/tachyonmcp/server/features/tasks/TaskRegistryTest.java
@@ -27,7 +27,8 @@ import org.junit.jupiter.api.Test;
 class TaskRegistryTest {
 
     private final ServerEngine engine = newEngine(b -> {});
-    private final TaskRegistry registry = new TaskRegistry(engine, TasksConfig.DEFAULT);
+    private final TaskRegistry registry =
+            new TaskRegistry(engine, TasksConfig.builder().build());
     private final HashMap<String, RpcMethodHandler> handlers = new HashMap<>();
 
     @AfterEach

--- a/tachyon-server/src/test/java/dev/tachyonmcp/server/features/tools/ToolRegistryTest.java
+++ b/tachyon-server/src/test/java/dev/tachyonmcp/server/features/tools/ToolRegistryTest.java
@@ -55,7 +55,11 @@ class ToolRegistryTest {
     private static final PayloadSerde TEST_SERDE = new JacksonPayloadSerde();
 
     private final ToolRegistry registry = new ToolRegistry(
-            JsonSchemaValidator.noop(), JsonSchemaValidator.noop(), TEST_SERDE, TEST_SERDE, FeatureConfig.DEFAULT);
+            JsonSchemaValidator.noop(),
+            JsonSchemaValidator.noop(),
+            TEST_SERDE,
+            TEST_SERDE,
+            FeatureConfig.builder().build());
 
     @Test
     void listToolsReturnsEmptyListWhenNoToolsRegistered() throws Exception {
@@ -682,7 +686,7 @@ class ToolRegistryTest {
                 new NetworkntJsonSchemaValidator(),
                 TEST_SERDE,
                 TEST_SERDE,
-                FeatureConfig.DEFAULT);
+                FeatureConfig.builder().build());
         var handlers = new HashMap<String, RpcMethodHandler>();
         registryVal.registerHandlers(handlers);
         var handler = ToolHandler.of(
@@ -719,7 +723,7 @@ class ToolRegistryTest {
                 new NetworkntJsonSchemaValidator(),
                 TEST_SERDE,
                 TEST_SERDE,
-                FeatureConfig.DEFAULT);
+                FeatureConfig.builder().build());
         var handlers = new HashMap<String, RpcMethodHandler>();
         registryVal.registerHandlers(handlers);
         var handler = ToolHandler.of(

--- a/tachyon-server/src/test/java/dev/tachyonmcp/server/features/tools/ToolRegistryTest.java
+++ b/tachyon-server/src/test/java/dev/tachyonmcp/server/features/tools/ToolRegistryTest.java
@@ -16,9 +16,9 @@ import dev.tachyonmcp.protocol.mcp.v2025_11_25.models.ListToolsResult;
 import dev.tachyonmcp.protocol.mcp.v2025_11_25.models.TextContent;
 import dev.tachyonmcp.runtime.InteractionContext;
 import dev.tachyonmcp.server.RpcMethodHandler;
+import dev.tachyonmcp.server.config.FeatureConfig;
 import dev.tachyonmcp.server.domain.Icon;
 import dev.tachyonmcp.server.domain.ToolAnnotations;
-import dev.tachyonmcp.server.features.Pagination;
 import dev.tachyonmcp.server.features.tasks.TaskSupport;
 import dev.tachyonmcp.server.internal.ServerEngine;
 import dev.tachyonmcp.server.json.JacksonPayloadSerde;
@@ -55,11 +55,7 @@ class ToolRegistryTest {
     private static final PayloadSerde TEST_SERDE = new JacksonPayloadSerde();
 
     private final ToolRegistry registry = new ToolRegistry(
-            JsonSchemaValidator.noop(),
-            JsonSchemaValidator.noop(),
-            TEST_SERDE,
-            TEST_SERDE,
-            Pagination.DEFAULT_PAGE_SIZE);
+            JsonSchemaValidator.noop(), JsonSchemaValidator.noop(), TEST_SERDE, TEST_SERDE, FeatureConfig.DEFAULT);
 
     @Test
     void listToolsReturnsEmptyListWhenNoToolsRegistered() throws Exception {
@@ -391,12 +387,29 @@ class ToolRegistryTest {
 
     @Test
     void listWithCustomPageSize() {
-        var reg = new ToolRegistry(JsonSchemaValidator.noop(), JsonSchemaValidator.noop(), TEST_SERDE, TEST_SERDE, 1);
+        var reg = new ToolRegistry(
+                JsonSchemaValidator.noop(),
+                JsonSchemaValidator.noop(),
+                TEST_SERDE,
+                TEST_SERDE,
+                FeatureConfig.builder().pageSize(1).build());
         reg.register(testTool("a", null, null));
         reg.register(testTool("b", null, null));
         var result = reg.list(0, null);
         assertThat(result.items()).hasSize(1);
         assertThat(result.nextCursor()).isEqualTo("a");
+    }
+
+    @Test
+    void registerIsNoOpWhenToolsCapabilityIsOff() {
+        var reg = new ToolRegistry(
+                JsonSchemaValidator.noop(),
+                JsonSchemaValidator.noop(),
+                TEST_SERDE,
+                TEST_SERDE,
+                FeatureConfig.builder().off().build());
+        reg.register(testTool("a", null, null));
+        assertThat(reg.isEmpty()).isTrue();
     }
 
     @Test
@@ -669,7 +682,7 @@ class ToolRegistryTest {
                 new NetworkntJsonSchemaValidator(),
                 TEST_SERDE,
                 TEST_SERDE,
-                Pagination.DEFAULT_PAGE_SIZE);
+                FeatureConfig.DEFAULT);
         var handlers = new HashMap<String, RpcMethodHandler>();
         registryVal.registerHandlers(handlers);
         var handler = ToolHandler.of(
@@ -706,7 +719,7 @@ class ToolRegistryTest {
                 new NetworkntJsonSchemaValidator(),
                 TEST_SERDE,
                 TEST_SERDE,
-                Pagination.DEFAULT_PAGE_SIZE);
+                FeatureConfig.DEFAULT);
         var handlers = new HashMap<String, RpcMethodHandler>();
         registryVal.registerHandlers(handlers);
         var handler = ToolHandler.of(


### PR DESCRIPTION
## feat!: unify feature capability configs

Capability configuration now uses nested Java records/builders and Kotlin DSL scopes for tools, resources, prompts, and tasks. Server resolution, registries, pagination, registration gating, tests, documentation, and examples were updated to consume the structured configuration.

- Extract shared per-feature config from the flat CapabilitiesConfig:
FeatureConfig (tools/prompts: mode, listChanged, pageSize), ResourcesConfig
(+subscribe), TasksConfig (enabled, list, cancel, requests, pageSize). Each
validates pageSize once in its compact constructor.

- CapabilitiesConfig becomes a record of the four nested configs plus
completions/logging. The builder keeps the flat setters and convenience
shortcuts (delegating to the nested sub-builders) so existing Java callers
compile unchanged.

- Registries take their feature config instead of a bare int page size, and
skip registration when the feature mode is OFF (no-op, logged at debug).

- Kotlin DSL nests: capabilities { tools { }; resources { }; prompts { }; tasks { } }.