### PR TITLE
update kotlin api

### DIFF
--- a/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/TachyonServer.kt
+++ b/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/TachyonServer.kt
@@ -31,22 +31,6 @@ public inline fun TachyonServer(
 }
 
 /**
- * Creates and starts a [TachyonServer] on [port]. Alias for [TachyonServer].
- *
- * @see TachyonServer
- */
-@OptIn(ExperimentalContracts::class)
-public inline fun tachyonServer(
-    port: Int? = null,
-    configure: (@TachyonDsl TachyonServerBuilder).() -> Unit = {},
-): TachyonServer {
-    contract { callsInPlace(configure, InvocationKind.EXACTLY_ONCE) }
-    val builder = TachyonServerBuilder().apply(configure)
-    builder.applyPort(port)
-    return builder.start()
-}
-
-/**
  * Builds a fully configured [TachyonServer] **without** starting Netty transport.
  * The returned server is not listening — it supports dynamic registration
  * through its feature registries but has no bound port.
@@ -54,7 +38,6 @@ public inline fun tachyonServer(
  * Use this for tests that don't need transport, or to set up handlers before
  * binding. To start, create with [TachyonServer] instead.
  */
-@Suppress("FunctionName")
 @OptIn(ExperimentalContracts::class)
 public inline fun buildServer(
     configure: (@TachyonDsl TachyonServerBuilder).() -> Unit = {},

--- a/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/config/ServerBuilderExtensions.kt
+++ b/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/config/ServerBuilderExtensions.kt
@@ -14,11 +14,11 @@ import dev.tachyonmcp.server.features.tools.ToolDescriptor
 import dev.tachyonmcp.server.features.tools.ToolResult
 import dev.tachyonmcp.server.features.tools.toolHandler
 import dev.tachyonmcp.server.json.schemas
-import dev.tachyonmcp.server.json.toJacksonNode
 import dev.tachyonmcp.server.json.toJacksonNodeOrNull
 import kotlinx.serialization.json.JsonObject
 import tools.jackson.databind.JsonNode
 
+@JvmSynthetic
 public fun ServerBuilder.resource(
     name: String,
     uri: String,
@@ -38,6 +38,7 @@ public fun ServerBuilder.resource(
  * @param handler The function that produces the resource contents.
  * @return This server builder.
  */
+@JvmSynthetic
 public fun ServerBuilder.resourceTemplate(
     name: String,
     uriTemplate: String,
@@ -72,6 +73,7 @@ public fun ServerBuilder.resourceTemplate(
  * @param handler The function that handles tool invocations.
  * @return This server builder.
  */
+@JvmSynthetic
 public fun ServerBuilder.tool(
     name: String,
     description: String? = null,
@@ -92,10 +94,11 @@ public fun ServerBuilder.tool(
         ),
     )
 
+@JvmSynthetic
 public fun ServerBuilder.tool(
     name: String,
     description: String? = null,
-    inputSchema: String,
+    inputSchema: String? = null,
     outputSchema: String? = null,
     handler: suspend ToolScope.() -> ToolResult,
 ): ServerBuilder =
@@ -115,17 +118,18 @@ public fun ServerBuilder.tool(
  * Registers a tool using a [JsonObject] input schema.
  * Requires kotlinx-serialization-json on the classpath.
  */
+@JvmSynthetic
 public fun ServerBuilder.tool(
     name: String,
     description: String? = null,
-    inputSchema: JsonObject,
+    inputSchema: JsonObject? = null,
     outputSchema: JsonObject? = null,
     handler: suspend ToolScope.() -> ToolResult,
 ): ServerBuilder =
     tool(
         name = name,
         description = description,
-        inputSchema = inputSchema.toJacksonNode(),
-        outputSchema = outputSchema?.toJacksonNodeOrNull(),
+        inputSchema = inputSchema.toJacksonNodeOrNull(),
+        outputSchema = outputSchema.toJacksonNodeOrNull(),
         handler = handler,
     )

--- a/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/config/SessionScope.kt
+++ b/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/config/SessionScope.kt
@@ -4,6 +4,7 @@ package dev.tachyonmcp.server.config
 
 import dev.tachyonmcp.server.TachyonDsl
 import dev.tachyonmcp.server.session.SessionEventStore
+import dev.tachyonmcp.server.session.SessionIdGenerator
 import dev.tachyonmcp.server.session.SessionStore
 import io.netty.handler.codec.http.HttpRequest
 import kotlin.time.Duration
@@ -28,12 +29,17 @@ public class SessionScope
         /** Custom session event store. */
         public var sessionEventStore: SessionEventStore? = null
 
-        /** Custom session ID generator function. */
-        public var sessionIdGenerator: ((HttpRequest) -> String)? = null
+        /** Session ID generator; defaults to [SessionIdGenerator.DEFAULT] (`sess_<uuid>`). Never null. */
+        public var sessionIdGenerator: SessionIdGenerator = SessionIdGenerator.DEFAULT
 
-        /** Lambda-friendly overload: `sessionIdGenerator { it.headers()["X-Tenant-Id"]!! }`. */
+        /**
+         * Lambda-friendly overload, e.g. deriving the id from an authenticated principal:
+         * `sessionIdGenerator { req -> principalFrom(req)?.sessionKey ?: SessionIdGenerator.DEFAULT.generate(req) }`.
+         * Do not key sessions off an unauthenticated client header — that invites session
+         * fixation and cross-tenant collisions, and a missing header would crash the request thread.
+         */
         public fun sessionIdGenerator(generator: (HttpRequest) -> String) {
-            sessionIdGenerator = generator
+            sessionIdGenerator = SessionIdGenerator { generator(it) }
         }
 
         @PublishedApi
@@ -43,6 +49,6 @@ public class SessionScope
             janitorInterval?.let { builder.janitorInterval(it.toJavaDuration()) }
             sessionStore?.let(builder::sessionStore)
             sessionEventStore?.let(builder::sessionEventStore)
-            sessionIdGenerator.let { builder.sessionIdGenerator(it) }
+            if (enabled) builder.sessionIdGenerator(sessionIdGenerator)
         }
     }

--- a/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/config/TachyonServerBuilder.kt
+++ b/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/config/TachyonServerBuilder.kt
@@ -104,6 +104,7 @@ public class TachyonServerBuilder
             return this
         }
 
+        @JvmSynthetic
         public fun tool(
             name: String,
             description: String? = null,
@@ -113,6 +114,7 @@ public class TachyonServerBuilder
         ): TachyonServerBuilder =
             this.also { delegate.tool(name, description, inputSchema, outputSchema, handler) }
 
+        @JvmSynthetic
         public fun tool(
             name: String,
             description: String? = null,
@@ -122,6 +124,7 @@ public class TachyonServerBuilder
         ): TachyonServerBuilder =
             this.also { delegate.tool(name, description, inputSchema, outputSchema, handler) }
 
+        @JvmSynthetic
         public fun resource(
             name: String,
             uri: String,
@@ -139,6 +142,7 @@ public class TachyonServerBuilder
          * @param handler The handler that generates the prompt messages.
          * @return This builder.
          */
+        @JvmSynthetic
         public fun prompt(
             name: String,
             description: String? = null,
@@ -162,6 +166,7 @@ public class TachyonServerBuilder
          * @param block Handles requests for resources matching the template.
          * @return This builder.
          */
+        @JvmSynthetic
         public fun resourceTemplate(
             name: String,
             uriTemplate: String,
@@ -189,6 +194,7 @@ public class TachyonServerBuilder
          * Registers a tool using a [kotlinx.serialization.json.JsonObject] input schema.
          * Requires kotlinx-serialization-json on the classpath.
          */
+        @JvmSynthetic
         public fun tool(
             name: String,
             description: String? = null,

--- a/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/json/JsonInterop.kt
+++ b/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/json/JsonInterop.kt
@@ -28,11 +28,17 @@ internal fun String.toJsonNode(): JsonNode =
     }
 
 internal fun ToolDescriptor.Builder.schemas(
-    inputSchema: String,
-    outputSchema: String?,
-): ToolDescriptor.Builder =
-    inputSchema(parseSchema(inputSchema))
-        .outputSchema(outputSchema?.let { parseSchema(it) })
+    inputSchema: String? = null,
+    outputSchema: String? = null,
+): ToolDescriptor.Builder {
+    if (inputSchema != null) {
+        inputSchema(parseSchema(inputSchema))
+    }
+    if (outputSchema != null) {
+        outputSchema(parseSchema(outputSchema))
+    }
+    return this
+}
 
 internal fun JsonElement.toJacksonNode(): JsonNode =
     when (this) {

--- a/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/json/KxSerializationSerde.kt
+++ b/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/json/KxSerializationSerde.kt
@@ -26,8 +26,8 @@ public class KxSerializationSerde(
     @Suppress("UNCHECKED_CAST")
     override fun <T : Any> serialize(value: T): String {
         val serializer =
-            serializerCache.getOrPut(value.javaClass) {
-                json.serializersModule.serializer(value.javaClass)
+            serializerCache.computeIfAbsent(value.javaClass) {
+                json.serializersModule.serializer(it)
             } as KSerializer<Any>
         return json.encodeToString(serializer, value)
     }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/session/SessionIdGenerator.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/session/SessionIdGenerator.java
@@ -23,8 +23,17 @@ public interface SessionIdGenerator {
     /**
      * Default generator: {@code sess_<UUID>}, ignoring the request.
      */
-    SessionIdGenerator DEFAULT =
-            request -> "sess_" + UUID.randomUUID().toString().replace("-", "");
+    SessionIdGenerator DEFAULT = new SessionIdGenerator() {
+        @Override
+        public String generate(HttpRequest request) {
+            return "sess_" + UUID.randomUUID().toString().replace("-", "");
+        }
+
+        @Override
+        public boolean readsRequest() {
+            return false;
+        }
+    };
 
     /**
      * Derives a session id from the initialize request (headers, URI, …).
@@ -39,4 +48,15 @@ public interface SessionIdGenerator {
      * </ul>
      */
     String generate(HttpRequest request);
+
+    /**
+     * Whether {@link #generate} inspects the request (headers, URI, …). When {@code false}, the
+     * transport skips detaching a per-request snapshot for the async session-creation dispatch.
+     *
+     * <p>Defaults to {@code true} so every custom generator is handed a valid request; override to
+     * {@code false} for a request-independent id (like {@link #DEFAULT}) to opt into the fast path.
+     */
+    default boolean readsRequest() {
+        return true;
+    }
 }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/ChannelHandlerUtils.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/ChannelHandlerUtils.java
@@ -57,7 +57,7 @@ public final class ChannelHandlerUtils {
      * request is released before the async dispatch runs.
      */
     public static void captureInitRequest(ChannelHandlerContext ctx, HttpRequest req, ServerEngine server) {
-        if (server.isStateless() || server.sessionIdGenerator() == SessionIdGenerator.DEFAULT) {
+        if (server.isStateless() || !server.sessionIdGenerator().readsRequest()) {
             return;
         }
         // Always build a fresh metadata-only snapshot. The aggregated request is a pooled


### PR DESCRIPTION
## New Features

- Tool definitions can now omit input schemas, supporting tools without structured input.
- Session ID generation supports request-independent strategies for faster session creation.
- Custom session ID generators can control whether request details are required.

## Changes

- The lower-case server startup entry point was removed; use the primary server startup API instead.
- Kotlin DSL configuration methods are no longer exposed to Java callers.
- Serialization and schema handling now better support optional values.