### PR TITLE
chore: 1.0.0-beta.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
     <dependency>
         <groupId>dev.tachyonmcp</groupId>
         <artifactId>tachyon-server</artifactId>
-        <version>1.0.0-beta.8</version>
+        <version>1.0.0-beta.9</version>
     </dependency>
     ```
 

--- a/docs/migrate-from-kotlin-mcp-to-tachyon.md
+++ b/docs/migrate-from-kotlin-mcp-to-tachyon.md
@@ -141,7 +141,7 @@ ToolResult.of(pojo)                                             // Jackson: POJO
 
 `inputSchema`/`outputSchema` accept a raw **String**, a Jackson **`JsonNode`**, or a kotlinx
 **`JsonObject`** on every overload. The `outputSchema` string overload arrived in
-**1.0.0-beta.8** — if you wrote a project-side shim for it against an earlier beta, delete the
+**1.0.0-beta.9** — if you wrote a project-side shim for it against an earlier beta, delete the
 shim now.
 
 - **Jackson 3**: `tools.jackson.databind.JsonNode`, *not* `com.fasterxml.jackson…`. Convert a

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -13,7 +13,7 @@ Build and run an MCP server in under 5 minutes.
 <dependency>
     <groupId>dev.tachyonmcp</groupId>
     <artifactId>tachyon-server</artifactId>
-    <version>1.0.0-beta.8</version>
+    <version>1.0.0-beta.9</version>
 </dependency>
 ```
 

--- a/examples/echo-kotlin/pom.xml
+++ b/examples/echo-kotlin/pom.xml
@@ -18,7 +18,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>21</java.version>
         <kotlin.version>2.2.21</kotlin.version>
-        <tachyon-server.version>1.0.0-beta.8</tachyon-server.version>
+        <tachyon-server.version>1.0.0-beta.9</tachyon-server.version>
 <!--        <tachyon-server.version>1.0.0-SNAPSHOT</tachyon-server.version>-->
         <junit.version>6.1.1</junit.version>
         <kotest.version>6.2.1</kotest.version>

--- a/examples/weather/pom.xml
+++ b/examples/weather/pom.xml
@@ -20,7 +20,7 @@
         <maven.compiler.release>21</maven.compiler.release>
         <jackson.version>3.2.0</jackson.version>
         <junit.version>6.1.1</junit.version>
-        <tachyon-server.version>1.0.0-beta.8</tachyon-server.version>
+        <tachyon-server.version>1.0.0-beta.9</tachyon-server.version>
 <!--        <tachyon-server.version>1.0.0-SNAPSHOT</tachyon-server.version>-->
         <assertj.version>3.27.7</assertj.version>
         <netty.version>4.2.15.Final</netty.version>

--- a/tachyon-server-kotlin/README.md
+++ b/tachyon-server-kotlin/README.md
@@ -8,7 +8,7 @@ Kotlin coroutine-first DSL for [Tachyon MCP](../README.md). Wraps the Java `Serv
 <dependency>
     <groupId>dev.tachyonmcp</groupId>
     <artifactId>tachyon-server-kotlin</artifactId>
-    <version>1.0.0-beta.8</version>
+    <version>1.0.0-beta.9</version>
 </dependency>
 ```
 


### PR DESCRIPTION
Documentation snippets and example Maven properties are updated from 1.0.0-beta.8 to 1.0.0-beta.9, including the migration note for the outputSchema string overload.