### PR TITLE
fix: tasks miss status notifications for facade-driven mutations; add Tasks.remove

### DIFF
--- a/.agents/skills/tachyon-mcp/SKILL.md
+++ b/.agents/skills/tachyon-mcp/SKILL.md
@@ -46,12 +46,12 @@ var server = TachyonServer.builder()
 | `.tool(name, desc, inJson, outJson, fn)` | shorthand — JSON **string** schemas + lambda |
 | `.resource(descriptor/configurer, handler)` | static resource with sync handler |
 | `.asyncResource(descriptor/configurer, handler)` | async static resource without casts |
-| `.resourceTemplate(...)` / `.resourceTemplateAsync(...)` | sync/async URI template |
+| `.resourceTemplate(...)` / `.asyncResourceTemplate(...)` | sync/async URI template |
 | `.prompt(descriptor/configurer, handler\|messages)` | sync prompt |
 | `.asyncPrompt(descriptor/configurer, handler)` | async prompt without casts |
 | `.extension(ext)` | `ServerExtension` plugin |
 | `.json(cfg)` | serde + input/output schema validators |
-| `.jsonSchemaValidator(v)` | ⚠️ deprecated (removal) → `.json(cfg)` / `.inputSchemaValidator` / `.outputSchemaValidator` |
+| ~~`.jsonSchemaValidator(v)`~~ | removed — use `.json(cfg -> cfg.inputSchemaValidator(v).outputSchemaValidator(v))` |
 | `.pipelineCustomizer(c)` | raw Netty pipeline escape hatch |
 
 ## Tools 🔧
@@ -185,6 +185,7 @@ Full: `resources/java/PromptHandlerExample.java`
 Configs: `FeatureConfig` (tools/prompts: `mode`, `listChanged`, `pageSize`), `ResourcesConfig` (+ `subscribe`), 
 `TasksConfig` (`enabled`, `list`, `cancel`, `requests`, `pageSize`, 
 `keepAlive` (default 5 min — retention window for a terminal task's result), 
+`pollInterval` (default none — suggested `tasks/get` polling cadence, wire-visible), 
 mapping 1:1 to MCP `tasks.list`/`tasks.cancel`/`tasks.requests.tools.call`).
 
 Default `Mode.AUTO` advertises only registered features. Force `Mode.ON`/`Mode.OFF`. **`OFF` also blocks registration**: registry `register` becomes a debug-logged no-op, not merely hidden from `initialize`.
@@ -283,7 +284,8 @@ ToolDescriptor.builder()
     .build();
 ```
 
-`builder(name)` and `builder(name, inJson, outJson)` remain deprecated. `.tool(name, desc, inJson, outJson, fn)` also takes String schemas.
+`ToolDescriptor.builder()` is no-arg only — the `builder(name)` / `builder(name, inJson, outJson)`
+overloads have been removed, use `.name(...)` on the builder instead. `.tool(name, desc, inJson, outJson, fn)` also takes String schemas.
 
 ## Extensions
 

--- a/.agents/skills/tachyon-mcp/resources/kotlin/ServerBasic.kt
+++ b/.agents/skills/tachyon-mcp/resources/kotlin/ServerBasic.kt
@@ -91,7 +91,7 @@ fun createServer(port: Int = NetworkConfig.UNSET_PORT): TachyonServer =
             readerIdleTimeout = NetworkConfig.DEFAULT_READER_IDLE_TIMEOUT.toKotlinDuration()
             writerIdleTimeout = NetworkConfig.DEFAULT_WRITER_IDLE_TIMEOUT.toKotlinDuration()
             heartbeatInterval = NetworkConfig.DEFAULT_HEARTBEAT_INTERVAL.toKotlinDuration()
-            maxContentLength = NetworkConfig.DEFAULT_MAX_CONTENT_LENGTH
+            maxContentLength = 1024 * 1024 // 1 MB — the actual default (NetworkConfig.DEFAULT_MAX_CONTENT_LENGTH is a stale, unwired 65535 constant)
             ioEngine = NettyIoEngine.AUTO
         }
 

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -4,9 +4,14 @@ Extensions add custom MCP methods and negotiate capabilities with clients via th
 
 ## The ServerExtension interface
 
+`bootstrap` receives a `ServerEngine` — Tachyon's internal server-side handle (`@InternalApi`:
+not a stability contract, but it's what extensions need to register raw JSON-RPC handlers).
+
 ```java
 import dev.tachyonmcp.server.extensions.ServerExtension;
-import dev.tachyonmcp.server.Server;
+import dev.tachyonmcp.server.internal.ServerEngine;
+import dev.tachyonmcp.server.RpcMethodHandler;
+import dev.tachyonmcp.server.session.DispatchContext;
 import dev.tachyonmcp.runtime.ChannelContext;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.node.JsonNodeFactory;
@@ -26,10 +31,20 @@ public class AuditExtension implements ServerExtension {
     }
 
     @Override
-    public void bootstrap(Server server) {
-        server.registerHandler("audit/log", (ctx, params) -> {
-            // handle audit/log method
-            return server.responseMapper().emptyResult();
+    public void bootstrap(ServerEngine server) {
+        // RpcMethodHandler declares both method() and handle(...), so it isn't a
+        // lambda-friendly SAM — implement it with an anonymous class.
+        server.registerHandler("audit/log", new RpcMethodHandler() {
+            @Override
+            public String method() {
+                return "audit/log";
+            }
+
+            @Override
+            public Object handle(DispatchContext context, Object params) {
+                // handle audit/log method
+                return server.responseMapper().emptyResult();
+            }
         });
     }
 

--- a/docs/kotlin.md
+++ b/docs/kotlin.md
@@ -75,7 +75,7 @@ tool(name = "reverse", description = "Reverse a string") {
     // this: ToolScope
     // ctx: InteractionContext
     // args: Args
-    val msg = args.string("message")
+    val msg = args.stringValue("message")
     ToolResult.text(msg.reversed())
 }
 ```
@@ -192,7 +192,7 @@ tool(name = "greet", inputSchema = ..., outputSchema = ...) {
 
 | Call | Behaviour |
 |---|---|
-| `args.string("k")` / `intValue` / `boolValue` / `doubleValue` | Required — throws when missing |
+| `args.stringValue("k")` / `intValue` / `boolValue` / `doubleValue` | Required — throws when missing |
 | `args.stringOrNull("k")` / `intOrNull` / `booleanOrNull` / `doubleOrNull` | Returns `null` when missing |
 | `args.stringOr("k", "d")` / `int("k", 0)` / `boolean("k", true)` / `double("k", 0.0)` | Falls back to default |
 | `args.decode<T>()` | typed decode via configured serde (default kotlinx ignores unknown keys) |
@@ -217,9 +217,9 @@ Add tools after the server starts — useful for dynamic registration:
 ```kotlin
 val server = buildServer { /* base config */ }
 server.registerTool(
-    ToolDescriptor.builder("echo").description("Echo a message").build(),
+    ToolDescriptor.builder().name("echo").description("Echo a message").build(),
 ) {
-    ToolResult.text(args.string("msg"))
+    ToolResult.text(args.stringValue("msg"))
 }
 ```
 

--- a/docs/migrate-from-kotlin-mcp-to-tachyon.md
+++ b/docs/migrate-from-kotlin-mcp-to-tachyon.md
@@ -105,7 +105,7 @@ server.registerTool(
     inputSchema = """{"type":"object","properties":{"query":{"type":"string"}},"required":["query"]}""",
     outputSchema = SearchResult::class.jsonSchemaString,   // nullable
 ) { // this: ToolScope
-    val query = args.string("query")
+    val query = args.stringValue("query")
     ToolResult.text(json.encodeToString(SearchResult.serializer(), run(query)))
 }
 ```
@@ -119,7 +119,7 @@ warns when a description exceeds 2048 chars (clients truncate there) pays off ac
 
 | Old                                                 | New                                                                                  |
 |-----------------------------------------------------|--------------------------------------------------------------------------------------|
-| `arguments["k"]?.jsonPrimitive?.content` (required) | `args.string("k")` — throws if missing                                               |
+| `arguments["k"]?.jsonPrimitive?.content` (required) | `args.stringValue("k")` — throws if missing                                          |
 | same, optional                                      | `args.stringOrNull("k")`                                                             |
 | with a default                                      | `args.stringOr("k", "d")`                                                            |
 | `…?.int` etc.                                       | `args.intValue/boolValue/doubleValue` (+ `…OrNull`, `…(k, default)`)                 |

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -67,7 +67,8 @@ by adding a `task` field to `tools/call`:
 ```java
 import dev.tachyonmcp.server.features.tasks.TaskSupport;
 
-var descriptor = ToolDescriptor.builder("import-data")
+var descriptor = ToolDescriptor.builder()
+    .name("import-data")
     .description("Long-running import")
     .taskSupport(TaskSupport.OPTIONAL)  // or REQUIRED; default FORBIDDEN
     .build();

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -57,7 +57,7 @@ class WeatherTool extends AbstractToolHandler {
 
     @Override
     public ToolResult handle(InteractionContext ctx, Args args) {
-        String city = args.string("city");
+        String city = args.stringValue("city");
         return ToolResult.text("☀️ 22°C in " + city);
     }
 }
@@ -76,7 +76,7 @@ lambda via `ToolHandler.ofAsync`, or override `handleAsync(ctx, Args)` on
 import dev.tachyonmcp.server.features.tools.ToolHandler;
 
 .tool(ToolHandler.ofAsync("get_weather_async",
-    (ctx, args) -> fetchWeather(args.string("city"))
+    (ctx, args) -> fetchWeather(args.stringValue("city"))
         .thenApply(w -> ToolResult.text(w.summary()))))
 ```
 
@@ -93,7 +93,7 @@ input responses — use the request-level entry points: the `ToolHandler.ofReque
 
 | Method                    | Returns    |
 |---------------------------|------------|
-| `args.string("key")`      | `String`   |
+| `args.stringValue("key")` | `String`   |
 | `args.intValue("key")`    | `int`      |
 | `args.boolValue("key")`   | `boolean`  |
 | `args.doubleValue("key")` | `double`   |
@@ -134,7 +134,7 @@ Tachyon uses **Jackson 3** (`tools.jackson.*`), not Jackson 2. Import `tools.jac
 
 ```kotlin
 tool(name = "reverse", description = "Reverse a string") {
-    val msg = args.string("message")
+    val msg = args.stringValue("message")
     ToolResult.text(msg.reversed())
 }
 ```

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/TasksExtensionTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/TasksExtensionTest.java
@@ -226,6 +226,116 @@ class TasksExtensionTest extends AbstractStatefulMcpE2eTest {
         }
     }
 
+    @Test
+    void shouldNotifyOnEveryFacadeDrivenMutation() throws Exception {
+        // Regression test: a caller holding only the public `Task` reference (never
+        // touching DefaultTaskRegistry's taskId-keyed methods) must still get a
+        // notification for every mutation, not just the initial creation push.
+        startServer(it -> it.tool(
+                        new AbstractToolHandler(
+                                ToolDescriptor.builder().name("drive-task-sync").build()) {
+                            @Override
+                            public ToolResult handle(InteractionContext ctx, ToolRequest req) {
+                                var task =
+                                        ((DispatchContext) ctx).engine().tasks().create();
+                                task.resume("step 1");
+                                task.updateMessage("step 2");
+                                task.complete(TaskResult.completed(JsonUtils.parse("{\"output\":\"done\"}")));
+                                return ToolResult.text("ok");
+                            }
+                        })
+                .extension(TasksExtension.instance())
+                .build());
+
+        try (var client = createTestClient()) {
+            var sessionId = initializeWithExtension(client);
+
+            var response = client.post(sessionId, """
+                    {"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"drive-task-sync","arguments":{}}}
+                    """);
+
+            assertThat(response.body()).contains("\"statusMessage\":\"step 1\"");
+            assertThat(response.body()).contains("\"statusMessage\":\"step 2\"");
+            assertThat(response.body()).contains("\"status\":\"completed\"");
+            var notificationCount = response.body().split("notifications/tasks/status", -1).length - 1;
+            assertThat(notificationCount)
+                    .as("one notification each for create, resume, updateMessage, complete")
+                    .isEqualTo(4);
+        }
+    }
+
+    @Test
+    void shouldCancelAndNotifyBeforeRemovingActiveTask() throws Exception {
+        startServer(it -> it.tool(
+                        new AbstractToolHandler(ToolDescriptor.builder()
+                                .name("remove-active-sync")
+                                .build()) {
+                            @Override
+                            public ToolResult handle(InteractionContext ctx, ToolRequest req) {
+                                var task =
+                                        ((DispatchContext) ctx).engine().tasks().create();
+                                task.resume(null);
+                                ((DispatchContext) ctx).engine().tasks().remove(task.id());
+                                return ToolResult.text(task.id());
+                            }
+                        })
+                .extension(TasksExtension.instance())
+                .build());
+
+        try (var client = createTestClient()) {
+            var sessionId = initializeWithExtension(client);
+
+            var response = client.post(sessionId, """
+                    {"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"remove-active-sync","arguments":{}}}
+                    """);
+            assertThat(response.body()).contains("\"status\":\"cancelled\"");
+            var taskId = extractText(extractJsonRpcResponse(response.body(), "2"));
+
+            var getAfterRemove = client.sendRpc("""
+                    {"jsonrpc":"2.0","id":3,"method":"tasks/get","params":{"taskId":"%s"}}
+                    """.formatted(taskId));
+            assertThatJson(getAfterRemove).inPath("$.error").isObject();
+        }
+    }
+
+    @Test
+    void shouldRemoveTerminalTaskSilently() throws Exception {
+        startServer(it -> it.tool(
+                        new AbstractToolHandler(ToolDescriptor.builder()
+                                .name("remove-terminal-sync")
+                                .build()) {
+                            @Override
+                            public ToolResult handle(InteractionContext ctx, ToolRequest req) {
+                                var task =
+                                        ((DispatchContext) ctx).engine().tasks().create();
+                                task.complete(TaskResult.completed(JsonUtils.parse("{\"output\":\"done\"}")));
+                                ((DispatchContext) ctx).engine().tasks().remove(task.id());
+                                return ToolResult.text(task.id());
+                            }
+                        })
+                .extension(TasksExtension.instance())
+                .build());
+
+        try (var client = createTestClient()) {
+            var sessionId = initializeWithExtension(client);
+
+            var response = client.post(sessionId, """
+                    {"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"remove-terminal-sync","arguments":{}}}
+                    """);
+            assertThat(response.body()).doesNotContain("\"status\":\"cancelled\"");
+            var notificationCount = response.body().split("notifications/tasks/status", -1).length - 1;
+            assertThat(notificationCount)
+                    .as("create + complete only, removal of an already-terminal task is silent")
+                    .isEqualTo(2);
+            var taskId = extractText(extractJsonRpcResponse(response.body(), "2"));
+
+            var getAfterRemove = client.sendRpc("""
+                    {"jsonrpc":"2.0","id":3,"method":"tasks/get","params":{"taskId":"%s"}}
+                    """.formatted(taskId));
+            assertThatJson(getAfterRemove).inPath("$.error").isObject();
+        }
+    }
+
     private static String buildInitializeJson(Map<String, JsonNode> extensions) {
         var capsBuilder = ClientCapabilities.builder();
         if (!extensions.isEmpty()) {

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tasks/DefaultTaskRegistry.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tasks/DefaultTaskRegistry.java
@@ -69,8 +69,16 @@ public class DefaultTaskRegistry extends AbstractRegistry<TaskDescriptor, TaskEn
         addItem(entry);
     }
 
-    public void remove(String taskId) {
-        removeItem(taskId);
+    @Override
+    public boolean remove(String taskId) {
+        var entry = get(taskId);
+        if (entry == null) {
+            return false;
+        }
+        if (!entry.status().isTerminal()) {
+            getAndCancelTask(taskId);
+        }
+        return removeItem(taskId);
     }
 
     @Override
@@ -105,7 +113,16 @@ public class DefaultTaskRegistry extends AbstractRegistry<TaskDescriptor, TaskEn
         var id = requestedId != null ? requestedId : taskIdGenerator.generateTaskId(meta, sessionId);
         var descriptor = TaskDescriptor.builder().id(id).build();
         var entry = new TaskEntry(
-                descriptor, id, TaskState.SUBMITTED, ttl, sessionId, progressToken, meta, keepAlive, pollInterval);
+                descriptor,
+                id,
+                TaskState.SUBMITTED,
+                ttl,
+                sessionId,
+                progressToken,
+                meta,
+                keepAlive,
+                pollInterval,
+                this::fireStatusNotification);
         if (!addItemIfAbsent(entry)) {
             throw new IllegalArgumentException("Task '" + id + "' already exists");
         }
@@ -148,7 +165,6 @@ public class DefaultTaskRegistry extends AbstractRegistry<TaskDescriptor, TaskEn
             return false;
         }
         running.remove(entry.id());
-        fireStatusNotification(entry);
         fireOnChange();
         return true;
     }
@@ -158,7 +174,6 @@ public class DefaultTaskRegistry extends AbstractRegistry<TaskDescriptor, TaskEn
             return false;
         }
         running.remove(entry.id());
-        fireStatusNotification(entry);
         fireOnChange();
         return true;
     }
@@ -184,7 +199,6 @@ public class DefaultTaskRegistry extends AbstractRegistry<TaskDescriptor, TaskEn
         if (future != null) {
             future.cancel(true);
         }
-        fireStatusNotification(entry);
         fireOnChange();
         return entry;
     }
@@ -200,21 +214,14 @@ public class DefaultTaskRegistry extends AbstractRegistry<TaskDescriptor, TaskEn
         }
         if (statusMessage != null) {
             if (newStatus == TaskState.WORKING && entry.resume(statusMessage)) {
-                fireStatusNotification(entry);
                 return true;
             }
-            if (entry.transitionTo(newStatus)) {
-                entry.updateMessage(statusMessage);
-                fireStatusNotification(entry);
-                return true;
-            }
-            return false;
+            return entry.transitionTo(newStatus, null, statusMessage);
         }
         if (!entry.transitionTo(newStatus)) {
             logger.debug("Invalid status transition from {} to {} for task {}", entry.status(), newStatus, taskId);
             return false;
         }
-        fireStatusNotification(entry);
         return true;
     }
 
@@ -246,7 +253,6 @@ public class DefaultTaskRegistry extends AbstractRegistry<TaskDescriptor, TaskEn
                 logger.info("Task expired: id={}, name={}", entry.id(), entry.name());
                 var failed = new TaskResult.Failed(List.of(TextContent.of("Task expired")), null, null);
                 if (entry.fail(failed)) {
-                    fireStatusNotification(entry);
                     fireOnChange();
                 }
             }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tasks/TaskEntry.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tasks/TaskEntry.java
@@ -20,6 +20,7 @@ import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 import org.jspecify.annotations.Nullable;
 import tools.jackson.databind.JsonNode;
 
@@ -38,9 +39,9 @@ public class TaskEntry implements ServerFeature<TaskDescriptor>, Task {
     private volatile long lastUpdatedAt;
     private volatile long expiredAt;
     private volatile @Nullable String statusMessage;
-    private volatile @Nullable TaskResult result;
     private final CompletableFuture<TaskResult> completionFuture = new CompletableFuture<>();
     private final @Nullable Object progressToken;
+    private final Consumer<TaskEntry> statusListener;
 
     public TaskEntry(String id, @Nullable String description) {
         this(
@@ -121,6 +122,25 @@ public class TaskEntry implements ServerFeature<TaskDescriptor>, Task {
             @Nullable Map<String, JsonNode> meta,
             Duration keepAlive,
             @Nullable Duration pollInterval) {
+        this(descriptor, id, status, ttl, sessionId, progressToken, meta, keepAlive, pollInterval, entry -> {});
+    }
+
+    /**
+     * Full constructor; {@code statusListener} is invoked with {@code this} after every
+     * successful status/message mutation, regardless of which method the caller used to reach
+     * it. Package-private: only {@link DefaultTaskRegistry} wires a non-default listener.
+     */
+    TaskEntry(
+            TaskDescriptor descriptor,
+            String id,
+            TaskState status,
+            @Nullable Duration ttl,
+            @Nullable String sessionId,
+            @Nullable Object progressToken,
+            @Nullable Map<String, JsonNode> meta,
+            Duration keepAlive,
+            @Nullable Duration pollInterval,
+            Consumer<TaskEntry> statusListener) {
         this.descriptor = descriptor;
         this.id = id;
         this.sessionId = sessionId;
@@ -132,6 +152,7 @@ public class TaskEntry implements ServerFeature<TaskDescriptor>, Task {
         this.keepAlive = Objects.requireNonNull(keepAlive, "keepAlive");
         this.pollInterval = pollInterval;
         this.progressToken = progressToken;
+        this.statusListener = Objects.requireNonNull(statusListener, "statusListener");
     }
 
     /** The session that created this task, or {@code null} for programmatic/server-global tasks. */
@@ -195,7 +216,9 @@ public class TaskEntry implements ServerFeature<TaskDescriptor>, Task {
 
     @Override
     public @Nullable TaskResult result() {
-        return result;
+        return completionFuture.isDone() && !completionFuture.isCompletedExceptionally()
+                ? completionFuture.join()
+                : null;
     }
 
     @Override
@@ -215,37 +238,22 @@ public class TaskEntry implements ServerFeature<TaskDescriptor>, Task {
 
     @Override
     public boolean cancel(@Nullable String statusMessage) {
-        if (transitionTo(TaskState.CANCELLED)) {
-            if (statusMessage != null) {
-                this.statusMessage = statusMessage;
-            }
-            completionFuture.completeExceptionally(
-                    new IllegalStateException("Task cancelled" + (statusMessage != null ? ": " + statusMessage : "")));
-            return true;
+        if (!transitionTo(TaskState.CANCELLED, null, statusMessage)) {
+            return false;
         }
-        return false;
+        completionFuture.completeExceptionally(
+                new IllegalStateException("Task cancelled" + (statusMessage != null ? ": " + statusMessage : "")));
+        return true;
     }
 
     @Override
     public boolean requireInput(InputRequest request, @Nullable String statusMessage) {
-        if (transitionTo(TaskState.INPUT_REQUIRED)) {
-            if (statusMessage != null) {
-                this.statusMessage = statusMessage;
-            }
-            return true;
-        }
-        return false;
+        return transitionTo(TaskState.INPUT_REQUIRED, null, statusMessage);
     }
 
     @Override
     public boolean resume(@Nullable String statusMessage) {
-        if (transitionTo(TaskState.WORKING)) {
-            if (statusMessage != null) {
-                this.statusMessage = statusMessage;
-            }
-            return true;
-        }
-        return false;
+        return transitionTo(TaskState.WORKING, null, statusMessage);
     }
 
     @Override
@@ -255,6 +263,7 @@ public class TaskEntry implements ServerFeature<TaskDescriptor>, Task {
         if (current == TaskState.WORKING || current == TaskState.INPUT_REQUIRED) {
             this.statusMessage = statusMessage;
             this.lastUpdatedAt = System.currentTimeMillis();
+            statusListener.accept(this);
             return true;
         }
         return false;
@@ -272,6 +281,7 @@ public class TaskEntry implements ServerFeature<TaskDescriptor>, Task {
     }
 
     public @Nullable String resultJson() {
+        var result = result();
         if (result instanceof TaskResult.Completed c) {
             return serializeResult(c.content(), c.structuredContent());
         }
@@ -295,13 +305,21 @@ public class TaskEntry implements ServerFeature<TaskDescriptor>, Task {
      * Transitions to {@code newStatus} without a result value.
      */
     public boolean transitionTo(TaskState newStatus) {
-        return transitionTo(newStatus, (TaskResult) null);
+        return transitionTo(newStatus, null, null);
     }
 
     /**
      * Transitions to {@code newStatus}, publishing {@code result} (when non-null).
      */
     public boolean transitionTo(TaskState newStatus, @Nullable TaskResult result) {
+        return transitionTo(newStatus, result, null);
+    }
+
+    /**
+     * Transitions to {@code newStatus}, publishing {@code result} and {@code statusMessage}
+     * (when non-null) atomically with the state change, then notifying the status listener.
+     */
+    boolean transitionTo(TaskState newStatus, @Nullable TaskResult result, @Nullable String statusMessage) {
         Objects.requireNonNull(newStatus, "status is required");
         if (newStatus == TaskState.COMPLETED) {
             Objects.requireNonNull(result, "result is required when transitioning to completed status");
@@ -310,20 +328,21 @@ public class TaskEntry implements ServerFeature<TaskDescriptor>, Task {
         if (!current.canTransitionTo(newStatus)) {
             return false;
         }
-        if (result != null) {
-            this.result = result;
-        }
         if (status.compareAndSet(current, newStatus)) {
             this.lastUpdatedAt = System.currentTimeMillis();
+            if (statusMessage != null) {
+                this.statusMessage = statusMessage;
+            }
             if (newStatus.isTerminal()) {
                 this.expiredAt = computeExpiredAt(this.lastUpdatedAt);
-                if (this.result != null) {
-                    completionFuture.complete(this.result);
+                if (result != null) {
+                    completionFuture.complete(result);
                 } else {
                     completionFuture.completeExceptionally(
                             new IllegalStateException("Terminal state reached without result"));
                 }
             }
+            statusListener.accept(this);
             return true;
         }
         return false;

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tasks/Tasks.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tasks/Tasks.java
@@ -17,4 +17,13 @@ public interface Tasks {
     Task create();
 
     Task create(TaskOptions options);
+
+    /**
+     * Removes a task from the registry, e.g. because it was removed on the caller's side.
+     * A non-terminal task is cancelled first (firing a final status notification) so its
+     * {@link Task#completion()} doesn't hang forever.
+     *
+     * @return {@code true} if a task with this id existed and was removed
+     */
+    boolean remove(String taskId);
 }

--- a/tachyon-server/src/test/java/dev/tachyonmcp/server/features/tasks/TaskRegistryTest.java
+++ b/tachyon-server/src/test/java/dev/tachyonmcp/server/features/tasks/TaskRegistryTest.java
@@ -443,14 +443,16 @@ class TaskRegistryTest {
 
     @Test
     void shouldFireOnChangeWhenExistingTaskRemoved() {
+        // Default single-arg constructor starts WORKING (non-terminal), so remove() cancels
+        // it first (1 onChange) before removing it from the index (2nd onChange).
         registry.add(new TaskEntry("id-x", "A task"));
 
         var callCount = new AtomicInteger(0);
         registry.onChange(callCount::incrementAndGet);
 
-        registry.remove("id-x");
+        assertThat(registry.remove("id-x")).isTrue();
 
-        assertThat(callCount).hasValue(1);
+        assertThat(callCount).hasValue(2);
     }
 
     @Test
@@ -458,8 +460,34 @@ class TaskRegistryTest {
         var callCount = new AtomicInteger(0);
         registry.onChange(callCount::incrementAndGet);
 
-        registry.remove("does-not-exist");
+        assertThat(registry.remove("does-not-exist")).isFalse();
 
         assertThat(callCount).hasValue(0);
+    }
+
+    @Test
+    void removeOfTerminalTaskSkipsCancelAndFiresOnChangeOnce() {
+        var entry = (TaskEntry) registry.create();
+        registry.completeTask(entry.id(), "{\"ok\":true}");
+
+        var callCount = new AtomicInteger(0);
+        registry.onChange(callCount::incrementAndGet);
+
+        assertThat(registry.remove(entry.id())).isTrue();
+
+        assertThat(callCount).hasValue(1);
+        assertThat(registry.get(entry.id())).isNull();
+    }
+
+    @Test
+    void removeOfActiveTaskCancelsFirstSoCompletionDoesNotHang() {
+        var entry = (TaskEntry) registry.create();
+        registry.updateStatus(entry.id(), TaskState.WORKING, null);
+
+        assertThat(registry.remove(entry.id())).isTrue();
+
+        assertThat(entry.status()).isEqualTo(TaskState.CANCELLED);
+        assertThat(entry.completion().toCompletableFuture()).isCompletedExceptionally();
+        assertThat(registry.get(entry.id())).isNull();
     }
 }


### PR DESCRIPTION
## Summary

Task status notifications only fired through DefaultTaskRegistry's own taskId-keyed methods, never from TaskEntry's own complete/fail/cancel/ resume/updateMessage — so any caller holding a bare Task from Tasks.create(...) (the only thing the public facade returns) got a notification at creation and silence after that. Notification firing now lives in TaskEntry itself via a listener wired at construction, so it fires regardless of which method the caller went through.

Also:
- Add Tasks.remove(taskId): boolean — cancels non-terminal tasks first (final notification, resolves completion()) before dropping them, silent for already-terminal tasks.
- Collapse TaskEntry's redundant result field into completionFuture, fixing a race where a thread losing the CAS still mutated shared state.
- Fix stale docs/skill examples found while reviewing tasks.md: nonexistent args.string()/ToolDescriptor.builder(name) APIs, a extensions.md snippet importing a nonexistent Server type, and a handful of drifted SKILL.md references (removed/renamed builder methods, missing TasksConfig.pollInterval field).