### PR TITLE
feat!: Id/token types, fix immutables parameter order

### DIFF
--- a/.agents/skills/tachyon-development/SKILL.md
+++ b/.agents/skills/tachyon-development/SKILL.md
@@ -34,3 +34,16 @@ description: Apply Tachyon MCP project rules when designing, implementing, revie
 
 - Static schema → parse text block. `ObjectMapper.readTree("""...""")` or shared `parseJson(String)` helper. `// language=json` for IDE.
 - Imperative `JsonNodeFactory` only for runtime-computed schemas.
+
+## Logging
+
+[Logging policy](https://kpavlov.me/blog/logging-policy/)
+
+| Level | Use |
+|---|---|
+| ERROR | Immediate action — ops enables Rollbar+PagerDuty alerting |
+| WARN | Action needed, can wait to next business day |
+| INFO (default on) | Normal-operation info |
+| DEBUG (off on PROD, on DEV) | Trace business logic |
+| TRACE (off by default) | Raw request/response dump — leaks confidential data if left on |
+

--- a/.agents/skills/tachyon-mcp/resources/java/ResourceHandlerExample.java
+++ b/.agents/skills/tachyon-mcp/resources/java/ResourceHandlerExample.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2026 Konstantin Pavlov and contributors.
  */
 
-import dev.tachyonmcp.runtime.InteractionContext;
 import dev.tachyonmcp.server.domain.BlobResourceContents;
 import dev.tachyonmcp.server.domain.TextResourceContents;
 import dev.tachyonmcp.server.features.resources.AsyncResourceHandler;
@@ -22,7 +21,7 @@ final class ResourceHandlerExample {
      */
     static ResourceHandler configHandler() {
         return ResourceHandler.of((ctx, uri) ->
-            TextResourceContents.of(uri, "application/json", "{\"mode\":\"production\"}"));
+            TextResourceContents.of(uri, "{\"mode\":\"production\"}", "application/json"));
     }
 
     static ResourceDescriptor configDescriptor() {
@@ -34,7 +33,7 @@ final class ResourceHandlerExample {
      */
     static ResourceHandler imageHandler() {
         return ResourceHandler.of((ctx, uri) ->
-            BlobResourceContents.of(uri, "image/png", "iVBORw0KGgoAAAANS..."));
+            BlobResourceContents.of(uri, "iVBORw0KGgoAAAANS...", "image/png"));
     }
 
     /**
@@ -52,7 +51,7 @@ final class ResourceHandlerExample {
     static ResourceHandler userProfileTemplateHandler() {
         return (ctx, uri, params, uriTemplate) -> {
             var userId = params.get("userId").scalarValue();
-            return TextResourceContents.of(uri, "application/json", "{\"userId\":\"" + userId + "\"}");
+            return TextResourceContents.of(uri, "{\"userId\":\"" + userId + "\"}", "application/json");
         };
     }
 
@@ -68,8 +67,8 @@ final class ResourceHandlerExample {
 
     static ResourceHandler forecastTemplateHandler() {
         return (ctx, uri, params, uriTemplate) -> TextResourceContents.of(
-            uri, "application/json",
-            "{\"city\":\"" + params.get("city") + "\",\"temp\":22}");
+            uri, "{\"city\":\"" + params.get("city") + "\",\"temp\":22}", "application/json"
+        );
     }
 
     /**
@@ -79,6 +78,6 @@ final class ResourceHandlerExample {
      */
     static AsyncResourceHandler asyncConfigHandler() {
         return ResourceHandler.ofAsync((ctx, uri) -> CompletableFuture.supplyAsync(
-            () -> TextResourceContents.of(uri, "application/json", "{\"mode\":\"production\"}")));
+            () -> TextResourceContents.of(uri, "{\"mode\":\"production\"}", "application/json")));
     }
 }

--- a/.agents/skills/tachyon-mcp/resources/java/ServerBasic.java
+++ b/.agents/skills/tachyon-mcp/resources/java/ServerBasic.java
@@ -50,7 +50,7 @@ public final class ServerBasic {
                     "config", "demo://config",
                     "Server configuration", "application/json"),
                 (ctx, uri, params, uriTemplate) ->
-                    TextResourceContents.of(uri, "application/json", "{\"mode\":\"production\"}"))
+                    TextResourceContents.of(uri, "{\"mode\":\"production\"}", "application/json"))
             .prompt(
                 PromptDescriptor.of("greet", "Generates a greeting"),
                 List.of(PromptMessage.user("Say hello")))
@@ -62,7 +62,7 @@ public final class ServerBasic {
                 (ctx, uri, params, uriTemplate) -> {
                     var userId = params.get("userId").scalarValue();
                     return TextResourceContents.of(
-                        uri, "application/json", "{\"userId\":\"" + userId + "\",\"name\":\"User\"}");
+                        uri, "{\"userId\":\"" + userId + "\",\"name\":\"User\"}", "application/json");
                 })
             .port(port)
             .start();

--- a/conformance/src/test/java/dev/tachyonmcp/conformance/AbstractConformanceServer.java
+++ b/conformance/src/test/java/dev/tachyonmcp/conformance/AbstractConformanceServer.java
@@ -217,7 +217,7 @@ abstract class AbstractConformanceServer {
                                 .inputSchema(INPUT_SCHEMA_NO_ARGS),
                         (ctx, request) -> {
                             var res = TextResourceContents.of(
-                                    "test://embedded-resource", "text/plain", "This is an embedded resource content.");
+                                    "test://embedded-resource", "This is an embedded resource content.", "text/plain");
                             return ToolResult.blocks(EmbeddedResource.of(res));
                         }));
 
@@ -229,8 +229,8 @@ abstract class AbstractConformanceServer {
                         (ctx, request) -> {
                             var mixed = TextResourceContents.of(
                                     "test://mixed-content-resource",
-                                    "application/json",
-                                    "{\"test\":\"data\",\"value\":123}");
+                                    "{\"test\":\"data\",\"value\":123}",
+                                    "application/json");
                             return ToolResult.blocks(
                                     TextContent.of("Multiple content types test:"),
                                     ImageContent.of(MINI_PNG_BASE64, "image/png"),
@@ -524,21 +524,21 @@ abstract class AbstractConformanceServer {
                 .register(
                         ResourceDescriptor.of("hello", "hello://world", "Hello resource", "text/plain"),
                         (ctx, rawUri, params, uriTemplate) ->
-                                TextResourceContents.of(rawUri, "text/plain", "Hello, World!"));
+                                TextResourceContents.of(rawUri, "Hello, World!", "text/plain"));
 
         server.resources()
                 .register(
                         ResourceDescriptor.of(
                                 "static-text", "test://static-text", "Static text resource", "text/plain"),
                         (ctx, rawUri, params, uriTemplate) -> TextResourceContents.of(
-                                rawUri, "text/plain", "This is static text content for testing."));
+                                rawUri, "This is static text content for testing.", "text/plain"));
 
         server.resources()
                 .register(
                         ResourceDescriptor.of(
                                 "static-binary", "test://static-binary", "Static binary resource", "image/png"),
                         (ctx, rawUri, params, uriTemplate) ->
-                                BlobResourceContents.of(rawUri, "image/png", MINI_PNG_BASE64));
+                                BlobResourceContents.of(rawUri, MINI_PNG_BASE64, "image/png"));
 
         server.resources()
                 .registerTemplate(
@@ -547,8 +547,8 @@ abstract class AbstractConformanceServer {
                                 .description("test-description"),
                         (ctx, rawUri, params, uriTemplate) -> TextResourceContents.of(
                                 rawUri,
-                                "text/plain",
-                                "Resource content for id: " + ((UriTemplateValue.Scalar) params.get("id")).value()));
+                                "Resource content for id: " + ((UriTemplateValue.Scalar) params.get("id")).value(),
+                                "text/plain"));
     }
 
     private void registerPrompts(ServerEngine server) {
@@ -567,8 +567,8 @@ abstract class AbstractConformanceServer {
                         PromptDescriptor.of("test_prompt_with_embedded_resource", "Prompt with embedded resource"),
                         List.of(PromptMessage.user(EmbeddedResource.of(TextResourceContents.of(
                                 "test://embedded-resource-content",
-                                "text/plain",
-                                "Embedded resource content for testing.")))));
+                                "Embedded resource content for testing.",
+                                "text/plain")))));
 
         server.prompts()
                 .register(

--- a/conformance/src/test/java/dev/tachyonmcp/conformance/AbstractServerConformanceIT.java
+++ b/conformance/src/test/java/dev/tachyonmcp/conformance/AbstractServerConformanceIT.java
@@ -11,17 +11,23 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.junit.jupiter.api.DynamicTest.dynamicTest;
 
 import dev.tachyonmcp.transport.netty.NettyServer;
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Tag("conformance")
 abstract class AbstractServerConformanceIT {
 
+    private static final Logger log = LoggerFactory.getLogger(AbstractServerConformanceIT.class);
     private final AbstractConformanceServer serverFactory;
     private final String conformanceVersion;
     private final String baselineFileName;
@@ -63,6 +69,32 @@ abstract class AbstractServerConformanceIT {
         return scenarios.stream()
                 .map(scenario ->
                         dynamicTest(scenario, () -> runConformanceScenario(scenario, outputDir, expectedFailures)));
+    }
+
+    @Test
+    @Disabled("Run it manually")
+    void runAll() throws IOException, InterruptedException {
+
+        var outputDir = "target/failsafe-reports/" + suiteName + "-conformance-results";
+
+        var server = serverFactory.startServer(true);
+        try (server;
+                var nettyServer = new NettyServer(0, server)) {
+            var port = nettyServer.port();
+
+            var runner = new ConformanceRunner(
+                    "http://localhost:" + port + "/mcp", conformanceVersion, outputDir, baselineFileName);
+
+            log.info("[conformance] Running suite {} successfully", suiteName);
+
+            var result = runner.runSuite("all");
+
+            System.out.println("[conformance] Result " + String.join("\n", result.outputLines()) + " successfully");
+
+            if (!result.passed()) {
+                fail("[conformance] Suite " + suiteName + " failed");
+            }
+        }
     }
 
     private void runConformanceScenario(String scenario, String outputDir, List<String> expectedFailures)

--- a/docs/architecture/guidance.md
+++ b/docs/architecture/guidance.md
@@ -9,10 +9,10 @@ Resources/prompts are the reference pattern — one call shape, two interfaces:
 ```java
 @FunctionalInterface
 public interface XHandler {
-    XResult handle(InteractionContext ctx, /* args */) throws Exception;
-    default CompletionStage<? extends XResult> handleAsync(InteractionContext ctx, /* args */) {
+    XResult handle(InteractionContext ctx, XRequest request) throws Exception;
+    default CompletionStage<? extends XResult> handleAsync(InteractionContext ctx, XRequest request) {
         try {
-            return CompletableFuture.completedFuture(handle(ctx, /* args */));
+            return CompletableFuture.completedFuture(handle(ctx, request));
         } catch (Exception e) {
             return CompletableFuture.failedFuture(e);
         }
@@ -21,11 +21,11 @@ public interface XHandler {
 
 public interface AsyncXHandler extends XHandler {
     @Override
-    CompletionStage<? extends XResult> handleAsync(InteractionContext ctx, /* args */);
+    CompletionStage<? extends XResult> handleAsync(InteractionContext ctx, XRequest request);
     @Override
-    default XResult handle(InteractionContext ctx, /* args */) throws Exception {
+    default XResult handle(InteractionContext ctx, XRequest request) throws Exception {
         HandlerFutures.assumeVirtualThread();
-        return HandlerFutures.joinInterruptibly(handleAsync(ctx, /* args */));
+        return HandlerFutures.joinInterruptibly(handleAsync(ctx, request));
     }
 }
 ```
@@ -39,11 +39,11 @@ Implement `XHandler` for sync, `AsyncXHandler` for async — one override each (
 ```java
 @FunctionalInterface
 public interface XFn {
-    XResult apply(InteractionContext ctx, Args args) throws Exception;
+    XResult apply(InteractionContext ctx, XRequest request) throws Exception;
 }
 ```
 
-`ToolFn`/`ToolRequestFn` are this applied to tools (fixed 2026-07-18, was raw `BiFunction`). The dispatcher already logs/maps thrown exceptions to a JSON-RPC error — a throwing SAM lets a handler use that path instead of hand-rolling it.
+`ToolFn` are this applied to tools (was raw `BiFunction`). The dispatcher already logs/maps thrown exceptions to a JSON-RPC error — a throwing SAM lets a handler use that path instead of hand-rolling it. Functional interfaces take `InteractionContext` + a feature-specific request; the request carries `_meta` alongside arguments so the shape extends later without an interface change.
 
 **Async entry types don't declare `throws Exception`** — errors propagate via a failed `CompletionStage`, matching `AsyncResourceHandler`/`AsyncPromptHandler`. Don't add `throws` there "for symmetry."
 

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/ListPaginationE2eTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/ListPaginationE2eTest.java
@@ -18,7 +18,7 @@ class ListPaginationE2eTest extends AbstractStatelessMcpE2eTest {
 
     private static final ObjectMapper MAPPER = new ObjectMapper();
     private static final ResourceHandler EMPTY_RESOURCE =
-            (ctx, rawUri, params, uriTemplate) -> TextResourceContents.of(rawUri, "text/plain", "");
+            (ctx, rawUri, params, uriTemplate) -> TextResourceContents.of(rawUri, "", "text/plain");
 
     @Test
     void resourcesListReturnsConfiguredPageSize() throws Exception {

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/PostStartRegistrationTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/PostStartRegistrationTest.java
@@ -29,7 +29,7 @@ class PostStartRegistrationTest extends AbstractStatelessMcpE2eTest {
                 .register(
                         ResourceDescriptor.of(
                                 "post-start-res", "test://post-start", "Post-start resource", "text/plain"),
-                        (ctx, rawUri, params, uriTemplate) -> TextResourceContents.of(rawUri, "text/plain", ""));
+                        (ctx, rawUri, params, uriTemplate) -> TextResourceContents.of(rawUri, "", "text/plain"));
 
         try (var client = createTestClient()) {
             client.initialize();
@@ -67,7 +67,7 @@ class PostStartRegistrationTest extends AbstractStatelessMcpE2eTest {
                 .register(
                         ResourceDescriptor.of("handled-res", "test://handled", "Handled resource", "text/plain"),
                         (ctx, rawUri, params, uriTemplate) ->
-                                TextResourceContents.of(rawUri, "text/plain", "post-start data", null));
+                                TextResourceContents.of(rawUri, "post-start data", "text/plain", null));
 
         try (var client = createTestClient()) {
             client.initialize();

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/PromptsTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/PromptsTest.java
@@ -121,7 +121,7 @@ class PromptsTest extends AbstractStatelessMcpE2eTest {
                 .register(
                         PromptDescriptor.of("embedded", "Prompt with embedded resource"),
                         List.of(PromptMessage.user(EmbeddedResource.of(
-                                TextResourceContents.of("test://embedded", "text/plain", "embedded content")))));
+                                TextResourceContents.of("test://embedded", "embedded content", "text/plain")))));
 
         try (var client = createTestClient()) {
             client.initialize();

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/ResourceTemplateTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/ResourceTemplateTest.java
@@ -19,7 +19,7 @@ class ResourceTemplateTest extends AbstractStatelessMcpE2eTest {
                                 .description("An item")
                                 .mimeType("text/plain"),
                         (ctx, rawUri, params, uriTemplate) -> TextResourceContents.of(
-                                rawUri, "text/plain", "item=" + params.get("id").scalarValue()));
+                                rawUri, "item=" + params.get("id").scalarValue(), "text/plain"));
 
         try (var client = createTestClient()) {
             client.initialize();
@@ -55,25 +55,21 @@ class ResourceTemplateTest extends AbstractStatelessMcpE2eTest {
                                 .description("An item")
                                 .mimeType("text/plain"),
                         (ctx, rawUri, params, uriTemplate) -> TextResourceContents.of(
-                                rawUri, "text/plain", "item=" + params.get("id").scalarValue()))
+                                rawUri, "item=" + params.get("id").scalarValue(), "text/plain"))
                 .registerTemplate(
                         builder -> builder.name("orders")
                                 .uriTemplate("resource://orders/{orderId}")
                                 .description("An order")
                                 .mimeType("text/plain"),
                         (ctx, rawUri, params, uriTemplate) -> TextResourceContents.of(
-                                rawUri,
-                                "text/plain",
-                                "order=" + params.get("orderId").scalarValue()))
+                                rawUri, "order=" + params.get("orderId").scalarValue(), "text/plain"))
                 .registerTemplate(
                         builder -> builder.name("users")
                                 .uriTemplate("resource://users/{userId}")
                                 .description("A user")
                                 .mimeType("text/plain"),
                         (ctx, rawUri, params, uriTemplate) -> TextResourceContents.of(
-                                rawUri,
-                                "text/plain",
-                                "user=" + params.get("userId").scalarValue()));
+                                rawUri, "user=" + params.get("userId").scalarValue(), "text/plain"));
 
         try (var client = createTestClient()) {
             client.initialize();
@@ -148,9 +144,9 @@ class ResourceTemplateTest extends AbstractStatelessMcpE2eTest {
                                 .mimeType("text/plain"),
                         (ctx, rawUri, params, uriTemplate) -> TextResourceContents.of(
                                 rawUri,
-                                "text/plain",
                                 "user=" + params.get("userId").scalarValue() + ",post="
-                                        + params.get("postId").scalarValue()));
+                                        + params.get("postId").scalarValue(),
+                                "text/plain"));
 
         try (var client = createTestClient()) {
             client.initialize();
@@ -186,7 +182,7 @@ class ResourceTemplateTest extends AbstractStatelessMcpE2eTest {
                                 .description("An item")
                                 .mimeType("text/plain"),
                         (ctx, rawUri, params, uriTemplate) -> TextResourceContents.of(
-                                rawUri, "text/plain", "item=" + params.get("id").scalarValue()));
+                                rawUri, "item=" + params.get("id").scalarValue(), "text/plain"));
 
         try (var client = createTestClient()) {
             client.initialize();
@@ -218,7 +214,7 @@ class ResourceTemplateTest extends AbstractStatelessMcpE2eTest {
         server.resources()
                 .registerTemplate(
                         builder -> builder.name("item").uriTemplate("resource://items/{id}"),
-                        (ctx, rawUri, params, uriTemplate) -> TextResourceContents.of(rawUri, "text/plain", "item"));
+                        (ctx, rawUri, params, uriTemplate) -> TextResourceContents.of(rawUri, "item", "text/plain"));
 
         try (var client = createTestClient()) {
             client.initialize();
@@ -249,7 +245,7 @@ class ResourceTemplateTest extends AbstractStatelessMcpE2eTest {
                                 .description("An item")
                                 .mimeType("text/plain"),
                         (ctx, rawUri, params, uriTemplate) -> TextResourceContents.of(
-                                rawUri, "text/plain", "item=" + params.get("id").scalarValue()));
+                                rawUri, "item=" + params.get("id").scalarValue(), "text/plain"));
 
         try (var client = createTestClient()) {
             client.initialize();

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/ResourceTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/ResourceTest.java
@@ -27,11 +27,11 @@ class ResourceTest extends AbstractStatefulMcpE2eTest {
         server.resources()
                 .register(
                         ResourceDescriptor.of("doc", "resource://doc", "A document", "text/plain"),
-                        (ctx, rawUri, params, uriTemplate) -> TextResourceContents.of(rawUri, "text/plain", "Hello"))
+                        (ctx, rawUri, params, uriTemplate) -> TextResourceContents.of(rawUri, "Hello", "text/plain"))
                 .register(
                         ResourceDescriptor.of("code", "resource://code", "Source code", "text/x-java"),
                         (ctx, rawUri, params, uriTemplate) ->
-                                TextResourceContents.of("resource://code", "text/x-java", "package com.example;"));
+                                TextResourceContents.of("resource://code", "package com.example;", "text/x-java"));
 
         try (var client = createTestClient()) {
             var sessionId = client.initialize();
@@ -59,7 +59,7 @@ class ResourceTest extends AbstractStatefulMcpE2eTest {
                 .register(
                         descriptor,
                         (ctx, rawUri, params, uriTemplate) ->
-                                TextResourceContents.of(rawUri, "text/plain", "Hello world"));
+                                TextResourceContents.of(rawUri, "Hello world", "text/plain"));
 
         try (var client = createTestClient()) {
             var sessionId = client.initialize();
@@ -82,15 +82,15 @@ class ResourceTest extends AbstractStatefulMcpE2eTest {
                 .register(
                         ResourceDescriptor.of("alpha", "resource://alpha", "Alpha", "text/plain"),
                         (ctx, rawUri, params, uriTemplate) ->
-                                TextResourceContents.of(rawUri, "text/plain", "content-alpha"))
+                                TextResourceContents.of(rawUri, "content-alpha", "text/plain"))
                 .register(
                         ResourceDescriptor.of("beta", "resource://beta", "Beta", "text/plain"),
                         (ctx, rawUri, params, uriTemplate) ->
-                                TextResourceContents.of(rawUri, "text/plain", "content-beta"))
+                                TextResourceContents.of(rawUri, "content-beta", "text/plain"))
                 .register(
                         ResourceDescriptor.of("gamma", "resource://gamma", "Gamma", "text/plain"),
                         (ctx, rawUri, params, uriTemplate) ->
-                                TextResourceContents.of(rawUri, "text/plain", "content-gamma"));
+                                TextResourceContents.of(rawUri, "content-gamma", "text/plain"));
 
         try (var client = createTestClient()) {
             var sessionId = client.initialize();
@@ -120,7 +120,7 @@ class ResourceTest extends AbstractStatefulMcpE2eTest {
     void shouldReadResourceFromAsyncHandler() throws Exception {
         var descriptor = ResourceDescriptor.of("async-doc", "resource://async-doc", "Async document", "text/plain");
         AsyncResourceHandler handler = (ctx, rawUri, params, uriTemplate) -> CompletableFuture.supplyAsync(
-                () -> TextResourceContents.of("resource://async-doc", "text/plain", "async content"));
+                () -> TextResourceContents.of("resource://async-doc", "async content", "text/plain"));
         startEmptyServer();
         server.resources().register(descriptor, handler);
 
@@ -203,11 +203,11 @@ class ResourceTest extends AbstractStatefulMcpE2eTest {
                 .register(
                         ResourceDescriptor.of("alpha", "resource://alpha", "Alpha", "text/plain"),
                         (ctx, rawUri, params, uriTemplate) ->
-                                TextResourceContents.of(rawUri, "text/plain", "content-alpha"))
+                                TextResourceContents.of(rawUri, "content-alpha", "text/plain"))
                 .register(
                         ResourceDescriptor.of("beta", "resource://beta", "Beta", "text/plain"),
                         (ctx, rawUri, params, uriTemplate) ->
-                                TextResourceContents.of(rawUri, "text/plain", "content-beta"));
+                                TextResourceContents.of(rawUri, "content-beta", "text/plain"));
 
         try (var client = createTestClient()) {
             var sessionId = client.initialize();
@@ -240,7 +240,7 @@ class ResourceTest extends AbstractStatefulMcpE2eTest {
             if ("remove".equals(action)) {
                 builder.resource(
                         ResourceDescriptor.of("doc", "resource://doc", "A document", "text/plain"),
-                        (ctx, rawUri, params, uriTemplate) -> TextResourceContents.of(rawUri, "text/plain", ""));
+                        (ctx, rawUri, params, uriTemplate) -> TextResourceContents.of(rawUri, "", "text/plain"));
             }
         });
 
@@ -258,7 +258,7 @@ class ResourceTest extends AbstractStatefulMcpE2eTest {
     void shouldNotifyResourceUpdated() throws Exception {
         startServer(it -> it.resource(
                         ResourceDescriptor.of("doc", "resource://doc", "A document", "text/plain"),
-                        (ctx, rawUri, params, uriTemplate) -> TextResourceContents.of(rawUri, "text/plain", ""))
+                        (ctx, rawUri, params, uriTemplate) -> TextResourceContents.of(rawUri, "", "text/plain"))
                 .tool(notifyUpdatedTool()));
 
         try (var client = createTestClient()) {
@@ -282,7 +282,7 @@ class ResourceTest extends AbstractStatefulMcpE2eTest {
     void shouldNotNotifyAfterUnsubscribe() throws Exception {
         startServer(it -> it.resource(
                         ResourceDescriptor.of("doc", "resource://doc", "A document", "text/plain"),
-                        (ctx, rawUri, params, uriTemplate) -> TextResourceContents.of(rawUri, "text/plain", ""))
+                        (ctx, rawUri, params, uriTemplate) -> TextResourceContents.of(rawUri, "", "text/plain"))
                 .tool(notifyUpdatedTool()));
 
         try (var client = createTestClient()) {
@@ -312,7 +312,7 @@ class ResourceTest extends AbstractStatefulMcpE2eTest {
             builder.capabilities(c -> c.resourcesListChanged(true)).tool(unregisterByUriTool());
             builder.resource(
                     ResourceDescriptor.of("doc", "resource://doc", "A document", "text/plain"),
-                    (ctx, rawUri, params, uriTemplate) -> TextResourceContents.of(rawUri, "text/plain", ""));
+                    (ctx, rawUri, params, uriTemplate) -> TextResourceContents.of(rawUri, "", "text/plain"));
         });
 
         try (var client = createTestClient()) {
@@ -337,7 +337,7 @@ class ResourceTest extends AbstractStatefulMcpE2eTest {
                                 ResourceDescriptor.of(
                                         "added-resource", "resource://added", "Added by handler", "text/plain"),
                                 (ctx, rawUri, params, uriTemplate) ->
-                                        TextResourceContents.of(rawUri, "text/plain", "content"));
+                                        TextResourceContents.of(rawUri, "content", "text/plain"));
                     } else {
                         resources.unregister("doc");
                     }

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp20260728/CachingHintsTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp20260728/CachingHintsTest.java
@@ -30,12 +30,12 @@ class CachingHintsTest extends AbstractStatelessMcpE2eTest {
                 .resource(
                         ResourceDescriptor.of("hello", "hello://world", "Hello resource", "text/plain"),
                         (ctx, rawUri, params, uriTemplate) ->
-                                TextResourceContents.of(rawUri, "text/plain", "Hello, World!"))
+                                TextResourceContents.of(rawUri, "Hello, World!", "text/plain"))
                 .resourceTemplate(
                         builder -> builder.name("tmpl")
                                 .uriTemplate("test://tmpl/{id}")
                                 .description("d"),
-                        (ctx, rawUri, params, uriTemplate) -> TextResourceContents.of(rawUri, "text/plain", "x"))
+                        (ctx, rawUri, params, uriTemplate) -> TextResourceContents.of(rawUri, "x", "text/plain"))
                 .prompt(PromptDescriptor.of("greeting", "A greeting"), java.util.List.of()));
     }
 

--- a/examples/echo-kotlin/pom.xml
+++ b/examples/echo-kotlin/pom.xml
@@ -18,8 +18,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>21</java.version>
         <kotlin.version>2.2.21</kotlin.version>
-        <tachyon-server.version>1.0.0-beta.12</tachyon-server.version>
-<!--        <tachyon-server.version>1.0.0-SNAPSHOT</tachyon-server.version>-->
+<!--        <tachyon-server.version>1.0.0-beta.12</tachyon-server.version>-->
+        <tachyon-server.version>1.0.0-SNAPSHOT</tachyon-server.version>
         <junit.version>6.1.1</junit.version>
         <kotest.version>6.2.1</kotest.version>
         <json-unit.version>5.1.2</json-unit.version>

--- a/examples/echo-kotlin/pom.xml
+++ b/examples/echo-kotlin/pom.xml
@@ -18,7 +18,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>21</java.version>
         <kotlin.version>2.2.21</kotlin.version>
-        <tachyon-server.version>1.0.0-beta.11</tachyon-server.version>
+        <tachyon-server.version>1.0.0-beta.12</tachyon-server.version>
 <!--        <tachyon-server.version>1.0.0-SNAPSHOT</tachyon-server.version>-->
         <junit.version>6.1.1</junit.version>
         <kotest.version>6.2.1</kotest.version>

--- a/examples/echo-kotlin/src/main/kotlin/com/example/echo/EchoServer.kt
+++ b/examples/echo-kotlin/src/main/kotlin/com/example/echo/EchoServer.kt
@@ -42,7 +42,7 @@ fun createServer(port: Int = 0): TachyonServer {
             .inputSchema(inputSchema)
             .build(),
     ) {
-        val message = args.stringValue("message")
+        val message = request.arguments().stringValue("message")
         ToolResult.text(message.reversed())
     }
     return server

--- a/examples/weather/src/main/java/com/example/weather/GetWeatherTool.java
+++ b/examples/weather/src/main/java/com/example/weather/GetWeatherTool.java
@@ -7,6 +7,7 @@ import com.example.weather.service.WeatherService;
 import com.example.weather.spi.CityNotFoundException;
 import com.example.weather.spi.WeatherObservation;
 import dev.tachyonmcp.runtime.InteractionContext;
+import dev.tachyonmcp.server.domain.ProgressToken;
 import dev.tachyonmcp.server.features.tools.ToolDescriptor;
 import dev.tachyonmcp.server.features.tools.ToolHandler;
 import dev.tachyonmcp.server.features.tools.ToolResult;
@@ -74,7 +75,7 @@ class GetWeatherTool {
     }
 
     private static WeatherObservation fetchWithProgress(
-            InteractionContext ctx, Object progressToken, WeatherService weatherService, String city)
+            InteractionContext ctx, ProgressToken progressToken, WeatherService weatherService, String city)
             throws Exception {
         ctx.notifications().progress(progressToken, 0.1, 1.0, "Fetching weather for " + city);
         var weather = weatherService.currentWeather(city);

--- a/examples/weather/src/main/java/com/example/weather/WeatherServer.java
+++ b/examples/weather/src/main/java/com/example/weather/WeatherServer.java
@@ -76,14 +76,14 @@ public final class WeatherServer {
                                 .description("Weather prediction article")
                                 .mimeType("text/markdown"),
                     ResourceHandler.of((ctx, uri) ->
-                        TextResourceContents.of(uri, "text/markdown", weatherService.predictionArticle())))
+                        TextResourceContents.of(uri, weatherService.predictionArticle(), "text/markdown")))
                 .asyncResource(
                         resource -> resource.name("featured-current-weather")
                                 .uri("weather://featured/current")
                                 .description("Current weather in Tallinn")
                                 .mimeType("application/json"),
                     ResourceHandler.ofAsync((ctx, uri) -> weatherService.currentWeatherAsync("Tallinn")
-                        .thenApply(weather -> TextResourceContents.of(uri, "application/json", asJson(weather)))))
+                        .thenApply(weather -> TextResourceContents.of(uri, asJson(weather), "application/json"))))
                 .prompt(
                         prompt -> prompt.name("rewrite-forecast")
                                 .description("Rewrites a weather forecast in a chosen style")
@@ -143,7 +143,7 @@ public final class WeatherServer {
             Map<String, UriTemplateValue> params) {
         var city = ((UriTemplateValue.Scalar) params.get("city")).value();
         try {
-            return TextResourceContents.of(uri, "application/json", asJson(weatherService.currentWeather(city)));
+            return TextResourceContents.of(uri, asJson(weatherService.currentWeather(city)), "application/json");
         } catch (CityNotFoundException e) {
             throw new InvalidArgumentException("city", e.getMessage());
         } catch (Exception e) {

--- a/examples/weather/src/test/java/com/example/weather/GetWeatherToolTest.java
+++ b/examples/weather/src/test/java/com/example/weather/GetWeatherToolTest.java
@@ -12,6 +12,7 @@ import dev.tachyonmcp.runtime.ContextNotifications;
 import dev.tachyonmcp.runtime.InteractionContext;
 import dev.tachyonmcp.server.domain.Args;
 import dev.tachyonmcp.server.domain.LoggingLevel;
+import dev.tachyonmcp.server.domain.ProgressToken;
 import dev.tachyonmcp.server.features.HandlerFutures;
 import dev.tachyonmcp.server.features.tools.ToolHandler;
 import dev.tachyonmcp.server.features.tools.ToolRequest;
@@ -80,13 +81,20 @@ class GetWeatherToolTest {
 
     private static final ContextNotifications NOOP_NOTIFICATIONS = new ContextNotifications() {
         @Override
-        public void log(LoggingLevel level, @Nullable String logger, @Nullable Object data) {}
+        public void log(LoggingLevel level, @Nullable String logger, @Nullable Object data) {
+            //noop
+        }
+
 
         @Override
-        public void progress(@Nullable Object progressToken, double progress, double total, String message) {}
+        public void progress(@Nullable ProgressToken progressToken, double progress, double total, String message) {
+            //noop
+        }
 
         @Override
-        public void comment(@Nullable String message) {}
+        public void comment(@Nullable String message) {
+            //noop
+        }
     };
 
     private static InteractionContext context(String response, AtomicReference<@Nullable String> method) {

--- a/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/config/ToolScope.kt
+++ b/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/config/ToolScope.kt
@@ -5,13 +5,16 @@ package dev.tachyonmcp.server.config
 import dev.tachyonmcp.runtime.InteractionContext
 import dev.tachyonmcp.server.TachyonDsl
 import dev.tachyonmcp.server.domain.Args
+import dev.tachyonmcp.server.features.tools.ToolRequest
 import dev.tachyonmcp.server.features.tools.ToolResult
 
 @TachyonDsl
 public class ToolScope
     internal constructor(
         public val ctx: InteractionContext,
+        @Deprecated("Use request instead", ReplaceWith("request.arguments()"))
         public val args: Args,
+        public val request: ToolRequest,
     )
 
 /**

--- a/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/domain/ResourceFactories.kt
+++ b/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/domain/ResourceFactories.kt
@@ -23,7 +23,7 @@ public fun TextResourceContents(
     text: String,
     mimeType: String? = null,
     meta: Map<String, JsonNode>? = null,
-): TextResourceContents = TextResourceContents.of(uri, mimeType, text, meta)
+): TextResourceContents = TextResourceContents.of(uri, text, mimeType, meta)
 
 /**
  * Creates [TextResourceContents] using a kotlinx-serialization metadata map.
@@ -37,7 +37,7 @@ public fun TextResourceContents(
     text: String,
     mimeType: String? = null,
     meta: Map<String, JsonObject>?,
-): TextResourceContents = TextResourceContents.of(uri, mimeType, text, meta?.toJacksonNodeMap())
+): TextResourceContents = TextResourceContents.of(uri, text, mimeType, meta?.toJacksonNodeMap())
 
 /**
  * Creates [BlobResourceContents] — binary resource data encoded as base64.
@@ -53,7 +53,7 @@ public fun BlobResourceContents(
     blob: String,
     mimeType: String? = null,
     meta: Map<String, JsonNode> = emptyMap(),
-): BlobResourceContents = BlobResourceContents.of(uri, mimeType, blob, meta)
+): BlobResourceContents = BlobResourceContents.of(uri, blob, mimeType, meta)
 
 /**
  * Creates [BlobResourceContents] using a kotlinx-serialization metadata map.
@@ -67,4 +67,4 @@ public fun BlobResourceContents(
     blob: String,
     mimeType: String? = null,
     meta: Map<String, JsonObject>,
-): BlobResourceContents = BlobResourceContents.of(uri, mimeType, blob, meta.toJacksonNodeMap())
+): BlobResourceContents = BlobResourceContents.of(uri, blob, mimeType, meta.toJacksonNodeMap())

--- a/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/features/tools/ToolHandlerFactory.kt
+++ b/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/features/tools/ToolHandlerFactory.kt
@@ -26,7 +26,11 @@ internal fun toolHandler(
             request: ToolRequest,
         ): ToolResult =
             runSuspendHandler(coroutineName) {
-                ToolScope(context, request.arguments()).block()
+                ToolScope(
+                    ctx = context,
+                    args = request.arguments(),
+                    request = request,
+                ).block()
             }
     }
 }

--- a/tachyon-server-kotlin/src/test/kotlin/dev/tachyonmcp/server/KotlinApiTest.kt
+++ b/tachyon-server-kotlin/src/test/kotlin/dev/tachyonmcp/server/KotlinApiTest.kt
@@ -13,8 +13,8 @@ import dev.tachyonmcp.server.domain.double
 import dev.tachyonmcp.server.domain.doubleOrNull
 import dev.tachyonmcp.server.domain.int
 import dev.tachyonmcp.server.domain.intOrNull
-import dev.tachyonmcp.server.domain.stringOrNull
 import dev.tachyonmcp.server.features.tools.Args
+import dev.tachyonmcp.server.features.tools.ToolRequest
 import dev.tachyonmcp.server.features.tools.ToolResult
 import dev.tachyonmcp.server.internal.ServerEngine
 import dev.tachyonmcp.server.json.KxSerializationSerde
@@ -280,7 +280,14 @@ internal class KotlinApiTest {
         val value = GreetingArgs("Charlie", 25)
         TachyonServer.builder().build().use { server ->
             val ctx = DefaultDispatchContext.stateless(server as ServerEngine)
-            val scope = ToolScope(ctx, Args(raw = null))
+            val args = Args(raw = null)
+            val request =
+                ToolRequest
+                    .builder()
+                    .name("greet")
+                    .arguments(args)
+                    .build()
+            val scope = ToolScope(ctx, args = args, request = request)
             val result = scope.success(value)
             result.shouldBeInstanceOf<ToolResult.Success>()
             result.structured().get() shouldBe value
@@ -292,7 +299,14 @@ internal class KotlinApiTest {
         val value = GreetingArgs("Dave", 50)
         TachyonServer.builder().build().use { server ->
             val ctx = DefaultDispatchContext.stateless(server as ServerEngine)
-            val scope = ToolScope(ctx, Args(raw = null))
+            val args = Args(raw = null)
+            val request =
+                ToolRequest
+                    .builder()
+                    .name("greet")
+                    .arguments(args)
+                    .build()
+            val scope = ToolScope(ctx, args = args, request = request)
             val result = scope.success(value, "custom text")
             result.shouldBeInstanceOf<ToolResult.Success>()
             result.structured().get() shouldBe value

--- a/tachyon-server/src/main/java/dev/tachyonmcp/protocol/mcp/v2025_11_25/codecs/McpToolMapper.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/protocol/mcp/v2025_11_25/codecs/McpToolMapper.java
@@ -137,9 +137,9 @@ final class McpToolMapper {
         if (protocol == null) return null;
         return switch (protocol) {
             case dev.tachyonmcp.protocol.mcp.v2025_11_25.models.TextResourceContents t ->
-                TextResourceContents.of(t.uri(), t.mimeType(), t.text(), t._meta());
+                TextResourceContents.of(t.uri(), t.text(), t.mimeType(), t._meta());
             case dev.tachyonmcp.protocol.mcp.v2025_11_25.models.BlobResourceContents b ->
-                BlobResourceContents.of(b.uri(), b.mimeType(), b.blob(), b._meta());
+                BlobResourceContents.of(b.uri(), b.blob(), b.mimeType(), b._meta());
         };
     }
 

--- a/tachyon-server/src/main/java/dev/tachyonmcp/protocol/mcp/v2026_07_28/transport/RequestValidationHandler.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/protocol/mcp/v2026_07_28/transport/RequestValidationHandler.java
@@ -7,6 +7,7 @@ package dev.tachyonmcp.protocol.mcp.v2026_07_28.transport;
 import dev.tachyonmcp.protocol.mcp.McpHeaderNames;
 import dev.tachyonmcp.protocol.mcp.v2026_07_28.McpProtocol;
 import dev.tachyonmcp.runtime.InteractionContext;
+import dev.tachyonmcp.server.domain.RequestId;
 import dev.tachyonmcp.server.domain.ServerError;
 import dev.tachyonmcp.server.domain.ServerErrors;
 import dev.tachyonmcp.server.internal.ServerEngine;
@@ -211,7 +212,7 @@ public final class RequestValidationHandler extends ChannelInboundHandlerAdapter
         };
     }
 
-    private void reject(ChannelHandlerContext ctx, FullHttpRequest req, Object id, ServerError error) {
+    private void reject(ChannelHandlerContext ctx, FullHttpRequest req, RequestId id, ServerError error) {
         InteractionContext interaction = ChannelHandlerUtils.requireInteractionContext(ctx);
         var wireError = interaction.protocol().responseMapper().error(error);
         var body = JsonRpcCodec.serializeError(id, wireError.code(), wireError.message(), wireError.data());

--- a/tachyon-server/src/main/java/dev/tachyonmcp/runtime/ContextNotifications.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/runtime/ContextNotifications.java
@@ -5,6 +5,7 @@
 package dev.tachyonmcp.runtime;
 
 import dev.tachyonmcp.annotations.ExperimentalApi;
+import dev.tachyonmcp.server.domain.ProgressToken;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -25,7 +26,7 @@ public interface ContextNotifications extends Notifications {
      * into progress, so the notification is silently dropped per the MCP spec — handlers may emit
      * progress unconditionally without null-checking the token.
      */
-    void progress(@Nullable Object progressToken, double progress, double total, String message);
+    void progress(@Nullable ProgressToken progressToken, double progress, double total, String message);
 
     /**
      * Sends a raw SSE comment line ({@code : message}) on the response stream, upgrading a buffered

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/DefaultTachyonServer.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/DefaultTachyonServer.java
@@ -15,6 +15,7 @@ import dev.tachyonmcp.runtime.SessionState;
 import dev.tachyonmcp.runtime.SseEvent;
 import dev.tachyonmcp.server.config.ServerConfig;
 import dev.tachyonmcp.server.domain.LoggingLevel;
+import dev.tachyonmcp.server.domain.RequestId;
 import dev.tachyonmcp.server.extensions.ServerExtension;
 import dev.tachyonmcp.server.features.completions.Completions;
 import dev.tachyonmcp.server.features.completions.DefaultCompletionRegistry;
@@ -82,7 +83,7 @@ final class DefaultTachyonServer implements ServerEngine {
     private final DefaultCompletionRegistry completionRegistry;
     private final Map<String, RpcMethodHandler> methodHandlers = new ConcurrentHashMap<>();
     final Map<String, LoggingLevel> loggingLevels = new ConcurrentHashMap<>();
-    final ConcurrentHashMap<Object, CompletableFuture<String>> pendingRequests = new ConcurrentHashMap<>();
+    final ConcurrentHashMap<RequestId, CompletableFuture<String>> pendingRequests = new ConcurrentHashMap<>();
     private final ExecutorService executor;
     private final boolean ownsExecutor;
     private final List<ServerExtension> extensions;
@@ -527,7 +528,7 @@ final class DefaultTachyonServer implements ServerEngine {
     public CompletableFuture<String> sendRequest(
             Session session, String method, Object params, @Nullable OutboundSseStream stream) {
         final var paramsStr = JsonRpcCodec.toJsonParams(params);
-        final var requestId = UUID.randomUUID().toString();
+        final var requestId = RequestId.of(UUID.randomUUID().toString());
         final var future = new CompletableFuture<String>();
         registerPendingRequest(requestId, future);
 
@@ -557,7 +558,7 @@ final class DefaultTachyonServer implements ServerEngine {
     }
 
     @Override
-    public boolean completePendingRequest(@Nullable Object requestId, String resultJson) {
+    public boolean completePendingRequest(@Nullable RequestId requestId, String resultJson) {
         // ConcurrentHashMap#remove throws NPE on a null key; a null id (malformed client
         // response, no JSON-RPC id) can never match a pending request, since registered ids are
         // always server-generated and non-null.
@@ -573,7 +574,7 @@ final class DefaultTachyonServer implements ServerEngine {
     }
 
     @Override
-    public boolean failPendingRequest(@Nullable Object requestId, String message) {
+    public boolean failPendingRequest(@Nullable RequestId requestId, String message) {
         if (requestId == null) {
             return false;
         }
@@ -586,7 +587,7 @@ final class DefaultTachyonServer implements ServerEngine {
     }
 
     @Override
-    public void registerPendingRequest(Object requestId, CompletableFuture<String> future) {
+    public void registerPendingRequest(RequestId requestId, CompletableFuture<String> future) {
         pendingRequests.put(requestId, future);
         var timeout = config.runtime().requestTimeout();
         future.orTimeout(timeout.toMillis(), TimeUnit.MILLISECONDS);

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/HandlerWatchdog.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/HandlerWatchdog.java
@@ -5,6 +5,7 @@
 package dev.tachyonmcp.server;
 
 import dev.tachyonmcp.annotations.InternalApi;
+import dev.tachyonmcp.server.domain.RequestId;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -39,14 +40,14 @@ public final class HandlerWatchdog {
      * When debug logging is disabled the output can never be seen, so no timer is scheduled at
      * all — avoids per-request schedule/cancel churn on the single timer thread.
      */
-    public static Future<?> watch(Object method, Object id, long startNs, long delayMs) {
+    public static Future<?> watch(Object method, RequestId id, long startNs, long delayMs) {
         if (!logger.isDebugEnabled()) {
             return NOOP;
         }
         return SCHEDULER.schedule(() -> fire(method, id, startNs), delayMs, TimeUnit.MILLISECONDS);
     }
 
-    private static void fire(Object method, Object id, long startNs) {
+    private static void fire(Object method, RequestId id, long startNs) {
         var elapsedMs = (System.nanoTime() - startNs) / 1_000_000;
         logger.debug("Handler slow: method={}, id={}, elapsed={}ms", method, id, elapsedMs);
     }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/McpDispatcher.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/McpDispatcher.java
@@ -13,6 +13,7 @@ import dev.tachyonmcp.runtime.InteractionContext;
 import dev.tachyonmcp.runtime.Session;
 import dev.tachyonmcp.runtime.SessionState;
 import dev.tachyonmcp.server.domain.LoggingLevel;
+import dev.tachyonmcp.server.domain.RequestId;
 import dev.tachyonmcp.server.domain.ServerError;
 import dev.tachyonmcp.server.domain.ServerErrors;
 import dev.tachyonmcp.server.features.tasks.TaskState;
@@ -146,12 +147,12 @@ public class McpDispatcher {
     }
 
     public CompletableFuture<DispatchResult> dispatchRequestAsync(
-            Object id, String method, Object params, @Nullable String sessionId) {
+            RequestId id, String method, Object params, @Nullable String sessionId) {
         return dispatchRequestAsync(id, method, params, sessionId, null, null);
     }
 
     public CompletableFuture<DispatchResult> dispatchRequestAsync(
-            Object id,
+            RequestId id,
             String method,
             Object params,
             @Nullable String sessionId,
@@ -226,7 +227,7 @@ public class McpDispatcher {
     }
 
     private CompletableFuture<DispatchResult> invokeHandlerAsync(
-            Object id,
+            RequestId id,
             String method,
             Object params,
             @Nullable OutboundSseStream outboundSseStream,
@@ -289,7 +290,7 @@ public class McpDispatcher {
                 });
     }
 
-    private DispatchResult handleHandlerError(Object id, String method, Throwable ex, DispatchContext context) {
+    private DispatchResult handleHandlerError(RequestId id, String method, Throwable ex, DispatchContext context) {
         var unwrapped = ex instanceof CompletionException ce && ce.getCause() != null ? ce.getCause() : ex;
         if (unwrapped instanceof CancellationException) {
             logger.debug("Handler cancelled: method={}, id={}", method, id);
@@ -300,7 +301,7 @@ public class McpDispatcher {
     }
 
     private DispatchResult handleSuccessOrError(
-            Object id, String method, Object result, @Nullable String sessionId, DispatchContext context) {
+            RequestId id, String method, Object result, @Nullable String sessionId, DispatchContext context) {
         if (result instanceof ServerError error) {
             logger.debug("Handler error for {}: {}", method, error.message());
             return errorResult(id, error, context);
@@ -342,10 +343,10 @@ public class McpDispatcher {
     }
 
     private void handleCancellation(@Nullable Object params, @Nullable String sessionId) {
-        Object rawRequestId = null;
+        RequestId rawRequestId = null;
         String rawReason = null;
         if (params instanceof Map<?, ?> map) {
-            rawRequestId = map.get("requestId");
+            rawRequestId = RequestId.ofNullable(map.get("requestId"));
             var r = map.get("reason");
             rawReason = r instanceof String s ? s : null;
         }
@@ -427,7 +428,7 @@ public class McpDispatcher {
     }
 
     private CompletableFuture<DispatchResult> dispatchInitializeAsync(
-            Object id, Object rawParams, DispatchContext ic, @Nullable ChannelContext channelContext) {
+            RequestId id, Object rawParams, DispatchContext ic, @Nullable ChannelContext channelContext) {
         logger.debug("Client initialize: id={} stateless={}", id, server.isStateless());
         var handler = server.getHandler("initialize");
         if (handler == null) {
@@ -460,13 +461,13 @@ public class McpDispatcher {
                 });
     }
 
-    private DispatchResult errorResult(Object id, ServerError error, DispatchContext context) {
+    private DispatchResult errorResult(RequestId id, ServerError error, DispatchContext context) {
         var wireError = context.responseMapper().error(error);
         var body = JsonRpcCodec.serializeError(id, wireError.code(), wireError.message(), wireError.data());
         return new DispatchResult.Response(body, null, wireError.httpStatus());
     }
 
-    private static byte[] encodeResponse(Object id, Object result, ProtocolResponseMapper mapper) {
+    private static byte[] encodeResponse(RequestId id, Object result, ProtocolResponseMapper mapper) {
         if (result instanceof String s) {
             return JsonRpcCodec.serializeResponse(id, s);
         }
@@ -480,7 +481,7 @@ public class McpDispatcher {
         }
     }
 
-    private static byte[] encodeError(@Nullable Object id, ServerError error, ProtocolResponseMapper mapper) {
+    private static byte[] encodeError(@Nullable RequestId id, ServerError error, ProtocolResponseMapper mapper) {
         var wireError = mapper.error(error);
         return JsonRpcCodec.serializeError(id, wireError.code(), wireError.message(), wireError.data());
     }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/McpDispatcher.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/McpDispatcher.java
@@ -346,7 +346,12 @@ public class McpDispatcher {
         RequestId rawRequestId = null;
         String rawReason = null;
         if (params instanceof Map<?, ?> map) {
-            rawRequestId = RequestId.ofNullable(map.get("requestId"));
+            var rawId = map.get("requestId");
+            if (rawId != null && !(rawId instanceof CharSequence) && !(rawId instanceof Number)) {
+                logger.debug("Cancellation notification has invalid requestId: {}", rawId);
+                return;
+            }
+            rawRequestId = RequestId.ofNullable(rawId);
             var r = map.get("reason");
             rawReason = r instanceof String s ? s : null;
         }
@@ -366,7 +371,7 @@ public class McpDispatcher {
                             var reasonMsg = finalReason != null ? ": " + finalReason : "";
                             var cancelled = server.failPendingRequest(finalRequestId, "Cancelled" + reasonMsg);
                             if (cancelled) {
-                                logger.info(
+                                logger.debug(
                                         "Cancelled pending request: requestId={}, sessionId={}, reason={}",
                                         finalRequestId,
                                         sessionId,

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/domain/BlobResourceContents.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/domain/BlobResourceContents.java
@@ -17,13 +17,25 @@ import tools.jackson.databind.JsonNode;
  * base64-encoded data.
  */
 @Value.Immutable
-@Value.Style(
-        allParameters = true,
-        visibility = Value.Style.ImplementationVisibility.PACKAGE,
-        typeImmutable = "Default*")
+@Value.Style(visibility = Value.Style.ImplementationVisibility.PACKAGE, typeImmutable = "Default*")
 public non-sealed interface BlobResourceContents extends ResourceContents {
 
+    @Override
+    @Value.Parameter(order = 1)
+    String uri();
+
+    @Override
+    @Nullable
+    @Value.Parameter(order = 2)
+    String mimeType();
+
+    @Value.Parameter(order = 3)
     String blob();
+
+    @Override
+    @Nullable
+    @Value.Parameter(order = 4)
+    Map<String, JsonNode> meta();
 
     @Value.Check
     default void check() {
@@ -31,12 +43,12 @@ public non-sealed interface BlobResourceContents extends ResourceContents {
         if (blob().isBlank()) throw new IllegalArgumentException("blob must not be blank");
     }
 
-    static BlobResourceContents of(String uri, @Nullable String mimeType, String blob) {
-        return DefaultBlobResourceContents.of(null, uri, mimeType, blob);
+    static BlobResourceContents of(String uri, String blob, @Nullable String mimeType) {
+        return DefaultBlobResourceContents.of(uri, mimeType, blob, null);
     }
 
-    static BlobResourceContents of(String uri, @Nullable String mimeType, String blob, Map<String, JsonNode> meta) {
-        return DefaultBlobResourceContents.of(meta, uri, mimeType, blob);
+    static BlobResourceContents of(String uri, String blob, @Nullable String mimeType, Map<String, JsonNode> meta) {
+        return DefaultBlobResourceContents.of(uri, mimeType, blob, meta);
     }
 
     static Builder builder() {
@@ -44,13 +56,13 @@ public non-sealed interface BlobResourceContents extends ResourceContents {
     }
 
     interface Builder {
-        Builder meta(@Nullable Map<String, ? extends JsonNode> entries);
-
         Builder uri(String uri);
+
+        Builder blob(String blob);
 
         Builder mimeType(@Nullable String mimeType);
 
-        Builder blob(String blob);
+        Builder meta(@Nullable Map<String, ? extends JsonNode> entries);
 
         BlobResourceContents build();
     }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/domain/BlobResourceContents.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/domain/BlobResourceContents.java
@@ -43,11 +43,27 @@ public non-sealed interface BlobResourceContents extends ResourceContents {
         if (blob().isBlank()) throw new IllegalArgumentException("blob must not be blank");
     }
 
+    /**
+     * Creates binary resource contents with no {@code _meta}.
+     *
+     * @param uri      the resource URI
+     * @param blob     the base64-encoded binary content
+     * @param mimeType the content's MIME type, or {@code null} if unspecified
+     */
     static BlobResourceContents of(String uri, String blob, @Nullable String mimeType) {
         return DefaultBlobResourceContents.of(uri, mimeType, blob, null);
     }
 
-    static BlobResourceContents of(String uri, String blob, @Nullable String mimeType, Map<String, JsonNode> meta) {
+    /**
+     * Creates binary resource contents.
+     *
+     * @param uri      the resource URI
+     * @param blob     the base64-encoded binary content
+     * @param mimeType the content's MIME type, or {@code null} if unspecified
+     * @param meta     the {@code _meta} entries, or {@code null} if none
+     */
+    static BlobResourceContents of(
+            String uri, String blob, @Nullable String mimeType, @Nullable Map<String, JsonNode> meta) {
         return DefaultBlobResourceContents.of(uri, mimeType, blob, meta);
     }
 

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/domain/ProgressToken.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/domain/ProgressToken.java
@@ -1,7 +1,17 @@
+/*
+ * Copyright (c) 2026 Konstantin Pavlov and contributors.
+ */
+
 package dev.tachyonmcp.server.domain;
 
+/**
+ * An MCP progress token: an opaque value the client attaches to a request via
+ * {@code _meta.progressToken} and the server echoes back on {@code notifications/progress}. Per
+ * the MCP spec, a progress token is a bare JSON string or number — never an object or array.
+ */
 public sealed interface ProgressToken permits ProgressToken.StringValue, ProgressToken.NumericValue {
 
+    /** A progress token carrying a string value. */
     record StringValue(java.lang.String value) implements ProgressToken {
         @Override
         public String toString() {
@@ -9,6 +19,7 @@ public sealed interface ProgressToken permits ProgressToken.StringValue, Progres
         }
     }
 
+    /** A progress token carrying a numeric value. */
     record NumericValue(Number value) implements ProgressToken {
         @Override
         public String toString() {
@@ -16,6 +27,14 @@ public sealed interface ProgressToken permits ProgressToken.StringValue, Progres
         }
     }
 
+    /**
+     * Wraps a raw value as a {@link ProgressToken}.
+     *
+     * @param value a {@link CharSequence} or {@link Number}
+     * @return the wrapped token
+     * @throws IllegalArgumentException if {@code value} is neither a {@link CharSequence} nor a
+     *                                  {@link Number}
+     */
     static ProgressToken of(Object value) {
         if (value instanceof CharSequence str) {
             return new StringValue(str.toString());

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/domain/ProgressToken.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/domain/ProgressToken.java
@@ -1,0 +1,28 @@
+package dev.tachyonmcp.server.domain;
+
+public sealed interface ProgressToken permits ProgressToken.StringValue, ProgressToken.NumericValue {
+
+    record StringValue(java.lang.String value) implements ProgressToken {
+        @Override
+        public String toString() {
+            return value;
+        }
+    }
+
+    record NumericValue(Number value) implements ProgressToken {
+        @Override
+        public String toString() {
+            return value.toString();
+        }
+    }
+
+    static ProgressToken of(Object value) {
+        if (value instanceof CharSequence str) {
+            return new StringValue(str.toString());
+        } else if (value instanceof Number number) {
+            return new NumericValue(number);
+        } else {
+            throw new IllegalArgumentException("String or numeric value expected");
+        }
+    }
+}

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/domain/RequestId.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/domain/RequestId.java
@@ -1,9 +1,18 @@
+/*
+ * Copyright (c) 2026 Konstantin Pavlov and contributors.
+ */
+
 package dev.tachyonmcp.server.domain;
 
 import org.jspecify.annotations.Nullable;
 
+/**
+ * A JSON-RPC 2.0 request/response id: a bare JSON string or number, never an object or array. See
+ * {@link #of(Object)} and {@link #ofNullable(Object)} for how raw wire values map to this type.
+ */
 public sealed interface RequestId permits RequestId.StringValue, RequestId.NumericValue {
 
+    /** An id carrying a string value. */
     record StringValue(java.lang.String value) implements RequestId {
         @Override
         public String toString() {
@@ -11,6 +20,7 @@ public sealed interface RequestId permits RequestId.StringValue, RequestId.Numer
         }
     }
 
+    /** An id carrying a numeric value. */
     record NumericValue(Number value) implements RequestId {
         @Override
         public String toString() {
@@ -18,6 +28,14 @@ public sealed interface RequestId permits RequestId.StringValue, RequestId.Numer
         }
     }
 
+    /**
+     * Wraps a raw value as a {@link RequestId}.
+     *
+     * @param value a {@link CharSequence} or {@link Number}
+     * @return the wrapped id
+     * @throws IllegalArgumentException if {@code value} is neither a {@link CharSequence} nor a
+     *                                  {@link Number}
+     */
     static RequestId of(Object value) {
         if (value instanceof CharSequence str) {
             return new RequestId.StringValue(str.toString());
@@ -28,6 +46,15 @@ public sealed interface RequestId permits RequestId.StringValue, RequestId.Numer
         }
     }
 
+    /**
+     * Wraps a raw value as a {@link RequestId}, passing through {@code null} — for the JSON-RPC
+     * {@code id} field, which is legitimately absent on notifications and some error responses.
+     *
+     * @param value a {@link CharSequence}, {@link Number}, or {@code null}
+     * @return the wrapped id, or {@code null} if {@code value} was {@code null}
+     * @throws IllegalArgumentException if {@code value} is non-null and neither a
+     *                                  {@link CharSequence} nor a {@link Number}
+     */
     static @Nullable RequestId ofNullable(@Nullable Object value) {
         if (value == null) {
             return null;

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/domain/RequestId.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/domain/RequestId.java
@@ -1,0 +1,37 @@
+package dev.tachyonmcp.server.domain;
+
+import org.jspecify.annotations.Nullable;
+
+public sealed interface RequestId permits RequestId.StringValue, RequestId.NumericValue {
+
+    record StringValue(java.lang.String value) implements RequestId {
+        @Override
+        public String toString() {
+            return value;
+        }
+    }
+
+    record NumericValue(Number value) implements RequestId {
+        @Override
+        public String toString() {
+            return value.toString();
+        }
+    }
+
+    static RequestId of(Object value) {
+        if (value instanceof CharSequence str) {
+            return new RequestId.StringValue(str.toString());
+        } else if (value instanceof Number number) {
+            return new RequestId.NumericValue(number);
+        } else {
+            throw new IllegalArgumentException("String or numeric value expected");
+        }
+    }
+
+    static @Nullable RequestId ofNullable(@Nullable Object value) {
+        if (value == null) {
+            return null;
+        }
+        return of(value);
+    }
+}

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/domain/TextResourceContents.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/domain/TextResourceContents.java
@@ -17,13 +17,25 @@ import tools.jackson.databind.JsonNode;
  * format (e.g. {@code application/json}, {@code text/markdown}).
  */
 @Value.Immutable
-@Value.Style(
-        allParameters = true,
-        visibility = Value.Style.ImplementationVisibility.PACKAGE,
-        typeImmutable = "Default*")
+@Value.Style(visibility = Value.Style.ImplementationVisibility.PACKAGE, typeImmutable = "Default*")
 public non-sealed interface TextResourceContents extends ResourceContents {
 
+    @Override
+    @Value.Parameter(order = 1)
+    String uri();
+
+    @Override
+    @Nullable
+    @Value.Parameter(order = 2)
+    String mimeType();
+
+    @Value.Parameter(order = 3)
     String text();
+
+    @Override
+    @Nullable
+    @Value.Parameter(order = 4)
+    Map<String, JsonNode> meta();
 
     @Value.Check
     default void check() {
@@ -35,23 +47,23 @@ public non-sealed interface TextResourceContents extends ResourceContents {
         return DefaultTextResourceContents.builder();
     }
 
-    static TextResourceContents of(String uri, @Nullable String mimeType, String text) {
-        return DefaultTextResourceContents.of(null, uri, mimeType, text);
+    static TextResourceContents of(String uri, String text, @Nullable String mimeType) {
+        return DefaultTextResourceContents.of(uri, mimeType, text, null);
     }
 
     static TextResourceContents of(
-            String uri, @Nullable String mimeType, String text, @Nullable Map<String, JsonNode> meta) {
-        return DefaultTextResourceContents.of(meta, uri, mimeType, text);
+            String uri, String text, @Nullable String mimeType, @Nullable Map<String, JsonNode> meta) {
+        return DefaultTextResourceContents.of(uri, mimeType, text, meta);
     }
 
     interface Builder {
-        Builder meta(@Nullable Map<String, ? extends JsonNode> entries);
-
         Builder uri(String uri);
+
+        Builder text(String text);
 
         Builder mimeType(@Nullable String mimeType);
 
-        Builder text(String text);
+        Builder meta(@Nullable Map<String, ? extends JsonNode> entries);
 
         TextResourceContents build();
     }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/domain/TextResourceContents.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/domain/TextResourceContents.java
@@ -47,10 +47,25 @@ public non-sealed interface TextResourceContents extends ResourceContents {
         return DefaultTextResourceContents.builder();
     }
 
+    /**
+     * Creates text resource contents with no {@code _meta}.
+     *
+     * @param uri      the resource URI
+     * @param text     the text content
+     * @param mimeType the content's MIME type, or {@code null} if unspecified
+     */
     static TextResourceContents of(String uri, String text, @Nullable String mimeType) {
         return DefaultTextResourceContents.of(uri, mimeType, text, null);
     }
 
+    /**
+     * Creates text resource contents.
+     *
+     * @param uri      the resource URI
+     * @param text     the text content
+     * @param mimeType the content's MIME type, or {@code null} if unspecified
+     * @param meta     the {@code _meta} entries, or {@code null} if none
+     */
     static TextResourceContents of(
             String uri, String text, @Nullable String mimeType, @Nullable Map<String, JsonNode> meta) {
         return DefaultTextResourceContents.of(uri, mimeType, text, meta);

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tasks/DefaultTaskRegistry.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tasks/DefaultTaskRegistry.java
@@ -10,6 +10,7 @@ import dev.tachyonmcp.protocol.ProtocolResponseMapper;
 import dev.tachyonmcp.protocol.mcp.v2025_11_25.McpProtocol;
 import dev.tachyonmcp.server.RpcMethodHandler;
 import dev.tachyonmcp.server.config.TasksConfig;
+import dev.tachyonmcp.server.domain.ProgressToken;
 import dev.tachyonmcp.server.domain.ServerErrors;
 import dev.tachyonmcp.server.domain.Task;
 import dev.tachyonmcp.server.domain.TaskResult;
@@ -98,7 +99,7 @@ public class DefaultTaskRegistry extends AbstractRegistry<TaskDescriptor, TaskEn
             @Nullable Duration ttl,
             @Nullable Map<String, JsonNode> meta,
             @Nullable String sessionId,
-            @Nullable Object progressToken) {
+            @Nullable ProgressToken progressToken) {
         return createTask(null, ttl, meta, sessionId, progressToken, defaultKeepAlive, defaultPollInterval);
     }
 
@@ -107,7 +108,7 @@ public class DefaultTaskRegistry extends AbstractRegistry<TaskDescriptor, TaskEn
             @Nullable Duration ttl,
             @Nullable Map<String, JsonNode> meta,
             @Nullable String sessionId,
-            @Nullable Object progressToken,
+            @Nullable ProgressToken progressToken,
             Duration keepAlive,
             @Nullable Duration pollInterval) {
         var id = requestedId != null ? requestedId : taskIdGenerator.generateTaskId(meta, sessionId);

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tasks/TaskEntry.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tasks/TaskEntry.java
@@ -9,6 +9,7 @@ import dev.tachyonmcp.server.ServerFeature;
 import dev.tachyonmcp.server.config.TasksConfig;
 import dev.tachyonmcp.server.domain.ContentBlock;
 import dev.tachyonmcp.server.domain.InputRequest;
+import dev.tachyonmcp.server.domain.ProgressToken;
 import dev.tachyonmcp.server.domain.Task;
 import dev.tachyonmcp.server.domain.TaskResult;
 import dev.tachyonmcp.server.domain.TextContent;
@@ -40,7 +41,7 @@ public class TaskEntry implements ServerFeature<TaskDescriptor>, Task {
     private volatile long expiredAt;
     private volatile @Nullable String statusMessage;
     private final CompletableFuture<TaskResult> completionFuture = new CompletableFuture<>();
-    private final @Nullable Object progressToken;
+    private final @Nullable ProgressToken progressToken;
     private final Consumer<TaskEntry> statusListener;
 
     TaskEntry(String id) {
@@ -85,7 +86,7 @@ public class TaskEntry implements ServerFeature<TaskDescriptor>, Task {
             TaskState status,
             @Nullable Duration ttl,
             @Nullable String sessionId,
-            @Nullable Object progressToken) {
+            @Nullable ProgressToken progressToken) {
         this(descriptor, id, status, ttl, sessionId, progressToken, null, TasksConfig.DEFAULT_TASK_KEEP_ALIVE);
     }
 
@@ -95,7 +96,7 @@ public class TaskEntry implements ServerFeature<TaskDescriptor>, Task {
             TaskState status,
             @Nullable Duration ttl,
             @Nullable String sessionId,
-            @Nullable Object progressToken,
+            @Nullable ProgressToken progressToken,
             @Nullable Map<String, JsonNode> meta) {
         this(descriptor, id, status, ttl, sessionId, progressToken, meta, TasksConfig.DEFAULT_TASK_KEEP_ALIVE);
     }
@@ -106,7 +107,7 @@ public class TaskEntry implements ServerFeature<TaskDescriptor>, Task {
             TaskState status,
             @Nullable Duration ttl,
             @Nullable String sessionId,
-            @Nullable Object progressToken,
+            @Nullable ProgressToken progressToken,
             @Nullable Map<String, JsonNode> meta,
             Duration keepAlive) {
         this(descriptor, id, status, ttl, sessionId, progressToken, meta, keepAlive, null);
@@ -118,7 +119,7 @@ public class TaskEntry implements ServerFeature<TaskDescriptor>, Task {
             TaskState status,
             @Nullable Duration ttl,
             @Nullable String sessionId,
-            @Nullable Object progressToken,
+            @Nullable ProgressToken progressToken,
             @Nullable Map<String, JsonNode> meta,
             Duration keepAlive,
             @Nullable Duration pollInterval) {
@@ -136,7 +137,7 @@ public class TaskEntry implements ServerFeature<TaskDescriptor>, Task {
             TaskState status,
             @Nullable Duration ttl,
             @Nullable String sessionId,
-            @Nullable Object progressToken,
+            @Nullable ProgressToken progressToken,
             @Nullable Map<String, JsonNode> meta,
             Duration keepAlive,
             @Nullable Duration pollInterval,
@@ -162,7 +163,7 @@ public class TaskEntry implements ServerFeature<TaskDescriptor>, Task {
         return sessionId;
     }
 
-    public @Nullable Object progressToken() {
+    public @Nullable ProgressToken progressToken() {
         return progressToken;
     }
 

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tasks/TaskRegistry.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tasks/TaskRegistry.java
@@ -5,6 +5,7 @@
 package dev.tachyonmcp.server.features.tasks;
 
 import dev.tachyonmcp.annotations.InternalApi;
+import dev.tachyonmcp.server.domain.ProgressToken;
 import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.Future;
@@ -18,7 +19,7 @@ public interface TaskRegistry extends Tasks {
             @Nullable Duration ttl,
             @Nullable Map<String, JsonNode> meta,
             @Nullable String sessionId,
-            @Nullable Object progressToken);
+            @Nullable ProgressToken progressToken);
 
     void registerRunning(String taskId, Future<?> future);
 

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tasks/TasksExtension.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tasks/TasksExtension.java
@@ -70,7 +70,7 @@ public class TasksExtension implements ServerExtension {
                             var id = params.get("id").scalarValue();
                             var entry = server.tasks().get(id);
                             var text = entry != null ? entry.status().name() : "not_found";
-                            return TextResourceContents.of(uri, "text/plain", text, null);
+                            return TextResourceContents.of(uri, text, "text/plain", null);
                         });
     }
 

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tools/DefaultToolRegistry.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tools/DefaultToolRegistry.java
@@ -21,6 +21,7 @@ import dev.tachyonmcp.server.domain.Args;
 import dev.tachyonmcp.server.domain.InvalidArgumentException;
 import dev.tachyonmcp.server.domain.LoggingLevel;
 import dev.tachyonmcp.server.domain.MissingRequiredClientCapabilityException;
+import dev.tachyonmcp.server.domain.ProgressToken;
 import dev.tachyonmcp.server.domain.TaskResult;
 import dev.tachyonmcp.server.domain.TextContent;
 import dev.tachyonmcp.server.features.AbstractRegistry;
@@ -416,12 +417,11 @@ public class DefaultToolRegistry extends AbstractRegistry<ToolDescriptor, ToolHa
             return context.responseMapper().createTaskResult(task);
         }
 
-        private static @Nullable Object parseProgressToken(@Nullable Map<String, JsonNode> meta) {
+        private static @Nullable ProgressToken parseProgressToken(@Nullable Map<String, JsonNode> meta) {
             if (meta == null) return null;
             var ptNode = meta.get("progressToken");
             if (ptNode == null) return null;
-            if (ptNode.isIntegralNumber()) return ptNode.asLong();
-            return ptNode.asString();
+            return ProgressToken.of(ptNode.isIntegralNumber() ? ptNode.asLong() : ptNode.asString());
         }
 
         private record CallParams(

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tools/DefaultToolRegistry.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tools/DefaultToolRegistry.java
@@ -421,7 +421,9 @@ public class DefaultToolRegistry extends AbstractRegistry<ToolDescriptor, ToolHa
             if (meta == null) return null;
             var ptNode = meta.get("progressToken");
             if (ptNode == null) return null;
-            return ProgressToken.of(ptNode.isIntegralNumber() ? ptNode.asLong() : ptNode.asString());
+            if (ptNode.isString()) return ProgressToken.of(ptNode.asString());
+            if (ptNode.isNumber()) return ProgressToken.of(ptNode.numberValue());
+            return null;
         }
 
         private record CallParams(

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tools/ToolRequest.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tools/ToolRequest.java
@@ -8,6 +8,7 @@ import dev.tachyonmcp.annotations.ExperimentalApi;
 import dev.tachyonmcp.runtime.Cancellation;
 import dev.tachyonmcp.server.domain.Args;
 import dev.tachyonmcp.server.domain.HasMeta;
+import dev.tachyonmcp.server.domain.ProgressToken;
 import dev.tachyonmcp.server.domain.Task;
 import dev.tachyonmcp.server.json.PayloadDeserializer;
 import java.util.Map;
@@ -51,7 +52,7 @@ public interface ToolRequest extends HasMeta {
     PayloadDeserializer payloadDeserializer();
 
     @Nullable
-    Object progressToken();
+    ProgressToken progressToken();
 
     @Nullable
     Cancellation cancellation();
@@ -82,7 +83,7 @@ public interface ToolRequest extends HasMeta {
         @ExperimentalApi
         Builder payloadDeserializer(@Nullable PayloadDeserializer deserializer);
 
-        Builder progressToken(@Nullable Object progressToken);
+        Builder progressToken(@Nullable ProgressToken progressToken);
 
         Builder cancellation(@Nullable Cancellation cancellation);
 

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tools/ToolRequest.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tools/ToolRequest.java
@@ -51,6 +51,10 @@ public interface ToolRequest extends HasMeta {
     @Nullable
     PayloadDeserializer payloadDeserializer();
 
+    /**
+     * The client's {@code _meta.progressToken} from this request, or {@code null} if the client
+     * did not opt into progress notifications for this call.
+     */
     @Nullable
     ProgressToken progressToken();
 
@@ -83,6 +87,7 @@ public interface ToolRequest extends HasMeta {
         @ExperimentalApi
         Builder payloadDeserializer(@Nullable PayloadDeserializer deserializer);
 
+        /** Sets the progress token, or {@code null} to leave progress notifications disabled. */
         Builder progressToken(@Nullable ProgressToken progressToken);
 
         Builder cancellation(@Nullable Cancellation cancellation);

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/internal/ServerEngine.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/internal/ServerEngine.java
@@ -13,6 +13,7 @@ import dev.tachyonmcp.server.RpcMethodHandler;
 import dev.tachyonmcp.server.ServerCapabilities;
 import dev.tachyonmcp.server.TachyonServer;
 import dev.tachyonmcp.server.domain.LoggingLevel;
+import dev.tachyonmcp.server.domain.RequestId;
 import dev.tachyonmcp.server.features.tasks.TaskRegistry;
 import dev.tachyonmcp.server.session.SessionEvent;
 import dev.tachyonmcp.server.session.SessionIdGenerator;
@@ -104,13 +105,13 @@ public interface ServerEngine extends TachyonServer {
             Session session, String method, Object params, @Nullable OutboundSseStream stream);
 
     /** Completes a pending client request with the given result JSON. {@code null} requestId is a no-op. */
-    boolean completePendingRequest(@Nullable Object requestId, String resultJson);
+    boolean completePendingRequest(@Nullable RequestId requestId, String resultJson);
 
     /** Fails a pending client request with the given error message. {@code null} requestId is a no-op. */
-    boolean failPendingRequest(@Nullable Object requestId, String message);
+    boolean failPendingRequest(@Nullable RequestId requestId, String message);
 
     /** Registers a pending request with a timeout. */
-    void registerPendingRequest(Object requestId, CompletableFuture<String> future);
+    void registerPendingRequest(RequestId requestId, CompletableFuture<String> future);
 
     /** Appends an event to the session log. */
     void appendEvent(SessionEvent event);

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/session/DefaultDispatchContext.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/session/DefaultDispatchContext.java
@@ -14,6 +14,7 @@ import dev.tachyonmcp.runtime.Session;
 import dev.tachyonmcp.runtime.SseEvent;
 import dev.tachyonmcp.server.OutboundSseStream;
 import dev.tachyonmcp.server.domain.LoggingLevel;
+import dev.tachyonmcp.server.domain.ProgressToken;
 import dev.tachyonmcp.server.internal.NotificationLogSupport;
 import dev.tachyonmcp.server.internal.ServerEngine;
 import dev.tachyonmcp.transport.jsonrpc.JsonRpcCodec;
@@ -199,13 +200,18 @@ public class DefaultDispatchContext implements DispatchContext {
         }
 
         @Override
-        public void progress(@Nullable Object progressToken, double progress, double total, String message) {
+        public void progress(@Nullable ProgressToken progressToken, double progress, double total, String message) {
             if (progressToken == null) {
                 logger.debug("Dropping progress notification: no progressToken (client did not opt into progress)");
                 return;
             }
+            Object wireToken =
+                    switch (progressToken) {
+                        case ProgressToken.StringValue(var v) -> v;
+                        case ProgressToken.NumericValue(var v) -> v;
+                    };
             var paramsMap = Map.of(
-                    "progressToken", progressToken,
+                    "progressToken", wireToken,
                     "progress", progress,
                     "total", total,
                     "message", message);

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/session/SessionEvent.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/session/SessionEvent.java
@@ -5,6 +5,7 @@
 package dev.tachyonmcp.server.session;
 
 import dev.tachyonmcp.annotations.InternalApi;
+import dev.tachyonmcp.server.domain.RequestId;
 import org.jspecify.annotations.Nullable;
 
 /** A recorded session event — request, response, notification, or cancellation. */
@@ -33,13 +34,13 @@ public sealed interface SessionEvent {
     }
 
     /** An inbound request from the client. */
-    record RequestEvent(String sessionId, Object requestId, String method, String paramsJson, long timestamp)
+    record RequestEvent(String sessionId, RequestId requestId, String method, String paramsJson, long timestamp)
             implements SessionEvent {}
 
     /** An outbound (server-to-client) request. */
     record OutboundRequestEvent(
             String sessionId,
-            Object requestId,
+            RequestId requestId,
             String method,
             String paramsJson,
             long timestamp,
@@ -50,7 +51,7 @@ public sealed interface SessionEvent {
     /** A response sent to the client. */
     record ResponseEvent(
             String sessionId,
-            Object requestId,
+            RequestId requestId,
             String resultJson,
             long timestamp,
             long sseEventId,
@@ -58,7 +59,7 @@ public sealed interface SessionEvent {
             implements SessionEvent {}
 
     /** A cancellation request. */
-    record CancelEvent(String sessionId, Object requestId, long timestamp) implements SessionEvent {}
+    record CancelEvent(String sessionId, RequestId requestId, long timestamp) implements SessionEvent {}
 
     /** A notification sent to or received from the client. */
     record NotificationEvent(

--- a/tachyon-server/src/main/java/dev/tachyonmcp/transport/jsonrpc/JsonRpcCodec.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/transport/jsonrpc/JsonRpcCodec.java
@@ -8,6 +8,7 @@ import static dev.tachyonmcp.server.json.JsonUtils.FACTORY;
 
 import dev.tachyonmcp.protocol.mcp.v2025_11_25.codecs.Codec;
 import dev.tachyonmcp.protocol.mcp.v2025_11_25.codecs.CodecRegistry;
+import dev.tachyonmcp.server.domain.RequestId;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufInputStream;
 import java.io.ByteArrayOutputStream;
@@ -57,7 +58,7 @@ public final class JsonRpcCodec {
     }
 
     /** Serializes a JSON-RPC response. */
-    public static byte[] serializeResponse(@Nullable Object id, @Nullable String resultJson) {
+    public static byte[] serializeResponse(@Nullable RequestId id, @Nullable String resultJson) {
         return serialize(gen -> {
             gen.writeStartObject();
             gen.writeStringProperty(JSONRPC, JSONRPC_VERSION);
@@ -73,7 +74,7 @@ public final class JsonRpcCodec {
     }
 
     /** Serializes a JSON-RPC error response. */
-    public static byte[] serializeError(@Nullable Object id, int code, String message, @Nullable String dataJson) {
+    public static byte[] serializeError(@Nullable RequestId id, int code, String message, @Nullable String dataJson) {
         return serialize(gen -> {
             gen.writeStartObject();
             gen.writeStringProperty(JSONRPC, JSONRPC_VERSION);
@@ -90,14 +91,18 @@ public final class JsonRpcCodec {
         });
     }
 
-    private static void writeId(JsonGenerator gen, @Nullable Object id) {
+    private static void writeId(JsonGenerator gen, @Nullable RequestId id) {
         gen.writeName(ID);
         switch (id) {
             case null -> gen.writeNull();
-            case Long l -> gen.writeNumber(l);
-            case Integer i -> gen.writeNumber(i);
-            case Number n -> gen.writeNumber(n.doubleValue());
-            default -> gen.writeString(id.toString());
+            case RequestId.StringValue(var v) -> gen.writeString(v);
+            case RequestId.NumericValue(var v) -> {
+                switch (v) {
+                    case Long l -> gen.writeNumber(l);
+                    case Integer i -> gen.writeNumber(i);
+                    default -> gen.writeNumber(v.doubleValue());
+                }
+            }
         }
     }
 
@@ -114,7 +119,7 @@ public final class JsonRpcCodec {
     }
 
     /** Serializes a JSON-RPC request to a string. */
-    public static String serializeRequestAsString(Object id, String method, String paramsJson) {
+    public static String serializeRequestAsString(RequestId id, String method, String paramsJson) {
         return serializeToString(gen -> {
             gen.writeStartObject();
             gen.writeStringProperty(JSONRPC, JSONRPC_VERSION);
@@ -145,7 +150,7 @@ public final class JsonRpcCodec {
     }
 
     private static JsonRpcMessage parseMessage(JsonParser p) throws IOException {
-        Object id = null;
+        RequestId id = null;
         String method = null;
         Object paramsObj = null;
         String resultJson = null;
@@ -207,11 +212,11 @@ public final class JsonRpcCodec {
         throw new IllegalArgumentException("Invalid JSON-RPC message: no method, result, or error");
     }
 
-    private static @Nullable Object parseId(JsonParser p) {
+    private static @Nullable RequestId parseId(JsonParser p) {
         return switch (p.currentToken()) {
-            case VALUE_NUMBER_INT -> p.getLongValue();
-            case VALUE_NUMBER_FLOAT -> p.getDoubleValue();
-            case VALUE_STRING -> p.getString();
+            case VALUE_NUMBER_INT -> RequestId.of(p.getLongValue());
+            case VALUE_NUMBER_FLOAT -> RequestId.of(p.getDoubleValue());
+            case VALUE_STRING -> RequestId.of(p.getString());
             case VALUE_NULL -> null;
             default -> throw new IllegalArgumentException("Unexpected id token: " + p.currentToken());
         };

--- a/tachyon-server/src/main/java/dev/tachyonmcp/transport/jsonrpc/JsonRpcMessage.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/transport/jsonrpc/JsonRpcMessage.java
@@ -19,6 +19,7 @@ public sealed interface JsonRpcMessage {
     record Request<T>(RequestId id, String method, @Nullable T params) implements JsonRpcMessage {
 
         public Request {
+            Objects.requireNonNull(id, "id");
             Objects.requireNonNull(method, "method");
         }
     }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/transport/jsonrpc/JsonRpcMessage.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/transport/jsonrpc/JsonRpcMessage.java
@@ -4,6 +4,7 @@
 
 package dev.tachyonmcp.transport.jsonrpc;
 
+import dev.tachyonmcp.server.domain.RequestId;
 import java.util.Objects;
 import org.jspecify.annotations.Nullable;
 
@@ -12,10 +13,10 @@ public sealed interface JsonRpcMessage {
 
     /** The request/response ID, or {@code null} for notifications. */
     @Nullable
-    Object id();
+    RequestId id();
 
     /** A JSON-RPC request with an ID (expecting a response). */
-    record Request<T>(Object id, String method, @Nullable T params) implements JsonRpcMessage {
+    record Request<T>(RequestId id, String method, @Nullable T params) implements JsonRpcMessage {
 
         public Request {
             Objects.requireNonNull(method, "method");
@@ -23,7 +24,7 @@ public sealed interface JsonRpcMessage {
     }
 
     /** A JSON-RPC success response. */
-    record Response(@Nullable Object id, String resultJson) implements JsonRpcMessage {
+    record Response(@Nullable RequestId id, String resultJson) implements JsonRpcMessage {
 
         public Response {
             Objects.requireNonNull(resultJson, "resultJson");
@@ -32,7 +33,7 @@ public sealed interface JsonRpcMessage {
 
     /** A JSON-RPC error response. */
     record Error(
-            @Nullable Object id,
+            @Nullable RequestId id,
             int code,
             String message,
             @Nullable String dataJson) implements JsonRpcMessage {
@@ -50,7 +51,7 @@ public sealed interface JsonRpcMessage {
         }
 
         @Override
-        public @Nullable Object id() {
+        public @Nullable RequestId id() {
             return null;
         }
     }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/McpInitializationHandler.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/McpInitializationHandler.java
@@ -15,6 +15,7 @@ import dev.tachyonmcp.protocol.mcp.McpHeaderNames;
 import dev.tachyonmcp.runtime.InteractionContext;
 import dev.tachyonmcp.runtime.InteractionEvent;
 import dev.tachyonmcp.server.McpDispatcher;
+import dev.tachyonmcp.server.domain.RequestId;
 import dev.tachyonmcp.server.internal.ServerEngine;
 import dev.tachyonmcp.transport.jsonrpc.JsonRpcMessage;
 import dev.tachyonmcp.transport.netty.sse.PostSseStream;
@@ -145,7 +146,7 @@ public class McpInitializationHandler extends ChannelInboundHandlerAdapter {
     }
 
     private void dispatchPreSessionRequest(ChannelHandlerContext ctx, JsonRpcMessage message, @Nullable String origin) {
-        if (!(message instanceof JsonRpcMessage.Request(Object id, String method, Object params))) {
+        if (!(message instanceof JsonRpcMessage.Request(RequestId id, String method, Object params))) {
             ctx.executor().execute(() -> {
                 if (server.isStateless()) {
                     sendAccepted(ctx, origin);
@@ -192,7 +193,7 @@ public class McpInitializationHandler extends ChannelInboundHandlerAdapter {
                 }));
     }
 
-    private void handleInitialize(ChannelHandlerContext ctx, Object id, Object params, @Nullable String origin) {
+    private void handleInitialize(ChannelHandlerContext ctx, RequestId id, Object params, @Nullable String origin) {
         var heartbeatInterval = server.config().network().heartbeatInterval();
         var postStream = new PostSseStream(ctx.channel(), origin, server::nextEventId, heartbeatInterval);
         final var startNs = System.nanoTime();

--- a/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/McpOperationHandler.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/McpOperationHandler.java
@@ -18,6 +18,7 @@ import dev.tachyonmcp.runtime.ChannelContext;
 import dev.tachyonmcp.runtime.InteractionEvent;
 import dev.tachyonmcp.runtime.SseEvent;
 import dev.tachyonmcp.server.McpDispatcher;
+import dev.tachyonmcp.server.domain.RequestId;
 import dev.tachyonmcp.server.internal.ServerEngine;
 import dev.tachyonmcp.server.session.SessionEvent;
 import dev.tachyonmcp.transport.jsonrpc.JsonRpcMessage;
@@ -242,7 +243,7 @@ public class McpOperationHandler extends ChannelInboundHandlerAdapter {
 
     private void completePostRequest(
             ChannelHandlerContext ctx,
-            Object requestId,
+            RequestId requestId,
             String method,
             @Nullable String sessionId,
             @Nullable String origin,
@@ -316,7 +317,7 @@ public class McpOperationHandler extends ChannelInboundHandlerAdapter {
     }
 
     private void finalizePostSseResponse(
-            Object requestId,
+            RequestId requestId,
             @Nullable String sessionId,
             PostSseStream postStream,
             McpDispatcher.@Nullable DispatchResult result) {

--- a/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/McpResponseWriter.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/McpResponseWriter.java
@@ -6,6 +6,7 @@ package dev.tachyonmcp.transport.netty;
 
 import dev.tachyonmcp.protocol.ProtocolResponseMapper;
 import dev.tachyonmcp.protocol.mcp.McpHeaderNames;
+import dev.tachyonmcp.server.domain.RequestId;
 import dev.tachyonmcp.server.domain.ServerErrors;
 import dev.tachyonmcp.transport.jsonrpc.JsonRpcCodec;
 import io.netty.buffer.Unpooled;
@@ -86,7 +87,7 @@ public final class McpResponseWriter {
     }
 
     public static ChannelFuture sendInternalError(
-            ChannelHandlerContext ctx, Object id, @Nullable String origin, ProtocolResponseMapper mapper) {
+            ChannelHandlerContext ctx, RequestId id, @Nullable String origin, ProtocolResponseMapper mapper) {
         var error = mapper.error(ServerErrors.internalError("Internal error"));
         var body = JsonRpcCodec.serializeError(id, error.code(), error.message(), error.data());
         return sendJsonResponse(ctx, body, HttpResponseStatus.valueOf(error.httpStatus()), true, null, origin);

--- a/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/McpResponseWriter.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/McpResponseWriter.java
@@ -86,6 +86,17 @@ public final class McpResponseWriter {
         return ctx.writeAndFlush(response);
     }
 
+    /**
+     * Writes a JSON-RPC internal-error response and closes the connection, for a dispatch failure
+     * that occurred after a POST-SSE stream had already started (so the normal response path can no
+     * longer send a result).
+     *
+     * @param ctx    the channel to write the response on
+     * @param id     the id of the request that failed
+     * @param origin the request's {@code Origin} header value, echoed via CORS headers, or {@code null}
+     * @param mapper the protocol response mapper used to encode the error
+     * @return the future for the write
+     */
     public static ChannelFuture sendInternalError(
             ChannelHandlerContext ctx, RequestId id, @Nullable String origin, ProtocolResponseMapper mapper) {
         var error = mapper.error(ServerErrors.internalError("Internal error"));

--- a/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/UnsupportedProtocolVersionHandler.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/transport/netty/UnsupportedProtocolVersionHandler.java
@@ -9,6 +9,7 @@ import static dev.tachyonmcp.transport.netty.ProtocolVersionHandler.LATEST_PROTO
 import static dev.tachyonmcp.transport.netty.ProtocolVersionHandler.SUPPORTED_VERSIONS;
 import static dev.tachyonmcp.transport.netty.ProtocolVersionHandler.UNSUPPORTED_VERSION_KEY;
 
+import dev.tachyonmcp.server.domain.RequestId;
 import dev.tachyonmcp.server.domain.ServerError;
 import dev.tachyonmcp.transport.jsonrpc.JsonRpcCodec;
 import dev.tachyonmcp.transport.jsonrpc.JsonRpcMessage;
@@ -50,7 +51,7 @@ public class UnsupportedProtocolVersionHandler extends ChannelInboundHandlerAdap
         sendResponseAndClose(ctx, HttpResponseStatus.BAD_REQUEST, "application/json", body, origin);
     }
 
-    private static @Nullable Object extractId(HttpRequest req) {
+    private static @Nullable RequestId extractId(HttpRequest req) {
         if (req instanceof FullHttpRequest fullHttpRequest) {
             try {
                 if (JsonRpcCodec.parseRequest(fullHttpRequest.content().duplicate())

--- a/tachyon-server/src/test/java/dev/tachyonmcp/protocol/mcp/v2025_11_25/codecs/McpToolMapperTest.java
+++ b/tachyon-server/src/test/java/dev/tachyonmcp/protocol/mcp/v2025_11_25/codecs/McpToolMapperTest.java
@@ -69,7 +69,7 @@ class McpToolMapperTest {
 
     @Test
     void toProtocolEmbeddedResourceCarriesCorrectType() {
-        var contents = TextResourceContents.of("test://embedded", "text/plain", "content");
+        var contents = TextResourceContents.of("test://embedded", "content", "text/plain");
         var domain = EmbeddedResource.of(contents);
         var protocol = (dev.tachyonmcp.protocol.mcp.v2025_11_25.models.EmbeddedResource)
                 McpToolMapper.toProtocolContentBlock(domain);
@@ -129,7 +129,7 @@ class McpToolMapperTest {
     @Test
     void metaSurvivesEmbeddedResourceRoundTrip() {
         var meta = Map.of("key", META_VALUE);
-        var contents = TextResourceContents.of("test://embedded", "text/plain", "content");
+        var contents = TextResourceContents.of("test://embedded", "content", "text/plain");
         var domain = EmbeddedResource.of(contents, null, meta);
         var protocol = (dev.tachyonmcp.protocol.mcp.v2025_11_25.models.EmbeddedResource)
                 McpToolMapper.toProtocolContentBlock(domain);
@@ -142,7 +142,7 @@ class McpToolMapperTest {
     @Test
     void metaSurvivesTextResourceContentsRoundTrip() {
         var meta = Map.of("key", META_VALUE);
-        var domain = TextResourceContents.of("test://uri", "text/plain", "content", meta);
+        var domain = TextResourceContents.of("test://uri", "content", "text/plain", meta);
         var protocol = (dev.tachyonmcp.protocol.mcp.v2025_11_25.models.TextResourceContents)
                 McpToolMapper.toProtocolResourceContents(domain);
         assertThat(protocol._meta()).containsEntry("key", META_VALUE);
@@ -154,7 +154,7 @@ class McpToolMapperTest {
     @Test
     void metaSurvivesBlobResourceContentsRoundTrip() {
         var meta = Map.of("key", META_VALUE);
-        var domain = BlobResourceContents.of("test://blob", "application/octet-stream", "blobdata", meta);
+        var domain = BlobResourceContents.of("test://blob", "blobdata", "application/octet-stream", meta);
         var protocol = (dev.tachyonmcp.protocol.mcp.v2025_11_25.models.BlobResourceContents)
                 McpToolMapper.toProtocolResourceContents(domain);
         assertThat(protocol._meta()).containsEntry("key", META_VALUE);
@@ -313,7 +313,7 @@ class McpToolMapperTest {
         assertThat(ImageContent.of("data", "image/png").type()).isEqualTo(ContentBlock.Type.IMAGE);
         assertThat(AudioContent.of("data", "audio/wav").type()).isEqualTo(ContentBlock.Type.AUDIO);
         assertThat(ResourceLink.of("test://uri", "name").type()).isEqualTo(ContentBlock.Type.RESOURCE_LINK);
-        assertThat(EmbeddedResource.of(TextResourceContents.of("u", null, "c")).type())
+        assertThat(EmbeddedResource.of(TextResourceContents.of("u", "c", null)).type())
                 .isEqualTo(ContentBlock.Type.RESOURCE);
     }
 }

--- a/tachyon-server/src/test/java/dev/tachyonmcp/server/McpDispatcherProtocolContextTest.java
+++ b/tachyon-server/src/test/java/dev/tachyonmcp/server/McpDispatcherProtocolContextTest.java
@@ -12,6 +12,7 @@ import dev.tachyonmcp.protocol.ProtocolResponseMapper;
 import dev.tachyonmcp.protocol.Protocols;
 import dev.tachyonmcp.runtime.ChannelContext;
 import dev.tachyonmcp.runtime.DefaultChannelContext;
+import dev.tachyonmcp.server.domain.RequestId;
 import dev.tachyonmcp.server.internal.ServerEngine;
 import dev.tachyonmcp.server.session.DefaultDispatchContext;
 import dev.tachyonmcp.server.session.DispatchContext;
@@ -94,7 +95,7 @@ class McpDispatcherProtocolContextTest {
             var dispatcher = new McpDispatcher(server, Runnable::run);
             var channelContext = protocol.createInteractionContext();
             var result = dispatcher
-                    .dispatchRequestAsync(1, "test/capture", Map.of(), "sess_p1", null, channelContext)
+                    .dispatchRequestAsync(RequestId.of(1), "test/capture", Map.of(), "sess_p1", null, channelContext)
                     .get(5, TimeUnit.SECONDS);
 
             assertThat(result).isInstanceOf(McpDispatcher.DispatchResult.Response.class);
@@ -120,7 +121,7 @@ class McpDispatcherProtocolContextTest {
             var channelContext = protocol.createInteractionContext();
 
             var result = dispatcher
-                    .dispatchRequestAsync(1, "ping", Map.of(), "sess_p2", null, channelContext)
+                    .dispatchRequestAsync(RequestId.of(1), "ping", Map.of(), "sess_p2", null, channelContext)
                     .get(5, TimeUnit.SECONDS);
 
             assertThat(result).isInstanceOf(McpDispatcher.DispatchResult.Response.class);
@@ -146,7 +147,7 @@ class McpDispatcherProtocolContextTest {
 
             var dispatcher = new McpDispatcher(server, Runnable::run);
             var result = dispatcher
-                    .dispatchRequestAsync(1, "test/capture", Map.of(), null)
+                    .dispatchRequestAsync(RequestId.of(1), "test/capture", Map.of(), null)
                     .get(5, TimeUnit.SECONDS);
 
             assertThat(result).isInstanceOf(McpDispatcher.DispatchResult.Response.class);

--- a/tachyon-server/src/test/java/dev/tachyonmcp/server/McpDispatcherTest.java
+++ b/tachyon-server/src/test/java/dev/tachyonmcp/server/McpDispatcherTest.java
@@ -6,6 +6,7 @@ package dev.tachyonmcp.server;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import dev.tachyonmcp.server.domain.RequestId;
 import dev.tachyonmcp.server.internal.ServerEngine;
 import java.util.Map;
 import java.util.function.Consumer;
@@ -31,12 +32,12 @@ class McpDispatcherTest {
             var dispatcher = new McpDispatcher(server, server.executor());
 
             var first = asResponse(dispatcher
-                    .dispatchRequestAsync(1, "ping", null, "sess_diff")
+                    .dispatchRequestAsync(RequestId.of(1), "ping", null, "sess_diff")
                     .join());
             assertThat(first.responseBodyString()).contains("result");
 
             var second = asResponse(dispatcher
-                    .dispatchRequestAsync(2, "ping", null, "sess_diff")
+                    .dispatchRequestAsync(RequestId.of(2), "ping", null, "sess_diff")
                     .join());
             assertThat(second.responseBodyString()).contains("result");
         }
@@ -49,12 +50,14 @@ class McpDispatcherTest {
             server.createSession("sess_b");
             var dispatcher = new McpDispatcher(server, server.executor());
 
-            var first = asResponse(
-                    dispatcher.dispatchRequestAsync(42, "ping", null, "sess_a").join());
+            var first = asResponse(dispatcher
+                    .dispatchRequestAsync(RequestId.of(42), "ping", null, "sess_a")
+                    .join());
             assertThat(first.responseBodyString()).contains("result");
 
-            var second = asResponse(
-                    dispatcher.dispatchRequestAsync(42, "ping", null, "sess_b").join());
+            var second = asResponse(dispatcher
+                    .dispatchRequestAsync(RequestId.of(42), "ping", null, "sess_b")
+                    .join());
             assertThat(second.responseBodyString()).contains("result");
         }
     }
@@ -67,7 +70,7 @@ class McpDispatcherTest {
             var dispatcher = new McpDispatcher(server, server.executor());
 
             var result = asResponse(dispatcher
-                    .dispatchRequestAsync(1, "tools/list", null, "sess_init")
+                    .dispatchRequestAsync(RequestId.of(1), "tools/list", null, "sess_init")
                     .join());
             var body = result.responseBodyString();
             assertThat(body).contains("error");
@@ -82,7 +85,7 @@ class McpDispatcherTest {
             var dispatcher = new McpDispatcher(server, server.executor());
 
             var result = asResponse(dispatcher
-                    .dispatchRequestAsync(1, "ping", null, "sess_ping")
+                    .dispatchRequestAsync(RequestId.of(1), "ping", null, "sess_ping")
                     .join());
             var body = result.responseBodyString();
             assertThat(body).contains("result");
@@ -98,7 +101,7 @@ class McpDispatcherTest {
             var dispatcher = new McpDispatcher(server, server.executor());
 
             var result = asResponse(dispatcher
-                    .dispatchRequestAsync(1, "ping", null, "sess_active")
+                    .dispatchRequestAsync(RequestId.of(1), "ping", null, "sess_active")
                     .join());
             var body = result.responseBodyString();
             assertThat(body).contains("result");
@@ -115,7 +118,7 @@ class McpDispatcherTest {
 
             var requestId = "test-req-1";
             var pending = new java.util.concurrent.CompletableFuture<String>();
-            server.registerPendingRequest(requestId, pending);
+            server.registerPendingRequest(RequestId.of(requestId), pending);
 
             var params = Map.of("requestId", requestId, "reason", "User cancelled");
             var result = dispatcher.dispatchNotification("notifications/cancelled", params, "sess_cancel-pending");
@@ -181,7 +184,7 @@ class McpDispatcherTest {
             var dispatcher = new McpDispatcher(server, server.executor());
 
             var result = asResponse(dispatcher
-                    .dispatchRequestAsync(1, "ping", null, "sess_closed")
+                    .dispatchRequestAsync(RequestId.of(1), "ping", null, "sess_closed")
                     .join());
             var body = result.responseBodyString();
             assertThat(body).contains("error");

--- a/tachyon-server/src/test/java/dev/tachyonmcp/server/McpDispatcherTest.java
+++ b/tachyon-server/src/test/java/dev/tachyonmcp/server/McpDispatcherTest.java
@@ -153,6 +153,19 @@ class McpDispatcherTest {
     }
 
     @Test
+    void cancelsWithMalformedRequestIdIsAcceptedWithoutThrowing() {
+        try (ServerEngine server = newEngine(b -> {})) {
+            var session = server.createSession("sess_cancel-malformed");
+            session.activate();
+            var dispatcher = new McpDispatcher(server, server.executor());
+
+            var result = dispatcher.dispatchNotification(
+                    "notifications/cancelled", Map.of("requestId", true), "sess_cancel-malformed");
+            assertThat(result).isInstanceOf(McpDispatcher.DispatchResult.Accepted.class);
+        }
+    }
+
+    @Test
     void cancelsWithEmptyParamsIsAccepted() {
         try (ServerEngine server = newEngine(b -> {})) {
             server.createSession("sess_cancel-empty");

--- a/tachyon-server/src/test/java/dev/tachyonmcp/server/ServerBuilderTest.java
+++ b/tachyon-server/src/test/java/dev/tachyonmcp/server/ServerBuilderTest.java
@@ -60,12 +60,12 @@ class ServerBuilderTest {
                 .tool(tool -> tool.name("sync-tool"), (ToolFn) (ctx, request) -> ToolResult.empty())
                 .resource(
                         resource -> resource.name("sync-resource").uri("test://sync"),
-                        (ctx, rawUri, params, uriTemplate) -> TextResourceContents.of(rawUri, "text/plain", "sync"))
+                        (ctx, rawUri, params, uriTemplate) -> TextResourceContents.of(rawUri, "sync", "text/plain"))
                 .prompt(prompt -> prompt.name("sync-prompt"), List.of(PromptMessage.user("sync")))
                 .resourceTemplate(
                         template -> template.name("sync-template").uriTemplate("test://sync/{id}"),
                         (ctx, rawUri, params, uriTemplate) -> TextResourceContents.of(
-                                rawUri, "text/plain", ((UriTemplateValue.Scalar) params.get("id")).value()))
+                                rawUri, ((UriTemplateValue.Scalar) params.get("id")).value(), "text/plain"))
                 .build()) {
             assertThat(server.tools().find("sync-tool")).isPresent();
             assertThat(server.resources().find("sync-resource")).isPresent();
@@ -83,7 +83,7 @@ class ServerBuilderTest {
                 .asyncResource(
                         resource -> resource.name("async-resource").uri("test://async"),
                         (ctx, rawUri, params, uriTemplate) -> CompletableFuture.completedFuture(
-                                TextResourceContents.of(rawUri, "text/plain", "async")))
+                                TextResourceContents.of(rawUri, "async", "text/plain")))
                 .asyncPrompt(
                         prompt -> prompt.name("async-prompt"),
                         (ctx, request) -> CompletableFuture.completedFuture(
@@ -91,7 +91,7 @@ class ServerBuilderTest {
                 .asyncResourceTemplate(
                         template -> template.name("async-template").uriTemplate("test://async/{id}"),
                         (ctx, rawUri, params, uriTemplate) -> CompletableFuture.completedFuture(TextResourceContents.of(
-                                rawUri, "text/plain", ((UriTemplateValue.Scalar) params.get("id")).value())))
+                                rawUri, ((UriTemplateValue.Scalar) params.get("id")).value(), "text/plain")))
                 .build()) {
             assertThat(server.tools().find("async-tool")).isPresent();
             assertThat(server.resources().find("async-resource")).isPresent();
@@ -106,7 +106,7 @@ class ServerBuilderTest {
         try (var server = TachyonServer.builder()
                 .resource(
                         resource -> resource.name("sync-resource").uri("test://sync-completed"),
-                        (ctx, rawUri, params, uriTemplate) -> TextResourceContents.of(rawUri, "text/plain", "text"))
+                        (ctx, rawUri, params, uriTemplate) -> TextResourceContents.of(rawUri, "text", "text/plain"))
                 .resourceCompletion("test://sync-completed", handler)
                 .build()) {
             assertThat(server.completions().findForResource("test://sync-completed"))
@@ -124,7 +124,7 @@ class ServerBuilderTest {
                 .prompt(prompt -> prompt.name("async-completed-prompt"), List.of(PromptMessage.user("prompt")))
                 .resource(
                         resource -> resource.name("async-resource").uri("test://async-completed"),
-                        (ctx, rawUri, params, uriTemplate) -> TextResourceContents.of(rawUri, "text/plain", "text"))
+                        (ctx, rawUri, params, uriTemplate) -> TextResourceContents.of(rawUri, "text", "text/plain"))
                 .asyncPromptCompletion("async-completed-prompt", promptHandler)
                 .asyncResourceCompletion("test://async-completed", resourceHandler)
                 .build()) {

--- a/tachyon-server/src/test/java/dev/tachyonmcp/server/ServerShutdownGraceTest.java
+++ b/tachyon-server/src/test/java/dev/tachyonmcp/server/ServerShutdownGraceTest.java
@@ -8,6 +8,7 @@ import static dev.tachyonmcp.test.TestUtils.newEngine;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import dev.tachyonmcp.server.config.RuntimeConfig;
+import dev.tachyonmcp.server.domain.RequestId;
 import dev.tachyonmcp.server.features.tools.ToolHandler;
 import dev.tachyonmcp.server.features.tools.ToolResult;
 import dev.tachyonmcp.server.internal.ServerEngine;
@@ -66,7 +67,7 @@ class ServerShutdownGraceTest {
         server.createSession("sess-slow").activate();
         var dispatcher = new McpDispatcher(server, server.executor());
         dispatcher.dispatchRequestAsync(
-                1, "tools/call", Map.of("name", "slow_probe", "arguments", Map.of()), "sess-slow");
+                RequestId.of(1), "tools/call", Map.of("name", "slow_probe", "arguments", Map.of()), "sess-slow");
 
         assertThat(started.await(5, TimeUnit.SECONDS))
                 .as("handler must be running before close")

--- a/tachyon-server/src/test/java/dev/tachyonmcp/server/ServerTest.java
+++ b/tachyon-server/src/test/java/dev/tachyonmcp/server/ServerTest.java
@@ -262,7 +262,7 @@ class ServerTest {
             server.resources()
                     .register(
                             ResourceDescriptor.of("dyn", "test://dyn", "Dyn resource", "text/plain"),
-                            (ctx, rawUri, params, uriTemplate) -> TextResourceContents.of(rawUri, "text/plain", ""));
+                            (ctx, rawUri, params, uriTemplate) -> TextResourceContents.of(rawUri, "", "text/plain"));
 
             var listChanged = conn.sent.stream()
                     .filter(e -> e.data().contains("notifications/resources/list_changed"))

--- a/tachyon-server/src/test/java/dev/tachyonmcp/server/ServerTest.java
+++ b/tachyon-server/src/test/java/dev/tachyonmcp/server/ServerTest.java
@@ -10,6 +10,7 @@ import dev.tachyonmcp.runtime.Backpressure;
 import dev.tachyonmcp.runtime.SessionState;
 import dev.tachyonmcp.runtime.SseConnection;
 import dev.tachyonmcp.runtime.SseEvent;
+import dev.tachyonmcp.server.domain.RequestId;
 import dev.tachyonmcp.server.domain.TextResourceContents;
 import dev.tachyonmcp.server.features.prompts.PromptDescriptor;
 import dev.tachyonmcp.server.features.resources.ResourceDescriptor;
@@ -51,7 +52,7 @@ class ServerTest {
                 (DefaultTachyonServer) TachyonServer.builder().build()) {
             var session = server.createSession("sess_1");
 
-            var response = new SessionEvent.ResponseEvent("sess_1", 1, "{\"ok\":true}", 1000L, -1, null);
+            var response = new SessionEvent.ResponseEvent("sess_1", RequestId.of(1), "{\"ok\":true}", 1000L, -1, null);
             var sseEvent = server.appendResponse(session, response);
 
             assertThat(sseEvent.event()).isEqualTo("message");
@@ -68,9 +69,9 @@ class ServerTest {
                 (DefaultTachyonServer) TachyonServer.builder().build()) {
             server.createSession("sess_1");
 
-            server.appendEvent(new SessionEvent.ResponseEvent("sess_1", 1, "{\"a\":1}", 100L, -1, null));
-            server.appendEvent(new SessionEvent.ResponseEvent("sess_1", 2, "{\"b\":2}", 200L, -1, null));
-            server.appendEvent(new SessionEvent.ResponseEvent("sess_1", 3, "{\"c\":3}", 300L, -1, null));
+            server.appendEvent(new SessionEvent.ResponseEvent("sess_1", RequestId.of(1), "{\"a\":1}", 100L, -1, null));
+            server.appendEvent(new SessionEvent.ResponseEvent("sess_1", RequestId.of(2), "{\"b\":2}", 200L, -1, null));
+            server.appendEvent(new SessionEvent.ResponseEvent("sess_1", RequestId.of(3), "{\"c\":3}", 300L, -1, null));
 
             var replayed = server.replay("sess_1", -1);
             assertThat(replayed).hasSize(3);
@@ -101,7 +102,7 @@ class ServerTest {
             var session = server.createSession("sess_1");
             session.connection(conn);
 
-            server.appendEvent(new SessionEvent.ResponseEvent("sess_1", 1, "{\"a\":1}", 100L, -1, null));
+            server.appendEvent(new SessionEvent.ResponseEvent("sess_1", RequestId.of(1), "{\"a\":1}", 100L, -1, null));
             server.appendEvent(
                     new SessionEvent.NotificationEvent("sess_1", "notifications/message", "{}", 200L, -1, null));
 
@@ -146,7 +147,7 @@ class ServerTest {
     @Test
     void toSseEventConvertsOutboundRequestEvent() {
         var event = new SessionEvent.OutboundRequestEvent(
-                "s", "req-1", "sampling/createMessage", "{\"p\":\"v\"}", 100L, 7L, null);
+                "s", RequestId.of("req-1"), "sampling/createMessage", "{\"p\":\"v\"}", 100L, 7L, null);
 
         var sseEvent = ServerEngine.toSseEvent(event);
 
@@ -161,8 +162,8 @@ class ServerTest {
     void toSseEventReturnsNullForNonSseEvents() {
         // RequestEvent and CancelEvent have sseEventId=-1 and must return null
         // to prevent NPE in replay path (replayEvents filter fix)
-        var requestEvent = new SessionEvent.RequestEvent("s", 1, "ping", "{}", 100L);
-        var cancelEvent = new SessionEvent.CancelEvent("s", 1, 100L);
+        var requestEvent = new SessionEvent.RequestEvent("s", RequestId.of(1), "ping", "{}", 100L);
+        var cancelEvent = new SessionEvent.CancelEvent("s", RequestId.of(1), 100L);
 
         assertThat(ServerEngine.toSseEvent(requestEvent)).isNull();
         assertThat(ServerEngine.toSseEvent(cancelEvent)).isNull();
@@ -170,7 +171,7 @@ class ServerTest {
 
     @Test
     void toSseEventConvertsResponseAndNotificationEvents() {
-        var response = new SessionEvent.ResponseEvent("s", 1, "{\"ok\":true}", 100L, 5L, null);
+        var response = new SessionEvent.ResponseEvent("s", RequestId.of(1), "{\"ok\":true}", 100L, 5L, null);
         var notification =
                 new SessionEvent.NotificationEvent("s", "notifications/tools/list_changed", "{}", 100L, 7L, null);
 
@@ -192,9 +193,10 @@ class ServerTest {
                 (DefaultTachyonServer) TachyonServer.builder().build()) {
             server.createSession("sess_replay");
 
-            server.appendEvent(new SessionEvent.RequestEvent("sess_replay", 1, "ping", "{}", 100L));
-            server.appendEvent(new SessionEvent.ResponseEvent("sess_replay", 1, "{\"pong\":true}", 200L, -1, null));
-            server.appendEvent(new SessionEvent.CancelEvent("sess_replay", 2, 300L));
+            server.appendEvent(new SessionEvent.RequestEvent("sess_replay", RequestId.of(1), "ping", "{}", 100L));
+            server.appendEvent(
+                    new SessionEvent.ResponseEvent("sess_replay", RequestId.of(1), "{\"pong\":true}", 200L, -1, null));
+            server.appendEvent(new SessionEvent.CancelEvent("sess_replay", RequestId.of(2), 300L));
 
             var allEvents = server.replay("sess_replay", -1);
             assertThat(allEvents).hasSize(3);

--- a/tachyon-server/src/test/java/dev/tachyonmcp/server/features/resources/ResourceRegistryTest.java
+++ b/tachyon-server/src/test/java/dev/tachyonmcp/server/features/resources/ResourceRegistryTest.java
@@ -42,7 +42,7 @@ import org.junit.jupiter.api.Test;
 class ResourceRegistryTest {
 
     private static final ResourceHandler EMPTY_HANDLER =
-            (ctx, rawUri, params, uriTemplate) -> TextResourceContents.of(rawUri, "text/plain", "");
+            (ctx, rawUri, params, uriTemplate) -> TextResourceContents.of(rawUri, "", "text/plain");
 
     private final ServerEngine server = newEngine(b -> {});
     private final DefaultResourceRegistry registry =
@@ -130,7 +130,7 @@ class ResourceRegistryTest {
         reg.register(resource("a"), EMPTY_HANDLER);
         reg.registerTemplate(
                 ResourceTemplateDescriptor.of("template-entry", "test://entry/{id}"),
-                (ctx, rawUri, params, uriTemplate) -> TextResourceContents.of(rawUri, "text/plain", ""));
+                (ctx, rawUri, params, uriTemplate) -> TextResourceContents.of(rawUri, "", "text/plain"));
 
         assertThat(reg.find("a")).isEmpty();
         assertThat(reg.descriptors()).isEmpty();
@@ -147,15 +147,15 @@ class ResourceRegistryTest {
                 .registerAsync(
                         resource -> resource.name("async").uri("test://async"),
                         (ctx, rawUri, params, uriTemplate) -> CompletableFuture.completedFuture(
-                                TextResourceContents.of(rawUri, "text/plain", "async")))
+                                TextResourceContents.of(rawUri, "async", "text/plain")))
                 .registerTemplate(
                         template -> template.name("sync-template").uriTemplate("test://sync/{id}"),
                         (ctx, rawUri, params, uriTemplate) ->
-                                TextResourceContents.of(rawUri, "text/plain", scalar(params, "id")))
+                                TextResourceContents.of(rawUri, scalar(params, "id"), "text/plain"))
                 .registerTemplateAsync(
                         template -> template.name("async-template").uriTemplate("test://async/{id}"),
                         (ctx, rawUri, params, uriTemplate) -> CompletableFuture.completedFuture(
-                                TextResourceContents.of(rawUri, "text/plain", scalar(params, "id"))));
+                                TextResourceContents.of(rawUri, scalar(params, "id"), "text/plain")));
 
         assertThat(api.descriptors()).extracting(ResourceDescriptor::name).containsExactly("async", "sync");
         assertThat(api.find("sync")).isPresent();
@@ -218,7 +218,7 @@ class ResourceRegistryTest {
     void unregisterByUriMakesHandlerUnresolvable() throws Exception {
         registry.register(
                 ResourceDescriptor.of("r1", "test://r1", null, "text/plain"),
-                (ctx, rawUri, params, uriTemplate) -> TextResourceContents.of(rawUri, "text/plain", "content"));
+                (ctx, rawUri, params, uriTemplate) -> TextResourceContents.of(rawUri, "content", "text/plain"));
 
         registry.unregisterByUri("test://r1");
 
@@ -285,7 +285,7 @@ class ResourceRegistryTest {
         registry.register(
                 descriptor,
                 (ctx, rawUri, params, uriTemplate) ->
-                        TextResourceContents.of("test://resource/1", "text/plain", "content"));
+                        TextResourceContents.of("test://resource/1", "content", "text/plain"));
 
         var result = runInVirtualThread(() -> handlers.get("resources/read")
                 .handle(DefaultDispatchContext.stateless(server), Map.<String, Object>of("uri", "test://resource/1")));
@@ -305,7 +305,7 @@ class ResourceRegistryTest {
             capturedUri.set(rawUri);
             capturedParams.set(params);
             capturedTemplate.set(uriTemplate);
-            return TextResourceContents.of(rawUri, "text/plain", "static");
+            return TextResourceContents.of(rawUri, "static", "text/plain");
         });
 
         runInVirtualThread(() -> handlers.get("resources/read")
@@ -327,7 +327,7 @@ class ResourceRegistryTest {
                     capturedUri.set(rawUri);
                     capturedParams.set(params);
                     capturedTemplate.set(uriTemplate);
-                    return TextResourceContents.of(rawUri, "text/plain", "template");
+                    return TextResourceContents.of(rawUri, "template", "text/plain");
                 });
 
         runInVirtualThread(() -> handlers.get("resources/read")
@@ -343,7 +343,7 @@ class ResourceRegistryTest {
         var handlerThread = new AtomicReference<Thread>();
         registry.register(resource("sync-thread"), (ctx, rawUri, params, uriTemplate) -> {
             handlerThread.set(Thread.currentThread());
-            return TextResourceContents.of(rawUri, "text/plain", "sync");
+            return TextResourceContents.of(rawUri, "sync", "text/plain");
         });
 
         runInVirtualThread(() -> handlers.get("resources/read")
@@ -356,7 +356,7 @@ class ResourceRegistryTest {
     void shouldInvokeAsynchronousResourceHandlerOnVirtualThreadWithoutBlockingIt() throws Exception {
         var handlerThread = new AtomicReference<@Nullable Thread>();
         var callerThread = new AtomicReference<@Nullable Thread>();
-        var contents = TextResourceContents.of("test://async-thread", "text/plain", "async");
+        var contents = TextResourceContents.of("test://async-thread", "async", "text/plain");
         var completion = new CompletableFuture<TextResourceContents>();
         registry.registerAsync(resource("async-thread"), (ctx, rawUri, params, uriTemplate) -> {
             handlerThread.set(Thread.currentThread());
@@ -506,7 +506,7 @@ class ResourceRegistryTest {
         handlers.get("resources/subscribe").handle(context(sess, server), Map.of("uri", "test://resource/1"));
         registry.register(
                 ResourceDescriptor.of("test-resource", "test://resource/1", "Test resource", "text/plain"),
-                (ctx, rawUri, params, uriTemplate) -> TextResourceContents.of(rawUri, "text/plain", ""));
+                (ctx, rawUri, params, uriTemplate) -> TextResourceContents.of(rawUri, "", "text/plain"));
 
         registry.notifyResourceUpdated("test://resource/1");
 
@@ -523,7 +523,7 @@ class ResourceRegistryTest {
 
         registry.register(
                 ResourceDescriptor.of("r1", "test://r1", null, null),
-                (ctx, rawUri, params, uriTemplate) -> TextResourceContents.of(rawUri, "text/plain", ""));
+                (ctx, rawUri, params, uriTemplate) -> TextResourceContents.of(rawUri, "", "text/plain"));
 
         assertThat(callCount).hasValue(1);
     }
@@ -532,7 +532,7 @@ class ResourceRegistryTest {
     void shouldFireOnChangeWhenExistingResourceRemoved() {
         registry.register(
                 ResourceDescriptor.of("r1", "test://r1", null, null),
-                (ctx, rawUri, params, uriTemplate) -> TextResourceContents.of(rawUri, "text/plain", ""));
+                (ctx, rawUri, params, uriTemplate) -> TextResourceContents.of(rawUri, "", "text/plain"));
 
         var callCount = new AtomicInteger(0);
         registry.onChange(callCount::incrementAndGet);
@@ -574,7 +574,7 @@ class ResourceRegistryTest {
 
         registry.registerTemplate(
                 ResourceTemplateDescriptor.of("tmpl", "test://tmpl/{id}"),
-                (ctx, rawUri, params, uriTemplate) -> TextResourceContents.of(rawUri, "text/plain", ""));
+                (ctx, rawUri, params, uriTemplate) -> TextResourceContents.of(rawUri, "", "text/plain"));
 
         assertThat(callCount).hasValue(1);
     }
@@ -583,14 +583,14 @@ class ResourceRegistryTest {
     void shouldReplaceHandlerAndFireOnChangeWhenAddedWithSameName() {
         registry.register(
                 ResourceDescriptor.of("doc", "resource://doc-v1", null, "text/plain"),
-                (ctx, rawUri, params, uriTemplate) -> TextResourceContents.of(rawUri, "text/plain", "v1"));
+                (ctx, rawUri, params, uriTemplate) -> TextResourceContents.of(rawUri, "v1", "text/plain"));
 
         var callCount = new AtomicInteger(0);
         registry.onChange(callCount::incrementAndGet);
 
         registry.register(
                 ResourceDescriptor.of("doc", "resource://doc-v1", null, "text/plain"),
-                (ctx, rawUri, params, uriTemplate) -> TextResourceContents.of(rawUri, "text/plain", "v2"));
+                (ctx, rawUri, params, uriTemplate) -> TextResourceContents.of(rawUri, "v2", "text/plain"));
 
         assertThat(callCount).hasValue(1);
         assertThat(registry.find("doc")).isPresent();
@@ -601,14 +601,14 @@ class ResourceRegistryTest {
     void shouldEvictOldUriWhenResourceUpdatedWithNewUri() throws Exception {
         registry.register(
                 ResourceDescriptor.of("doc", "resource://doc-v1", null, "text/plain"),
-                (ctx, rawUri, params, uriTemplate) -> TextResourceContents.of(rawUri, "text/plain", "v1"));
+                (ctx, rawUri, params, uriTemplate) -> TextResourceContents.of(rawUri, "v1", "text/plain"));
 
         var callCount = new AtomicInteger(0);
         registry.onChange(callCount::incrementAndGet);
 
         registry.register(
                 ResourceDescriptor.of("doc", "resource://doc-v2", null, "text/plain"),
-                (ctx, rawUri, params, uriTemplate) -> TextResourceContents.of(rawUri, "text/plain", "v2"));
+                (ctx, rawUri, params, uriTemplate) -> TextResourceContents.of(rawUri, "v2", "text/plain"));
 
         // updating a resource's URI is a single change
         assertThat(callCount).hasValue(1);
@@ -652,7 +652,7 @@ class ResourceRegistryTest {
                 List.of(icon));
         registry.register(
                 descriptor,
-                (ctx, rawUri, params, uriTemplate) -> TextResourceContents.of(rawUri, "text/plain", "content"));
+                (ctx, rawUri, params, uriTemplate) -> TextResourceContents.of(rawUri, "content", "text/plain"));
 
         var result = (ListResourcesResult)
                 handlers.get("resources/list").handle(DefaultDispatchContext.stateless(server), null);
@@ -723,7 +723,7 @@ class ResourceRegistryTest {
                 ResourceTemplateDescriptor.of("files", "resource://files{/segments*}"),
                 (ctx, rawUri, params, uriTemplate) -> {
                     captured.set(params);
-                    return TextResourceContents.of(rawUri, "text/plain", "ok");
+                    return TextResourceContents.of(rawUri, "ok", "text/plain");
                 });
 
         var result = runInVirtualThread(() -> handlers.get("resources/read")
@@ -743,13 +743,13 @@ class ResourceRegistryTest {
                 ResourceTemplateDescriptor.of("generic", "resource://{type}/{id}"),
                 (ctx, rawUri, params, uriTemplate) -> {
                     matched.set("generic");
-                    return TextResourceContents.of(rawUri, "text/plain", "generic");
+                    return TextResourceContents.of(rawUri, "generic", "text/plain");
                 });
         registry.registerTemplate(
                 ResourceTemplateDescriptor.of("specific", "resource://users/{id}"),
                 (ctx, rawUri, params, uriTemplate) -> {
                     matched.set("specific");
-                    return TextResourceContents.of(rawUri, "text/plain", "specific");
+                    return TextResourceContents.of(rawUri, "specific", "text/plain");
                 });
 
         runInVirtualThread(() -> handlers.get("resources/read")
@@ -774,7 +774,7 @@ class ResourceRegistryTest {
                         annotations,
                         List.of(icon)),
                 (ctx, rawUri, params, uriTemplate) ->
-                        TextResourceContents.of(rawUri, "text/plain", "content-" + scalar(params, "id")));
+                        TextResourceContents.of(rawUri, "content-" + scalar(params, "id"), "text/plain"));
 
         var result = (ListResourceTemplatesResult)
                 handlers.get("resources/templates/list").handle(DefaultDispatchContext.stateless(server), null);
@@ -800,7 +800,7 @@ class ResourceRegistryTest {
         var contentLoaded = new java.util.concurrent.atomic.AtomicBoolean(false);
         registry.register(descriptor, (ctx, rawUri, params, uriTemplate) -> {
             contentLoaded.set(true);
-            return TextResourceContents.of("test://sized", "application/octet-stream", "data");
+            return TextResourceContents.of("test://sized", "data", "application/octet-stream");
         });
 
         // resources/list returns size WITHOUT loading content

--- a/tachyon-server/src/test/java/dev/tachyonmcp/server/features/tools/ToolRequestTest.java
+++ b/tachyon-server/src/test/java/dev/tachyonmcp/server/features/tools/ToolRequestTest.java
@@ -5,6 +5,7 @@ package dev.tachyonmcp.server.features.tools;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import dev.tachyonmcp.server.domain.Args;
+import dev.tachyonmcp.server.domain.ProgressToken;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import tools.jackson.databind.JsonNode;
@@ -54,8 +55,11 @@ class ToolRequestTest {
 
     @Test
     void builderSetsProgressToken() {
-        var req = ToolRequest.builder().name("t").progressToken(42L).build();
-        assertThat(req.progressToken()).isEqualTo(42L);
+        var req = ToolRequest.builder()
+                .name("t")
+                .progressToken(ProgressToken.of(42L))
+                .build();
+        assertThat(req.progressToken()).isEqualTo(ProgressToken.of(42L));
     }
 
     @Test

--- a/tachyon-server/src/test/java/dev/tachyonmcp/server/session/InMemorySessionEventStoreTest.java
+++ b/tachyon-server/src/test/java/dev/tachyonmcp/server/session/InMemorySessionEventStoreTest.java
@@ -6,6 +6,7 @@ package dev.tachyonmcp.server.session;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import dev.tachyonmcp.server.domain.RequestId;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
@@ -17,7 +18,11 @@ import org.junitpioneer.jupiter.RetryingTest;
 class InMemorySessionEventStoreTest {
 
     private static SessionEvent requestEvent(String sessionId, int i) {
-        return new SessionEvent.RequestEvent(sessionId, i, "ping", "{}", System.currentTimeMillis());
+        return new SessionEvent.RequestEvent(sessionId, RequestId.of(i), "ping", "{}", System.currentTimeMillis());
+    }
+
+    private static int intId(SessionEvent.RequestEvent event) {
+        return ((RequestId.NumericValue) event.requestId()).value().intValue();
     }
 
     @Test
@@ -46,7 +51,7 @@ class InMemorySessionEventStoreTest {
             var result = store.replay("s1", 5);
             assertThat(result).hasSize(4);
             var first = (SessionEvent.RequestEvent) result.getFirst();
-            assertThat((Integer) first.requestId()).isEqualTo(6);
+            assertThat(intId(first)).isEqualTo(6);
         }
     }
 
@@ -148,7 +153,7 @@ class InMemorySessionEventStoreTest {
                     continue;
                 }
                 var ids = result.stream()
-                        .map(e -> (int) (Integer) ((SessionEvent.RequestEvent) e).requestId())
+                        .map(e -> intId((SessionEvent.RequestEvent) e))
                         .toList();
                 assertThat(ids.getLast()).isEqualTo(eventsPerThread - 1);
                 for (int i = 1; i < ids.size(); i++) {
@@ -171,14 +176,14 @@ class InMemorySessionEventStoreTest {
             var all = store.replay("s1", -1);
             assertThat(all).hasSize(store.maxEvents);
             var first = (SessionEvent.RequestEvent) all.getFirst();
-            assertThat((Integer) first.requestId()).isEqualTo(overflow);
+            assertThat(intId(first)).isEqualTo(overflow);
 
             // Global-index cursor from inside the window is not misaligned by the trim: replay
             // resumes AFTER lastSeq (exclusive, matching drain).
             var tail = store.replay("s1", total - 5);
             assertThat(tail).hasSize(4);
             var tailFirst = (SessionEvent.RequestEvent) tail.getFirst();
-            assertThat((Integer) tailFirst.requestId()).isEqualTo(total - 5 + 1);
+            assertThat(intId(tailFirst)).isEqualTo(total - 5 + 1);
         }
     }
 }

--- a/tachyon-server/src/test/java/dev/tachyonmcp/server/session/McpSessionEventTest.java
+++ b/tachyon-server/src/test/java/dev/tachyonmcp/server/session/McpSessionEventTest.java
@@ -6,16 +6,17 @@ package dev.tachyonmcp.server.session;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import dev.tachyonmcp.server.domain.RequestId;
 import org.junit.jupiter.api.Test;
 
 class McpSessionEventTest {
 
     @Test
     void requestEvent() {
-        var event = new SessionEvent.RequestEvent("sess_1", 1, "tools/list", "{}", 1000L);
+        var event = new SessionEvent.RequestEvent("sess_1", RequestId.of(1), "tools/list", "{}", 1000L);
 
         assertThat(event.sessionId()).isEqualTo("sess_1");
-        assertThat(event.requestId()).isEqualTo(1);
+        assertThat(event.requestId()).isEqualTo(RequestId.of(1));
         assertThat(event.method()).isEqualTo("tools/list");
         assertThat(event.paramsJson()).isEqualTo("{}");
         assertThat(event.timestamp()).isEqualTo(1000L);
@@ -23,10 +24,10 @@ class McpSessionEventTest {
 
     @Test
     void responseEvent() {
-        var event = new SessionEvent.ResponseEvent("sess_1", 1, "{\"result\":\"ok\"}", 2000L, -1, null);
+        var event = new SessionEvent.ResponseEvent("sess_1", RequestId.of(1), "{\"result\":\"ok\"}", 2000L, -1, null);
 
         assertThat(event.sessionId()).isEqualTo("sess_1");
-        assertThat(event.requestId()).isEqualTo(1);
+        assertThat(event.requestId()).isEqualTo(RequestId.of(1));
         assertThat(event.resultJson()).isEqualTo("{\"result\":\"ok\"}");
         assertThat(event.timestamp()).isEqualTo(2000L);
         assertThat(event.streamKey()).isNull();
@@ -34,20 +35,20 @@ class McpSessionEventTest {
 
     @Test
     void cancelEvent() {
-        var event = new SessionEvent.CancelEvent("sess_1", 42, 3000L);
+        var event = new SessionEvent.CancelEvent("sess_1", RequestId.of(42), 3000L);
 
         assertThat(event.sessionId()).isEqualTo("sess_1");
-        assertThat(event.requestId()).isEqualTo(42);
+        assertThat(event.requestId()).isEqualTo(RequestId.of(42));
         assertThat(event.timestamp()).isEqualTo(3000L);
     }
 
     @Test
     void outboundRequestEvent() {
         var event = new SessionEvent.OutboundRequestEvent(
-                "sess_1", "uuid-123", "sampling/createMessage", "{\"prompt\":\"hi\"}", 5000L, 42L, "17");
+                "sess_1", RequestId.of("uuid-123"), "sampling/createMessage", "{\"prompt\":\"hi\"}", 5000L, 42L, "17");
 
         assertThat(event.sessionId()).isEqualTo("sess_1");
-        assertThat(event.requestId()).isEqualTo("uuid-123");
+        assertThat(event.requestId()).isEqualTo(RequestId.of("uuid-123"));
         assertThat(event.method()).isEqualTo("sampling/createMessage");
         assertThat(event.paramsJson()).isEqualTo("{\"prompt\":\"hi\"}");
         assertThat(event.timestamp()).isEqualTo(5000L);
@@ -57,10 +58,10 @@ class McpSessionEventTest {
 
     @Test
     void allEventsAreSealed() {
-        var request = new SessionEvent.RequestEvent("a", 1, "m", "{}", 1L);
-        var response = new SessionEvent.ResponseEvent("a", 2, "{}", 2L, -1, null);
-        var cancel = new SessionEvent.CancelEvent("a", 3, 3L);
-        var outbound = new SessionEvent.OutboundRequestEvent("a", 5, "m", "{}", 5L, 5L, null);
+        var request = new SessionEvent.RequestEvent("a", RequestId.of(1), "m", "{}", 1L);
+        var response = new SessionEvent.ResponseEvent("a", RequestId.of(2), "{}", 2L, -1, null);
+        var cancel = new SessionEvent.CancelEvent("a", RequestId.of(3), 3L);
+        var outbound = new SessionEvent.OutboundRequestEvent("a", RequestId.of(5), "m", "{}", 5L, 5L, null);
 
         assertThat(request).isInstanceOf(SessionEvent.class);
         assertThat(response).isInstanceOf(SessionEvent.class);

--- a/tachyon-server/src/test/java/dev/tachyonmcp/transport/jsonrpc/JsonRpcCodecTest.java
+++ b/tachyon-server/src/test/java/dev/tachyonmcp/transport/jsonrpc/JsonRpcCodecTest.java
@@ -8,6 +8,7 @@ import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import dev.tachyonmcp.protocol.mcp.v2025_11_25.models.CallToolResult;
+import dev.tachyonmcp.server.domain.RequestId;
 import org.junit.jupiter.api.Test;
 
 class JsonRpcCodecTest {
@@ -28,7 +29,8 @@ class JsonRpcCodecTest {
 
     @Test
     void serializeRequestAsStringContainsRequiredFields() {
-        var json = JsonRpcCodec.serializeRequestAsString("req-1", "sampling/createMessage", "{\"prompt\":\"hi\"}");
+        var json = JsonRpcCodec.serializeRequestAsString(
+                RequestId.of("req-1"), "sampling/createMessage", "{\"prompt\":\"hi\"}");
 
         // language=JSON
         assertThatJson(json).isEqualTo("""
@@ -43,7 +45,7 @@ class JsonRpcCodecTest {
 
     @Test
     void serializeNotificationAsStringWithNumericId() {
-        var json = JsonRpcCodec.serializeRequestAsString(99L, "ping", "{}");
+        var json = JsonRpcCodec.serializeRequestAsString(RequestId.of(99L), "ping", "{}");
 
         // language=JSON
         assertThatJson(json).isEqualTo("""

--- a/tachyon-server/src/test/java/dev/tachyonmcp/transport/netty/ExtensionMethodRoutingTest.java
+++ b/tachyon-server/src/test/java/dev/tachyonmcp/transport/netty/ExtensionMethodRoutingTest.java
@@ -13,6 +13,7 @@ import dev.tachyonmcp.runtime.Session;
 import dev.tachyonmcp.server.McpDispatcher;
 import dev.tachyonmcp.server.RpcMethodHandler;
 import dev.tachyonmcp.server.TachyonServer;
+import dev.tachyonmcp.server.domain.RequestId;
 import dev.tachyonmcp.server.extensions.ServerExtension;
 import dev.tachyonmcp.server.internal.ServerEngine;
 import dev.tachyonmcp.server.session.DefaultDispatchContext;
@@ -45,7 +46,7 @@ class ExtensionMethodRoutingTest {
         var ctx = DefaultDispatchContext.create(Protocols.list().get(0), server);
         ctx.setSession(session);
         var result = (McpDispatcher.DispatchResult.Response) dispatcher
-                .dispatchRequestAsync(1, "test/ext-method", null, "sess_routing", null, ctx)
+                .dispatchRequestAsync(RequestId.of(1), "test/ext-method", null, "sess_routing", null, ctx)
                 .join();
         var body = result.responseBodyString();
         assertThat(body).contains("error");
@@ -58,7 +59,7 @@ class ExtensionMethodRoutingTest {
         session.activate();
         var params = Map.of("_meta", Map.of("com.test/ext", JsonNodeFactory.instance.objectNode()));
         var result = (McpDispatcher.DispatchResult.Response) dispatcher
-                .dispatchRequestAsync(1, "test/ext-method", params, "sess_routing", null, context)
+                .dispatchRequestAsync(RequestId.of(1), "test/ext-method", params, "sess_routing", null, context)
                 .join();
         var body = result.responseBodyString();
         assertThat(body).contains("result");

--- a/tachyon-server/src/test/java/dev/tachyonmcp/transport/netty/ForeignThreadContinuationTest.java
+++ b/tachyon-server/src/test/java/dev/tachyonmcp/transport/netty/ForeignThreadContinuationTest.java
@@ -8,6 +8,7 @@ import static dev.tachyonmcp.test.TestUtils.newEngine;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import dev.tachyonmcp.server.McpDispatcher;
+import dev.tachyonmcp.server.domain.RequestId;
 import dev.tachyonmcp.server.features.tools.ToolDescriptor;
 import dev.tachyonmcp.server.features.tools.ToolHandler;
 import dev.tachyonmcp.server.features.tools.ToolResult;
@@ -67,7 +68,7 @@ class ForeignThreadContinuationTest {
             var dispatcher = new McpDispatcher(server, server.executor());
             var params = Map.of("name", "foreign-thread-tool", "arguments", Map.of());
             dispatcher
-                    .dispatchRequestAsync(1, "tools/call", params, "sess-foreign")
+                    .dispatchRequestAsync(RequestId.of(1), "tools/call", params, "sess-foreign")
                     .get(10, TimeUnit.SECONDS);
         }
 

--- a/tachyon-server/src/test/java/dev/tachyonmcp/transport/netty/NettyServerThreadingTest.java
+++ b/tachyon-server/src/test/java/dev/tachyonmcp/transport/netty/NettyServerThreadingTest.java
@@ -8,6 +8,7 @@ import static dev.tachyonmcp.test.TestUtils.newEngine;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import dev.tachyonmcp.server.McpDispatcher;
+import dev.tachyonmcp.server.domain.RequestId;
 import dev.tachyonmcp.server.features.tools.ToolHandler;
 import dev.tachyonmcp.server.features.tools.ToolResult;
 import dev.tachyonmcp.server.internal.ServerEngine;
@@ -48,7 +49,7 @@ class NettyServerThreadingTest {
             var dispatcher = new McpDispatcher(server, server.executor());
             var params = java.util.Map.of("name", "thread_probe", "arguments", java.util.Map.of());
             dispatcher
-                    .dispatchRequestAsync(1, "tools/call", params, "sess_thread-probe")
+                    .dispatchRequestAsync(RequestId.of(1), "tools/call", params, "sess_thread-probe")
                     .join();
 
             String toolThread = handlerThread.get(10, TimeUnit.SECONDS);
@@ -72,7 +73,7 @@ class NettyServerThreadingTest {
             var dispatcher = new McpDispatcher(server, server.executor());
             dispatcher
                     .dispatchRequestAsync(
-                            1,
+                            RequestId.of(1),
                             "tools/call",
                             java.util.Map.of("name", "name_probe", "arguments", java.util.Map.of()),
                             "sess-name")

--- a/tachyon-server/src/test/java/dev/tachyonmcp/transport/netty/NotificationDeliveryTest.java
+++ b/tachyon-server/src/test/java/dev/tachyonmcp/transport/netty/NotificationDeliveryTest.java
@@ -100,6 +100,50 @@ class NotificationDeliveryTest {
     }
 
     @Test
+    void shouldSendProgressNotificationWithStringToken() {
+        var params = java.util.Map.of(
+                "name", "test_tool",
+                "arguments", java.util.Map.of(),
+                "_meta", java.util.Map.of("progressToken", "abc123"));
+        var result = dispatcher
+                .dispatchRequestAsync(RequestId.of(1), "tools/call", params, "sess_test")
+                .join();
+
+        assertThat(result).isInstanceOf(McpDispatcher.DispatchResult.Response.class);
+        assertThat(((McpDispatcher.DispatchResult.Response) result).responseBodyString())
+                .doesNotContain("\"error\":")
+                .doesNotContain("\"isError\":true");
+
+        var progressEvents = testConn.sent.stream()
+                .filter(e -> e.data().contains("notifications/progress"))
+                .toList();
+        assertThat(progressEvents).hasSize(3);
+        assertThat(progressEvents.get(0).data()).contains("\"progressToken\":\"abc123\"");
+    }
+
+    @Test
+    void shouldNotSendProgressWithMalformedToken() {
+        var params = java.util.Map.of(
+                "name", "test_tool",
+                "arguments", java.util.Map.of(),
+                "_meta", java.util.Map.of("progressToken", true));
+        var result = dispatcher
+                .dispatchRequestAsync(RequestId.of(1), "tools/call", params, "sess_test")
+                .join();
+
+        assertThat(result).isInstanceOf(McpDispatcher.DispatchResult.Response.class);
+        assertThat(((McpDispatcher.DispatchResult.Response) result).responseBodyString())
+                .doesNotContain("\"error\":")
+                .doesNotContain("\"isError\":true");
+        var progressEvents = testConn.sent.stream()
+                .filter(e -> e.data().contains("notifications/progress"))
+                .toList();
+        assertThat(progressEvents)
+                .as("a non-string/non-numeric progressToken must be treated as absent, not crash the call")
+                .isEmpty();
+    }
+
+    @Test
     void shouldSendLoggingNotificationWhenLevelIsSet() {
         var levelParams = java.util.Map.of("level", "info");
         dispatcher

--- a/tachyon-server/src/test/java/dev/tachyonmcp/transport/netty/NotificationDeliveryTest.java
+++ b/tachyon-server/src/test/java/dev/tachyonmcp/transport/netty/NotificationDeliveryTest.java
@@ -12,6 +12,7 @@ import dev.tachyonmcp.runtime.SseConnection;
 import dev.tachyonmcp.runtime.SseEvent;
 import dev.tachyonmcp.server.McpDispatcher;
 import dev.tachyonmcp.server.domain.LoggingLevel;
+import dev.tachyonmcp.server.domain.RequestId;
 import dev.tachyonmcp.server.features.tools.ToolDescriptor;
 import dev.tachyonmcp.server.features.tools.ToolHandler;
 import dev.tachyonmcp.server.features.tools.ToolResult;
@@ -81,7 +82,7 @@ class NotificationDeliveryTest {
                 "arguments", java.util.Map.of(),
                 "_meta", java.util.Map.of("progressToken", 42));
         var result = dispatcher
-                .dispatchRequestAsync(1, "tools/call", params, "sess_test")
+                .dispatchRequestAsync(RequestId.of(1), "tools/call", params, "sess_test")
                 .join();
 
         assertThat(result).isInstanceOf(McpDispatcher.DispatchResult.Response.class);
@@ -102,7 +103,7 @@ class NotificationDeliveryTest {
     void shouldSendLoggingNotificationWhenLevelIsSet() {
         var levelParams = java.util.Map.of("level", "info");
         dispatcher
-                .dispatchRequestAsync(1, "logging/setLevel", levelParams, "sess_test")
+                .dispatchRequestAsync(RequestId.of(1), "logging/setLevel", levelParams, "sess_test")
                 .join();
 
         var toolParams = java.util.Map.of(
@@ -110,7 +111,7 @@ class NotificationDeliveryTest {
                 "arguments", java.util.Map.of(),
                 "_meta", java.util.Map.of("progressToken", 42));
         dispatcher
-                .dispatchRequestAsync(2, "tools/call", toolParams, "sess_test")
+                .dispatchRequestAsync(RequestId.of(2), "tools/call", toolParams, "sess_test")
                 .join();
 
         var logEvents = testConn.sent.stream()
@@ -124,12 +125,15 @@ class NotificationDeliveryTest {
     @Test
     void shouldFilterHandlerLogsAtClientThresholdAndAllowMissingLogger() {
         dispatcher
-                .dispatchRequestAsync(1, "logging/setLevel", Map.of("level", "warning"), "sess_test")
+                .dispatchRequestAsync(RequestId.of(1), "logging/setLevel", Map.of("level", "warning"), "sess_test")
                 .join();
 
         dispatcher
                 .dispatchRequestAsync(
-                        2, "tools/call", Map.of("name", "filtered_log", "arguments", Map.of()), "sess_test")
+                        RequestId.of(2),
+                        "tools/call",
+                        Map.of("name", "filtered_log", "arguments", Map.of()),
+                        "sess_test")
                 .join();
 
         var logEvents = testConn.sent.stream()
@@ -152,7 +156,7 @@ class NotificationDeliveryTest {
             var disabledDispatcher = new McpDispatcher(disabledServer, disabledServer.executor());
 
             var result = disabledDispatcher
-                    .dispatchRequestAsync(1, "logging/setLevel", Map.of("level", "info"), "sess_disabled")
+                    .dispatchRequestAsync(RequestId.of(1), "logging/setLevel", Map.of("level", "info"), "sess_disabled")
                     .join();
 
             assertThat(result).isInstanceOf(McpDispatcher.DispatchResult.Response.class);
@@ -161,7 +165,10 @@ class NotificationDeliveryTest {
 
             disabledDispatcher
                     .dispatchRequestAsync(
-                            2, "tools/call", Map.of("name", "filtered_log", "arguments", Map.of()), "sess_disabled")
+                            RequestId.of(2),
+                            "tools/call",
+                            Map.of("name", "filtered_log", "arguments", Map.of()),
+                            "sess_disabled")
                     .join();
             assertThat(disabledConnection.sent).noneMatch(event -> event.data().contains("notifications/message"));
         }
@@ -170,7 +177,7 @@ class NotificationDeliveryTest {
     @Test
     void shouldRejectMissingLogLevelAsInvalidParams() {
         var result = dispatcher
-                .dispatchRequestAsync(1, "logging/setLevel", Map.of(), "sess_test")
+                .dispatchRequestAsync(RequestId.of(1), "logging/setLevel", Map.of(), "sess_test")
                 .join();
 
         assertThat(result).isInstanceOf(McpDispatcher.DispatchResult.Response.class);
@@ -182,7 +189,9 @@ class NotificationDeliveryTest {
     @Test
     void shouldNotSendProgressWithoutMeta() {
         var params = java.util.Map.of("name", "test_tool", "arguments", java.util.Map.of());
-        dispatcher.dispatchRequestAsync(1, "tools/call", params, "sess_test").join();
+        dispatcher
+                .dispatchRequestAsync(RequestId.of(1), "tools/call", params, "sess_test")
+                .join();
 
         var progressEvents = testConn.sent.stream()
                 .filter(e -> e.data().contains("notifications/progress"))
@@ -196,7 +205,9 @@ class NotificationDeliveryTest {
                 "name", "test_tool",
                 "arguments", java.util.Map.of(),
                 "_meta", java.util.Map.of("progressToken", 42));
-        dispatcher.dispatchRequestAsync(1, "tools/call", params, "sess_test").join();
+        dispatcher
+                .dispatchRequestAsync(RequestId.of(1), "tools/call", params, "sess_test")
+                .join();
 
         var logEvents = testConn.sent.stream()
                 .filter(e -> e.data().contains("notifications/message"))
@@ -211,7 +222,8 @@ class NotificationDeliveryTest {
     @Test
     void shouldHandleMultipleToolsSequentially() {
         dispatcher
-                .dispatchRequestAsync(1, "logging/setLevel", java.util.Map.of("level", "debug"), "sess_test")
+                .dispatchRequestAsync(
+                        RequestId.of(1), "logging/setLevel", java.util.Map.of("level", "debug"), "sess_test")
                 .join();
 
         for (int i = 0; i < 3; i++) {
@@ -220,7 +232,7 @@ class NotificationDeliveryTest {
                     "arguments", java.util.Map.of(),
                     "_meta", java.util.Map.of("progressToken", i));
             dispatcher
-                    .dispatchRequestAsync(2 + i, "tools/call", params, "sess_test")
+                    .dispatchRequestAsync(RequestId.of(2 + i), "tools/call", params, "sess_test")
                     .join();
         }
 
@@ -255,17 +267,21 @@ class NotificationDeliveryTest {
         session2.activate();
 
         dispatcher
-                .dispatchRequestAsync(1, "logging/setLevel", java.util.Map.of("level", "info"), "sess_test")
+                .dispatchRequestAsync(
+                        RequestId.of(1), "logging/setLevel", java.util.Map.of("level", "info"), "sess_test")
                 .join();
         dispatcher
-                .dispatchRequestAsync(2, "logging/setLevel", java.util.Map.of("level", "warning"), "sess_other")
+                .dispatchRequestAsync(
+                        RequestId.of(2), "logging/setLevel", java.util.Map.of("level", "warning"), "sess_other")
                 .join();
 
         var params = java.util.Map.of(
                 "name", "test_tool",
                 "arguments", java.util.Map.of(),
                 "_meta", java.util.Map.of("progressToken", 1));
-        dispatcher.dispatchRequestAsync(3, "tools/call", params, "sess_test").join();
+        dispatcher
+                .dispatchRequestAsync(RequestId.of(3), "tools/call", params, "sess_test")
+                .join();
 
         var testLogEvents = testConn.sent.stream()
                 .filter(e -> e.data().contains("notifications/message"))

--- a/tachyon-server/src/test/java/dev/tachyonmcp/transport/netty/sse/SseManagerTest.java
+++ b/tachyon-server/src/test/java/dev/tachyonmcp/transport/netty/sse/SseManagerTest.java
@@ -9,6 +9,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import dev.tachyonmcp.runtime.SseConnection;
 import dev.tachyonmcp.runtime.SseEvent;
+import dev.tachyonmcp.server.domain.RequestId;
 import dev.tachyonmcp.server.internal.ServerEngine;
 import dev.tachyonmcp.server.session.SessionEvent;
 import java.util.ArrayList;
@@ -23,8 +24,8 @@ class SseManagerTest {
             var session = server.createSession("sess_replay");
             session.connection(conn);
             for (long id = 1; id <= 5; id++) {
-                server.appendEvent(
-                        new SessionEvent.ResponseEvent("sess_replay", id, "{\"n\":" + id + "}", 1000L + id, id, null));
+                server.appendEvent(new SessionEvent.ResponseEvent(
+                        "sess_replay", RequestId.of(id), "{\"n\":" + id + "}", 1000L + id, id, null));
             }
 
             var manager = new SseManager(server);
@@ -42,7 +43,7 @@ class SseManagerTest {
             var conn = new TrackingConnection();
             var session = server.createSession("sess_bad");
             session.connection(conn);
-            server.appendEvent(new SessionEvent.ResponseEvent("sess_bad", 1, "{}", 1000L, 1L, null));
+            server.appendEvent(new SessionEvent.ResponseEvent("sess_bad", RequestId.of(1), "{}", 1000L, 1L, null));
 
             var manager = new SseManager(server);
             manager.replayEvents(session, "not-a-number");
@@ -58,7 +59,8 @@ class SseManagerTest {
             var session = server.createSession("sess_future");
             session.connection(conn);
             for (long id = 1; id <= 3; id++) {
-                server.appendEvent(new SessionEvent.ResponseEvent("sess_future", id, "{}", 1000L + id, id, null));
+                server.appendEvent(
+                        new SessionEvent.ResponseEvent("sess_future", RequestId.of(id), "{}", 1000L + id, id, null));
             }
 
             var manager = new SseManager(server);
@@ -75,7 +77,8 @@ class SseManagerTest {
             var session = server.createSession("sess_zero");
             session.connection(conn);
             for (long id = 1; id <= 3; id++) {
-                server.appendEvent(new SessionEvent.ResponseEvent("sess_zero", id, "{}", 1000L + id, id, null));
+                server.appendEvent(
+                        new SessionEvent.ResponseEvent("sess_zero", RequestId.of(id), "{}", 1000L + id, id, null));
             }
 
             var manager = new SseManager(server);
@@ -94,9 +97,10 @@ class SseManagerTest {
             var conn = new TrackingConnection();
             var session = server.createSession("sess_mixed");
             session.connection(conn);
-            server.appendEvent(new SessionEvent.RequestEvent("sess_mixed", 1, "ping", "{}", 1000L));
-            server.appendEvent(new SessionEvent.ResponseEvent("sess_mixed", 1, "{\"pong\":true}", 1100L, 1L, null));
-            server.appendEvent(new SessionEvent.CancelEvent("sess_mixed", 2, 1200L));
+            server.appendEvent(new SessionEvent.RequestEvent("sess_mixed", RequestId.of(1), "ping", "{}", 1000L));
+            server.appendEvent(
+                    new SessionEvent.ResponseEvent("sess_mixed", RequestId.of(1), "{\"pong\":true}", 1100L, 1L, null));
+            server.appendEvent(new SessionEvent.CancelEvent("sess_mixed", RequestId.of(2), 1200L));
             server.appendEvent(
                     new SessionEvent.NotificationEvent("sess_mixed", "notifications/test", "{}", 1300L, 2L, null));
 


### PR DESCRIPTION
The change corrects `TextResourceContents` and `BlobResourceContents` factory argument ordering across production code, examples, conformance fixtures, and tests. It introduces typed sealed `RequestId` and `ProgressToken` models, propagating them through JSON-RPC codecs, dispatch, transport, session events, pending requests, tasks, and notifications. Tests are updated for typed values. A disabled full conformance-suite runner, documentation updates, and a Kotlin example dependency update were also added.