### PR TITLE
fix: SSE POST reconnect redelivery

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -8,3 +8,7 @@
 * [Extensions](extensions.md)
 * [Kotlin DSL](kotlin.md)
   * [Migrating from the Kotlin MCP SDK to Tachyon](migrate-from-kotlin-mcp-to-tachyon.md)
+
+### Internals
+
+* [POST-SSE reconnect re-delivery](sse-reconnect-redelivery.md)

--- a/docs/sse-reconnect-redelivery.md
+++ b/docs/sse-reconnect-redelivery.md
@@ -1,0 +1,161 @@
+# POST-SSE reconnect re-delivery
+
+How Tachyon guarantees a tool's final response reaches a client that reconnects after the tool
+closes its SSE stream mid-call — and the race that used to make it flaky.
+
+## Background: streams, event ids, and resume
+
+Tachyon speaks MCP **Streamable HTTP**. A `POST /mcp` for a `tools/call` can *upgrade* from a
+buffered JSON reply to a live SSE stream (`text/event-stream`) the moment the handler emits a
+server→client message (a progress notification, a `comment`, or by explicitly starting the stream).
+See [configuration.md → keep-alive for long-running tools](configuration.md).
+
+Every SSE event carries an id. For a POST-upgraded stream the wire id is `<n>#<key>`:
+
+- `<n>` — a monotonic per-session sequence number (`ServerEngine.nextEventId()`).
+- `<key>` — the **stream key**, drawn once per POST (`PostSseStream.streamKey`). It tags every event
+  of that stream in the event log and suffixes the SSE ids, so a `Last-Event-ID` resolves back to
+  *this* stream and no other.
+
+Every emitted event is also appended to the session **event log** (`SessionLogRouter`). If the
+connection drops, the client reconnects with `Last-Event-ID: <n>#<key>` and the server replays the
+missed events of **that stream only** — never another stream's (MCP resumability: *"the server MUST
+NOT replay messages that would have been sent on a different stream"*, guarded by
+`SseReplayPerStreamTest`).
+
+Replay is a **one-shot** read of the log at reconnect time (`SseManager.replayEvents`): it scans the
+log once, sends events with `id > lastSeen` and matching stream key, and stops.
+
+## The scenario: a tool that closes its stream mid-call
+
+Some tools deliberately close their SSE stream *before* producing a result, to force the client to
+reconnect and resume (the MCP conformance suite's `test_reconnection` tool does exactly this):
+
+```java
+var stream = OutboundSseStreamMessageRouter.currentOutboundSseStream();
+stream.start();   // upgrades POST → SSE, sends the priming event  (id 4#3)
+stream.close();   // closes the channel; the client observes a disconnect
+// ...tool keeps working, then returns its result
+```
+
+The result is finalized only *after* the handler returns, in
+`McpOperationHandler.finalizePostSseResponse`:
+
+1. draw an id (say `5`),
+2. **append** the response to the event log as `5#3`,
+3. write it to the POST stream — but the stream is already closed, so the write is **dropped**,
+4. close.
+
+So the client can only obtain the response by reconnecting and replaying it from the log.
+
+## The bug: a reconnect-vs-append race
+
+After the mid-call close, two things happen concurrently on different threads:
+
+- **A — append** (server-local): handler returns → dispatch completes → `finalizePostSseResponse`
+  appends `5#3` to the log.
+- **B — reconnect + replay** (network round-trip): the client sees the close → sends
+  `GET` with `Last-Event-ID: 4#3` → `SseManager.replayEvents` reads the log.
+
+Nothing orders A before B.
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Server
+    participant Handler as Tool handler
+    participant Log as Event log
+
+    Client->>Server: POST tools/call
+    Server->>Handler: invoke
+    Handler->>Client: start() → priming event 4#3
+    Handler->>Client: close() → stream ends
+    Note over Handler,Log: A — handler returns, response 5#3 appended
+    Note over Client,Server: B — client reconnects, replays from 4#3
+    alt A before B (usual)
+        Log-->>Client: replay finds 5#3 ✅
+    else B before A (flake)
+        Log-->>Client: replay finds nothing; 5#3 appended too late ❌
+    end
+```
+
+- **A wins (usual):** `5#3` is in the log before the replay → client gets the response. ✅
+- **B wins (flake):** the replay runs first and finds nothing; `5#3` is appended a moment later, but
+  the one-shot replay already ran and the dropped POST write goes nowhere. **Nothing retries**, so
+  the client waits out its window and never receives the response. ❌
+
+On localhost the reconnect round-trip is fast enough to occasionally beat the local append, so the
+same code passes or fails depending on thread scheduling — a classic flake. It surfaced as an
+intermittent `server-sse-disconnect-resume` **WARNING** (a `SHOULD`-level check) in the default
+conformance suite.
+
+### Why production tools don't hit this
+
+A normal tool never closes its own stream. The server's own `finalizePostSseResponse` always
+**appends the response before it closes** the stream, so a client only ever reconnects *after* the
+response is already in the log. The race exists only when user code closes the stream before the
+result exists.
+
+## The fix: live re-delivery on the resumed stream
+
+When the final response write is dropped because the stream is already closed, deliver it **live**
+to the client's current connection — but only if that connection explicitly resumed *this* stream.
+
+Two pieces:
+
+1. **Remember what the reconnect is resuming.** `SseManager.openStream` parses the `#<key>` out of
+   `Last-Event-ID` and records it on the session (`Session.resumingStreamKey`). A general GET
+   listening stream (numeric `Last-Event-ID`, no key) records `null`.
+
+2. **Fall back on a dropped write.** `PostSseStream.writeEvent(id, body, onDropped)` invokes
+   `onDropped` (on the event loop) when the write is discarded because the stream is closed or its
+   channel is dead. `finalizePostSseResponse` supplies a callback
+   (`McpOperationHandler.redeliverOnReconnect`) that, if the session's current connection is resuming
+   this stream key, re-sends the response on it:
+
+   ```java
+   if (streamKey.equals(session.resumingStreamKey())) {
+       session.send(new SseEvent(wireId, "message", resultJson));
+   }
+   ```
+
+Now both orderings succeed:
+
+- **B wins:** the replay missed `5#3`, but by the time the append+drop callback runs the client has
+  reconnected and resumed key `3` → the response is delivered live.
+- **A wins:** `5#3` was appended first; the replay finds it (and if the drop callback also fires,
+  see the note below).
+
+### Invariants and trade-offs
+
+- **No cross-stream delivery.** The fallback fires only when `session.resumingStreamKey()` equals the
+  POST stream's key, so a response is never pushed onto a *different* stream (e.g. a general GET
+  listening stream). This preserves the MCP resumability rule that `SseReplayPerStreamTest` asserts.
+- **Happy path untouched.** The fallback runs *only* when the POST write is dropped. For every normal
+  tool call the write succeeds, `onDropped` never fires, and behavior is exactly as before.
+- **Rare double-delivery is tolerated.** In a narrow window both the replay and the fallback can
+  deliver the same event (same SSE id). This is harmless: a client dedupes the JSON-RPC response by
+  request id. Marked with a `ponytail:` comment in `redeliverOnReconnect` noting per-connection id
+  de-dup as the upgrade path if it ever matters.
+
+## Testing
+
+[SsePostReconnectRedeliveryTest](../e2e/src/test/java/dev/tachyonmcp/e2e/SsePostReconnectRedeliveryTest.java) makes the race **deterministic**: the tool closes its stream and
+then `Thread.sleep(300)` before returning, so the response is appended only *after* the client has
+reconnected and run its one-shot replay. Without the fallback the reconnecting client never receives
+the response; with it, the response is delivered live on the resumed stream.
+
+[SseReplayPerStreamTest](e2e/src/test/java/dev/tachyonmcp/e2e/SseReplayPerStreamTest.java) guards the companion invariant: a resumed stream must not receive another
+stream's messages.
+
+## Touch points
+
+| Concern | Location |
+|---|---|
+| Stream key allocation + priming | `PostSseStream` (`streamKey`, `doStart`) |
+| Dropped-write callback | `PostSseStream.writeEvent(long, ByteBuf, Runnable)` / `doWriteEvent` |
+| Response finalize + fallback | `McpOperationHandler.finalizePostSseResponse` / `redeliverOnReconnect` |
+| Record resumed stream key | `SseManager.openStream`; `Session.resumingStreamKey` |
+| One-shot replay | `SseManager.replayEvents` |
+| Regression test | `e2e/.../SsePostReconnectRedeliveryTest` |
+| Cross-stream invariant test | `e2e/.../SseReplayPerStreamTest` |

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/SsePostReconnectRedeliveryTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/SsePostReconnectRedeliveryTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2026 Konstantin Pavlov and contributors.
+ */
+
+package dev.tachyonmcp.e2e;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.tachyonmcp.server.OutboundSseStreamMessageRouter;
+import dev.tachyonmcp.server.features.tools.ToolHandler;
+import dev.tachyonmcp.server.features.tools.ToolResult;
+import java.io.IOException;
+import java.net.Socket;
+import java.net.SocketTimeoutException;
+import java.nio.charset.StandardCharsets;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.Test;
+
+/**
+ * MCP 2025-11-25 Streamable HTTP resumability: a tool that closes its POST-SSE stream mid-call
+ * before producing its result. The client observes the disconnect and resumes the stream with
+ * {@code Last-Event-ID: <n>#<key>}; the server MUST still deliver the final response on that stream.
+ *
+ * <p>The tool sleeps after closing so the response is finalized (and appended to the event log)
+ * only AFTER the client has already reconnected and run its one-shot replay — deterministically
+ * exercising the reconnect-before-append race. Without live re-delivery on resume, the reconnecting
+ * client would never receive the response.
+ */
+class SsePostReconnectRedeliveryTest extends AbstractMcpE2eTest {
+
+    private static final Pattern PRIMING_ID = Pattern.compile("id: (\\d+#\\d+)", Pattern.MULTILINE);
+
+    @Override
+    protected void startDefaultServer() {
+        startServer(it -> it.tool(selfClosingTool()));
+    }
+
+    @Test
+    void reconnectAfterMidCallCloseReceivesResponse() throws Exception {
+        try (var client = createTestClient()) {
+            var sessionId = client.initialize();
+
+            // POST tools/call: the tool upgrades the POST to SSE, emits the priming event, then
+            // closes the stream — so the POST completes carrying only that priming event.
+            var post = client.sendRequest(sessionId, """
+                    {"jsonrpc":"2.0","id":9,"method":"tools/call","params":{"name":"self-closing","arguments":{}}}
+                    """);
+            assertThat(post.headers().firstValue("Content-Type").orElse("")).contains("text/event-stream");
+            var matcher = PRIMING_ID.matcher(post.body());
+            assertThat(matcher.find())
+                    .as("POST-SSE priming event id (<n>#<key>) in:\n%s", post.body())
+                    .isTrue();
+            var lastEventId = matcher.group(1);
+
+            // Resume that exact POST stream. The tool is still sleeping, so its response has not
+            // been appended yet: the one-shot replay finds nothing, and only live re-delivery on
+            // resume can hand the client its result.
+            try (var socket = openGetStream(sessionId, lastEventId)) {
+                var received = readStream(socket, body -> body.contains("resumed-payload"), 5000);
+                assertThat(received)
+                        .as("resumed POST stream must receive the final response delivered after reconnect")
+                        .contains("\"id\":9")
+                        .contains("resumed-payload");
+            }
+        }
+    }
+
+    private Socket openGetStream(String sessionId, String lastEventId) throws IOException {
+        var socket = new Socket("localhost", port);
+        var req = "GET /mcp HTTP/1.1\r\n"
+                + "Host: localhost:" + port + "\r\n"
+                + "MCP-Session-Id: " + sessionId + "\r\n"
+                + "MCP-Protocol-Version: 2025-11-25\r\n"
+                + "Accept: text/event-stream\r\n"
+                + "Last-Event-ID: " + lastEventId + "\r\n"
+                + "\r\n";
+        socket.getOutputStream().write(req.getBytes(StandardCharsets.UTF_8));
+        socket.getOutputStream().flush();
+        socket.setSoTimeout(50);
+        return socket;
+    }
+
+    private static String readStream(Socket socket, java.util.function.Predicate<String> until, long timeoutMs)
+            throws IOException {
+        var sb = new StringBuilder();
+        var buf = new byte[1024];
+        var deadline = System.currentTimeMillis() + timeoutMs;
+        while (System.currentTimeMillis() < deadline && !until.test(sb.toString())) {
+            try {
+                var n = socket.getInputStream().read(buf);
+                if (n < 0) break;
+                if (n > 0) sb.append(new String(buf, 0, n, StandardCharsets.UTF_8));
+            } catch (SocketTimeoutException e) {
+                // No data this poll; keep reading until the deadline.
+            }
+        }
+        return sb.toString();
+    }
+
+    private static ToolHandler selfClosingTool() {
+        return ToolHandler.of(
+                b -> b.name("self-closing").description("Closes its SSE stream mid-call, then returns after a delay"),
+                (ctx, args) -> {
+                    var stream = OutboundSseStreamMessageRouter.currentOutboundSseStream();
+                    if (stream != null) {
+                        stream.start();
+                        stream.close();
+                    }
+                    // Return only after the client has had time to observe the close and reconnect,
+                    // so the response is appended after the resume's one-shot replay has run.
+                    try {
+                        Thread.sleep(300);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    }
+                    return ToolResult.text("resumed-payload");
+                });
+    }
+}

--- a/tachyon-server/src/main/java/dev/tachyonmcp/runtime/Session.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/runtime/Session.java
@@ -26,6 +26,7 @@ public class Session {
     private final AtomicReference<Backpressure> backpressure;
     private final AtomicLong cursor;
     private final Set<String> enabledExtensions = ConcurrentHashMap.newKeySet();
+    private volatile @Nullable String resumingStreamKey;
 
     public Session(String id, SseConnection connection) {
         this.id = Objects.requireNonNull(id, "id");
@@ -68,6 +69,21 @@ public class Session {
     /** Returns the current SSE connection. */
     public SseConnection connection() {
         return connection.get();
+    }
+
+    /**
+     * The POST-SSE stream key the current connection is resuming, parsed from a
+     * {@code <n>#<key>} {@code Last-Event-ID}; {@code null} for the general GET listening stream or
+     * a fresh connection. Lets a late POST-SSE response be re-delivered live to a connection that
+     * explicitly resumed that stream, without crossing streams.
+     */
+    public @Nullable String resumingStreamKey() {
+        return resumingStreamKey;
+    }
+
+    /** Records the POST-SSE stream key the current connection is resuming (or {@code null}). */
+    public void resumingStreamKey(@Nullable String streamKey) {
+        this.resumingStreamKey = streamKey;
     }
 
     /**

--- a/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/McpOperationHandler.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/McpOperationHandler.java
@@ -10,6 +10,7 @@ import static dev.tachyonmcp.transport.netty.McpResponseWriter.*;
 import dev.tachyonmcp.protocol.mcp.McpHeaderNames;
 import dev.tachyonmcp.runtime.ChannelContext;
 import dev.tachyonmcp.runtime.InteractionEvent;
+import dev.tachyonmcp.runtime.SseEvent;
 import dev.tachyonmcp.server.RpcDispatcher;
 import dev.tachyonmcp.server.internal.ServerEngine;
 import dev.tachyonmcp.server.session.SessionEvent;
@@ -297,6 +298,7 @@ public class McpOperationHandler extends ChannelInboundHandlerAdapter {
         var responseBody = response.responseBody();
         try {
             var sseEventId = server.nextEventId();
+            Runnable onDropped = null;
             if (!server.isStateless()) {
                 var resultJson = responseBody.toString(StandardCharsets.UTF_8);
                 server.appendEvent(new SessionEvent.ResponseEvent(
@@ -306,8 +308,9 @@ public class McpOperationHandler extends ChannelInboundHandlerAdapter {
                         System.currentTimeMillis(),
                         sseEventId,
                         postStream.streamKey()));
+                onDropped = redeliverOnReconnect(sessionId, postStream.streamKey(), sseEventId, resultJson);
             }
-            postStream.writeEvent(sseEventId, responseBody);
+            postStream.writeEvent(sseEventId, responseBody, onDropped);
             responseBody = null;
         } catch (RuntimeException e) {
             logger.error("Failed to write final response on POST-SSE stream", e);
@@ -317,6 +320,28 @@ public class McpOperationHandler extends ChannelInboundHandlerAdapter {
             }
             postStream.close();
         }
+    }
+
+    /**
+     * Builds the fallback that runs when the final response could not be written because the tool
+     * already closed its POST-SSE stream: if the client has reconnected and explicitly resumed this
+     * stream key, deliver the response live on that stream. Otherwise it stays in the event log for
+     * {@code Last-Event-ID} replay. Never crosses to a different stream (MCP resumability rule).
+     */
+    private @Nullable Runnable redeliverOnReconnect(
+            @Nullable String sessionId, String streamKey, long sseEventId, String resultJson) {
+        if (sessionId == null) {
+            return null;
+        }
+        var wireId = ServerEngine.wireEventId(sseEventId, streamKey);
+        return () -> server.getSession(sessionId).ifPresent(session -> {
+            // ponytail: the resumed reconnect may also replay this event from the log, so a rare
+            // race can deliver it twice with the same SSE id — harmless (the client dedupes the
+            // JSON-RPC response by request id). Per-connection id de-dup if that ever bites.
+            if (streamKey.equals(session.resumingStreamKey())) {
+                session.send(new SseEvent(wireId, "message", resultJson));
+            }
+        });
     }
 
     private void handleGet(ChannelHandlerContext ctx, FullHttpRequest req, @Nullable String origin) {

--- a/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/sse/PostSseStream.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/sse/PostSseStream.java
@@ -81,12 +81,22 @@ public final class PostSseStream implements OutboundSseStream {
     }
 
     public void writeEvent(long sseEventId, ByteBuf body) {
+        writeEvent(sseEventId, body, null);
+    }
+
+    /**
+     * Writes a final response event, invoking {@code onDropped} (on the event loop) when the write
+     * is discarded because this stream is already closed or its channel is dead — letting the caller
+     * re-deliver the buffered response to a reconnected stream instead of losing it.
+     */
+    public void writeEvent(long sseEventId, ByteBuf body, @Nullable Runnable onDropped) {
         // The task owns `body`; if the event loop is shutting down and rejects it, the release
         // inside doWriteEvent never runs — release here instead of leaking.
         try {
-            runOnEventLoop(() -> doWriteEvent(sseEventId, body));
+            runOnEventLoop(() -> doWriteEvent(sseEventId, body, onDropped));
         } catch (java.util.concurrent.RejectedExecutionException e) {
             body.release();
+            if (onDropped != null) onDropped.run();
         }
     }
 
@@ -161,9 +171,10 @@ public final class PostSseStream implements OutboundSseStream {
         });
     }
 
-    private void doWriteEvent(long sseEventId, ByteBuf body) {
+    private void doWriteEvent(long sseEventId, ByteBuf body, @Nullable Runnable onDropped) {
         if (closed || !channel.isActive()) {
             body.release();
+            if (onDropped != null) onDropped.run();
             return;
         }
         if (!started) {

--- a/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/sse/SseManager.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/sse/SseManager.java
@@ -51,7 +51,13 @@ public class SseManager {
         writeOpeningFrames(ctx, origin, connection);
 
         if (lastEventId != null && !lastEventId.isEmpty()) {
+            var hash = lastEventId.indexOf('#');
+            // Remember which POST-SSE stream (if any) this connection is resuming, so a response
+            // finalized after the replay window can still be delivered live on this stream.
+            session.resumingStreamKey(hash < 0 ? null : lastEventId.substring(hash + 1));
             server.executor().execute(() -> replayEvents(session, lastEventId));
+        } else {
+            session.resumingStreamKey(null);
         }
 
         logger.debug("SSE stream opened for session={}", session.id());


### PR DESCRIPTION
## fix: re-deliver POST-SSE response to a resumed stream after mid-call close

When a tool closes its POST-SSE stream before producing its result, the final
response was only appended to the event log and (dropped) written to the dead
POST channel. A client that reconnected and ran its one-shot Last-Event-ID
replay before that append never received the response — a timing-dependent
loss surfacing as a flaky `server-sse-disconnect-resume` conformance warning.

The reconnecting GET now records which POST stream key it resumes; when the
final response write is dropped because the stream is closed, it is delivered
live on that resumed stream. Delivery is scoped to the exact resumed stream
key, so it never crosses to a different stream (MCP resumability rule, guarded
by SseReplayPerStreamTest). The happy path (write succeeds) is unchanged.

Adds SsePostReconnectRedeliveryTest, which deterministically forces the
reconnect-before-append ordering.