### PR TITLE
feat: DTO Builders

### DIFF
--- a/examples/weather/src/test/java/com/example/weather/WeatherServerTest.java
+++ b/examples/weather/src/test/java/com/example/weather/WeatherServerTest.java
@@ -11,7 +11,6 @@ import io.modelcontextprotocol.spec.McpError;
 import io.modelcontextprotocol.spec.McpSchema;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
@@ -47,11 +46,6 @@ class WeatherServerTest {
             .build();
 
         initResult = client.initialize();
-    }
-
-    @BeforeEach
-    void clearProgressNotifications() {
-        progressNotifications.clear();
     }
 
     @AfterAll

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/domain/Annotations.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/domain/Annotations.java
@@ -42,7 +42,7 @@ public interface Annotations {
         }
     }
 
-    static DefaultAnnotations.Builder builder() {
+    static Builder builder() {
         return DefaultAnnotations.builder();
     }
 
@@ -52,5 +52,16 @@ public interface Annotations {
                 .priority(priority)
                 .lastModified(lastModified)
                 .build();
+    }
+
+    interface Builder {
+
+        Builder audience(@Nullable Iterable<? extends Role> elements);
+
+        Builder priority(@Nullable Double priority);
+
+        Builder lastModified(@Nullable String lastModified);
+
+        Annotations build();
     }
 }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/domain/AudioContent.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/domain/AudioContent.java
@@ -16,7 +16,10 @@ import tools.jackson.databind.JsonNode;
  * {@code mimeType} describing the encoding (e.g. {@code audio/mp3}).
  */
 @Value.Immutable
-@Value.Style(allParameters = true, typeImmutable = "Default*")
+@Value.Style(
+        allParameters = true,
+        typeImmutable = "Default*",
+        visibility = Value.Style.ImplementationVisibility.PACKAGE)
 public non-sealed interface AudioContent extends ContentBlock, HasMeta {
 
     String data();
@@ -34,7 +37,13 @@ public non-sealed interface AudioContent extends ContentBlock, HasMeta {
         return Type.AUDIO;
     }
 
-    static DefaultAudioContent.Builder builder() {
+    @Value.Check
+    default void check() {
+        if (data().isBlank()) throw new IllegalArgumentException("data must not be blank");
+        if (mimeType().isBlank()) throw new IllegalArgumentException("mimeType must not be blank");
+    }
+
+    static Builder builder() {
         return DefaultAudioContent.builder();
     }
 
@@ -52,5 +61,17 @@ public non-sealed interface AudioContent extends ContentBlock, HasMeta {
     static AudioContent of(
             String data, String mimeType, @Nullable Annotations annotations, @Nullable Map<String, JsonNode> meta) {
         return DefaultAudioContent.of(data, mimeType, annotations, meta);
+    }
+
+    interface Builder {
+        Builder data(String data);
+
+        Builder mimeType(String mimeType);
+
+        Builder annotations(@Nullable Annotations annotations);
+
+        Builder meta(@Nullable Map<String, ? extends JsonNode> entries);
+
+        AudioContent build();
     }
 }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/domain/BlobResourceContents.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/domain/BlobResourceContents.java
@@ -25,11 +25,33 @@ public non-sealed interface BlobResourceContents extends ResourceContents {
 
     String blob();
 
+    @Value.Check
+    default void check() {
+        if (uri().isBlank()) throw new IllegalArgumentException("uri must not be blank");
+        if (blob().isBlank()) throw new IllegalArgumentException("blob must not be blank");
+    }
+
     static BlobResourceContents of(String uri, @Nullable String mimeType, String blob) {
         return DefaultBlobResourceContents.of(null, uri, mimeType, blob);
     }
 
     static BlobResourceContents of(String uri, @Nullable String mimeType, String blob, Map<String, JsonNode> meta) {
         return DefaultBlobResourceContents.of(meta, uri, mimeType, blob);
+    }
+
+    static Builder builder() {
+        return DefaultBlobResourceContents.builder();
+    }
+
+    interface Builder {
+        Builder meta(@Nullable Map<String, ? extends JsonNode> entries);
+
+        Builder uri(String uri);
+
+        Builder mimeType(@Nullable String mimeType);
+
+        Builder blob(String blob);
+
+        BlobResourceContents build();
     }
 }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/domain/EmbeddedResource.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/domain/EmbeddedResource.java
@@ -36,7 +36,7 @@ public non-sealed interface EmbeddedResource extends ContentBlock, HasMeta {
         return Type.RESOURCE;
     }
 
-    static DefaultEmbeddedResource.Builder builder() {
+    static Builder builder() {
         return DefaultEmbeddedResource.builder();
     }
 
@@ -54,5 +54,15 @@ public non-sealed interface EmbeddedResource extends ContentBlock, HasMeta {
     static EmbeddedResource of(
             ResourceContents resource, @Nullable Annotations annotations, @Nullable Map<String, JsonNode> meta) {
         return DefaultEmbeddedResource.of(resource, annotations, meta);
+    }
+
+    interface Builder {
+        Builder resource(ResourceContents resource);
+
+        Builder annotations(@Nullable Annotations annotations);
+
+        Builder meta(@Nullable Map<String, ? extends JsonNode> entries);
+
+        EmbeddedResource build();
     }
 }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/domain/FormInputRequest.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/domain/FormInputRequest.java
@@ -20,11 +20,24 @@ public non-sealed interface FormInputRequest extends InputRequest {
     /** JSON schema describing the expected form fields. */
     Map<String, JsonNode> requestedSchema();
 
-    static DefaultFormInputRequest.Builder builder() {
+    @Value.Check
+    default void check() {
+        if (message().isBlank()) throw new IllegalArgumentException("message must not be blank");
+    }
+
+    static Builder builder() {
         return DefaultFormInputRequest.builder();
     }
 
     static FormInputRequest of(String message, Map<String, JsonNode> requestedSchema) {
         return DefaultFormInputRequest.of(message, requestedSchema);
+    }
+
+    interface Builder {
+        Builder message(String message);
+
+        Builder requestedSchema(Map<String, ? extends JsonNode> entries);
+
+        FormInputRequest build();
     }
 }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/domain/Icon.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/domain/Icon.java
@@ -16,7 +16,10 @@ import org.jspecify.annotations.Nullable;
  * vs. dark variants.
  */
 @Value.Immutable
-@Value.Style(allParameters = true, typeImmutable = "Default*")
+@Value.Style(
+        allParameters = true,
+        typeImmutable = "Default*",
+        visibility = Value.Style.ImplementationVisibility.PACKAGE)
 public interface Icon {
 
     String src();
@@ -30,11 +33,29 @@ public interface Icon {
     @Nullable
     String theme();
 
-    static DefaultIcon.Builder builder() {
+    @Value.Check
+    default void check() {
+        if (src().isBlank()) throw new IllegalArgumentException("src must not be blank");
+    }
+
+    static Builder builder() {
         return DefaultIcon.builder();
     }
 
     static Icon of(String src, @Nullable String mimeType, @Nullable List<String> sizes, @Nullable String theme) {
         return DefaultIcon.of(src, mimeType, sizes, theme);
+    }
+
+    interface Builder {
+
+        Builder src(String src);
+
+        Builder mimeType(@Nullable String mimeType);
+
+        Builder sizes(@Nullable Iterable<String> elements);
+
+        Builder theme(@Nullable String theme);
+
+        Icon build();
     }
 }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/domain/ImageContent.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/domain/ImageContent.java
@@ -37,7 +37,13 @@ public non-sealed interface ImageContent extends ContentBlock {
         return Type.IMAGE;
     }
 
-    static DefaultImageContent.Builder builder() {
+    @Value.Check
+    default void check() {
+        if (data().isBlank()) throw new IllegalArgumentException("data must not be blank");
+        if (mimeType().isBlank()) throw new IllegalArgumentException("mimeType must not be blank");
+    }
+
+    static Builder builder() {
         return DefaultImageContent.builder();
     }
 
@@ -55,5 +61,17 @@ public non-sealed interface ImageContent extends ContentBlock {
     static ImageContent of(
             String data, String mimeType, @Nullable Annotations annotations, @Nullable Map<String, JsonNode> meta) {
         return DefaultImageContent.of(data, mimeType, annotations, meta);
+    }
+
+    interface Builder {
+        Builder data(String data);
+
+        Builder mimeType(String mimeType);
+
+        Builder annotations(@Nullable Annotations annotations);
+
+        Builder meta(@Nullable Map<String, ? extends JsonNode> entries);
+
+        ImageContent build();
     }
 }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/domain/PromptArgument.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/domain/PromptArgument.java
@@ -17,8 +17,8 @@ import org.jspecify.annotations.Nullable;
 @Value.Immutable
 @Value.Style(
         allParameters = true,
-        visibility = Value.Style.ImplementationVisibility.PACKAGE,
-        typeImmutable = "Default*")
+        typeImmutable = "Default*",
+        visibility = Value.Style.ImplementationVisibility.PACKAGE)
 public interface PromptArgument {
 
     String name();
@@ -32,12 +32,30 @@ public interface PromptArgument {
     @Nullable
     Boolean required();
 
-    static DefaultPromptArgument.Builder builder() {
+    @Value.Check
+    default void check() {
+        if (name().isBlank()) throw new IllegalArgumentException("name must not be blank");
+    }
+
+    static Builder builder() {
         return DefaultPromptArgument.builder();
     }
 
     static PromptArgument of(
             String name, @Nullable String title, @Nullable String description, @Nullable Boolean required) {
         return DefaultPromptArgument.of(name, title, description, required);
+    }
+
+    interface Builder {
+
+        Builder name(String name);
+
+        Builder title(@Nullable String title);
+
+        Builder description(@Nullable String description);
+
+        Builder required(@Nullable Boolean required);
+
+        PromptArgument build();
     }
 }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/domain/PromptMessage.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/domain/PromptMessage.java
@@ -23,6 +23,10 @@ public interface PromptMessage {
 
     ContentBlock content();
 
+    static Builder builder() {
+        return DefaultPromptMessage.builder();
+    }
+
     static PromptMessage of(Role role, ContentBlock content) {
         return DefaultPromptMessage.of(role, content);
     }
@@ -35,5 +39,13 @@ public interface PromptMessage {
     /** Creates a user-role message whose content is plain text (no annotations). */
     static PromptMessage user(String text) {
         return DefaultPromptMessage.of(Role.USER, TextContent.of(text));
+    }
+
+    interface Builder {
+        Builder role(Role role);
+
+        Builder content(ContentBlock content);
+
+        PromptMessage build();
     }
 }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/domain/ResourceLink.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/domain/ResourceLink.java
@@ -17,7 +17,10 @@ import tools.jackson.databind.JsonNode;
  * metadata (URI, name, title, description, MIME type) without the actual content data.
  */
 @Value.Immutable
-@Value.Style(allParameters = true, typeImmutable = "Default*")
+@Value.Style(
+        allParameters = true,
+        typeImmutable = "Default*",
+        visibility = Value.Style.ImplementationVisibility.PACKAGE)
 public non-sealed interface ResourceLink extends ContentBlock {
 
     String name();
@@ -49,7 +52,8 @@ public non-sealed interface ResourceLink extends ContentBlock {
     default void check() {
         if (name().isBlank()) throw new IllegalArgumentException("name must not be blank");
         if (uri().isBlank()) throw new IllegalArgumentException("uri must not be blank");
-        if (size() != null && size() < 0) throw new IllegalArgumentException("size must be >= 0, got: " + size());
+        Long size = size();
+        if (size != null && size < 0) throw new IllegalArgumentException("size must be >= 0, got: " + size);
     }
 
     @Override
@@ -82,24 +86,26 @@ public non-sealed interface ResourceLink extends ContentBlock {
         return builder().uri(uri).name(name);
     }
 
-    public interface Builder {
+    interface Builder {
 
-        DefaultResourceLink.Builder name(String name);
+        Builder name(String name);
 
-        DefaultResourceLink.Builder title(@Nullable String title);
+        Builder title(@Nullable String title);
 
-        DefaultResourceLink.Builder icons(@Nullable Iterable<? extends Icon> elements);
+        Builder icons(@Nullable Iterable<? extends Icon> elements);
 
-        DefaultResourceLink.Builder uri(String uri);
+        Builder uri(String uri);
 
-        DefaultResourceLink.Builder description(@Nullable String description);
+        Builder description(@Nullable String description);
 
-        DefaultResourceLink.Builder annotations(@Nullable Annotations annotations);
+        Builder mimeType(@Nullable String mimeType);
 
-        DefaultResourceLink.Builder size(@Nullable Long size);
+        Builder annotations(@Nullable Annotations annotations);
 
-        DefaultResourceLink.Builder meta(@Nullable Map<String, ? extends JsonNode> entries);
+        Builder size(@Nullable Long size);
 
-        DefaultResourceLink build();
+        Builder meta(@Nullable Map<String, ? extends JsonNode> entries);
+
+        ResourceLink build();
     }
 }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/domain/RpcMethodRequest.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/domain/RpcMethodRequest.java
@@ -21,11 +21,24 @@ public non-sealed interface RpcMethodRequest extends InputRequest {
     @Nullable
     JsonNode params();
 
-    static DefaultRpcMethodRequest.Builder builder() {
+    @Value.Check
+    default void check() {
+        if (method().isBlank()) throw new IllegalArgumentException("method must not be blank");
+    }
+
+    static Builder builder() {
         return DefaultRpcMethodRequest.builder();
     }
 
     static RpcMethodRequest of(String method, @Nullable JsonNode params) {
         return DefaultRpcMethodRequest.of(method, params);
+    }
+
+    interface Builder {
+        Builder method(String method);
+
+        Builder params(@Nullable JsonNode params);
+
+        RpcMethodRequest build();
     }
 }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/domain/TextContent.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/domain/TextContent.java
@@ -5,6 +5,7 @@
 package dev.tachyonmcp.server.domain;
 
 import java.util.Map;
+import java.util.Objects;
 import org.immutables.value.Value;
 import org.jspecify.annotations.Nullable;
 import tools.jackson.databind.JsonNode;
@@ -34,7 +35,12 @@ public non-sealed interface TextContent extends ContentBlock {
         return ContentBlock.Type.TEXT;
     }
 
-    static DefaultTextContent.Builder builder() {
+    @Value.Check
+    default void check() {
+        Objects.requireNonNull(text(), "text must not be null");
+    }
+
+    static Builder builder() {
         return DefaultTextContent.builder();
     }
 
@@ -51,5 +57,15 @@ public non-sealed interface TextContent extends ContentBlock {
     /** Creates a text content block with metadata and optional annotations. */
     static TextContent of(String text, @Nullable Map<String, JsonNode> meta, @Nullable Annotations annotations) {
         return DefaultTextContent.of(text, meta, annotations);
+    }
+
+    interface Builder {
+        Builder text(String text);
+
+        Builder meta(@Nullable Map<String, ? extends JsonNode> entries);
+
+        Builder annotations(@Nullable Annotations annotations);
+
+        TextContent build();
     }
 }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/domain/TextResourceContents.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/domain/TextResourceContents.java
@@ -25,7 +25,13 @@ public non-sealed interface TextResourceContents extends ResourceContents {
 
     String text();
 
-    static DefaultTextResourceContents.Builder builder() {
+    @Value.Check
+    default void check() {
+        if (uri().isBlank()) throw new IllegalArgumentException("uri must not be blank");
+        if (text().isBlank()) throw new IllegalArgumentException("text must not be blank");
+    }
+
+    static Builder builder() {
         return DefaultTextResourceContents.builder();
     }
 
@@ -36,5 +42,17 @@ public non-sealed interface TextResourceContents extends ResourceContents {
     static TextResourceContents of(
             String uri, @Nullable String mimeType, String text, @Nullable Map<String, JsonNode> meta) {
         return DefaultTextResourceContents.of(meta, uri, mimeType, text);
+    }
+
+    interface Builder {
+        Builder meta(@Nullable Map<String, ? extends JsonNode> entries);
+
+        Builder uri(String uri);
+
+        Builder mimeType(@Nullable String mimeType);
+
+        Builder text(String text);
+
+        TextResourceContents build();
     }
 }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/domain/ToolAnnotations.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/domain/ToolAnnotations.java
@@ -38,7 +38,7 @@ public interface ToolAnnotations {
     @Nullable
     Boolean openWorldHint();
 
-    static DefaultToolAnnotations.Builder builder() {
+    static Builder builder() {
         return DefaultToolAnnotations.builder();
     }
 
@@ -49,5 +49,19 @@ public interface ToolAnnotations {
             @Nullable Boolean idempotentHint,
             @Nullable Boolean openWorldHint) {
         return DefaultToolAnnotations.of(title, readOnlyHint, destructiveHint, idempotentHint, openWorldHint);
+    }
+
+    interface Builder {
+        Builder title(@Nullable String title);
+
+        Builder readOnlyHint(@Nullable Boolean readOnlyHint);
+
+        Builder destructiveHint(@Nullable Boolean destructiveHint);
+
+        Builder idempotentHint(@Nullable Boolean idempotentHint);
+
+        Builder openWorldHint(@Nullable Boolean openWorldHint);
+
+        ToolAnnotations build();
     }
 }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/domain/UrlInputRequest.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/domain/UrlInputRequest.java
@@ -21,11 +21,28 @@ public non-sealed interface UrlInputRequest extends InputRequest {
     /** URL to open for user input. */
     String url();
 
-    static DefaultUrlInputRequest.Builder builder() {
+    @Value.Check
+    default void check() {
+        if (message().isBlank()) throw new IllegalArgumentException("message must not be blank");
+        if (elicitationId().isBlank()) throw new IllegalArgumentException("elicitationId must not be blank");
+        if (url().isBlank()) throw new IllegalArgumentException("url must not be blank");
+    }
+
+    static Builder builder() {
         return DefaultUrlInputRequest.builder();
     }
 
     static UrlInputRequest of(String message, String elicitationId, String url) {
         return DefaultUrlInputRequest.of(message, elicitationId, url);
+    }
+
+    interface Builder {
+        Builder message(String message);
+
+        Builder elicitationId(String elicitationId);
+
+        Builder url(String url);
+
+        UrlInputRequest build();
     }
 }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/features/PaginatedResult.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/features/PaginatedResult.java
@@ -45,11 +45,21 @@ public interface PaginatedResult<R> {
      */
     boolean cursorValid();
 
-    static <R> DefaultPaginatedResult.Builder<R> builder() {
+    static <R> Builder<R> builder() {
         return DefaultPaginatedResult.builder();
     }
 
     static <R> PaginatedResult<R> of(List<R> items, @Nullable String nextCursor, boolean cursorValid) {
         return DefaultPaginatedResult.of(items, nextCursor, cursorValid);
+    }
+
+    interface Builder<R> {
+        Builder<R> items(Iterable<? extends R> elements);
+
+        Builder<R> nextCursor(@Nullable String nextCursor);
+
+        Builder<R> cursorValid(boolean cursorValid);
+
+        PaginatedResult<R> build();
     }
 }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tools/ToolRequest.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tools/ToolRequest.java
@@ -22,6 +22,11 @@ public interface ToolRequest extends HasMeta {
 
     String name();
 
+    @Value.Check
+    default void check() {
+        if (name().isBlank()) throw new IllegalArgumentException("name must not be blank");
+    }
+
     @Value.Default
     default Map<String, JsonNode> arguments() {
         return Map.of();


### PR DESCRIPTION
## Summary

Domain interfaces now validate required fields with @Value.Check and expose public builder contracts instead of generated builder types. Request, content, resource, annotation, prompt, tool, and pagination models receive corresponding API updates. The weather server test no longer resets progress notifications before each test.

## New Features

- Added consistent builder interfaces for creating requests, content, resources, annotations, and paginated results.
- Added validation for required fields, including names, messages, methods, URLs, resource identifiers, content data, and MIME types.
- Invalid or incomplete values now produce clear errors during object creation.

## Improvements

- Builder APIs now expose stable abstraction types, making integrations less dependent on implementation details.
- Pagination builders provide a consistent way to configure items, cursors, and cursor validity.
