### PR TITLE
fix: task status message and millis fields; add keepAlive, poolInterval

### DIFF
--- a/e2e/src/test/java/dev/tachyonmcp/e2e/ResourceTemplateTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/ResourceTemplateTest.java
@@ -6,7 +6,6 @@ import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 
 import dev.tachyonmcp.server.domain.TextResourceContents;
 import org.junit.jupiter.api.Test;
-import tools.jackson.databind.ObjectMapper;
 
 class ResourceTemplateTest extends AbstractStatelessMcpE2eTest {
 
@@ -195,8 +194,6 @@ class ResourceTemplateTest extends AbstractStatelessMcpE2eTest {
                 {"jsonrpc":"2.0","id":2,"method":"resources/templates/list"}
                 """);
 
-            var mapper = new ObjectMapper();
-            var templates = mapper.readTree(response.body()).at("/result/resourceTemplates");
             assertThatJson(response.body())
                     .inPath("$.result.resourceTemplates")
                     .isArray()

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/TasksCoreTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/TasksCoreTest.java
@@ -11,6 +11,8 @@ import dev.tachyonmcp.protocol.mcp.v2025_11_25.models.Implementation;
 import dev.tachyonmcp.protocol.mcp.v2025_11_25.models.InitializeRequestParams;
 import dev.tachyonmcp.server.config.CapabilitiesConfig;
 import dev.tachyonmcp.server.domain.TaskResult;
+import dev.tachyonmcp.server.features.tasks.DefaultTaskRegistry;
+import dev.tachyonmcp.server.features.tasks.TaskState;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import tools.jackson.databind.JsonNode;
@@ -64,6 +66,33 @@ class TasksCoreTest extends AbstractStatefulMcpE2eTest {
                     """.formatted(task.id()));
             assertThatJson(getJson).inPath("$.result.taskId").isEqualTo(task.id());
             assertThatJson(getJson).inPath("$.result.status").isEqualTo("working");
+        }
+    }
+
+    @Test
+    void statusMessageReflectsCallerSuppliedTextNotTheBareStatusName() throws Exception {
+        // Regression test: the wire mapper used to hardcode statusMessage to entry.status().toString(),
+        // discarding whatever message updateStatus/complete callers actually set.
+        startDefaultServer();
+        try (var client = createTestClient()) {
+            client.initialize();
+            var task = server.tasks().create();
+            var registry = (DefaultTaskRegistry) server.tasks();
+            registry.updateStatus(task.id(), TaskState.WORKING, "step 1 of 3");
+
+            var workingJson = client.sendRpc("""
+                    {"jsonrpc":"2.0","id":2,"method":"tasks/get","params":{"taskId":"%s"}}
+                    """.formatted(task.id()));
+            assertThatJson(workingJson).inPath("$.result.statusMessage").isEqualTo("step 1 of 3");
+
+            task.complete(
+                    TaskResult.completed(JsonNodeFactory.instance.objectNode().put("output", "success")));
+
+            var completedJson = client.sendRpc("""
+                    {"jsonrpc":"2.0","id":3,"method":"tasks/get","params":{"taskId":"%s"}}
+                    """.formatted(task.id()));
+            assertThatJson(completedJson).inPath("$.result.status").isEqualTo("completed");
+            assertThatJson(completedJson).inPath("$.result.statusMessage").isEqualTo("step 1 of 3");
         }
     }
 

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/TasksCoreTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/TasksCoreTest.java
@@ -71,8 +71,6 @@ class TasksCoreTest extends AbstractStatefulMcpE2eTest {
 
     @Test
     void statusMessageReflectsCallerSuppliedTextNotTheBareStatusName() throws Exception {
-        // Regression test: the wire mapper used to hardcode statusMessage to entry.status().toString(),
-        // discarding whatever message updateStatus/complete callers actually set.
         startDefaultServer();
         try (var client = createTestClient()) {
             client.initialize();

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/TasksExtensionTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/TasksExtensionTest.java
@@ -198,8 +198,6 @@ class TasksExtensionTest extends AbstractStatefulMcpE2eTest {
 
     @Test
     void shouldNotifyTaskStatusWithCallerSuppliedMessage() throws Exception {
-        // Regression test: McpTaskMapper used to hardcode statusMessage to entry.status().toString(),
-        // silently discarding whatever message the caller passed to DefaultTaskRegistry.updateStatus.
         startServer(it -> it.tool(
                         new AbstractToolHandler(ToolDescriptor.builder()
                                 .name("update-status-sync")

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/TasksExtensionTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/TasksExtensionTest.java
@@ -13,6 +13,8 @@ import dev.tachyonmcp.protocol.mcp.v2025_11_25.models.InitializeRequestParams;
 import dev.tachyonmcp.runtime.InteractionContext;
 import dev.tachyonmcp.server.config.CapabilitiesConfig;
 import dev.tachyonmcp.server.domain.TaskResult;
+import dev.tachyonmcp.server.features.tasks.DefaultTaskRegistry;
+import dev.tachyonmcp.server.features.tasks.TaskState;
 import dev.tachyonmcp.server.features.tasks.TasksExtension;
 import dev.tachyonmcp.server.features.tools.AbstractToolHandler;
 import dev.tachyonmcp.server.features.tools.ToolDescriptor;
@@ -191,6 +193,38 @@ class TasksExtensionTest extends AbstractStatefulMcpE2eTest {
             assertThat(response.body()).contains("\"status\":\"working\"");
             assertThat(response.body()).contains("\"taskId\":\"");
             assertThat(response.body()).contains("\"createdAt\":");
+        }
+    }
+
+    @Test
+    void shouldNotifyTaskStatusWithCallerSuppliedMessage() throws Exception {
+        // Regression test: McpTaskMapper used to hardcode statusMessage to entry.status().toString(),
+        // silently discarding whatever message the caller passed to DefaultTaskRegistry.updateStatus.
+        startServer(it -> it.tool(
+                        new AbstractToolHandler(ToolDescriptor.builder()
+                                .name("update-status-sync")
+                                .build()) {
+                            @Override
+                            public ToolResult handle(InteractionContext ctx, ToolRequest req) {
+                                var task =
+                                        ((DispatchContext) ctx).engine().tasks().create();
+                                ((DefaultTaskRegistry)
+                                                ((DispatchContext) ctx).engine().tasks())
+                                        .updateStatus(task.id(), TaskState.WORKING, "step 1 of 3");
+                                return ToolResult.text("ok");
+                            }
+                        })
+                .extension(TasksExtension.instance())
+                .build());
+
+        try (var client = createTestClient()) {
+            var sessionId = initializeWithExtension(client);
+
+            var response = client.post(sessionId, """
+                    {"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"update-status-sync","arguments":{}}}
+                    """);
+            assertThat(response.body()).contains("\"statusMessage\":\"step 1 of 3\"");
+            assertThat(response.body()).doesNotContain("\"statusMessage\":\"WORKING\"");
         }
     }
 

--- a/tachyon-server/protocol/mcp-2025-11-25_config.json
+++ b/tachyon-server/protocol/mcp-2025-11-25_config.json
@@ -5,13 +5,20 @@
     "JSONValue": "tools.jackson.databind.ValueNode",
     "JSONObject": "tools.jackson.databind.node.ObjectNode",
     "JSONArray": "tools.jackson.databind.node.ArrayNode",
-    "Tool.inputSchema": "String",
-    "Tool.outputSchema": "String",
     "ElicitRequestFormParams.requestedSchema": "String",
     "Resource.size": "Long",
+    "CancelTaskResult.pollInterval": "Long",
+    "CancelTaskResult.ttl": "Long",
+    "GetTaskResult.pollInterval": "Long",
+    "GetTaskResult.ttl": "Long",
     "ResourceLink.size": "Long",
+    "Task.pollInterval": "Long",
+    "Task.ttl": "Long",
     "TaskMetadata.ttl": "Long",
-    "TaskStatusNotificationParams.ttl": "Long"
+    "TaskStatusNotificationParams.pollInterval": "Long",
+    "TaskStatusNotificationParams.ttl": "Long",
+    "Tool.inputSchema": "String",
+    "Tool.outputSchema": "String"
   },
   "additionalProperties": {
     "ClientCapabilities": [

--- a/tachyon-server/src/main/java/dev/tachyonmcp/protocol/mcp/v2025_11_25/codecs/McpTaskMapper.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/protocol/mcp/v2025_11_25/codecs/McpTaskMapper.java
@@ -44,15 +44,19 @@ final class McpTaskMapper {
         return ttl != null ? (double) ttl.toMillis() : 0.0;
     }
 
+    private static @Nullable Double pollIntervalToMillis(@Nullable Duration pollInterval) {
+        return pollInterval != null ? (double) pollInterval.toMillis() : null;
+    }
+
     static Task toTaskProto(TaskEntry entry) {
         return new Task(
                 entry.id(),
                 toWireStatus(entry.status()),
-                entry.status().toString(),
+                entry.statusMessage(),
                 entry.createdAtIso(),
                 entry.lastUpdatedAtIso(),
                 ttlToMillis(entry.ttl()),
-                null);
+                pollIntervalToMillis(entry.pollInterval()));
     }
 
     static GetTaskResult toGetTaskResult(TaskEntry entry) {
@@ -60,11 +64,11 @@ final class McpTaskMapper {
                 null,
                 entry.id(),
                 toWireStatus(entry.status()),
-                entry.status().toString(),
+                entry.statusMessage(),
                 entry.createdAtIso(),
                 entry.lastUpdatedAtIso(),
                 ttlToMillis(entry.ttl()),
-                null);
+                pollIntervalToMillis(entry.pollInterval()));
     }
 
     public static CancelTaskResult toCancelTaskResult(TaskEntry entry) {
@@ -72,11 +76,11 @@ final class McpTaskMapper {
                 null,
                 entry.id(),
                 toWireStatus(entry.status()),
-                entry.status().toString(),
+                entry.statusMessage(),
                 entry.createdAtIso(),
                 entry.lastUpdatedAtIso(),
                 ttlToMillis(entry.ttl()),
-                null);
+                pollIntervalToMillis(entry.pollInterval()));
     }
 
     static CreateTaskResult toCreateTaskResult(TaskEntry entry) {
@@ -89,10 +93,10 @@ final class McpTaskMapper {
                 null,
                 entry.id(),
                 toWireStatus(entry.status()),
-                entry.status().toString(),
+                entry.statusMessage(),
                 entry.createdAtIso(),
                 entry.lastUpdatedAtIso(),
                 ttl != null ? ttl.toMillis() : null,
-                null);
+                pollIntervalToMillis(entry.pollInterval()));
     }
 }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/protocol/mcp/v2025_11_25/codecs/McpTaskMapper.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/protocol/mcp/v2025_11_25/codecs/McpTaskMapper.java
@@ -30,22 +30,8 @@ final class McpTaskMapper {
         };
     }
 
-    static TaskState toInternalStatus(TaskStatus wireStatus) {
-        return switch (wireStatus) {
-            case WORKING -> TaskState.WORKING;
-            case INPUT_REQUIRED -> TaskState.INPUT_REQUIRED;
-            case COMPLETED -> TaskState.COMPLETED;
-            case FAILED -> TaskState.FAILED;
-            case CANCELLED -> TaskState.CANCELLED;
-        };
-    }
-
-    private static double ttlToMillis(@Nullable Duration ttl) {
-        return ttl != null ? (double) ttl.toMillis() : 0.0;
-    }
-
-    private static @Nullable Double pollIntervalToMillis(@Nullable Duration pollInterval) {
-        return pollInterval != null ? (double) pollInterval.toMillis() : null;
+    private static @Nullable Long pollIntervalToMillis(@Nullable Duration pollInterval) {
+        return pollInterval != null ? pollInterval.toMillis() : null;
     }
 
     static Task toTaskProto(TaskEntry entry) {
@@ -55,7 +41,7 @@ final class McpTaskMapper {
                 entry.statusMessage(),
                 entry.createdAtIso(),
                 entry.lastUpdatedAtIso(),
-                ttlToMillis(entry.ttl()),
+                entry.ttl(),
                 pollIntervalToMillis(entry.pollInterval()));
     }
 
@@ -67,7 +53,7 @@ final class McpTaskMapper {
                 entry.statusMessage(),
                 entry.createdAtIso(),
                 entry.lastUpdatedAtIso(),
-                ttlToMillis(entry.ttl()),
+                entry.ttl(),
                 pollIntervalToMillis(entry.pollInterval()));
     }
 
@@ -79,7 +65,7 @@ final class McpTaskMapper {
                 entry.statusMessage(),
                 entry.createdAtIso(),
                 entry.lastUpdatedAtIso(),
-                ttlToMillis(entry.ttl()),
+                entry.ttl(),
                 pollIntervalToMillis(entry.pollInterval()));
     }
 
@@ -88,7 +74,6 @@ final class McpTaskMapper {
     }
 
     static TaskStatusNotificationParams toStatusNotification(TaskEntry entry) {
-        final var ttl = entry.ttl();
         return new TaskStatusNotificationParams(
                 null,
                 entry.id(),
@@ -96,7 +81,7 @@ final class McpTaskMapper {
                 entry.statusMessage(),
                 entry.createdAtIso(),
                 entry.lastUpdatedAtIso(),
-                ttl != null ? ttl.toMillis() : null,
+                entry.ttl(),
                 pollIntervalToMillis(entry.pollInterval()));
     }
 }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/config/TasksConfig.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/config/TasksConfig.java
@@ -7,25 +7,38 @@ package dev.tachyonmcp.server.config;
 import dev.tachyonmcp.server.features.Pagination;
 import java.time.Duration;
 import java.util.Objects;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Configuration for the tasks capability. Fields map 1:1 to the MCP {@code tasks} capability
  * object ({@code tasks.list}, {@code tasks.cancel}, {@code tasks.requests.tools.call}).
  *
- * @param enabled   whether the {@code tasks} capability is advertised at all (default
- *                  {@code false}); the capability is also advertised, regardless of this flag,
- *                  when a registered tool supports task augmentation
- * @param list      whether {@code tasks/list} is exposed (default {@code false})
- * @param cancel    whether {@code tasks/cancel} is supported (default {@code false})
- * @param requests  whether task-augmented {@code tools/call} requests are accepted
- *                  (default {@code false})
- * @param pageSize  default page size when a list request omits its limit
- * @param keepAlive default retention window for a terminal task's result before it's dropped
- *                  from memory (default 5 minutes); overridable per task via
- *                  {@code TaskOptions.keepAlive()}
+ * @param enabled      whether the {@code tasks} capability is advertised at all (default
+ *                     {@code false}); the capability is also advertised, regardless of this flag,
+ *                     when a registered tool supports task augmentation
+ * @param list         whether {@code tasks/list} is exposed (default {@code false})
+ * @param cancel       whether {@code tasks/cancel} is supported (default {@code false})
+ * @param requests     whether task-augmented {@code tools/call} requests are accepted
+ *                     (default {@code false})
+ * @param pageSize     default page size when a list request omits its limit
+ * @param keepAlive    default retention window for a terminal task's result before it's dropped
+ *                     from memory (default 5 minutes); overridable per task via
+ *                     {@code TaskOptions.keepAlive()}
+ * @param pollInterval default {@code pollInterval} suggested to requestors in task responses, or
+ *                     {@code null} (the default) to suggest none; overridable per task via
+ *                     {@code TaskOptions.pollInterval()}. Unlike {@code keepAlive}, this value is
+ *                     wire-visible and spec-compliant requestors {@code SHOULD} throttle their own
+ *                     polling cadence to match it — pick a value that fits how long tasks in this
+ *                     server actually run, there's no one-size-fits-all default.
  */
 public record TasksConfig(
-        boolean enabled, boolean list, boolean cancel, boolean requests, int pageSize, Duration keepAlive) {
+        boolean enabled,
+        boolean list,
+        boolean cancel,
+        boolean requests,
+        int pageSize,
+        Duration keepAlive,
+        @Nullable Duration pollInterval) {
 
     static final boolean DEFAULT_TASKS_ENABLED = false;
     static final boolean DEFAULT_TASK_LIST = false;
@@ -36,7 +49,7 @@ public record TasksConfig(
     public static final Duration DEFAULT_TASK_KEEP_ALIVE = Duration.ofMinutes(5);
 
     static final TasksConfig DEFAULT =
-            new TasksConfig(false, false, false, false, Pagination.DEFAULT_PAGE_SIZE, DEFAULT_TASK_KEEP_ALIVE);
+            new TasksConfig(false, false, false, false, Pagination.DEFAULT_PAGE_SIZE, DEFAULT_TASK_KEEP_ALIVE, null);
 
     public TasksConfig {
         if (pageSize <= 0) {
@@ -60,6 +73,7 @@ public record TasksConfig(
         private boolean requests = DEFAULT.requests;
         private int pageSize = DEFAULT.pageSize;
         private Duration keepAlive = DEFAULT.keepAlive;
+        private @Nullable Duration pollInterval = DEFAULT.pollInterval;
 
         private Builder() {}
 
@@ -95,6 +109,16 @@ public record TasksConfig(
         }
 
         /**
+         * Sets the default {@code pollInterval} suggested in task responses. Default is {@code null}
+         * (suggest none); pass a value only if it fits how long tasks on this server actually run —
+         * spec-compliant requestors throttle their own polling to match it.
+         */
+        public Builder pollInterval(@Nullable Duration pollInterval) {
+            this.pollInterval = pollInterval;
+            return this;
+        }
+
+        /**
          * Enables the tasks capability with the list surface on.
          */
         public Builder on() {
@@ -102,7 +126,7 @@ public record TasksConfig(
         }
 
         public TasksConfig build() {
-            return new TasksConfig(enabled, list, cancel, requests, pageSize, keepAlive);
+            return new TasksConfig(enabled, list, cancel, requests, pageSize, keepAlive, pollInterval);
         }
     }
 }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/domain/Task.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/domain/Task.java
@@ -24,7 +24,7 @@ public interface Task extends HasMeta {
     Instant createdAt();
 
     @Nullable
-    Duration ttl();
+    Long ttl();
 
     /** Suggested polling interval for {@code tasks/get}, or {@code null} to not suggest one. */
     @Nullable

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/domain/Task.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/domain/Task.java
@@ -26,6 +26,10 @@ public interface Task extends HasMeta {
     @Nullable
     Duration ttl();
 
+    /** Suggested polling interval for {@code tasks/get}, or {@code null} to not suggest one. */
+    @Nullable
+    Duration pollInterval();
+
     @Nullable
     TaskResult result();
 

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tasks/DefaultTaskRegistry.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tasks/DefaultTaskRegistry.java
@@ -43,6 +43,7 @@ public class DefaultTaskRegistry extends AbstractRegistry<TaskDescriptor, TaskEn
     private final ServerEngine server;
     private final TaskIdGenerator taskIdGenerator;
     private final Duration defaultKeepAlive;
+    private final @Nullable Duration defaultPollInterval;
     private final AbstractJanitor janitor = new AbstractJanitor("task-janitor") {
         @Override
         protected void sweep() {
@@ -54,6 +55,7 @@ public class DefaultTaskRegistry extends AbstractRegistry<TaskDescriptor, TaskEn
         super(config.pageSize());
         this.taskIdGenerator = DefaultTaskIdGenerator.INSTANCE;
         this.defaultKeepAlive = config.keepAlive();
+        this.defaultPollInterval = config.pollInterval();
         this.server = server;
     }
 
@@ -79,7 +81,8 @@ public class DefaultTaskRegistry extends AbstractRegistry<TaskDescriptor, TaskEn
     @Override
     public Task create(TaskOptions options) {
         var keepAlive = options.keepAlive() != null ? options.keepAlive() : defaultKeepAlive;
-        return createTask(options.id(), options.ttl(), options.meta(), null, null, keepAlive);
+        var pollInterval = options.pollInterval() != null ? options.pollInterval() : defaultPollInterval;
+        return createTask(options.id(), options.ttl(), options.meta(), null, null, keepAlive, pollInterval);
     }
 
     @Override
@@ -88,7 +91,7 @@ public class DefaultTaskRegistry extends AbstractRegistry<TaskDescriptor, TaskEn
             @Nullable Map<String, JsonNode> meta,
             @Nullable String sessionId,
             @Nullable Object progressToken) {
-        return createTask(null, ttl, meta, sessionId, progressToken, defaultKeepAlive);
+        return createTask(null, ttl, meta, sessionId, progressToken, defaultKeepAlive, defaultPollInterval);
     }
 
     private TaskEntry createTask(
@@ -97,10 +100,12 @@ public class DefaultTaskRegistry extends AbstractRegistry<TaskDescriptor, TaskEn
             @Nullable Map<String, JsonNode> meta,
             @Nullable String sessionId,
             @Nullable Object progressToken,
-            Duration keepAlive) {
+            Duration keepAlive,
+            @Nullable Duration pollInterval) {
         var id = requestedId != null ? requestedId : taskIdGenerator.generateTaskId(meta, sessionId);
         var descriptor = TaskDescriptor.builder().id(id).build();
-        var entry = new TaskEntry(descriptor, id, TaskState.SUBMITTED, ttl, sessionId, progressToken, meta, keepAlive);
+        var entry = new TaskEntry(
+                descriptor, id, TaskState.SUBMITTED, ttl, sessionId, progressToken, meta, keepAlive, pollInterval);
         if (!addItemIfAbsent(entry)) {
             throw new IllegalArgumentException("Task '" + id + "' already exists");
         }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tasks/TaskEntry.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tasks/TaskEntry.java
@@ -32,7 +32,7 @@ public class TaskEntry implements ServerFeature<TaskDescriptor>, Task {
     private final @Nullable Map<String, JsonNode> meta;
     private final AtomicReference<TaskState> status;
     private final long createdAt;
-    private final @Nullable Duration ttl;
+    private final @Nullable Long ttl;
     private final Duration keepAlive;
     private final @Nullable Duration pollInterval;
     private volatile long lastUpdatedAt;
@@ -128,7 +128,7 @@ public class TaskEntry implements ServerFeature<TaskDescriptor>, Task {
         this.status = new AtomicReference<>(status);
         this.createdAt = System.currentTimeMillis();
         this.lastUpdatedAt = this.createdAt;
-        this.ttl = ttl;
+        this.ttl = ttl != null ? ttl.toMillis() : null;
         this.keepAlive = Objects.requireNonNull(keepAlive, "keepAlive");
         this.pollInterval = pollInterval;
         this.progressToken = progressToken;
@@ -179,7 +179,7 @@ public class TaskEntry implements ServerFeature<TaskDescriptor>, Task {
     }
 
     @Override
-    public @Nullable Duration ttl() {
+    public @Nullable Long ttl() {
         return ttl;
     }
 
@@ -271,10 +271,6 @@ public class TaskEntry implements ServerFeature<TaskDescriptor>, Task {
         return lastUpdatedAt;
     }
 
-    public double ttlSeconds() {
-        return ttl != null ? ttl.getSeconds() : 0.0;
-    }
-
     public @Nullable String resultJson() {
         if (result instanceof TaskResult.Completed c) {
             return serializeResult(c.content(), c.structuredContent());
@@ -334,10 +330,10 @@ public class TaskEntry implements ServerFeature<TaskDescriptor>, Task {
     }
 
     public boolean isExpired() {
-        if (ttl == null || ttl.isNegative() || ttl.isZero()) {
+        if (ttl == null || ttl <= 0) {
             return false;
         }
-        return System.currentTimeMillis() - lastUpdatedAt > ttl.toMillis();
+        return System.currentTimeMillis() - lastUpdatedAt > ttl;
     }
 
     /** Whether this task's result has outlived its {@code keepAlive} retention window. */

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tasks/TaskEntry.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tasks/TaskEntry.java
@@ -34,6 +34,7 @@ public class TaskEntry implements ServerFeature<TaskDescriptor>, Task {
     private final long createdAt;
     private final @Nullable Duration ttl;
     private final Duration keepAlive;
+    private final @Nullable Duration pollInterval;
     private volatile long lastUpdatedAt;
     private volatile long expiredAt;
     private volatile @Nullable String statusMessage;
@@ -107,6 +108,19 @@ public class TaskEntry implements ServerFeature<TaskDescriptor>, Task {
             @Nullable Object progressToken,
             @Nullable Map<String, JsonNode> meta,
             Duration keepAlive) {
+        this(descriptor, id, status, ttl, sessionId, progressToken, meta, keepAlive, null);
+    }
+
+    public TaskEntry(
+            TaskDescriptor descriptor,
+            String id,
+            TaskState status,
+            @Nullable Duration ttl,
+            @Nullable String sessionId,
+            @Nullable Object progressToken,
+            @Nullable Map<String, JsonNode> meta,
+            Duration keepAlive,
+            @Nullable Duration pollInterval) {
         this.descriptor = descriptor;
         this.id = id;
         this.sessionId = sessionId;
@@ -116,6 +130,7 @@ public class TaskEntry implements ServerFeature<TaskDescriptor>, Task {
         this.lastUpdatedAt = this.createdAt;
         this.ttl = ttl;
         this.keepAlive = Objects.requireNonNull(keepAlive, "keepAlive");
+        this.pollInterval = pollInterval;
         this.progressToken = progressToken;
     }
 
@@ -171,6 +186,11 @@ public class TaskEntry implements ServerFeature<TaskDescriptor>, Task {
     /** How long after this task reaches a terminal state its result stays retrievable. */
     public Duration keepAlive() {
         return keepAlive;
+    }
+
+    @Override
+    public @Nullable Duration pollInterval() {
+        return pollInterval;
     }
 
     @Override

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tasks/TaskOptions.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tasks/TaskOptions.java
@@ -28,6 +28,10 @@ public interface TaskOptions {
     @Nullable
     Duration keepAlive();
 
+    /** Suggested {@code tasks/get} polling interval to advertise, or {@code null} to use the server default. */
+    @Nullable
+    Duration pollInterval();
+
     @Nullable
     Map<String, JsonNode> meta();
 
@@ -48,6 +52,8 @@ public interface TaskOptions {
         Builder ttl(@Nullable Duration ttl);
 
         Builder keepAlive(@Nullable Duration keepAlive);
+
+        Builder pollInterval(@Nullable Duration pollInterval);
 
         Builder meta(@Nullable Map<String, ? extends JsonNode> meta);
 


### PR DESCRIPTION
## New Features

- Added configurable polling intervals for task responses and status notifications.
- Task-specific polling preferences can now override the server default.
- Task expiration values are reported consistently in milliseconds.

## Bug Fixes

- Task status responses and notifications now preserve caller-provided status messages instead of replacing them with the status name.
- Improved consistency of task timing information across task operations.