### PR TITLE
feat: Improve tasks

### DIFF
--- a/.agents/skills/tachyon-mcp/SKILL.md
+++ b/.agents/skills/tachyon-mcp/SKILL.md
@@ -181,7 +181,11 @@ Full: `resources/java/PromptHandlerExample.java`
 ## Config️
 
 ### Capabilities `capabilities(cfg -> ...)`
-Configs: `FeatureConfig` (tools/prompts: `mode`, `listChanged`, `pageSize`), `ResourcesConfig` (+ `subscribe`), `TasksConfig` (`enabled`, `list`, `cancel`, `requests`, `pageSize`, mapping 1:1 to MCP `tasks.list`/`tasks.cancel`/`tasks.requests.tools.call`).
+
+Configs: `FeatureConfig` (tools/prompts: `mode`, `listChanged`, `pageSize`), `ResourcesConfig` (+ `subscribe`), 
+`TasksConfig` (`enabled`, `list`, `cancel`, `requests`, `pageSize`, 
+`keepAlive` (default 5 min — retention window for a terminal task's result), 
+mapping 1:1 to MCP `tasks.list`/`tasks.cancel`/`tasks.requests.tools.call`).
 
 Default `Mode.AUTO` advertises only registered features. Force `Mode.ON`/`Mode.OFF`. **`OFF` also blocks registration**: registry `register` becomes a debug-logged no-op, not merely hidden from `initialize`.
 

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -53,6 +53,10 @@ runner. IDs must be unique — `create` throws `IllegalArgumentException` if a t
 already exists. Leave `id` unset to let the server generate one (`UUID.randomUUID()`-backed,
 same idiom as session IDs).
 
+Supply `TaskOptions.builder().keepAlive(Duration.ofMinutes(30)).build()` to override how long
+this task's result stays retrievable via `tasks/get`/`tasks/result` after it reaches a terminal
+state, overriding the server-wide default (`TasksConfig.keepAlive`, 5 minutes).
+
 Status notifications are broadcast automatically on each transition.
 
 ## Task-augmented tool calls
@@ -99,7 +103,15 @@ Clients that include `"extensions": {"io.modelcontextprotocol/tasks": {}}` in th
 
 ## Task janitor
 
-Tachyon runs a background janitor that removes stale tasks past their TTL. Configure TTL per task or rely on the server default (30 s session TTL applies).
+A background janitor sweeps every 30s and does two independent things:
+
+- **Active tasks** (`WORKING`/`INPUT_REQUIRED`) past their `task.ttl` are transitioned to `FAILED`.
+- **Terminal tasks'** (`COMPLETED`/`FAILED`/`CANCELLED`) results are dropped from memory once
+  `keepAlive` has elapsed since they entered the terminal state — default 5 minutes, configurable
+  server-wide via `TasksConfig.keepAlive`/`CapabilitiesConfig.Builder.tasksKeepAlive(...)`
+  (Kotlin DSL: `tasks { keepAlive = 10.minutes }`), or per task via `TaskOptions.keepAlive(...)`.
+  Once dropped, `tasks/get`/`tasks/result` return "Task not found", same as an ID that never
+  existed.
 
 ## MCP methods
 

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -30,20 +30,28 @@ Tachyon enforces valid transitions. Invalid moves throw `IllegalStateException`.
 ## Create and update tasks
 
 ```java
-import dev.tachyonmcp.server.features.tasks.TaskEntry;
-import dev.tachyonmcp.server.features.tasks.TaskState;
+import dev.tachyonmcp.server.domain.Task;
+import dev.tachyonmcp.server.domain.TaskResult;
+import dev.tachyonmcp.server.features.tasks.TaskOptions;
 
 Server server = handle.server();
 
-// Create
-TaskEntry task = server.tasks().create("task-001", "Processing...", null);
+// Create — server generates the ID
+Task task = server.tasks().create();
 
-// Update state
-server.tasks().update(task.id(), TaskState.WORKING, "Running step 1...");
+// Create — correlate with your own task runner's ID
+Task ownedTask = server.tasks().create(
+        TaskOptions.builder().id("my-runner-task-42").build());
 
-// Complete
-server.tasks().update(task.id(), TaskState.COMPLETED, "Done");
+// Update state via the returned Task handle
+ownedTask.updateMessage("Running step 1...");
+ownedTask.complete(new TaskResult.Completed(...));
 ```
+
+Supply `TaskOptions.builder().id(...)` to map a task onto an ID from your own external task
+runner. IDs must be unique — `create` throws `IllegalArgumentException` if a task with that ID
+already exists. Leave `id` unset to let the server generate one (`UUID.randomUUID()`-backed,
+same idiom as session IDs).
 
 Status notifications are broadcast automatically on each transition.
 

--- a/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/config/TasksScope.kt
+++ b/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/config/TasksScope.kt
@@ -3,7 +3,11 @@
 package dev.tachyonmcp.server.config
 
 import dev.tachyonmcp.server.TachyonDsl
+import dev.tachyonmcp.server.config.TasksConfig.DEFAULT_TASK_KEEP_ALIVE
 import dev.tachyonmcp.server.features.Pagination
+import kotlin.time.Duration
+import kotlin.time.toJavaDuration
+import kotlin.time.toKotlinDuration
 
 @TachyonDsl
 public class TasksScope
@@ -24,6 +28,12 @@ public class TasksScope
         /** Default page size when a list request omits its limit. */
         public var pageSize: Int = Pagination.DEFAULT_PAGE_SIZE
 
+        /**
+         * How long a completed/failed/cancelled task's result stays retrievable before eviction.
+         * Zero or negative disables eviction — the result is kept indefinitely.
+         */
+        public var keepAlive: Duration = DEFAULT_TASK_KEEP_ALIVE.toKotlinDuration()
+
         @PublishedApi
         internal fun toConfig(): TasksConfig =
             TasksConfig
@@ -33,5 +43,6 @@ public class TasksScope
                 .cancel(cancel)
                 .requests(requests)
                 .pageSize(pageSize)
+                .keepAlive(keepAlive.toJavaDuration())
                 .build()
     }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/config/CapabilitiesConfig.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/config/CapabilitiesConfig.java
@@ -2,6 +2,8 @@
 
 package dev.tachyonmcp.server.config;
 
+import java.time.Duration;
+
 /**
  * Configuration of which MCP capabilities to enable and their behaviour.
  *
@@ -82,7 +84,8 @@ public record CapabilitiesConfig(
                     .list(config.list())
                     .cancel(config.cancel())
                     .requests(config.requests())
-                    .pageSize(config.pageSize());
+                    .pageSize(config.pageSize())
+                    .keepAlive(config.keepAlive());
             return this;
         }
 
@@ -172,6 +175,11 @@ public record CapabilitiesConfig(
 
         public Builder tasksPageSize(int tasksPageSize) {
             tasksBuilder.pageSize(tasksPageSize);
+            return this;
+        }
+
+        public Builder tasksKeepAlive(Duration tasksKeepAlive) {
+            tasksBuilder.keepAlive(tasksKeepAlive);
             return this;
         }
 

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/config/TasksConfig.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/config/TasksConfig.java
@@ -5,33 +5,44 @@
 package dev.tachyonmcp.server.config;
 
 import dev.tachyonmcp.server.features.Pagination;
+import java.time.Duration;
+import java.util.Objects;
 
 /**
  * Configuration for the tasks capability. Fields map 1:1 to the MCP {@code tasks} capability
  * object ({@code tasks.list}, {@code tasks.cancel}, {@code tasks.requests.tools.call}).
  *
- * @param enabled  whether the {@code tasks} capability is advertised at all (default
- *                 {@code false}); the capability is also advertised, regardless of this flag,
- *                 when a registered tool supports task augmentation
- * @param list     whether {@code tasks/list} is exposed (default {@code false})
- * @param cancel   whether {@code tasks/cancel} is supported (default {@code false})
- * @param requests whether task-augmented {@code tools/call} requests are accepted
- *                 (default {@code false})
- * @param pageSize default page size when a list request omits its limit
+ * @param enabled   whether the {@code tasks} capability is advertised at all (default
+ *                  {@code false}); the capability is also advertised, regardless of this flag,
+ *                  when a registered tool supports task augmentation
+ * @param list      whether {@code tasks/list} is exposed (default {@code false})
+ * @param cancel    whether {@code tasks/cancel} is supported (default {@code false})
+ * @param requests  whether task-augmented {@code tools/call} requests are accepted
+ *                  (default {@code false})
+ * @param pageSize  default page size when a list request omits its limit
+ * @param keepAlive default retention window for a terminal task's result before it's dropped
+ *                  from memory (default 5 minutes); overridable per task via
+ *                  {@code TaskOptions.keepAlive()}
  */
-public record TasksConfig(boolean enabled, boolean list, boolean cancel, boolean requests, int pageSize) {
+public record TasksConfig(
+        boolean enabled, boolean list, boolean cancel, boolean requests, int pageSize, Duration keepAlive) {
 
     static final boolean DEFAULT_TASKS_ENABLED = false;
     static final boolean DEFAULT_TASK_LIST = false;
     static final boolean DEFAULT_TASK_CANCEL = false;
     static final boolean DEFAULT_TASK_REQUESTS = false;
 
-    static final TasksConfig DEFAULT = new TasksConfig(false, false, false, false, Pagination.DEFAULT_PAGE_SIZE);
+    /** Public (unlike the defaults above) — {@code TaskEntry} in a different package reuses this as the resolved default. */
+    public static final Duration DEFAULT_TASK_KEEP_ALIVE = Duration.ofMinutes(5);
+
+    static final TasksConfig DEFAULT =
+            new TasksConfig(false, false, false, false, Pagination.DEFAULT_PAGE_SIZE, DEFAULT_TASK_KEEP_ALIVE);
 
     public TasksConfig {
         if (pageSize <= 0) {
             throw new IllegalArgumentException("pageSize must be positive, got: " + pageSize);
         }
+        Objects.requireNonNull(keepAlive, "keepAlive");
     }
 
     public static Builder builder() {
@@ -48,6 +59,7 @@ public record TasksConfig(boolean enabled, boolean list, boolean cancel, boolean
         private boolean cancel = DEFAULT.cancel;
         private boolean requests = DEFAULT.requests;
         private int pageSize = DEFAULT.pageSize;
+        private Duration keepAlive = DEFAULT.keepAlive;
 
         private Builder() {}
 
@@ -76,6 +88,12 @@ public record TasksConfig(boolean enabled, boolean list, boolean cancel, boolean
             return this;
         }
 
+        /** Sets the default retention window for a terminal task's result. Default is 5 minutes. */
+        public Builder keepAlive(Duration keepAlive) {
+            this.keepAlive = Objects.requireNonNull(keepAlive, "keepAlive cannot be null");
+            return this;
+        }
+
         /**
          * Enables the tasks capability with the list surface on.
          */
@@ -84,7 +102,7 @@ public record TasksConfig(boolean enabled, boolean list, boolean cancel, boolean
         }
 
         public TasksConfig build() {
-            return new TasksConfig(enabled, list, cancel, requests, pageSize);
+            return new TasksConfig(enabled, list, cancel, requests, pageSize, keepAlive);
         }
     }
 }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/features/AbstractRegistry.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/features/AbstractRegistry.java
@@ -46,6 +46,16 @@ public abstract class AbstractRegistry<D extends ServerFeature.Descriptor, R ext
         fireOnChange();
     }
 
+    /** Adds the item if none is registered under the same name; returns {@code false} if one already exists. */
+    protected boolean addItemIfAbsent(R item) {
+        var previous = items.putIfAbsent(item.descriptor().name(), item);
+        if (previous == null) {
+            fireOnChange();
+            return true;
+        }
+        return false;
+    }
+
     /**
      * Removes the item with the specified name and notifies change listeners when an item is removed.
      *

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tasks/DefaultTaskRegistry.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tasks/DefaultTaskRegistry.java
@@ -74,7 +74,7 @@ public class DefaultTaskRegistry extends AbstractRegistry<TaskDescriptor, TaskEn
 
     @Override
     public Task create(TaskOptions options) {
-        return createSessionTask(options.ttl(), options.meta(), null, null);
+        return createTask(options.id(), options.ttl(), options.meta(), null, null);
     }
 
     @Override
@@ -83,10 +83,21 @@ public class DefaultTaskRegistry extends AbstractRegistry<TaskDescriptor, TaskEn
             @Nullable Map<String, JsonNode> meta,
             @Nullable String sessionId,
             @Nullable Object progressToken) {
-        var id = taskIdGenerator.generateTaskId(meta, sessionId);
-        var build = TaskDescriptor.builder().id(id).build();
-        var entry = new TaskEntry(build, id, TaskState.SUBMITTED, ttl, sessionId, progressToken, meta);
-        add(entry);
+        return createTask(null, ttl, meta, sessionId, progressToken);
+    }
+
+    private TaskEntry createTask(
+            @Nullable String requestedId,
+            @Nullable Duration ttl,
+            @Nullable Map<String, JsonNode> meta,
+            @Nullable String sessionId,
+            @Nullable Object progressToken) {
+        var id = requestedId != null ? requestedId : taskIdGenerator.generateTaskId(meta, sessionId);
+        var descriptor = TaskDescriptor.builder().id(id).build();
+        var entry = new TaskEntry(descriptor, id, TaskState.SUBMITTED, ttl, sessionId, progressToken, meta);
+        if (!addItemIfAbsent(entry)) {
+            throw new IllegalArgumentException("Task '" + id + "' already exists");
+        }
         fireStatusNotification(entry);
         return entry;
     }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tasks/DefaultTaskRegistry.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tasks/DefaultTaskRegistry.java
@@ -15,6 +15,7 @@ import dev.tachyonmcp.server.domain.TaskResult;
 import dev.tachyonmcp.server.domain.TextContent;
 import dev.tachyonmcp.server.features.AbstractRegistry;
 import dev.tachyonmcp.server.features.ListRequests;
+import dev.tachyonmcp.server.internal.AbstractJanitor;
 import dev.tachyonmcp.server.internal.ServerEngine;
 import dev.tachyonmcp.server.session.DispatchContext;
 import dev.tachyonmcp.transport.jsonrpc.JsonRpcErrors;
@@ -23,11 +24,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -45,11 +42,18 @@ public class DefaultTaskRegistry extends AbstractRegistry<TaskDescriptor, TaskEn
     private final ConcurrentHashMap<String, Future<?>> running = new ConcurrentHashMap<>();
     private final ServerEngine server;
     private final TaskIdGenerator taskIdGenerator;
-    private volatile @Nullable ScheduledExecutorService ttlJanitor;
+    private final Duration defaultKeepAlive;
+    private final AbstractJanitor janitor = new AbstractJanitor("task-janitor") {
+        @Override
+        protected void sweep() {
+            runJanitorSweep();
+        }
+    };
 
     public DefaultTaskRegistry(ServerEngine server, TasksConfig config) {
         super(config.pageSize());
         this.taskIdGenerator = DefaultTaskIdGenerator.INSTANCE;
+        this.defaultKeepAlive = config.keepAlive();
         this.server = server;
     }
 
@@ -74,7 +78,8 @@ public class DefaultTaskRegistry extends AbstractRegistry<TaskDescriptor, TaskEn
 
     @Override
     public Task create(TaskOptions options) {
-        return createTask(options.id(), options.ttl(), options.meta(), null, null);
+        var keepAlive = options.keepAlive() != null ? options.keepAlive() : defaultKeepAlive;
+        return createTask(options.id(), options.ttl(), options.meta(), null, null, keepAlive);
     }
 
     @Override
@@ -83,7 +88,7 @@ public class DefaultTaskRegistry extends AbstractRegistry<TaskDescriptor, TaskEn
             @Nullable Map<String, JsonNode> meta,
             @Nullable String sessionId,
             @Nullable Object progressToken) {
-        return createTask(null, ttl, meta, sessionId, progressToken);
+        return createTask(null, ttl, meta, sessionId, progressToken, defaultKeepAlive);
     }
 
     private TaskEntry createTask(
@@ -91,10 +96,11 @@ public class DefaultTaskRegistry extends AbstractRegistry<TaskDescriptor, TaskEn
             @Nullable Duration ttl,
             @Nullable Map<String, JsonNode> meta,
             @Nullable String sessionId,
-            @Nullable Object progressToken) {
+            @Nullable Object progressToken,
+            Duration keepAlive) {
         var id = requestedId != null ? requestedId : taskIdGenerator.generateTaskId(meta, sessionId);
         var descriptor = TaskDescriptor.builder().id(id).build();
-        var entry = new TaskEntry(descriptor, id, TaskState.SUBMITTED, ttl, sessionId, progressToken, meta);
+        var entry = new TaskEntry(descriptor, id, TaskState.SUBMITTED, ttl, sessionId, progressToken, meta, keepAlive);
         if (!addItemIfAbsent(entry)) {
             throw new IllegalArgumentException("Task '" + id + "' already exists");
         }
@@ -207,27 +213,25 @@ public class DefaultTaskRegistry extends AbstractRegistry<TaskDescriptor, TaskEn
         return true;
     }
 
-    private final AtomicBoolean ttlJanitorStarted = new AtomicBoolean();
-
     public void startTtlJanitor() {
-        if (!ttlJanitorStarted.compareAndSet(false, true)) {
-            return;
-        }
-        var executor = Executors.newSingleThreadScheduledExecutor(r -> {
-            var t = new Thread(r, "task-janitor");
-            t.setDaemon(true);
-            return t;
-        });
-        ttlJanitor = executor;
-        executor.scheduleAtFixedRate(
-                this::expireStaleTasks, TTL_JANITOR_INTERVAL_SECONDS, TTL_JANITOR_INTERVAL_SECONDS, TimeUnit.SECONDS);
+        janitor.start(Duration.ofSeconds(TTL_JANITOR_INTERVAL_SECONDS));
     }
 
     public void stopTtlJanitor() {
-        var executor = ttlJanitor;
-        if (executor != null) {
-            executor.shutdown();
-            ttlJanitor = null;
+        janitor.close();
+    }
+
+    void runJanitorSweep() {
+        expireStaleTasks();
+        dropExpiredResults();
+    }
+
+    private void dropExpiredResults() {
+        for (var entry : getAll()) {
+            if (entry.status().isTerminal() && entry.isResultExpired()) {
+                logger.debug("Dropping task result after keepAlive: id={}", entry.id());
+                remove(entry.id());
+            }
         }
     }
 

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tasks/TaskEntry.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tasks/TaskEntry.java
@@ -6,6 +6,7 @@ package dev.tachyonmcp.server.features.tasks;
 
 import dev.tachyonmcp.annotations.InternalApi;
 import dev.tachyonmcp.server.ServerFeature;
+import dev.tachyonmcp.server.config.TasksConfig;
 import dev.tachyonmcp.server.domain.ContentBlock;
 import dev.tachyonmcp.server.domain.InputRequest;
 import dev.tachyonmcp.server.domain.Task;
@@ -32,22 +33,48 @@ public class TaskEntry implements ServerFeature<TaskDescriptor>, Task {
     private final AtomicReference<TaskState> status;
     private final long createdAt;
     private final @Nullable Duration ttl;
+    private final Duration keepAlive;
     private volatile long lastUpdatedAt;
+    private volatile long expiredAt;
     private volatile @Nullable String statusMessage;
     private volatile @Nullable TaskResult result;
     private final CompletableFuture<TaskResult> completionFuture = new CompletableFuture<>();
     private final @Nullable Object progressToken;
 
     public TaskEntry(String id, @Nullable String description) {
-        this(TaskDescriptor.builder().id(id).build(), id, TaskState.WORKING, null, null, null, null);
+        this(
+                TaskDescriptor.builder().id(id).build(),
+                id,
+                TaskState.WORKING,
+                null,
+                null,
+                null,
+                null,
+                TasksConfig.DEFAULT_TASK_KEEP_ALIVE);
     }
 
     public TaskEntry(TaskDescriptor descriptor, String id, TaskState status, double ttl) {
-        this(descriptor, id, status, ttl > 0 ? Duration.ofSeconds((long) ttl) : null, null, null, null);
+        this(
+                descriptor,
+                id,
+                status,
+                ttl > 0 ? Duration.ofSeconds((long) ttl) : null,
+                null,
+                null,
+                null,
+                TasksConfig.DEFAULT_TASK_KEEP_ALIVE);
     }
 
     public TaskEntry(TaskDescriptor descriptor, String id, TaskState status, double ttl, @Nullable String sessionId) {
-        this(descriptor, id, status, ttl > 0 ? Duration.ofSeconds((long) ttl) : null, sessionId, null, null);
+        this(
+                descriptor,
+                id,
+                status,
+                ttl > 0 ? Duration.ofSeconds((long) ttl) : null,
+                sessionId,
+                null,
+                null,
+                TasksConfig.DEFAULT_TASK_KEEP_ALIVE);
     }
 
     public TaskEntry(
@@ -57,7 +84,7 @@ public class TaskEntry implements ServerFeature<TaskDescriptor>, Task {
             @Nullable Duration ttl,
             @Nullable String sessionId,
             @Nullable Object progressToken) {
-        this(descriptor, id, status, ttl, sessionId, progressToken, null);
+        this(descriptor, id, status, ttl, sessionId, progressToken, null, TasksConfig.DEFAULT_TASK_KEEP_ALIVE);
     }
 
     public TaskEntry(
@@ -68,6 +95,18 @@ public class TaskEntry implements ServerFeature<TaskDescriptor>, Task {
             @Nullable String sessionId,
             @Nullable Object progressToken,
             @Nullable Map<String, JsonNode> meta) {
+        this(descriptor, id, status, ttl, sessionId, progressToken, meta, TasksConfig.DEFAULT_TASK_KEEP_ALIVE);
+    }
+
+    public TaskEntry(
+            TaskDescriptor descriptor,
+            String id,
+            TaskState status,
+            @Nullable Duration ttl,
+            @Nullable String sessionId,
+            @Nullable Object progressToken,
+            @Nullable Map<String, JsonNode> meta,
+            Duration keepAlive) {
         this.descriptor = descriptor;
         this.id = id;
         this.sessionId = sessionId;
@@ -76,6 +115,7 @@ public class TaskEntry implements ServerFeature<TaskDescriptor>, Task {
         this.createdAt = System.currentTimeMillis();
         this.lastUpdatedAt = this.createdAt;
         this.ttl = ttl;
+        this.keepAlive = Objects.requireNonNull(keepAlive, "keepAlive");
         this.progressToken = progressToken;
     }
 
@@ -126,6 +166,11 @@ public class TaskEntry implements ServerFeature<TaskDescriptor>, Task {
     @Override
     public @Nullable Duration ttl() {
         return ttl;
+    }
+
+    /** How long after this task reaches a terminal state its result stays retrievable. */
+    public Duration keepAlive() {
+        return keepAlive;
     }
 
     @Override
@@ -255,6 +300,7 @@ public class TaskEntry implements ServerFeature<TaskDescriptor>, Task {
         if (status.compareAndSet(current, newStatus)) {
             this.lastUpdatedAt = System.currentTimeMillis();
             if (newStatus.isTerminal()) {
+                this.expiredAt = computeExpiredAt(this.lastUpdatedAt);
                 if (this.result != null) {
                     completionFuture.complete(this.result);
                 } else {
@@ -272,6 +318,26 @@ public class TaskEntry implements ServerFeature<TaskDescriptor>, Task {
             return false;
         }
         return System.currentTimeMillis() - lastUpdatedAt > ttl.toMillis();
+    }
+
+    /** Whether this task's result has outlived its {@code keepAlive} retention window. */
+    public boolean isResultExpired() {
+        var deadline = expiredAt;
+        return deadline != 0 && System.currentTimeMillis() > deadline;
+    }
+
+    /**
+     * Computes the absolute deadline at which the result expires, given the instant the task
+     * became terminal. {@code keepAlive <= 0} means "never expires" ({@link Long#MAX_VALUE}).
+     * Computed once at the terminal transition rather than on every {@link #isResultExpired()}
+     * call — {@code expiredAt} isn't exposed by the protocol, so there's no need to keep the raw
+     * terminal timestamp around.
+     */
+    private long computeExpiredAt(long terminalAtMillis) {
+        if (keepAlive.isNegative() || keepAlive.isZero()) {
+            return Long.MAX_VALUE;
+        }
+        return terminalAtMillis + keepAlive.toMillis();
     }
 
     public String createdAtIso() {

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tasks/TaskOptions.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tasks/TaskOptions.java
@@ -6,12 +6,45 @@ package dev.tachyonmcp.server.features.tasks;
 
 import java.time.Duration;
 import java.util.Map;
+import org.immutables.value.Value;
 import org.jspecify.annotations.Nullable;
 import tools.jackson.databind.JsonNode;
 
-public record TaskOptions(@Nullable Duration ttl, @Nullable Map<String, JsonNode> meta) {
+@Value.Immutable
+@Value.Style(
+        allParameters = true,
+        visibility = Value.Style.ImplementationVisibility.PACKAGE,
+        typeImmutable = "Default*")
+public interface TaskOptions {
 
-    public TaskOptions {
-        meta = meta != null ? Map.copyOf(meta) : null;
+    /** Caller-supplied task ID to correlate with an external task runner, or {@code null} to auto-generate. */
+    @Nullable
+    String id();
+
+    @Nullable
+    Duration ttl();
+
+    @Nullable
+    Map<String, JsonNode> meta();
+
+    @Value.Check
+    default void check() {
+        if (id() != null && id().isBlank()) {
+            throw new IllegalArgumentException("id must not be blank");
+        }
+    }
+
+    static Builder builder() {
+        return DefaultTaskOptions.builder();
+    }
+
+    interface Builder {
+        Builder id(@Nullable String id);
+
+        Builder ttl(@Nullable Duration ttl);
+
+        Builder meta(@Nullable Map<String, ? extends JsonNode> meta);
+
+        TaskOptions build();
     }
 }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tasks/TaskOptions.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tasks/TaskOptions.java
@@ -24,6 +24,10 @@ public interface TaskOptions {
     @Nullable
     Duration ttl();
 
+    /** How long after this task reaches a terminal state its result stays retrievable, or {@code null} to use the server default. */
+    @Nullable
+    Duration keepAlive();
+
     @Nullable
     Map<String, JsonNode> meta();
 
@@ -42,6 +46,8 @@ public interface TaskOptions {
         Builder id(@Nullable String id);
 
         Builder ttl(@Nullable Duration ttl);
+
+        Builder keepAlive(@Nullable Duration keepAlive);
 
         Builder meta(@Nullable Map<String, ? extends JsonNode> meta);
 

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tasks/TasksExtension.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tasks/TasksExtension.java
@@ -14,7 +14,6 @@ import dev.tachyonmcp.server.features.tools.AbstractToolHandler;
 import dev.tachyonmcp.server.features.tools.ToolDescriptor;
 import dev.tachyonmcp.server.features.tools.ToolResult;
 import dev.tachyonmcp.server.internal.ServerEngine;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -103,8 +102,9 @@ public class TasksExtension implements ServerExtension {
                                 if (description != null) {
                                     meta.put("description", description);
                                 }
-                                final var task = tasks.create(new TaskOptions(
-                                        null, !meta.isEmpty() ? Collections.unmodifiableMap(meta) : null));
+                                final var task = tasks.create(TaskOptions.builder()
+                                        .meta(!meta.isEmpty() ? meta : null)
+                                        .build());
                                 return ToolResult.text(task.id());
                             });
                         } catch (Exception e) {

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/internal/AbstractJanitor.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/internal/AbstractJanitor.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2026 Konstantin Pavlov and contributors.
+ */
+
+package dev.tachyonmcp.server.internal;
+
+import dev.tachyonmcp.annotations.InternalApi;
+import java.time.Duration;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Shared periodic-sweep scheduling for background cleanup tasks (session eviction, task
+ * expiry/retention). A single daemon thread runs {@link #sweep()} at a fixed delay; exceptions
+ * from a sweep are caught and logged so one failed pass doesn't cancel future runs.
+ */
+@InternalApi
+public abstract class AbstractJanitor implements AutoCloseable {
+
+    private static final Logger logger = LoggerFactory.getLogger(AbstractJanitor.class);
+
+    private final String threadName;
+    private final AtomicBoolean started = new AtomicBoolean();
+    private volatile @Nullable ScheduledExecutorService executor;
+
+    protected AbstractJanitor(String threadName) {
+        this.threadName = threadName;
+    }
+
+    /** Starts the periodic sweep at the given interval. Idempotent — later calls no-op. */
+    public final void start(Duration interval) {
+        if (!started.compareAndSet(false, true)) {
+            return;
+        }
+        var exec = Executors.newSingleThreadScheduledExecutor(r -> {
+            var t = new Thread(r, threadName);
+            t.setDaemon(true);
+            return t;
+        });
+        executor = exec;
+        var intervalMs = interval.toMillis();
+        exec.scheduleWithFixedDelay(this::safeSweep, intervalMs, intervalMs, TimeUnit.MILLISECONDS);
+    }
+
+    private void safeSweep() {
+        try {
+            sweep();
+        } catch (Exception e) {
+            logger.warn("Janitor sweep failed", e);
+        }
+    }
+
+    /** One janitor pass. */
+    protected abstract void sweep();
+
+    @Override
+    public void close() {
+        var exec = executor;
+        if (exec != null) {
+            exec.shutdownNow();
+            executor = null;
+        }
+    }
+}

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/session/SessionManager.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/session/SessionManager.java
@@ -8,12 +8,10 @@ import dev.tachyonmcp.annotations.InternalApi;
 import dev.tachyonmcp.runtime.Session;
 import dev.tachyonmcp.runtime.SessionState;
 import dev.tachyonmcp.runtime.SseConnection;
+import dev.tachyonmcp.server.internal.AbstractJanitor;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.Optional;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -25,16 +23,11 @@ public class SessionManager implements AutoCloseable {
     private static final Logger logger = LoggerFactory.getLogger(SessionManager.class);
 
     private final SessionStore store;
-    private final ScheduledExecutorService janitor;
+    private @Nullable AbstractJanitor janitor;
 
     /** Creates a session manager backed by the given store. */
     public SessionManager(SessionStore store) {
         this.store = store;
-        this.janitor = Executors.newSingleThreadScheduledExecutor(r -> {
-            var t = new Thread(r, "session-janitor");
-            t.setDaemon(true);
-            return t;
-        });
     }
 
     /** Creates a session with no initial connection. */
@@ -79,19 +72,14 @@ public class SessionManager implements AutoCloseable {
     /** Starts the background janitor that closes expired sessions. */
     public void startJanitor(Duration ttl, Duration interval) {
         final var ttlNanos = ttl.toNanos();
-        final var intervalMs = interval.toMillis();
-        janitor.scheduleWithFixedDelay(
-                () -> {
-                    try {
-                        sweep(ttlNanos);
-                    } catch (Exception e) {
-                        logger.warn("Janitor sweep failed", e);
-                    }
-                },
-                intervalMs,
-                intervalMs,
-                TimeUnit.MILLISECONDS);
-        logger.debug("Session janitor started (interval={}ms, ttl={}ms)", intervalMs, ttlNanos / 1_000_000);
+        janitor = new AbstractJanitor("session-janitor") {
+            @Override
+            protected void sweep() {
+                SessionManager.this.sweep(ttlNanos);
+            }
+        };
+        janitor.start(interval);
+        logger.debug("Session janitor started (interval={}ms, ttl={}ms)", interval.toMillis(), ttlNanos / 1_000_000);
     }
 
     /** One janitor pass: closes and evicts sessions that are CLOSED or idle beyond the TTL. */
@@ -118,7 +106,9 @@ public class SessionManager implements AutoCloseable {
 
     public void close() {
         try {
-            janitor.shutdownNow();
+            if (janitor != null) {
+                janitor.close();
+            }
             store.values().forEach(Session::close);
             store.close();
             logger.debug("SessionManager closed");

--- a/tachyon-server/src/test/java/dev/tachyonmcp/server/features/tasks/TaskRegistryTest.java
+++ b/tachyon-server/src/test/java/dev/tachyonmcp/server/features/tasks/TaskRegistryTest.java
@@ -292,6 +292,78 @@ class TaskRegistryTest {
     }
 
     @Test
+    void taskResultNotExpiredBeforeKeepAliveElapses() {
+        var entry = new TaskEntry(
+                TaskDescriptor.builder().id("res-1").build(),
+                "res-1",
+                TaskState.WORKING,
+                null,
+                null,
+                null,
+                null,
+                Duration.ofMillis(200));
+        entry.complete(new TaskResult.Completed(null));
+        assertThat(entry.isResultExpired()).isFalse();
+    }
+
+    @Test
+    void taskResultExpiresAfterKeepAlive() throws Exception {
+        var entry = new TaskEntry(
+                TaskDescriptor.builder().id("res-2").build(),
+                "res-2",
+                TaskState.WORKING,
+                null,
+                null,
+                null,
+                null,
+                Duration.ofMillis(10));
+        entry.complete(new TaskResult.Completed(null));
+
+        var deadline = System.currentTimeMillis() + 500;
+        while (!entry.isResultExpired() && System.currentTimeMillis() < deadline) {
+            Thread.sleep(1);
+        }
+        assertThat(entry.isResultExpired()).isTrue();
+    }
+
+    @Test
+    void taskResultNeverExpiresWithZeroKeepAlive() {
+        var entry = new TaskEntry(
+                TaskDescriptor.builder().id("res-3").build(),
+                "res-3",
+                TaskState.WORKING,
+                null,
+                null,
+                null,
+                null,
+                Duration.ZERO);
+        entry.complete(new TaskResult.Completed(null));
+        assertThat(entry.isResultExpired()).isFalse();
+    }
+
+    @Test
+    void createWithKeepAliveOverrideAppliesToEntry() {
+        var entry = (TaskEntry) registry.create(
+                TaskOptions.builder().keepAlive(Duration.ofSeconds(1)).build());
+        assertThat(entry.keepAlive()).isEqualTo(Duration.ofSeconds(1));
+    }
+
+    @Test
+    void runJanitorSweepDropsExpiredTerminalTaskResult() throws Exception {
+        var entry = (TaskEntry) registry.create(
+                TaskOptions.builder().keepAlive(Duration.ofMillis(10)).build());
+        registry.completeTask(entry.id(), "{\"ok\":true}");
+
+        var deadline = System.currentTimeMillis() + 500;
+        while (!entry.isResultExpired() && System.currentTimeMillis() < deadline) {
+            Thread.sleep(1);
+        }
+        registry.runJanitorSweep();
+
+        assertThat(registry.get(entry.id())).isNull();
+    }
+
+    @Test
     void statusEnumFsmTerminalStates() {
         assertThat(TaskState.COMPLETED.isTerminal()).isTrue();
         assertThat(TaskState.FAILED.isTerminal()).isTrue();

--- a/tachyon-server/src/test/java/dev/tachyonmcp/server/features/tasks/TaskRegistryTest.java
+++ b/tachyon-server/src/test/java/dev/tachyonmcp/server/features/tasks/TaskRegistryTest.java
@@ -6,6 +6,7 @@ package dev.tachyonmcp.server.features.tasks;
 
 import static dev.tachyonmcp.test.TestUtils.newEngine;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import dev.tachyonmcp.protocol.mcp.v2025_11_25.models.CallToolResult;
 import dev.tachyonmcp.protocol.mcp.v2025_11_25.models.CancelTaskResult;
@@ -214,6 +215,26 @@ class TaskRegistryTest {
         var listHandler = handlers.get("tasks/list");
         var listResult = (ListTasksResult) listHandler.handle(DefaultDispatchContext.noop(), null);
         assertThat(listResult.tasks()).hasSize(1);
+    }
+
+    @Test
+    void createWithCallerSuppliedIdUsesThatId() throws Exception {
+        var entry = registry.create(TaskOptions.builder().id("my-task-1").build());
+        assertThat(entry.id()).isEqualTo("my-task-1");
+
+        var getHandler = handlers.get("tasks/get");
+        var result = (GetTaskResult) getHandler.handle(DefaultDispatchContext.noop(), Map.of("taskId", "my-task-1"));
+        assertThat(result.taskId()).isEqualTo("my-task-1");
+    }
+
+    @Test
+    void createWithDuplicateIdIsRejected() {
+        registry.create(TaskOptions.builder().id("dup-1").build());
+
+        assertThatThrownBy(
+                        () -> registry.create(TaskOptions.builder().id("dup-1").build()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("dup-1");
     }
 
     @Test

--- a/tachyon-server/src/test/java/dev/tachyonmcp/server/internal/AbstractJanitorTest.java
+++ b/tachyon-server/src/test/java/dev/tachyonmcp/server/internal/AbstractJanitorTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2026 Konstantin Pavlov and contributors.
+ */
+
+package dev.tachyonmcp.server.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+class AbstractJanitorTest {
+
+    @Test
+    @Timeout(5)
+    void sweepRunsPeriodically() throws Exception {
+        var count = new AtomicInteger();
+        var janitor = new AbstractJanitor("test-janitor") {
+            @Override
+            protected void sweep() {
+                count.incrementAndGet();
+            }
+        };
+
+        janitor.start(Duration.ofMillis(5));
+        try {
+            var deadline = System.currentTimeMillis() + 2000;
+            while (count.get() < 2 && System.currentTimeMillis() < deadline) {
+                Thread.sleep(5);
+            }
+            assertThat(count.get()).isGreaterThanOrEqualTo(2);
+        } finally {
+            janitor.close();
+        }
+    }
+
+    @Test
+    @Timeout(5)
+    void sweepExceptionDoesNotCancelFutureRuns() throws Exception {
+        var count = new AtomicInteger();
+        var janitor = new AbstractJanitor("test-janitor") {
+            @Override
+            protected void sweep() {
+                if (count.getAndIncrement() == 0) {
+                    throw new RuntimeException("boom");
+                }
+            }
+        };
+
+        janitor.start(Duration.ofMillis(5));
+        try {
+            var deadline = System.currentTimeMillis() + 2000;
+            while (count.get() < 2 && System.currentTimeMillis() < deadline) {
+                Thread.sleep(5);
+            }
+            assertThat(count.get()).isGreaterThanOrEqualTo(2);
+        } finally {
+            janitor.close();
+        }
+    }
+
+    @Test
+    void startIsIdempotent() throws Exception {
+        var count = new AtomicInteger();
+        var janitor = new AbstractJanitor("test-janitor") {
+            @Override
+            protected void sweep() {
+                count.incrementAndGet();
+            }
+        };
+
+        janitor.start(Duration.ofMillis(500));
+        janitor.start(Duration.ofMillis(500));
+        try {
+            Thread.sleep(50);
+            assertThat(count.get()).isZero();
+        } finally {
+            janitor.close();
+        }
+    }
+
+    @Test
+    @Timeout(5)
+    void closeStopsSweeping() throws Exception {
+        var count = new AtomicInteger();
+        var janitor = new AbstractJanitor("test-janitor") {
+            @Override
+            protected void sweep() {
+                count.incrementAndGet();
+            }
+        };
+
+        janitor.start(Duration.ofMillis(5));
+        var deadline = System.currentTimeMillis() + 2000;
+        while (count.get() < 1 && System.currentTimeMillis() < deadline) {
+            Thread.sleep(5);
+        }
+        janitor.close();
+
+        var countAfterClose = count.get();
+        Thread.sleep(50);
+        assertThat(count.get()).isEqualTo(countAfterClose);
+    }
+}


### PR DESCRIPTION
**Allow caller-supplied task ID in TaskOptions** 

TaskOptions moves from a record to an Immutables builder and gains an
optional id() so embedders can correlate an MCP task with an ID from
their own task runner. Duplicate IDs are rejected via a new
addItemIfAbsent primitive on AbstractRegistry; auto-generated IDs are
unaffected.

**Add per-task keepAlive retention window and extract shared janitor** 

TaskOptions/TasksConfig gain a keepAlive Duration (default 5 min) controlling how long a terminal task's result stays retrievable before eviction, server-wide default or per-task override. Extracts AbstractJanitor (shared scheduled-sweep base) out of the ad-hoc scheduling SessionManager and DefaultTaskRegistry each had, reused by both; DefaultTaskRegistry's janitor now also drops expired terminal task results, not just failing stale active ones.