### PR TITLE
feat: logging api refactoring: TachyonServer.notifications()

### DIFF
--- a/.agents/skills/tachyon-development/SKILL.md
+++ b/.agents/skills/tachyon-development/SKILL.md
@@ -1,7 +1,11 @@
 ---
-name: tachyon-testing
-description: Apply project specific rules when designing and writing tests
+name: tachyon-development
+description: Apply project specific rules when designing, writing code and tests
 ---
+
+# Prime directives
+
+- Use acceptance-test-driven development (ATDD). Prefer testing e2e with unit tests for edge conditions. Start e2e tests before prod code.
 
 # Test Rules 🧪
 

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ buildNumber.properties
 .idea/**/libraries
 cmake-build-*/
 .idea/**/mongoSettings.xml
+.run/
 *.iws
 out/
 .idea_modules/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,6 @@ Me Caveman. Talk short. Use emoji.
 - Claims about code carry `file:line` proof. Verify in code, never answer from memory.
 - Status tables for checklists: ✅ done / 🔴 open, one row per item, evidence column.
 - Emoji as markers: 🎯 goals, 🔴 breaking, 🐛 bugs, 🪶 polish/decisions, 🏹 order of battle, ⚠️ caveats, 🔥 delete.
-- Plans → `fable-plan-N.md` in repo root. Done items stay listed briefly (✅ + one line), open items get file:line + fix.
 - Short sentences. No filler words. Dead docs go fire 🔥.
 
 ## Project
@@ -27,7 +26,7 @@ mvn spotless:apply  # auto-fix
 ## Parts
 
 - **`tachyon-runtime`** — Core: Netty HTTP/SSE, JSON-RPC, event log, MCP registries
-- **`e2e`** — E2E tests via `io.modelcontextprotocol.sdk:mcp-core:2.0.0-RC1`
+- **`e2e`** — E2E tests via `io.modelcontextprotocol.sdk:mcp-core:2.0.0`
 - **`conformance`** — Conformance via `@modelcontextprotocol/conformance`
 
 ## Rules

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/LoggingTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/LoggingTest.java
@@ -7,9 +7,20 @@ package dev.tachyonmcp.e2e;
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.net.Socket;
+import java.net.SocketTimeoutException;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 class LoggingTest extends AbstractMcpE2eTest {
+
+    @Override
+    protected void startDefaultServer() {
+        startServer(b -> b.capabilities(c -> c.tools().logging()).tool(EchoToolHandler.create()));
+    }
 
     @Test
     void shouldReceiveLoggingNotificationAfterToolCall() throws Exception {
@@ -17,24 +28,97 @@ class LoggingTest extends AbstractMcpE2eTest {
 
             var sessionId = client.initialize();
 
-            var setLevelBody = """
-                {"jsonrpc":"2.0","id":2,"method":"logging/setLevel","params":{"level":"debug"}}
-                """;
+            var setLevelBody =
+                    // language=JSON
+                    """
+                    {"jsonrpc":"2.0","id":2,"method":"logging/setLevel","params":{"level":"debug"}}
+                    """;
             var setLevelResponse = client.sendRequest(sessionId, setLevelBody);
             assertThatJson(setLevelResponse.body()).inPath("$.result").isObject();
 
-            var toolBody = """
-                {"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"echo","arguments":{"message":"hello"}}}
-                """;
+            var toolBody =
+                    // language=JSON
+                    """
+                    {"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"echo","arguments":{"message":"hello"}}}
+                    """;
             var toolResponse = client.sendRequest(sessionId, toolBody);
-            final String responseBody = toolResponse.body();
 
-            assertThat(responseBody)
+            assertThat(toolResponse.body())
                     .contains(
                             // language=json
                             """
-                {"jsonrpc":"2.0","id":3,"result":{"content":[{"type":"text","text":"hello"}]}}
-                """.trim());
+                            {"jsonrpc":"2.0","id":3,"result":{"content":[{"type":"text","text":"hello"}]}}
+                            """.trim());
+        }
+    }
+
+    @Test
+    @Timeout(30)
+    void shouldBroadcastServerLogToListeningClient() throws Exception {
+        // server.notifications().log(...) fans out to every active session, delivered on its GET listen stream
+        try (var client = createTestClient()) {
+            var sessionId = client.initialize();
+            client.sendRequest(
+                    sessionId,
+                    // language=JSON
+                    """
+                    {"jsonrpc":"2.0","id":2,"method":"logging/setLevel","params":{"level":"debug"}}
+                    """);
+
+            var events = readListenStreamWhileBroadcasting(sessionId).toList();
+
+            assertThat(events)
+                    .as("the server-scoped error broadcast must arrive on the client's listen stream")
+                    .anyMatch(data -> data.contains("notifications/message")
+                            && data.contains("\"level\":\"error\"")
+                            && data.contains("\"logger\":\"tachyon.svc\"")
+                            && data.contains("server-broadcast"));
+        }
+    }
+
+    /**
+     * Opens a raw GET SSE listen stream and, once it is primed, triggers a server-scoped broadcast so
+     * it rides that stream. Returns each SSE event's {@code data:} payload as a stream, read until the
+     * broadcast is observed (or the read window elapses).
+     */
+    private Stream<String> readListenStreamWhileBroadcasting(String sessionId) throws Exception {
+        try (var socket = new Socket("localhost", port)) {
+            var req = ("GET /mcp HTTP/1.1\r\n"
+                            + "Host: localhost:" + port + "\r\n"
+                            + "MCP-Session-Id: " + sessionId + "\r\n"
+                            + "MCP-Protocol-Version: 2025-11-25\r\n"
+                            + "Accept: text/event-stream\r\n"
+                            + "\r\n")
+                    .getBytes(StandardCharsets.UTF_8);
+            socket.getOutputStream().write(req);
+            socket.getOutputStream().flush();
+            socket.setSoTimeout(100);
+
+            var sb = new StringBuilder();
+            var buf = new byte[2048];
+            var broadcast = false;
+            var deadline = System.currentTimeMillis() + 15_000;
+            while (System.currentTimeMillis() < deadline) {
+                try {
+                    var n = socket.getInputStream().read(buf);
+                    if (n < 0) break;
+                    sb.append(new String(buf, 0, n, StandardCharsets.UTF_8));
+                } catch (SocketTimeoutException ignored) {
+                    // idle tick — fall through to broadcast/exit checks
+                }
+                if (!broadcast && sb.indexOf("id:") >= 0) {
+                    // stream is primed; fire a server-scoped broadcast that must ride this stream
+                    server.notifications().error("tachyon.svc", Map.of("event", "server-broadcast"));
+                    broadcast = true;
+                }
+                if (sb.indexOf("server-broadcast") >= 0) break;
+            }
+            // The stream is materialized over the accumulated text, so it outlives the closed socket.
+            return sb.toString()
+                    .lines()
+                    .filter(line -> line.startsWith("data:"))
+                    .map(line -> line.substring("data:".length()).trim())
+                    .filter(data -> !data.isEmpty());
         }
     }
 }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/runtime/AbstractNotifications.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/runtime/AbstractNotifications.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2026 Konstantin Pavlov and contributors.
+ */
+
+package dev.tachyonmcp.runtime;
+
+import dev.tachyonmcp.server.domain.LoggingLevel;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Base class holding the shared logging logic for {@link InternalNotifications} implementations.
+ *
+ * <p>It owns the single wire-shape builder ({@link #logParams}) and the gated {@code log} template:
+ * every log funnels through {@link #shouldEmit} before {@link #send}, so gating cannot be bypassed.
+ * Subclasses supply the transport ({@code send}/{@code progress}/{@code comment}) and, when they are
+ * connection-bound, override {@link #shouldEmit} to apply capability and threshold policy.
+ */
+public abstract class AbstractNotifications implements InternalNotifications {
+
+    /** The MCP method for structured log notifications. */
+    public static final String LOG_METHOD = "notifications/message";
+
+    /**
+     * Builds the {@code notifications/message} params in wire order. Uses a {@link LinkedHashMap} so
+     * a {@code null} {@code data} value is retained (spec-legal) rather than rejected by
+     * {@code Map.of}, and an absent {@code logger} is omitted entirely.
+     */
+    public static Map<String, Object> logParams(LoggingLevel level, @Nullable String logger, @Nullable Object data) {
+        var params = new LinkedHashMap<String, Object>(3);
+        params.put("level", level.getValue());
+        if (logger != null) {
+            params.put("logger", logger);
+        }
+        params.put("data", data);
+        return params;
+    }
+
+    /**
+     * Decides whether a log message at the given level should be emitted. The single gate every
+     * {@link #log} call funnels through. Defaults to always emitting; connection-bound
+     * implementations override this to apply the client's configured threshold and the server's
+     * advertised {@code logging} capability.
+     */
+    public boolean shouldEmit(LoggingLevel level) {
+        return true;
+    }
+
+    @Override
+    public void log(LoggingLevel level, @Nullable String logger, @Nullable Object data) {
+        if (!shouldEmit(level)) {
+            return;
+        }
+        send(LOG_METHOD, logParams(level, logger, data));
+    }
+}

--- a/tachyon-server/src/main/java/dev/tachyonmcp/runtime/DefaultChannelContext.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/runtime/DefaultChannelContext.java
@@ -67,7 +67,7 @@ public class DefaultChannelContext implements ChannelContext {
     }
 
     @Override
-    public Notifications notifications() {
+    public InternalNotifications notifications() {
         throw new UnsupportedOperationException("notifications are not supported in this context");
     }
 

--- a/tachyon-server/src/main/java/dev/tachyonmcp/runtime/InteractionContext.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/runtime/InteractionContext.java
@@ -43,7 +43,7 @@ public interface InteractionContext {
     boolean isExtensionEnabled(String extensionId);
 
     /** Returns the notification sender bound to this interaction. */
-    Notifications notifications();
+    InternalNotifications notifications();
 
     /**
      * Sends a request to the client and returns a future that completes with the raw JSON response.

--- a/tachyon-server/src/main/java/dev/tachyonmcp/runtime/InternalNotifications.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/runtime/InternalNotifications.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026 Konstantin Pavlov and contributors.
+ */
+
+package dev.tachyonmcp.runtime;
+
+import dev.tachyonmcp.annotations.ExperimentalApi;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Internal notification surface used from within an interaction (handler dispatch) context. Extends
+ * the public {@link Notifications} logging surface with the raw transport primitives.
+ *
+ * <p>Only wire operations live here. Log gating and wire-shape construction are provided by
+ * {@link AbstractNotifications}; this interface declares no logic beyond a single delegating default.
+ */
+public interface InternalNotifications extends Notifications {
+
+    /**
+     * Sends a generic notification with the given method and params.
+     */
+    void send(String method, Object params);
+
+    /**
+     * Sends a progress notification.
+     *
+     * <p>The first server→client message on a POST also upgrades its response to an SSE stream and
+     * arms the heartbeat, keeping the connection alive past {@code readerIdleTimeout} — so emitting
+     * an early {@code progress(...)} is the keep-alive mechanism for long-running tools.
+     *
+     * <p>{@code progressToken} should be the client's request {@code _meta.progressToken}
+     * (e.g. {@code ToolRequest.progressToken()}). When it is {@code null} the client did not opt
+     * into progress, so the notification is silently dropped per the MCP spec — handlers may emit
+     * progress unconditionally without null-checking the token.
+     */
+    void progress(@Nullable Object progressToken, double progress, double total, String message);
+
+    /**
+     * Sends a raw SSE comment line ({@code : message}) on the response stream, upgrading a buffered
+     * POST response to {@code text/event-stream} if it has not started yet.
+     *
+     * <p>Unlike {@link #progress}, this needs no progress token — it carries no MCP message, only
+     * transport-level bytes the client ignores. Use it to keep a long-running request's connection
+     * alive when no progress token is available. A {@code null} or blank message emits a bare
+     * {@code :} heartbeat comment. No-op when no outbound stream is bound to the context.
+     */
+    @ExperimentalApi
+    void comment(@Nullable String message);
+
+    /**
+     * Sends empty SSE comment line ({@code :\r\n}).
+     *
+     * @see #comment(String)
+     */
+    @ExperimentalApi
+    default void comment() {
+        comment(null);
+    }
+}

--- a/tachyon-server/src/main/java/dev/tachyonmcp/runtime/Notifications.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/runtime/Notifications.java
@@ -4,121 +4,46 @@
 
 package dev.tachyonmcp.runtime;
 
-import dev.tachyonmcp.annotations.ExperimentalApi;
 import dev.tachyonmcp.server.domain.LoggingLevel;
-import java.util.LinkedHashMap;
 import org.jspecify.annotations.Nullable;
 
 /**
- * Sends notifications from within an interaction (handler dispatch) context.
+ * Emits structured MCP {@code notifications/message} logs.
+ *
+ * <p>This is the public logging surface. The single abstract method
+ * {@link #log(LoggingLevel, String, Object)} carries all behavior; the other methods are pure
+ * delegating conveniences, so implementations (including lambdas) only implement that one method.
+ * Threshold and capability gating, plus the wire-shape construction, live in
+ * {@link AbstractNotifications} — never in this interface.
  */
+@FunctionalInterface
 public interface Notifications {
 
     /**
-     * Sends a generic notification with the given method and params.
-     */
-    void send(String method, Object params);
-
-    /**
-     * Sends a progress notification.
-     *
-     * <p>The first server→client message on a POST also upgrades its response to an SSE stream and
-     * arms the heartbeat, keeping the connection alive past {@code readerIdleTimeout} — so emitting
-     * an early {@code progress(...)} is the keep-alive mechanism for long-running tools.
-     *
-     * <p>{@code progressToken} should be the client's request {@code _meta.progressToken}
-     * (e.g. {@code ToolRequest.progressToken()}). When it is {@code null} the client did not opt
-     * into progress, so the notification is silently dropped per the MCP spec — handlers may emit
-     * progress unconditionally without null-checking the token.
-     */
-    void progress(@Nullable Object progressToken, double progress, double total, String message);
-
-    /**
-     * Sends a raw SSE comment line ({@code : message}) on the response stream, upgrading a buffered
-     * POST response to {@code text/event-stream} if it has not started yet.
-     *
-     * <p>Unlike {@link #progress}, this needs no progress token — it carries no MCP message, only
-     * transport-level bytes the client ignores. Use it to keep a long-running request's connection
-     * alive when no progress token is available. A {@code null} or blank message emits a bare
-     * {@code :} heartbeat comment. No-op when no outbound stream is bound to the context.
-     */
-    @ExperimentalApi
-    void comment(@Nullable String message);
-
-    /**
-     * Sends empty SSE comment line ({@code :\r\n}).
-     *
-     * @see #comment(String)
-     */
-    @ExperimentalApi
-    default void comment() {
-        comment(null);
-    }
-
-    /**
-     * Decides whether a log message at the given level should be emitted. This is the single gate
-     * every {@link #log} call funnels through, so gating cannot be bypassed by a caller.
-     *
-     * <p>The base implementation always returns {@code true} (an unbound sender writes
-     * unconditionally). Connection-bound implementations override this to apply the client's
-     * configured threshold and the server's advertised {@code logging} capability.
-     *
-     * @param level the message severity
-     * @return {@code true} if a {@code notifications/message} at this level should be sent
-     */
-    default boolean shouldEmit(LoggingLevel level) {
-        return true;
-    }
-
-    /**
-     * Sends a structured MCP {@code notifications/message} log, gated by {@link #shouldEmit}.
-     *
-     * <p>This default is the unconditional wire writer once {@link #shouldEmit} allows the level:
-     * it serializes the params and delegates to {@link #send}. All threshold and capability policy
-     * lives in {@link #shouldEmit}, never here — so overriding that predicate is the only supported
-     * way to change what gets emitted.
+     * Emits a structured MCP log message.
      *
      * @param level the message severity
      * @param logger the optional logger name
      * @param data JSON-serializable message data, including {@code null}
      */
-    default void log(LoggingLevel level, @Nullable String logger, @Nullable Object data) {
-        if (!shouldEmit(level)) {
-            return;
-        }
-        var params = new LinkedHashMap<String, Object>(3);
-        params.put("level", level.getValue());
-        if (logger != null) {
-            params.put("logger", logger);
-        }
-        params.put("data", data);
-        send("notifications/message", params);
-    }
+    void log(LoggingLevel level, @Nullable String logger, @Nullable Object data);
 
-    /**
-     * Sends a structured MCP log message without a logger name.
-     */
+    /** Emits a structured MCP log message without a logger name. */
     default void log(LoggingLevel level, @Nullable Object data) {
         log(level, null, data);
     }
 
-    /**
-     * Sends an info-level log message.
-     */
+    /** Emits an info-level log message. */
     default void info(String logger, @Nullable Object data) {
         log(LoggingLevel.INFO, logger, data);
     }
 
-    /**
-     * Sends a warning-level log message.
-     */
+    /** Emits a warning-level log message. */
     default void warning(String logger, @Nullable Object data) {
         log(LoggingLevel.WARNING, logger, data);
     }
 
-    /**
-     * Sends an error-level log message.
-     */
+    /** Emits an error-level log message. */
     default void error(String logger, @Nullable Object data) {
         log(LoggingLevel.ERROR, logger, data);
     }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/DefaultTachyonServer.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/DefaultTachyonServer.java
@@ -8,7 +8,9 @@ import dev.tachyonmcp.protocol.Protocol;
 import dev.tachyonmcp.protocol.ProtocolResponseMapper;
 import dev.tachyonmcp.protocol.Protocols;
 import dev.tachyonmcp.protocol.mcp.v2025_11_25.McpProtocol;
+import dev.tachyonmcp.runtime.AbstractNotifications;
 import dev.tachyonmcp.runtime.Backpressure;
+import dev.tachyonmcp.runtime.Notifications;
 import dev.tachyonmcp.runtime.Session;
 import dev.tachyonmcp.runtime.SessionState;
 import dev.tachyonmcp.runtime.SseEvent;
@@ -387,6 +389,36 @@ final class DefaultTachyonServer implements ServerEngine {
     @Override
     public InternalTaskRegistry tasks() {
         return taskRegistry;
+    }
+
+    private final Notifications serverNotifications = this::broadcastLog;
+
+    @Override
+    public Notifications notifications() {
+        return serverNotifications;
+    }
+
+    /**
+     * Broadcasts a structured MCP log to every active session whose configured threshold admits the
+     * level. No-op when the server does not advertise the {@code logging} capability. The wire form
+     * is serialized once and reused across recipients.
+     */
+    public void broadcastLog(LoggingLevel level, @Nullable String logger, @Nullable Object data) {
+        if (!config.capabilities().logging()) {
+            return;
+        }
+        var paramsStr = JsonRpcCodec.toJsonParams(AbstractNotifications.logParams(level, logger, data));
+        var notificationJson = JsonRpcCodec.serializeNotificationAsString(AbstractNotifications.LOG_METHOD, paramsStr);
+        for (var session : sessionManager.allSessions()) {
+            if (session.state() != SessionState.ACTIVE) {
+                continue;
+            }
+            var threshold = loggingLevels.getOrDefault(session.id(), LoggingLevel.INFO);
+            if (level.ordinal() < threshold.ordinal()) {
+                continue;
+            }
+            sendSerializedNotification(session, AbstractNotifications.LOG_METHOD, paramsStr, notificationJson, null);
+        }
     }
 
     @Override

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/TachyonServer.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/TachyonServer.java
@@ -5,6 +5,7 @@
 package dev.tachyonmcp.server;
 
 import dev.tachyonmcp.runtime.InteractionContext;
+import dev.tachyonmcp.runtime.Notifications;
 import dev.tachyonmcp.server.config.ServerConfig;
 import dev.tachyonmcp.server.domain.Args;
 import dev.tachyonmcp.server.extensions.ServerExtension;
@@ -44,6 +45,8 @@ public interface TachyonServer extends AutoCloseable {
 
     /** Returns the task registry. */
     TaskRegistry tasks();
+
+    Notifications notifications();
 
     /**
      * Returns the port the server is bound to, or 0 if not yet started.

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/session/DefaultDispatchContext.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/session/DefaultDispatchContext.java
@@ -8,8 +8,9 @@ import dev.tachyonmcp.annotations.InternalApi;
 import dev.tachyonmcp.protocol.Protocol;
 import dev.tachyonmcp.protocol.ProtocolResponseMapper;
 import dev.tachyonmcp.protocol.Protocols;
+import dev.tachyonmcp.runtime.AbstractNotifications;
 import dev.tachyonmcp.runtime.ChannelContext;
-import dev.tachyonmcp.runtime.Notifications;
+import dev.tachyonmcp.runtime.InternalNotifications;
 import dev.tachyonmcp.runtime.Session;
 import dev.tachyonmcp.runtime.SseEvent;
 import dev.tachyonmcp.server.OutboundSseStream;
@@ -29,7 +30,7 @@ public class DefaultDispatchContext implements DispatchContext {
 
     private final ChannelContext channel;
     private final ServerEngine server;
-    private final Notifications notifications = new NotificationsImpl();
+    private final InternalNotifications notifications = new NotificationsImpl();
     private volatile @Nullable OutboundSseStream outboundStream;
 
     public DefaultDispatchContext(ChannelContext channel, ServerEngine server) {
@@ -130,7 +131,7 @@ public class DefaultDispatchContext implements DispatchContext {
     }
 
     @Override
-    public Notifications notifications() {
+    public InternalNotifications notifications() {
         return notifications;
     }
 
@@ -159,7 +160,7 @@ public class DefaultDispatchContext implements DispatchContext {
         return protocol().responseMapper();
     }
 
-    private class NotificationsImpl implements Notifications {
+    private class NotificationsImpl extends AbstractNotifications {
 
         @Override
         public void send(String method, Object params) {

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/session/NoopInteractionContext.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/session/NoopInteractionContext.java
@@ -9,7 +9,7 @@ import dev.tachyonmcp.protocol.Protocol;
 import dev.tachyonmcp.protocol.ProtocolMappers;
 import dev.tachyonmcp.protocol.ProtocolResponseMapper;
 import dev.tachyonmcp.protocol.mcp.v2025_11_25.McpProtocol;
-import dev.tachyonmcp.runtime.Notifications;
+import dev.tachyonmcp.runtime.InternalNotifications;
 import dev.tachyonmcp.runtime.Session;
 import dev.tachyonmcp.server.OutboundSseStream;
 import dev.tachyonmcp.server.domain.LoggingLevel;
@@ -67,7 +67,7 @@ public class NoopInteractionContext implements DispatchContext {
     }
 
     @Override
-    public Notifications notifications() {
+    public InternalNotifications notifications() {
         throw new UnsupportedOperationException("No interaction context available");
     }
 

--- a/tachyon-server/src/test/java/dev/tachyonmcp/runtime/NotificationsTest.java
+++ b/tachyon-server/src/test/java/dev/tachyonmcp/runtime/NotificationsTest.java
@@ -15,20 +15,9 @@ import org.junit.jupiter.api.Test;
 class NotificationsTest {
 
     @Test
-    void logUsesExistingSendContract() {
+    void logFunnelsThroughSendWithWireShape() {
         var sent = new AtomicReference<Sent>();
-        Notifications notifications = new Notifications() {
-            @Override
-            public void send(String method, Object params) {
-                sent.set(new Sent(method, params));
-            }
-
-            @Override
-            public void progress(@Nullable Object progressToken, double progress, double total, String message) {}
-
-            @Override
-            public void comment(@Nullable String message) {}
-        };
+        var notifications = collecting(sent);
 
         notifications.log(LoggingLevel.NOTICE, null, null);
 
@@ -36,6 +25,58 @@ class NotificationsTest {
         var params = params(sent.get().params());
         assertThat(params).containsEntry("level", "notice").containsEntry("data", null);
         assertThat(params).doesNotContainKey("logger");
+    }
+
+    @Test
+    void convenienceMethodsDelegateToLog() {
+        var sent = new AtomicReference<Sent>();
+        var notifications = collecting(sent);
+
+        notifications.warning("logger.x", "boom");
+
+        var params = params(sent.get().params());
+        assertThat(params).containsEntry("level", "warning").containsEntry("logger", "logger.x");
+    }
+
+    @Test
+    void shouldEmitFalseSuppressesSend() {
+        var sent = new AtomicReference<Sent>();
+        AbstractNotifications notifications = new AbstractNotifications() {
+            @Override
+            public boolean shouldEmit(LoggingLevel level) {
+                return false;
+            }
+
+            @Override
+            public void send(String method, Object params) {
+                sent.set(new Sent(method, params));
+            }
+
+            @Override
+            public void progress(@Nullable Object token, double progress, double total, String message) {}
+
+            @Override
+            public void comment(@Nullable String message) {}
+        };
+
+        notifications.error("logger.x", "boom");
+
+        assertThat(sent.get()).isNull();
+    }
+
+    private static AbstractNotifications collecting(AtomicReference<Sent> sent) {
+        return new AbstractNotifications() {
+            @Override
+            public void send(String method, Object params) {
+                sent.set(new Sent(method, params));
+            }
+
+            @Override
+            public void progress(@Nullable Object token, double progress, double total, String message) {}
+
+            @Override
+            public void comment(@Nullable String message) {}
+        };
     }
 
     @SuppressWarnings("unchecked")

--- a/tachyon-server/src/test/java/dev/tachyonmcp/transport/netty/NotificationDeliveryTest.java
+++ b/tachyon-server/src/test/java/dev/tachyonmcp/transport/netty/NotificationDeliveryTest.java
@@ -279,6 +279,77 @@ class NotificationDeliveryTest {
         assertThat(otherLogEvents).isEmpty();
     }
 
+    @Test
+    void shouldBroadcastServerLogToSessionsAboveTheirOwnThreshold() {
+        // server.notifications() fans out, gated by each session's configured threshold
+        var warnConn = new CollectingConnection();
+        var warnSession = server.createSession("sess_warn");
+        warnSession.connection(warnConn);
+        warnSession.activate();
+        server.setLoggingLevel("sess_warn", LoggingLevel.WARNING);
+        server.setLoggingLevel("sess_test", LoggingLevel.DEBUG);
+
+        server.notifications().log(LoggingLevel.INFO, "svc", Map.of("m", "hi"));
+        assertThat(logMessages(testConn)).hasSize(1);
+        assertThat(logMessages(warnConn)).isEmpty();
+
+        server.notifications().error("svc", Map.of("m", "bad"));
+        assertThat(logMessages(testConn)).hasSize(2);
+        assertThat(logMessages(warnConn))
+                .singleElement()
+                .satisfies(e ->
+                        assertThat(e.data()).contains("\"level\":\"error\"").contains("\"logger\":\"svc\""));
+    }
+
+    @Test
+    void shouldNotBroadcastServerLogToInactiveSession() {
+        var idleConn = new CollectingConnection();
+        var idleSession = server.createSession("sess_idle"); // created but never activated
+        idleSession.connection(idleConn);
+        server.setLoggingLevel("sess_idle", LoggingLevel.DEBUG);
+
+        server.notifications().error("svc", "boom");
+
+        assertThat(logMessages(idleConn)).isEmpty();
+        assertThat(logMessages(testConn)).hasSize(1); // active session at default INFO, ERROR passes
+    }
+
+    @Test
+    void shouldOmitLoggerAndRetainNullDataInBroadcast() {
+        server.setLoggingLevel("sess_test", LoggingLevel.DEBUG);
+
+        server.notifications().log(LoggingLevel.NOTICE, null);
+
+        assertThat(logMessages(testConn))
+                .singleElement()
+                .satisfies(e -> assertThat(e.data())
+                        .contains("\"level\":\"notice\"")
+                        .contains("\"data\":null")
+                        .doesNotContain("\"logger\""));
+    }
+
+    @Test
+    void shouldNotBroadcastServerLogWhenLoggingCapabilityDisabled() {
+        try (var noLog = newEngine(b -> b.session(s -> s.enabled(true)))) {
+            var conn = new CollectingConnection();
+            var session = noLog.createSession("s1");
+            session.connection(conn);
+            session.activate();
+            noLog.setLoggingLevel("s1", LoggingLevel.DEBUG);
+
+            noLog.notifications().error("svc", "x");
+
+            assertThat(conn.sent.stream().filter(e -> e.data().contains("notifications/message")))
+                    .isEmpty();
+        }
+    }
+
+    private static java.util.List<SseEvent> logMessages(CollectingConnection conn) {
+        return conn.sent.stream()
+                .filter(e -> e.data().contains("notifications/message"))
+                .toList();
+    }
+
     private static class CollectingConnection implements SseConnection {
 
         final ArrayList<SseEvent> sent = new ArrayList<>();


### PR DESCRIPTION
- feat: Implement `TachyonServer.notifications()` - It now emits a server-scoped `log(...)`
 that broadcasts to every connected client with logging enabled — the fan-out analogue of the per-connection `DefaultDispatchContext.NotificationsImpl`. Interfaces stay logic-free (delegating defaults only); the real logic lives in a base abstract class.

- docs: Update dev skill