### PR TITLE
feat: MCP 2026-07-28 basic support and server discovery endpoint

### DIFF
--- a/conformance/conformance-baseline-0.2.yml
+++ b/conformance/conformance-baseline-0.2.yml
@@ -1,27 +1,21 @@
 server:
-  - server-stateless
-  - sep-2164-resource-not-found
+  - none
   - caching
-  - tasks-lifecycle
-  - tasks-capability-negotiation
-  - tasks-wire-fields
-  - tasks-request-state-removal
-  - tasks-mrtr-input
-  - tasks-request-headers
-  - tasks-dispatch-and-envelope
-  - tasks-required-task-error
-  - tasks-mrtr-composition
-  - http-header-validation
   - http-custom-header-server-validation
+  - http-header-validation
   - input-required-result-basic-elicitation
-  - input-required-result-basic-sampling
   - input-required-result-basic-list-roots
-  - input-required-result-request-state
-  - input-required-result-multiple-input-requests
-  - input-required-result-multi-round
-  - input-required-result-missing-input-response
-  - input-required-result-non-tool-request
-  - input-required-result-result-type
-  - input-required-result-tampered-state
+  - input-required-result-basic-sampling
   - input-required-result-capability-check
   - input-required-result-ignore-extra-params
+  - input-required-result-missing-input-response
+  - input-required-result-multi-round
+  - input-required-result-multiple-input-requests
+  - input-required-result-non-tool-request
+  - input-required-result-request-state
+  - input-required-result-result-type
+  - input-required-result-tampered-state
+  - input-required-result-unsupported-methods
+  - input-required-result-validate-input
+  - sep-2164-resource-not-found
+  - server-stateless

--- a/conformance/src/test/java/dev/tachyonmcp/conformance/EdgeServerConformanceIT.java
+++ b/conformance/src/test/java/dev/tachyonmcp/conformance/EdgeServerConformanceIT.java
@@ -10,6 +10,6 @@ package dev.tachyonmcp.conformance;
 class EdgeServerConformanceIT extends AbstractServerConformanceIT {
 
     EdgeServerConformanceIT() {
-        super(new EdgeConformanceServer(), "0.2.0-alpha.7", "conformance-baseline-0.2.yml", "edge", "2026-07-28");
+        super(new EdgeConformanceServer(), "0.2.0-alpha.9", "conformance-baseline-0.2.yml", "edge", "2026-07-28");
     }
 }

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/AbstractMcpE2eTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/AbstractMcpE2eTest.java
@@ -6,6 +6,7 @@ package dev.tachyonmcp.e2e;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import dev.tachyonmcp.e2e.mcp20260728.Mcp20260728TestClient;
 import dev.tachyonmcp.server.ServerBuilder;
 import dev.tachyonmcp.server.TachyonServer;
 import dev.tachyonmcp.server.internal.ServerEngine;
@@ -16,14 +17,14 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.TestInstance;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-abstract class AbstractMcpE2eTest {
+public abstract class AbstractMcpE2eTest {
 
     protected TachyonServer server;
     protected NettyServer nettyServer;
     protected int port;
     protected boolean usingCustomServer;
 
-    enum SessionMode {
+    protected enum SessionMode {
         STATEFUL,
         STATELESS
     }
@@ -47,7 +48,11 @@ abstract class AbstractMcpE2eTest {
     }
 
     protected TestMcpClient createTestClient() {
-        return new TestMcpClient(port);
+        return new Mcp20251125TestClient(port);
+    }
+
+    protected TestMcpClient createModernTestClient() {
+        return new Mcp20260728TestClient(port);
     }
 
     // region: ---- McpServer lifecycle management (call from subclass setup / teardown) ----

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/AbstractStatelessMcpE2eTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/AbstractStatelessMcpE2eTest.java
@@ -4,7 +4,7 @@
 
 package dev.tachyonmcp.e2e;
 
-abstract class AbstractStatelessMcpE2eTest extends AbstractMcpE2eTest {
+public abstract class AbstractStatelessMcpE2eTest extends AbstractMcpE2eTest {
 
     @Override
     protected final SessionMode sessionMode() {

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/Mcp20251125TestClient.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/Mcp20251125TestClient.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2026 Konstantin Pavlov and contributors.
+ */
+
+package dev.tachyonmcp.e2e;
+
+final class Mcp20251125TestClient extends TestMcpClient {
+
+    Mcp20251125TestClient(int port) {
+        super(port);
+    }
+
+    @Override
+    protected String protocolVersion() {
+        return "2025-11-25";
+    }
+}

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/ProgressKeepAliveTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/ProgressKeepAliveTest.java
@@ -130,7 +130,7 @@ class ProgressKeepAliveTest {
      * the reader-idle timer.
      */
     private void warmUp() throws Exception {
-        try (var client = new TestMcpClient(port)) {
+        try (var client = new Mcp20251125TestClient(port)) {
             var sessionId = client.initialize();
             client.post(
                     sessionId, // language=JSON
@@ -156,7 +156,7 @@ class ProgressKeepAliveTest {
     @Timeout(30)
     void progressKeepAliveEmitsHeartbeat() throws Exception {
         var lines = new CopyOnWriteArrayList<String>();
-        try (var client = new TestMcpClient(port)) {
+        try (var client = new Mcp20251125TestClient(port)) {
             var sessionId = client.initialize();
             var response = client.sendStreamingRequest(sessionId, TOOL_CALL);
             assertThat(response.statusCode()).isEqualTo(200);
@@ -177,7 +177,7 @@ class ProgressKeepAliveTest {
     @Timeout(30)
     void commentKeepAliveUpgradesWithoutProgressToken() throws Exception {
         var lines = new CopyOnWriteArrayList<String>();
-        try (var client = new TestMcpClient(port)) {
+        try (var client = new Mcp20251125TestClient(port)) {
             var sessionId = client.initialize();
             var response = client.sendStreamingRequest(sessionId, COMMENT_CALL);
             assertThat(response.statusCode()).isEqualTo(200);
@@ -201,7 +201,7 @@ class ProgressKeepAliveTest {
      * content type, progress notification, tool result) and returns the accumulated SSE body.
      */
     private void callSlowProgressAndAssertSse() throws Exception {
-        try (var client = new TestMcpClient(port)) {
+        try (var client = new Mcp20251125TestClient(port)) {
             var sessionId = client.initialize();
             var response = client.post(sessionId, TOOL_CALL);
 

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/SessionJanitorOutboundActivityTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/SessionJanitorOutboundActivityTest.java
@@ -66,7 +66,7 @@ class SessionJanitorOutboundActivityTest {
                 assertThat(session.get().state()).isEqualTo(SessionState.ACTIVE);
             });
 
-            try (var client = new TestMcpClient(port)) {
+            try (var client = new Mcp20251125TestClient(port)) {
                 var ping = client.post(sessionId, """
                     {"jsonrpc":"2.0","id":1,"method":"ping"}
                     """);
@@ -117,7 +117,7 @@ class SessionJanitorOutboundActivityTest {
     }
 
     private String initializeAndActivate(int targetPort) throws Exception {
-        try (var client = new TestMcpClient(targetPort)) {
+        try (var client = new Mcp20251125TestClient(targetPort)) {
             return client.initialize();
         }
     }

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/SseHeartbeatTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/SseHeartbeatTest.java
@@ -78,7 +78,7 @@ class SseHeartbeatTest {
     }
 
     private String initializeSession() throws Exception {
-        try (var client = new TestMcpClient(port)) {
+        try (var client = new Mcp20251125TestClient(port)) {
             return client.initialize();
         }
     }

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/StatelessServerTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/StatelessServerTest.java
@@ -42,7 +42,7 @@ class StatelessServerTest {
 
     @Test
     void shouldCompleteLifecycleAndDispatchWithoutSessionId() throws Exception {
-        try (var client = new TestMcpClient(port)) {
+        try (var client = new Mcp20251125TestClient(port)) {
             // MCP 2025-11-25 lifecycle: initialize first, then notify initialized.
             var sessionId = client.initialize();
 
@@ -80,7 +80,7 @@ class StatelessServerTest {
 
     @Test
     void shouldExecuteToolCallWithoutSessionId() throws Exception {
-        try (var client = new TestMcpClient(port)) {
+        try (var client = new Mcp20251125TestClient(port)) {
             client.initialize();
 
             var response = client.sendRpc("""
@@ -104,7 +104,7 @@ class StatelessServerTest {
 
     @Test
     void shouldAcceptNotificationWithoutSessionId() throws Exception {
-        try (var client = new TestMcpClient(port)) {
+        try (var client = new Mcp20251125TestClient(port)) {
             var response = client.post(null, """
                     {"jsonrpc":"2.0","method":"notifications/initialized"}
                     """);
@@ -116,7 +116,7 @@ class StatelessServerTest {
     @ParameterizedTest(name = "POST method={0}")
     @ValueSource(strings = {"tools/list", "tools/call", "ping"})
     void shouldReturn404WhenPostCarriesSessionId(String method) throws Exception {
-        try (var client = new TestMcpClient(port)) {
+        try (var client = new Mcp20251125TestClient(port)) {
             var response = client.post("sess_12345678", """
                     {"jsonrpc":"2.0","id":1,"method":"%s"}
                     """.formatted(method));

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/TestMcpClient.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/TestMcpClient.java
@@ -19,18 +19,20 @@ import org.intellij.lang.annotations.Language;
 import org.jspecify.annotations.Nullable;
 import tools.jackson.databind.ObjectMapper;
 
-public final class TestMcpClient implements Closeable {
+public abstract class TestMcpClient implements Closeable {
     private static final Duration DEFAULT_TASK_POLL_INTERVAL = Duration.ofMillis(100);
-    private static final ObjectMapper MAPPER = new ObjectMapper();
+    protected static final ObjectMapper MAPPER = new ObjectMapper();
 
     private final int serverPort;
     private final HttpClient httpClient;
     private volatile @Nullable String sessionId;
 
-    TestMcpClient(int port) {
+    protected TestMcpClient(int port) {
         this.serverPort = port;
         this.httpClient = HttpClient.newHttpClient();
     }
+
+    protected abstract String protocolVersion();
 
     @Override
     public void close() {
@@ -94,8 +96,9 @@ public final class TestMcpClient implements Closeable {
      * DNS-rebinding protection, which validates {@code Origin} before {@code Host}.
      */
     public HttpResponse<String> postWithOrigin(String origin, @Language("json") String body) throws Exception {
+        body = requestBody(body);
         return httpClient.send(
-                baseRequest()
+                requestBuilder(body)
                         .header("Origin", origin)
                         .POST(HttpRequest.BodyPublishers.ofString(body))
                         .build(),
@@ -103,7 +106,8 @@ public final class TestMcpClient implements Closeable {
     }
 
     public HttpResponse<String> post(@Nullable String sessionId, @Language("json") String body) throws Exception {
-        var builder = baseRequest();
+        body = requestBody(body);
+        var builder = requestBuilder(body);
         if (sessionId != null) {
             builder.header("MCP-Session-Id", sessionId);
         }
@@ -118,7 +122,8 @@ public final class TestMcpClient implements Closeable {
 
     public HttpResponse<Stream<String>> sendStreamingRequest(@Nullable String sessionId, @Language("json") String body)
             throws Exception {
-        var builder = baseRequest();
+        body = requestBody(body);
+        var builder = requestBuilder(body);
         if (sessionId != null) builder.header("MCP-Session-Id", sessionId);
         return httpClient.send(
                 builder.POST(HttpRequest.BodyPublishers.ofString(body)).build(), HttpResponse.BodyHandlers.ofLines());
@@ -210,8 +215,20 @@ public final class TestMcpClient implements Closeable {
                 .uri(URI.create("http://localhost:" + serverPort + "/mcp"))
                 .header("Content-Type", "application/json")
                 .header("Accept", "application/json, text/event-stream")
-                .header("MCP-Protocol-Version", "2025-11-25");
+                .header("MCP-Protocol-Version", protocolVersion());
     }
+
+    private HttpRequest.Builder requestBuilder(String body) throws Exception {
+        var builder = baseRequest();
+        configureRequest(builder, body);
+        return builder;
+    }
+
+    protected String requestBody(String body) throws Exception {
+        return body;
+    }
+
+    protected void configureRequest(HttpRequest.Builder builder, String body) throws Exception {}
 
     private static TaskSnapshot taskSnapshot(String json, String taskId) {
         var response = MAPPER.readTree(json);

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp20260728/DiscoverEndpointTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp20260728/DiscoverEndpointTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2026 Konstantin Pavlov and contributors.
+ */
+
+package dev.tachyonmcp.e2e.mcp20260728;
+
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.tachyonmcp.e2e.AbstractStatelessMcpE2eTest;
+import org.junit.jupiter.api.Test;
+
+class DiscoverEndpointTest extends AbstractStatelessMcpE2eTest {
+
+    @Test
+    void discoversTheModernProtocol() throws Exception {
+        startEmptyServer();
+        try (var client = createModernTestClient()) {
+            var response = client.post("""
+                    {
+                      "jsonrpc": "2.0",
+                      "id": "discover-1",
+                      "method": "server/discover"
+                    }
+                    """);
+
+            assertThat(response.statusCode()).isEqualTo(200);
+            assertThat(response.headers().firstValue("MCP-Session-Id")).isEmpty();
+            assertThatJson(response.body())
+                    .isEqualTo(
+                            // language=json
+                            """
+                    {
+                      "jsonrpc": "2.0",
+                      "id": "discover-1",
+                      "result": {
+                        "supportedVersions": ["2026-07-28", "2025-11-25"],
+                        "capabilities": {},
+                        "serverInfo": {"name": "tachyon-mcp", "version": "0.1"},
+                        "resultType": "complete",
+                        "ttlMs": 0.0,
+                        "cacheScope": "public"
+                      }
+                    }
+                    """);
+        }
+    }
+}

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp20260728/Mcp20260728TestClient.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp20260728/Mcp20260728TestClient.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2026 Konstantin Pavlov.
+ */
+
+package dev.tachyonmcp.e2e.mcp20260728;
+
+import dev.tachyonmcp.e2e.TestMcpClient;
+import dev.tachyonmcp.protocol.mcp.McpHeaderNames;
+import java.net.http.HttpRequest;
+import tools.jackson.databind.node.ObjectNode;
+
+public final class Mcp20260728TestClient extends TestMcpClient {
+
+    public Mcp20260728TestClient(int port) {
+        super(port);
+    }
+
+    @Override
+    protected String protocolVersion() {
+        return "2026-07-28";
+    }
+
+    @Override
+    protected String requestBody(String body) throws Exception {
+        var request = MAPPER.readTree(body);
+        if (!(request instanceof ObjectNode requestObject)) {
+            throw new IllegalArgumentException("MCP request must be a JSON object");
+        }
+        var meta = objectField(objectField(requestObject, "params"), "_meta");
+        meta.put("io.modelcontextprotocol/protocolVersion", protocolVersion());
+        var clientInfo = objectField(meta, "io.modelcontextprotocol/clientInfo");
+        if (!clientInfo.hasNonNull("name")) clientInfo.put("name", "test");
+        if (!clientInfo.hasNonNull("version")) clientInfo.put("version", "1.0");
+        objectField(meta, "io.modelcontextprotocol/clientCapabilities");
+        return MAPPER.writeValueAsString(requestObject);
+    }
+
+    @Override
+    protected void configureRequest(HttpRequest.Builder builder, String body) throws Exception {
+        var request = MAPPER.readTree(body);
+        var method = request.path("method").asString(null);
+        if (method != null) builder.header(McpHeaderNames.MCP_METHOD, method);
+
+        var params = request.path("params");
+        var name = params.path("name").asString(null);
+        if (name == null) name = params.path("uri").asString(null);
+        if (name != null) builder.header(McpHeaderNames.MCP_NAME, name);
+    }
+
+    private static ObjectNode objectField(ObjectNode parent, String name) {
+        var node = parent.get(name);
+        if (node instanceof ObjectNode object) return object;
+        var object = MAPPER.createObjectNode();
+        parent.set(name, object);
+        return object;
+    }
+}

--- a/tachyon-server/pom.xml
+++ b/tachyon-server/pom.xml
@@ -150,7 +150,6 @@
                             <goal>exec</goal>
                         </goals>
                         <configuration>
-                            <skip>true</skip>
                             <executable>python3</executable>
                             <arguments>
                                 <argument>${project.basedir}/ts2java.py</argument>

--- a/tachyon-server/src/main/java/dev/tachyonmcp/annotations/InternalApi.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/annotations/InternalApi.java
@@ -6,8 +6,6 @@ package dev.tachyonmcp.annotations;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
@@ -16,6 +14,5 @@ import java.lang.annotation.Target;
  * notice. Do not depend on it from application code.
  */
 @Documented
-@Retention(RetentionPolicy.SOURCE)
 @Target({ElementType.TYPE, ElementType.METHOD, ElementType.CONSTRUCTOR, ElementType.FIELD, ElementType.PACKAGE})
 public @interface InternalApi {}

--- a/tachyon-server/src/main/java/dev/tachyonmcp/protocol/ProtocolResponseMapper.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/protocol/ProtocolResponseMapper.java
@@ -4,6 +4,8 @@
 
 package dev.tachyonmcp.protocol;
 
+import dev.tachyonmcp.server.ServerCapabilities;
+import dev.tachyonmcp.server.config.ServerIdentity;
 import dev.tachyonmcp.server.domain.InitializeResponse;
 import dev.tachyonmcp.server.domain.InputRequest;
 import dev.tachyonmcp.server.domain.PromptMessage;
@@ -33,6 +35,12 @@ public interface ProtocolResponseMapper {
 
     /** Returns the protocol-specific empty result sent for methods that return no data. */
     Object emptyResult();
+
+    /** Maps the server discovery response into a protocol-specific shape. */
+    default Object discoverResult(
+            List<String> supportedVersions, ServerCapabilities capabilities, ServerIdentity serverIdentity) {
+        throw new UnsupportedOperationException("server/discover is not supported by this protocol version");
+    }
 
     /** Builds a completion result from a list of candidate values with optional pagination. */
     Object completeResult(List<String> values, @Nullable Double total, @Nullable Boolean hasMore);

--- a/tachyon-server/src/main/java/dev/tachyonmcp/protocol/mcp/McpHeaderNames.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/protocol/mcp/McpHeaderNames.java
@@ -22,5 +22,8 @@ public final class McpHeaderNames {
      */
     public static final String LAST_EVENT_ID = "Last-Event-ID";
 
+    public static final String MCP_METHOD = "Mcp-Method";
+    public static final String MCP_NAME = "Mcp-Name";
+
     private McpHeaderNames() {}
 }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/protocol/mcp/v2025_11_25/codecs/McpResponseMapper.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/protocol/mcp/v2025_11_25/codecs/McpResponseMapper.java
@@ -53,7 +53,7 @@ import tools.jackson.core.JsonParser;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.node.ObjectNode;
 
-public final class McpResponseMapper implements ProtocolResponseMapper {
+public class McpResponseMapper implements ProtocolResponseMapper {
 
     private static final Object EMPTY = new EmptyResult(null, null);
 

--- a/tachyon-server/src/main/java/dev/tachyonmcp/protocol/mcp/v2025_11_25/codecs/ProtocolCodecUtil.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/protocol/mcp/v2025_11_25/codecs/ProtocolCodecUtil.java
@@ -4,15 +4,13 @@
 
 package dev.tachyonmcp.protocol.mcp.v2025_11_25.codecs;
 
-import static dev.tachyonmcp.transport.jsonrpc.JsonRpcCodec.FACTORY;
-import static dev.tachyonmcp.transport.jsonrpc.JsonRpcCodec.TREE_READ_CONTEXT;
-import static dev.tachyonmcp.transport.jsonrpc.JsonRpcCodec.readTreeValue;
+import static dev.tachyonmcp.server.json.JsonUtils.FACTORY;
+import static dev.tachyonmcp.server.json.JsonUtils.TREE_READ_CONTEXT;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import tools.jackson.core.JsonToken;
-import tools.jackson.databind.JsonNode;
 
 public final class ProtocolCodecUtil {
 
@@ -29,15 +27,6 @@ public final class ProtocolCodecUtil {
             }
         } catch (IOException e) {
             throw new UncheckedIOException("Failed to decode " + targetType.getSimpleName(), e);
-        }
-    }
-
-    public static JsonNode parseJsonNode(String json) {
-        try (var p = FACTORY.createParser(TREE_READ_CONTEXT, json.getBytes(StandardCharsets.UTF_8))) {
-            p.nextToken();
-            return readTreeValue(p);
-        } catch (IOException e) {
-            throw new UncheckedIOException("Failed to parse JSON", e);
         }
     }
 }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/protocol/mcp/v2026_07_28/McpProtocol.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/protocol/mcp/v2026_07_28/McpProtocol.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2026 Konstantin Pavlov and contributors.
+ */
+
+package dev.tachyonmcp.protocol.mcp.v2026_07_28;
+
+import dev.tachyonmcp.protocol.Protocol;
+import dev.tachyonmcp.protocol.ProtocolResponseMapper;
+import dev.tachyonmcp.protocol.mcp.McpHeaderNames;
+import dev.tachyonmcp.protocol.mcp.v2026_07_28.codecs.McpResponseMapper;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpRequest;
+
+/** MCP protocol implementation for the modern, per-request 2026-07-28 revision. */
+public final class McpProtocol implements Protocol {
+
+    private static final String ENDPOINT = "/mcp";
+    public static final String VERSION = "2026-07-28";
+    private static final ProtocolResponseMapper RESPONSE_MAPPER = new McpResponseMapper();
+
+    @Override
+    public String endpoint() {
+        return ENDPOINT;
+    }
+
+    @Override
+    public String familyName() {
+        return "mcp";
+    }
+
+    @Override
+    public String versionString() {
+        return VERSION;
+    }
+
+    @Override
+    public boolean matches(HttpRequest request) {
+        return request.method() == HttpMethod.POST
+                && request.uri().startsWith(endpoint())
+                && VERSION.equals(request.headers().get(McpHeaderNames.MCP_PROTOCOL_VERSION));
+    }
+
+    @Override
+    public ProtocolResponseMapper responseMapper() {
+        return RESPONSE_MAPPER;
+    }
+}

--- a/tachyon-server/src/main/java/dev/tachyonmcp/protocol/mcp/v2026_07_28/codecs/McpResponseMapper.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/protocol/mcp/v2026_07_28/codecs/McpResponseMapper.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2026 Konstantin Pavlov and contributors.
+ */
+
+package dev.tachyonmcp.protocol.mcp.v2026_07_28.codecs;
+
+import dev.tachyonmcp.protocol.mcp.v2026_07_28.McpProtocol;
+import dev.tachyonmcp.protocol.mcp.v2026_07_28.models.DiscoverResult;
+import dev.tachyonmcp.protocol.mcp.v2026_07_28.models.EmptyResult;
+import dev.tachyonmcp.protocol.mcp.v2026_07_28.models.Icon;
+import dev.tachyonmcp.protocol.mcp.v2026_07_28.models.Implementation;
+import dev.tachyonmcp.protocol.mcp.v2026_07_28.models.ServerCapabilities;
+import dev.tachyonmcp.server.config.ServerIdentity;
+import java.io.IOException;
+import java.util.List;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.node.JsonNodeFactory;
+import tools.jackson.databind.node.ObjectNode;
+
+/**
+ * Maps the modern MCP discovery and empty response shapes.
+ */
+public final class McpResponseMapper extends dev.tachyonmcp.protocol.mcp.v2025_11_25.codecs.McpResponseMapper {
+
+    private static final String COMPLETE = "complete";
+    private static final String PUBLIC = "public";
+    private static final ObjectNode EMPTY_NODE = JsonNodeFactory.instance.objectNode();
+
+    static {
+        register(DiscoverResult.class, new DiscoverResultCodec());
+        register(EmptyResult.class, new EmptyResultCodec());
+    }
+
+    @Override
+    public boolean supports(String protocolName, String protocolVersion) {
+        return "mcp".equalsIgnoreCase(protocolName) && McpProtocol.VERSION.equals(protocolVersion);
+    }
+
+    @Override
+    public Object emptyResult() {
+        return new EmptyResult(null, COMPLETE, null);
+    }
+
+    @Override
+    public Object discoverResult(
+            List<String> supportedVersions,
+            dev.tachyonmcp.server.ServerCapabilities capabilities,
+            ServerIdentity serverIdentity) {
+        return new DiscoverResult(
+                supportedVersions,
+                capabilities(capabilities),
+                implementation(serverIdentity),
+                serverIdentity.instructions(),
+                null,
+                COMPLETE,
+                0,
+                PUBLIC,
+                null);
+    }
+
+    private static ServerCapabilities capabilities(dev.tachyonmcp.server.ServerCapabilities capabilities) {
+        var builder = ServerCapabilities.builder().experimental(capabilities.experimental());
+        if (capabilities.logging()) builder.logging(EMPTY_NODE);
+        if (capabilities.completions()) builder.completions(EMPTY_NODE);
+        if (capabilities.prompts() != null) {
+            builder.prompts(
+                    new ServerCapabilities.Prompts(capabilities.prompts().listChanged()));
+        }
+        if (capabilities.resources() != null) {
+            var resources = capabilities.resources();
+            builder.resources(new ServerCapabilities.Resources(resources.subscribe(), resources.listChanged()));
+        }
+        if (capabilities.tools() != null) {
+            builder.tools(new ServerCapabilities.Tools(capabilities.tools().listChanged()));
+        }
+        return builder.build();
+    }
+
+    private static Implementation implementation(ServerIdentity identity) {
+        var builder = Implementation.builder()
+                .name(identity.name())
+                .version(identity.version())
+                .description(identity.description())
+                .title(identity.title())
+                .websiteUrl(identity.websiteUrl());
+        if (identity.icons() != null && !identity.icons().isEmpty()) {
+            builder.icons(identity.icons().stream()
+                    .map(icon -> new Icon(icon.src(), icon.mimeType(), icon.sizes(), icon.theme()))
+                    .toList());
+        }
+        return builder.build();
+    }
+
+    private static <T> void register(Class<T> type, Codec<T> codec) {
+        dev.tachyonmcp.protocol.mcp.v2025_11_25.codecs.CodecRegistry.registerOverride(
+                type, new dev.tachyonmcp.protocol.mcp.v2025_11_25.codecs.Codec<>() {
+                    @Override
+                    public T decode(JsonParser parser) throws IOException {
+                        return codec.decode(parser);
+                    }
+
+                    @Override
+                    public void encode(JsonGenerator generator, T value) throws IOException {
+                        codec.encode(generator, value);
+                    }
+                });
+    }
+}

--- a/tachyon-server/src/main/java/dev/tachyonmcp/protocol/mcp/v2026_07_28/codecs/package-info.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/protocol/mcp/v2026_07_28/codecs/package-info.java
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2026 Konstantin Pavlov and contributors.
+ */
+
+@NullMarked
+package dev.tachyonmcp.protocol.mcp.v2026_07_28.codecs;
+
+import org.jspecify.annotations.NullMarked;

--- a/tachyon-server/src/main/java/dev/tachyonmcp/protocol/mcp/v2026_07_28/package-info.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/protocol/mcp/v2026_07_28/package-info.java
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2026 Konstantin Pavlov and contributors.
+ */
+
+@NullMarked
+package dev.tachyonmcp.protocol.mcp.v2026_07_28;
+
+import org.jspecify.annotations.NullMarked;

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/DefaultTachyonServer.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/DefaultTachyonServer.java
@@ -28,6 +28,7 @@ import dev.tachyonmcp.server.features.tasks.TaskSupport;
 import dev.tachyonmcp.server.features.tasks.Tasks;
 import dev.tachyonmcp.server.features.tools.DefaultToolRegistry;
 import dev.tachyonmcp.server.features.tools.Tools;
+import dev.tachyonmcp.server.handlers.DiscoverHandler;
 import dev.tachyonmcp.server.handlers.InitializeHandler;
 import dev.tachyonmcp.server.handlers.LoggingHandlers;
 import dev.tachyonmcp.server.handlers.PingHandler;
@@ -316,6 +317,7 @@ final class DefaultTachyonServer implements ServerEngine {
 
     private void registerDefaults() {
         methodHandlers.put("initialize", new InitializeHandler(this, extensions));
+        methodHandlers.put("server/discover", new DiscoverHandler(this));
         methodHandlers.put("ping", new PingHandler());
         toolRegistry.registerHandlers(methodHandlers);
         resourceRegistry.registerHandlers(methodHandlers);

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/McpDispatcher.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/McpDispatcher.java
@@ -7,6 +7,7 @@ package dev.tachyonmcp.server;
 import dev.tachyonmcp.annotations.InternalApi;
 import dev.tachyonmcp.protocol.Protocols;
 import dev.tachyonmcp.protocol.mcp.v2025_11_25.models.TaskStatus;
+import dev.tachyonmcp.protocol.mcp.v2026_07_28.McpProtocol;
 import dev.tachyonmcp.runtime.ChannelContext;
 import dev.tachyonmcp.runtime.Session;
 import dev.tachyonmcp.runtime.SessionState;
@@ -54,6 +55,7 @@ public class McpDispatcher {
     private static final Logger logger = LoggerFactory.getLogger(McpDispatcher.class);
 
     private static final String METHOD_INITIALIZE = "initialize";
+    private static final String METHOD_DISCOVER = "server/discover";
     private static final String METHOD_PING = "ping";
 
     /**
@@ -153,15 +155,20 @@ public class McpDispatcher {
             return CompletableFuture.completedFuture(errorResult(id, err.code(), err.message()));
         }
 
-        if (server.isStateless() || (METHOD_PING.equals(method) && sessionId == null)) {
-            var statelessIc = dispatchContext(channelContext);
-            statelessIc.setOutboundStream(outboundSseStream);
-            var handler = lookupHandler(method, params, statelessIc);
+        var requestCtx = dispatchContext(channelContext);
+        if (server.isStateless()
+                || (sessionId == null
+                        && (METHOD_PING.equals(method)
+                                || (METHOD_DISCOVER.equals(method)
+                                        && McpProtocol.VERSION.equals(requestCtx.protocolVersion()))))) {
+
+            requestCtx.setOutboundStream(outboundSseStream);
+            var handler = lookupHandler(method, params, requestCtx);
             if (handler == null) {
                 return CompletableFuture.completedFuture(
                         errorResult(id, JsonRpcErrors.METHOD_NOT_FOUND, "Method not found"));
             }
-            return invokeHandlerAsync(id, method, params, outboundSseStream, statelessIc, null, handler);
+            return invokeHandlerAsync(id, method, params, outboundSseStream, requestCtx, null, handler);
         }
 
         if (sessionId == null) {
@@ -175,7 +182,6 @@ public class McpDispatcher {
         var session = sessionOpt.get();
         session.touch();
 
-        var requestCtx = dispatchContext(channelContext);
         requestCtx.setSession(session);
         requestCtx.setOutboundStream(outboundSseStream);
 
@@ -250,13 +256,13 @@ public class McpDispatcher {
                                             try {
                                                 return handler.handleAsync(context, params);
                                             } catch (Exception e) {
-                                                return CompletableFuture.<Object>failedFuture(e);
+                                                return CompletableFuture.failedFuture(e);
                                             }
                                         });
                                 return stage.whenComplete((r, e) -> watchdog.cancel(false));
                             } catch (Exception e) {
                                 watchdog.cancel(false);
-                                return CompletableFuture.<Object>failedFuture(e);
+                                return CompletableFuture.failedFuture(e);
                             }
                         },
                         executor)

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/features/ListRequests.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/features/ListRequests.java
@@ -5,7 +5,7 @@
 package dev.tachyonmcp.server.features;
 
 import dev.tachyonmcp.annotations.InternalApi;
-import dev.tachyonmcp.protocol.mcp.v2025_11_25.codecs.ProtocolCodecUtil;
+import dev.tachyonmcp.server.json.JsonUtils;
 import dev.tachyonmcp.transport.jsonrpc.JsonRpcCodec;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -28,7 +28,7 @@ public final class ListRequests {
         var result = new LinkedHashMap<String, JsonNode>();
         for (var entry : rawMap.entrySet()) {
             if (entry.getKey() instanceof String k) {
-                result.put(k, ProtocolCodecUtil.parseJsonNode(JsonRpcCodec.writeValueAsString(entry.getValue())));
+                result.put(k, JsonUtils.parseJsonNode(JsonRpcCodec.writeValueAsString(entry.getValue())));
             }
         }
         return result.isEmpty() ? null : result;

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/features/resources/DefaultResourceRegistry.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/features/resources/DefaultResourceRegistry.java
@@ -507,7 +507,8 @@ public class DefaultResourceRegistry implements Resources {
             }
             var match = registry.matchTemplate(uri);
             if (match == null) {
-                return CompletableFuture.completedFuture(JsonRpcErrors.resourceNotFound("Resource not found"));
+                return CompletableFuture.completedFuture(
+                        JsonRpcErrors.resourceNotFound("Resource not found", Map.of("uri", uri)));
             }
             return readResult(
                     context,

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/handlers/DiscoverHandler.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/handlers/DiscoverHandler.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026 Konstantin Pavlov and contributors.
+ */
+
+package dev.tachyonmcp.server.handlers;
+
+import dev.tachyonmcp.protocol.Protocols;
+import dev.tachyonmcp.server.RpcMethodHandler;
+import dev.tachyonmcp.server.internal.ServerEngine;
+import dev.tachyonmcp.server.session.DispatchContext;
+import java.util.Comparator;
+
+/** Handles the mandatory modern MCP {@code server/discover} request. */
+public final class DiscoverHandler implements RpcMethodHandler {
+
+    private final ServerEngine server;
+
+    public DiscoverHandler(ServerEngine server) {
+        this.server = server;
+    }
+
+    @Override
+    public String method() {
+        return "server/discover";
+    }
+
+    @Override
+    public Object handle(DispatchContext context, Object params) {
+        var supportedVersions = Protocols.list().stream()
+                .map(protocol -> protocol.versionString())
+                .sorted(Comparator.reverseOrder())
+                .toList();
+        return context.responseMapper()
+                .discoverResult(
+                        supportedVersions,
+                        server.resolveCapabilities(),
+                        server.config().identity());
+    }
+}

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/json/JsonUtils.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/json/JsonUtils.java
@@ -4,14 +4,22 @@
 
 package dev.tachyonmcp.server.json;
 
+import static dev.tachyonmcp.transport.jsonrpc.JsonRpcCodec.readTreeValue;
+
 import dev.tachyonmcp.annotations.InternalApi;
-import dev.tachyonmcp.protocol.mcp.v2025_11_25.codecs.ProtocolCodecUtil;
 import dev.tachyonmcp.server.domain.ContentBlock;
 import dev.tachyonmcp.server.features.tools.ToolResult;
 import dev.tachyonmcp.transport.jsonrpc.JsonRpcCodec;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import org.jspecify.annotations.Nullable;
+import tools.jackson.core.JsonParser;
+import tools.jackson.core.ObjectReadContext;
+import tools.jackson.core.TreeNode;
+import tools.jackson.core.json.JsonFactory;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.json.JsonMapper;
 import tools.jackson.databind.node.JsonNodeFactory;
@@ -20,6 +28,19 @@ import tools.jackson.databind.node.JsonNodeFactory;
 public final class JsonUtils {
 
     private static final JsonMapper MAPPER = new JsonMapper();
+    public static final JsonFactory FACTORY = new JsonFactory();
+
+    public static final ObjectReadContext TREE_READ_CONTEXT = new ObjectReadContext.Base() {
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T extends TreeNode> T readTree(JsonParser p) {
+            try {
+                return (T) readTreeValue(p);
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
+    };
 
     private JsonUtils() {}
 
@@ -33,6 +54,15 @@ public final class JsonUtils {
 
     public static String writeString(Object value) {
         return MAPPER.writeValueAsString(value);
+    }
+
+    public static JsonNode parseJsonNode(String json) {
+        try (var p = FACTORY.createParser(TREE_READ_CONTEXT, json.getBytes(StandardCharsets.UTF_8))) {
+            p.nextToken();
+            return readTreeValue(p);
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to parse JSON", e);
+        }
     }
 
     /**
@@ -64,7 +94,7 @@ public final class JsonUtils {
                     if (v instanceof JsonNode jn) {
                         contentNode.set(k, jn);
                     } else if (v != null) {
-                        contentNode.set(k, ProtocolCodecUtil.parseJsonNode(JsonRpcCodec.writeValueAsString(v)));
+                        contentNode.set(k, JsonUtils.parseJsonNode(JsonRpcCodec.writeValueAsString(v)));
                     }
                 }
             }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/transport/jsonrpc/JsonRpcCodec.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/transport/jsonrpc/JsonRpcCodec.java
@@ -4,6 +4,8 @@
 
 package dev.tachyonmcp.transport.jsonrpc;
 
+import static dev.tachyonmcp.server.json.JsonUtils.FACTORY;
+
 import dev.tachyonmcp.protocol.mcp.v2025_11_25.codecs.Codec;
 import dev.tachyonmcp.protocol.mcp.v2025_11_25.codecs.CodecRegistry;
 import io.netty.buffer.ByteBuf;
@@ -25,27 +27,11 @@ import tools.jackson.core.JsonParser;
 import tools.jackson.core.JsonToken;
 import tools.jackson.core.ObjectReadContext;
 import tools.jackson.core.ObjectWriteContext;
-import tools.jackson.core.TreeNode;
-import tools.jackson.core.json.JsonFactory;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.node.JsonNodeFactory;
 
 /** Low-level JSON-RPC 2.0 codec: parse and serialize messages to/from Netty {@link ByteBuf}. */
 public final class JsonRpcCodec {
-
-    public static final ObjectReadContext TREE_READ_CONTEXT = new ObjectReadContext.Base() {
-        @Override
-        @SuppressWarnings("unchecked")
-        public <T extends TreeNode> T readTree(JsonParser p) {
-            try {
-                return (T) readTreeValue(p);
-            } catch (IOException e) {
-                throw new UncheckedIOException(e);
-            }
-        }
-    };
-
-    public static final JsonFactory FACTORY = new JsonFactory();
 
     private static final String JSONRPC = "jsonrpc";
     private static final String JSONRPC_VERSION = "2.0";

--- a/tachyon-server/src/main/java/dev/tachyonmcp/transport/jsonrpc/JsonRpcErrors.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/transport/jsonrpc/JsonRpcErrors.java
@@ -4,6 +4,9 @@
 
 package dev.tachyonmcp.transport.jsonrpc;
 
+import dev.tachyonmcp.server.json.JsonUtils;
+import java.util.Map;
+
 /** Standard JSON-RPC error codes and factory methods. */
 public final class JsonRpcErrors {
 
@@ -50,5 +53,9 @@ public final class JsonRpcErrors {
     /** Creates a resource-not-found error with the given detail. */
     public static JsonRpcError resourceNotFound(String detail) {
         return new JsonRpcError(RESOURCE_NOT_FOUND, detail);
+    }
+
+    public static JsonRpcError resourceNotFound(String detail, Map<String, String> data) {
+        return new JsonRpcError(RESOURCE_NOT_FOUND, detail, JsonUtils.writeString(data));
     }
 }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/McpInitializationHandler.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/McpInitializationHandler.java
@@ -158,7 +158,8 @@ public class McpInitializationHandler extends ChannelInboundHandlerAdapter {
         var heartbeatInterval = server.config().network().heartbeatInterval();
         var postStream = new PostSseStream(ctx.channel(), origin, server::nextEventId, heartbeatInterval);
         dispatcher
-                .dispatchRequestAsync(id, method, params, null, postStream, null)
+                .dispatchRequestAsync(
+                        id, method, params, null, postStream, ChannelHandlerUtils.requireInteractionContext(ctx))
                 .whenComplete((result, ex) -> ctx.executor().execute(() -> {
                     // Neutralize the unused stream so a late server→client message cannot open a
                     // second response on this (potentially keep-alive) channel.

--- a/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/ProtocolVersionHandler.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/ProtocolVersionHandler.java
@@ -6,10 +6,11 @@ package dev.tachyonmcp.transport.netty;
 
 import static dev.tachyonmcp.transport.netty.ChannelHandlerUtils.sendResponseAndClose;
 
+import dev.tachyonmcp.protocol.Protocol;
+import dev.tachyonmcp.protocol.Protocols;
 import dev.tachyonmcp.protocol.mcp.McpHeaderNames;
-import dev.tachyonmcp.protocol.mcp.v2025_11_25.McpProtocol;
+import dev.tachyonmcp.protocol.mcp.v2026_07_28.McpProtocol;
 import dev.tachyonmcp.transport.jsonrpc.JsonRpcCodec;
-import dev.tachyonmcp.transport.jsonrpc.JsonRpcErrors;
 import io.netty.channel.ChannelHandler.Sharable;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
@@ -17,19 +18,25 @@ import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponseStatus;
-import java.util.Set;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
 
 /**
- * Validates the {@code MCP-Protocol-Version} header on POST requests.
- * Rejects unsupported versions with a {@code 400 Bad Request} JSON-RPC error.
+ * Negotiates the protocol for each MCP POST and binds it to the interaction context.
  */
 @Sharable
 public class ProtocolVersionHandler extends ChannelInboundHandlerAdapter {
 
-    private static final Set<String> SUPPORTED_VERSIONS =
-            Set.of("2024-11-05", "2025-03-26", "2025-06-18", McpProtocol.VERSION);
-
     private final String mcpEndpoint;
+    private static final List<String> SUPPORTED_VERSIONS;
+
+    static {
+        SUPPORTED_VERSIONS = Protocols.list().stream()
+                .map(Protocol::versionString)
+                .sorted(Comparator.reverseOrder())
+                .toList();
+    }
 
     public ProtocolVersionHandler(String mcpEndpoint) {
         this.mcpEndpoint = mcpEndpoint;
@@ -41,12 +48,20 @@ public class ProtocolVersionHandler extends ChannelInboundHandlerAdapter {
                 && req.method() == HttpMethod.POST
                 && req.uri().startsWith(mcpEndpoint)) {
             var protoVersion = req.headers().get(McpHeaderNames.MCP_PROTOCOL_VERSION);
-            if (protoVersion != null && !SUPPORTED_VERSIONS.contains(protoVersion)) {
-                var err = JsonRpcErrors.invalidRequest("Unsupported protocol version");
-                var body = JsonRpcCodec.serializeError(-1, err.code(), err.message(), null);
+            var protocol = Protocols.resolve(req);
+            if (protocol.isEmpty()) {
+                var data = JsonRpcCodec.writeValueAsString(
+                        Map.of("supported", SUPPORTED_VERSIONS, "requested", protoVersion));
+                var body = JsonRpcCodec.serializeError(-1, -32022, "Unsupported protocol version", data);
                 var origin = req.headers().get(HttpHeaderNames.ORIGIN);
                 sendResponseAndClose(ctx, HttpResponseStatus.BAD_REQUEST, "application/json", body, origin);
                 return;
+            }
+            var interaction = ctx.channel().attr(InteractionHandler.INTERACTION_CONTEXT_KEY);
+            if (McpProtocol.VERSION.equals(protocol.get().versionString())) {
+                interaction.set(protocol.get().createInteractionContext());
+            } else {
+                interaction.setIfAbsent(protocol.get().createInteractionContext());
             }
         }
         ctx.fireChannelRead(msg);

--- a/tachyon-server/src/main/resources/META-INF/services/dev.tachyonmcp.protocol.Protocol
+++ b/tachyon-server/src/main/resources/META-INF/services/dev.tachyonmcp.protocol.Protocol
@@ -1,1 +1,2 @@
 dev.tachyonmcp.protocol.mcp.v2025_11_25.McpProtocol
+dev.tachyonmcp.protocol.mcp.v2026_07_28.McpProtocol

--- a/tachyon-server/src/test/java/dev/tachyonmcp/test/TestUtils.java
+++ b/tachyon-server/src/test/java/dev/tachyonmcp/test/TestUtils.java
@@ -4,6 +4,8 @@
 
 package dev.tachyonmcp.test;
 
+import static dev.tachyonmcp.server.json.JsonUtils.TREE_READ_CONTEXT;
+
 import dev.tachyonmcp.protocol.mcp.v2025_11_25.codecs.Codec;
 import dev.tachyonmcp.server.ServerBuilder;
 import dev.tachyonmcp.server.TachyonServer;
@@ -23,7 +25,7 @@ public class TestUtils {
     }
 
     public static JsonNode parseJson(String json) {
-        try (var p = Codec.FACTORY.createParser(JsonRpcCodec.TREE_READ_CONTEXT, json)) {
+        try (var p = Codec.FACTORY.createParser(TREE_READ_CONTEXT, json)) {
             p.nextToken();
             return JsonRpcCodec.readTreeValue(p);
         } catch (Exception e) {

--- a/tachyon-server/src/test/java/dev/tachyonmcp/transport/netty/McpInitializationHandlerTest.java
+++ b/tachyon-server/src/test/java/dev/tachyonmcp/transport/netty/McpInitializationHandlerTest.java
@@ -4,8 +4,10 @@
 
 package dev.tachyonmcp.transport.netty;
 
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import dev.tachyonmcp.protocol.mcp.v2026_07_28.McpProtocol;
 import dev.tachyonmcp.runtime.Session;
 import dev.tachyonmcp.server.McpDispatcher;
 import dev.tachyonmcp.server.TachyonServer;
@@ -34,7 +36,7 @@ class McpInitializationHandlerTest {
         server = (ServerEngine)
                 TachyonServer.builder().session(s -> s.enabled(true)).build();
         McpDispatcher dispatcher = new McpDispatcher(server, Runnable::run);
-        channel = new EmbeddedChannel(new InteractionHandler());
+        channel = new EmbeddedChannel(new ProtocolVersionHandler("/mcp"), new InteractionHandler());
         channel.pipeline()
                 .addLast(
                         McpHandlerManager.HANDLER_INIT,
@@ -101,6 +103,27 @@ class McpInitializationHandlerTest {
         assertThat(server.getSession(sessionId)).isPresent().map(Session::id).hasValue(sessionId);
 
         assertThat(channel.isOpen()).isTrue();
+    }
+
+    @Test
+    void pingWithLatestProtocolUsesModernEmptyResult() {
+        var body = "{" + "\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"ping\"}";
+        var request = new DefaultFullHttpRequest(
+                HttpVersion.HTTP_1_1, HttpMethod.POST, "/mcp", Unpooled.copiedBuffer(body, StandardCharsets.UTF_8));
+        request.headers().set("MCP-Protocol-Version", McpProtocol.VERSION);
+
+        channel.writeInbound(request);
+
+        var response = readResponse();
+        assertThat(response.status()).isEqualTo(HttpResponseStatus.OK);
+        assertThatJson(response.content().toString(StandardCharsets.UTF_8)).isEqualTo("""
+                        {
+                          "jsonrpc": "2.0",
+                          "id": 1,
+                          "result": {"resultType": "complete"}
+                        }
+                        """);
+        response.release();
     }
 
     @Test

--- a/tachyon-server/src/test/java/dev/tachyonmcp/transport/netty/ProtocolVersionHandlerTest.java
+++ b/tachyon-server/src/test/java/dev/tachyonmcp/transport/netty/ProtocolVersionHandlerTest.java
@@ -6,6 +6,7 @@ package dev.tachyonmcp.transport.netty;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import dev.tachyonmcp.protocol.mcp.v2026_07_28.McpProtocol;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.http.DefaultFullHttpRequest;
@@ -70,6 +71,22 @@ class ProtocolVersionHandlerTest {
         channel.writeInbound(request);
 
         assertThat((Object) channel.readOutbound()).isNull();
+    }
+
+    @Test
+    void latestVersionBindsItsProtocolToTheInteraction() {
+        var negotiationChannel = new EmbeddedChannel(new ProtocolVersionHandler("/mcp"), new InteractionHandler());
+        var request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/mcp");
+        request.headers().set("MCP-Protocol-Version", McpProtocol.VERSION);
+
+        negotiationChannel.writeInbound(request);
+
+        assertThat(negotiationChannel
+                        .attr(InteractionHandler.INTERACTION_CONTEXT_KEY)
+                        .get())
+                .extracting(context -> context.protocolVersion())
+                .isEqualTo(McpProtocol.VERSION);
+        negotiationChannel.finishAndReleaseAll();
     }
 
     @Test


### PR DESCRIPTION
Adds MCP protocol version 2026-07-28 support, including protocol matching, response mapping, dynamic negotiation, and generated-code activation. Registers and routes server/discover, with capability and server identity mapping. Refactors JSON parsing utilities and resource-not-found errors. Extends E2E infrastructure with versioned clients and discovery tests, updates existing tests, and adjusts conformance baselines.

- Added 2026-07-28 protocol SPI, Netty negotiation, context mapper binding and [server discovery endpoint](https://modelcontextprotocol.io/specification/draft/server/discover)
- Added wire-level regression tests, refactor e2e tests