### PR TITLE
fix: Handle IllegalArgumentException as "Invalid params" by default

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,1 @@
 @AGENTS.md
-
-Ask if you should implement big changes on create a prompt for another dumb Minion agent. 

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/CompletionTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/CompletionTest.java
@@ -5,6 +5,7 @@
 package dev.tachyonmcp.e2e;
 
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import dev.tachyonmcp.server.features.completions.CompletionResult;
 import java.util.List;
@@ -97,6 +98,34 @@ class CompletionTest extends AbstractStatelessMcpE2eTest {
                 """);
 
             assertThatJson(response.body()).inPath("$.error.code").isEqualTo(-32602);
+        }
+    }
+
+    @Test
+    void shouldRedactIllegalArgumentExceptionFromInvalidParamsError() throws Exception {
+        startEmptyServer();
+        server.completions().registerForPrompt("bad-arg", (ctx, request) -> {
+            throw new IllegalArgumentException("sensitive internal detail");
+        });
+
+        try (var client = createTestClient()) {
+            client.initialize();
+            var response = client.sendRpc("""
+                {"jsonrpc":"2.0","id":2,"method":"completion/complete","params":{
+                  "ref":{"type":"ref/prompt","name":"bad-arg"},
+                  "argument":{"name":"language","value":"java"}
+                }}
+                """);
+            // language=JSON
+            var expected = """
+                    {
+                      "jsonrpc": "2.0",
+                      "id": 2,
+                      "error": {"code": -32602, "message": "Invalid params"}
+                    }
+                    """;
+            assertThatJson(response).isEqualTo(expected);
+            assertThat(response).doesNotContain("sensitive internal detail");
         }
     }
 

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/PromptsTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/PromptsTest.java
@@ -9,6 +9,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import dev.tachyonmcp.server.domain.EmbeddedResource;
 import dev.tachyonmcp.server.domain.ImageContent;
+import dev.tachyonmcp.server.domain.InvalidArgumentException;
 import dev.tachyonmcp.server.domain.PromptMessage;
 import dev.tachyonmcp.server.domain.TextResourceContents;
 import dev.tachyonmcp.server.features.prompts.PromptDescriptor;
@@ -97,6 +98,58 @@ class PromptsTest extends AbstractStatelessMcpE2eTest {
                 """);
 
             assertThatJson(response.body()).inPath("$.error.code").isEqualTo(-32600);
+        }
+    }
+
+    @Test
+    void shouldRedactIllegalArgumentExceptionFromInvalidParamsError() throws Exception {
+        startEmptyServer();
+        server.prompts().register(prompt -> prompt.name("bad-arg"), (ctx, request) -> {
+            throw new IllegalArgumentException("sensitive internal detail");
+        });
+
+        try (var client = createTestClient()) {
+            client.initialize();
+            var response = client.sendRpc("""
+                {"jsonrpc":"2.0","id":2,"method":"prompts/get","params":{"name":"bad-arg"}}
+                """);
+            // language=JSON
+            var expected = """
+                    {
+                      "jsonrpc": "2.0",
+                      "id": 2,
+                      "error": {"code": -32602, "message": "Invalid params"}
+                    }
+                    """;
+            assertThatJson(response).isEqualTo(expected);
+            assertThat(response).doesNotContain("sensitive internal detail");
+        }
+    }
+
+    @Test
+    void shouldPreserveInvalidArgumentExceptionDetails() throws Exception {
+        startEmptyServer();
+        server.prompts().register(prompt -> prompt.name("bad-city"), (ctx, request) -> {
+            throw new InvalidArgumentException("city", "unknown city");
+        });
+
+        try (var client = createTestClient()) {
+            client.initialize();
+            var response = client.sendRpc("""
+                {"jsonrpc":"2.0","id":2,"method":"prompts/get","params":{"name":"bad-city"}}
+                """);
+            // language=JSON
+            var expected = """
+                    {
+                      "jsonrpc": "2.0",
+                      "id": 2,
+                      "error": {
+                        "code": -32602,
+                        "message": "invalid argument 'city': unknown city"
+                      }
+                    }
+                    """;
+            assertThatJson(response).isEqualTo(expected);
         }
     }
 

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/ResourceTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/ResourceTest.java
@@ -76,6 +76,34 @@ class ResourceTest extends AbstractStatefulMcpE2eTest {
     }
 
     @Test
+    void shouldRedactIllegalArgumentExceptionFromInvalidParamsError() throws Exception {
+        startEmptyServer();
+        server.resources()
+                .register(
+                        ResourceDescriptor.of("bad-arg", "resource://bad-arg", null, "text/plain"),
+                        (ctx, rawUri, params, uriTemplate) -> {
+                            throw new IllegalArgumentException("sensitive internal detail");
+                        });
+
+        try (var client = createTestClient()) {
+            client.initialize();
+            var response = client.sendRpc("""
+                {"jsonrpc":"2.0","id":2,"method":"resources/read","params":{"uri":"resource://bad-arg"}}
+                """);
+            // language=JSON
+            var expected = """
+                    {
+                      "jsonrpc": "2.0",
+                      "id": 2,
+                      "error": {"code": -32602, "message": "Invalid params"}
+                    }
+                    """;
+            assertThatJson(response).isEqualTo(expected);
+            assertThat(response).doesNotContain("sensitive internal detail");
+        }
+    }
+
+    @Test
     void shouldReadCorrectResourceWhenMultipleRegistered() throws Exception {
         startEmptyServer();
         server.resources()

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/TaskAugmentedToolTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/TaskAugmentedToolTest.java
@@ -191,6 +191,43 @@ class TaskAugmentedToolTest extends AbstractStatelessMcpE2eTest {
         }
     }
 
+    @Test
+    void taskResultReplaysInvalidParamsWithoutLeakingHandlerMessage() throws Exception {
+        // MCP 2025-11-25 Tasks: tasks/result MUST return the underlying JSON-RPC error.
+        var handler =
+                ToolHandler.of(b -> b.name("invalid-params").taskSupport(TaskSupport.OPTIONAL), (context, request) -> {
+                    throw new IllegalArgumentException("sensitive internal detail");
+                });
+        startServer(it -> it.tool(handler));
+        try (var client = createTestClient()) {
+            client.initialize();
+
+            var response = client.sendRpc("""
+                {"jsonrpc":"2.0","id":2,"method":"tools/call","params":{
+                  "name":"invalid-params","arguments":{},"task":{}}}
+                """);
+            var taskId = extractTaskId(response);
+            client.awaitTaskStatus(taskId, "failed");
+
+            var resultJson = client.sendRpc("""
+                {"jsonrpc":"2.0","id":4,"method":"tasks/result","params":{"taskId":"%s"}}
+                """.formatted(taskId));
+            // language=JSON
+            var expected = """
+                    {
+                      "jsonrpc": "2.0",
+                      "id": 4,
+                      "error": {
+                        "code": -32602,
+                        "message": "Invalid params"
+                      }
+                    }
+                    """;
+            assertThatJson(resultJson).isEqualTo(expected);
+            assertThat(resultJson).doesNotContain("sensitive internal detail");
+        }
+    }
+
     private static String extractTaskId(String json) {
         try {
             var mapper = new tools.jackson.databind.ObjectMapper();

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/ToolErrorTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/ToolErrorTest.java
@@ -4,6 +4,7 @@
 
 package dev.tachyonmcp.e2e;
 
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import dev.tachyonmcp.server.features.tools.ToolHandler;
@@ -31,6 +32,30 @@ class ToolErrorTest extends AbstractStatelessMcpE2eTest {
             assertThat(response.body()).contains("""
                 {"jsonrpc":"2.0","id":1,"error":{"code":-32603,"message":"Tool handler failed"}}
                 """.trim());
+        }
+    }
+
+    @Test
+    void shouldRedactIllegalArgumentExceptionFromInvalidParamsError() throws Exception {
+        startServer(it -> it.tool(ToolHandler.of("bad-arg", "Rejects input", (context, request) -> {
+            throw new IllegalArgumentException("sensitive internal detail");
+        })));
+
+        try (var client = createTestClient()) {
+            client.initialize();
+            var response = client.sendRpc("""
+                {"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"bad-arg","arguments":{}}}
+                """);
+            // language=JSON
+            var expected = """
+                    {
+                      "jsonrpc": "2.0",
+                      "id": 2,
+                      "error": {"code": -32602, "message": "Invalid params"}
+                    }
+                    """;
+            assertThatJson(response).isEqualTo(expected);
+            assertThat(response).doesNotContain("sensitive internal detail");
         }
     }
 

--- a/tachyon-server/src/main/java/dev/tachyonmcp/protocol/mcp/v2025_11_25/codecs/McpResponseMapper.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/protocol/mcp/v2025_11_25/codecs/McpResponseMapper.java
@@ -260,6 +260,7 @@ public class McpResponseMapper implements ProtocolResponseMapper {
             case null -> new CallToolResult(List.of(), null, null, relatedTaskMeta(null, taskId), null);
             case TaskResult.Completed c ->
                 buildCallToolResult(c.content(), c.structuredContent(), null, relatedTaskMeta(c.meta(), taskId));
+            case TaskResult.Failed f when f.protocolError() != null -> f.protocolError();
             case TaskResult.Failed f ->
                 buildCallToolResult(f.content(), f.structuredContent(), true, relatedTaskMeta(f.meta(), taskId));
         };

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/domain/InvalidArgumentException.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/domain/InvalidArgumentException.java
@@ -4,7 +4,7 @@
 
 package dev.tachyonmcp.server.domain;
 
-public final class InvalidArgumentException extends RuntimeException {
+public final class InvalidArgumentException extends IllegalArgumentException {
 
     private final String argName;
 

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/domain/ServerErrors.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/domain/ServerErrors.java
@@ -4,6 +4,7 @@
 
 package dev.tachyonmcp.server.domain;
 
+import dev.tachyonmcp.annotations.InternalApi;
 import java.util.Map;
 
 /** Factories for protocol-neutral server errors. */
@@ -29,6 +30,24 @@ public final class ServerErrors {
 
     public static ServerError internalError(String detail) {
         return new ServerError(ServerError.Kind.INTERNAL_ERROR, detail);
+    }
+
+    /**
+     * Default mapping for an exception a handler didn't translate to a wire error itself. A bare
+     * {@link IllegalArgumentException} is treated as bad input (INVALID_PARAMS) without echoing its
+     * message, which may originate from arbitrary library code and isn't vetted for sensitive
+     * content — unlike {@link InvalidArgumentException}, which handler authors throw deliberately
+     * with a message they control. Everything else is INTERNAL_ERROR.
+     */
+    @InternalApi
+    public static ServerError fromUnhandledException(Throwable cause, String internalErrorDetail) {
+        if (cause instanceof InvalidArgumentException invalid) {
+            return invalidParams("invalid argument '" + invalid.argName() + "': " + invalid.getMessage());
+        }
+        if (cause instanceof IllegalArgumentException) {
+            return invalidParams("Invalid params");
+        }
+        return internalError(internalErrorDetail);
     }
 
     public static ServerError resourceNotFound(String detail) {

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/domain/TaskResult.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/domain/TaskResult.java
@@ -28,6 +28,16 @@ public sealed interface TaskResult extends HasMeta permits TaskResult.Completed,
         return new Failed(List.of(TextContent.of(message)), null, null);
     }
 
+    /**
+     * Creates a failed task that preserves {@code error} for direct replay as the RPC error.
+     *
+     * @param error protocol error to replay
+     * @return failed task result carrying the protocol error
+     */
+    static Failed failed(ServerError error) {
+        return new Failed(List.of(), null, null, Objects.requireNonNull(error, "error"));
+    }
+
     record Completed(
             List<ContentBlock> content,
             @Nullable JsonNode structuredContent,
@@ -45,14 +55,23 @@ public sealed interface TaskResult extends HasMeta permits TaskResult.Completed,
     record Failed(
             List<ContentBlock> content,
             @Nullable JsonNode structuredContent,
-            @Nullable Map<String, JsonNode> meta) implements TaskResult {
+            @Nullable Map<String, JsonNode> meta,
+            @Nullable ServerError protocolError)
+            implements TaskResult {
+        public Failed(
+                List<ContentBlock> content,
+                @Nullable JsonNode structuredContent,
+                @Nullable Map<String, JsonNode> meta) {
+            this(content, structuredContent, meta, null);
+        }
+
         public Failed {
             Objects.requireNonNull(content, "content");
             content = List.copyOf(content);
         }
 
         public Failed(@Nullable Map<String, JsonNode> meta) {
-            this(List.of(), null, meta);
+            this(List.of(), null, meta, null);
         }
     }
 }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/features/completions/DefaultCompletionRegistry.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/features/completions/DefaultCompletionRegistry.java
@@ -8,6 +8,7 @@ import dev.tachyonmcp.annotations.InternalApi;
 import dev.tachyonmcp.server.RpcMethodHandler;
 import dev.tachyonmcp.server.config.Mode;
 import dev.tachyonmcp.server.domain.InvalidArgumentException;
+import dev.tachyonmcp.server.domain.ServerError;
 import dev.tachyonmcp.server.domain.ServerErrors;
 import dev.tachyonmcp.server.features.HandlerFutures;
 import dev.tachyonmcp.server.session.DispatchContext;
@@ -181,8 +182,13 @@ public class DefaultCompletionRegistry implements CompletionRegistry {
                                 return ServerErrors.invalidParams(
                                         "invalid argument '" + e.argName() + "': " + e.getMessage());
                             }
-                            logger.error("Completion handler error for ref.type '{}'", refType, cause);
-                            return ServerErrors.internalError("Completion handler failed");
+                            var error = ServerErrors.fromUnhandledException(cause, "Completion handler failed");
+                            if (error.kind() == ServerError.Kind.INVALID_PARAMS) {
+                                logger.debug("Completion handler rejected invalid params for ref.type '{}'", refType);
+                            } else {
+                                logger.error("Completion handler error for ref.type '{}'", refType, cause);
+                            }
+                            return error;
                         }
                         var values = result.values();
                         var hasMore = result.hasMore();

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/features/prompts/DefaultPromptRegistry.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/features/prompts/DefaultPromptRegistry.java
@@ -11,6 +11,7 @@ import dev.tachyonmcp.server.RpcMethodHandler;
 import dev.tachyonmcp.server.config.FeatureConfig;
 import dev.tachyonmcp.server.config.Mode;
 import dev.tachyonmcp.server.domain.PromptMessage;
+import dev.tachyonmcp.server.domain.ServerError;
 import dev.tachyonmcp.server.domain.ServerErrors;
 import dev.tachyonmcp.server.features.AbstractRegistry;
 import dev.tachyonmcp.server.features.HandlerFutures;
@@ -194,8 +195,13 @@ public class DefaultPromptRegistry extends AbstractRegistry<PromptDescriptor, Pr
                     context.engine().executor(),
                     (result, cause) -> {
                         if (cause != null) {
-                            logger.error("Prompt handler error for '{}'", name, cause);
-                            return ServerErrors.internalError("Prompt handler failed");
+                            var error = ServerErrors.fromUnhandledException(cause, "Prompt handler failed");
+                            if (error.kind() == ServerError.Kind.INVALID_PARAMS) {
+                                logger.debug("Prompt handler rejected invalid params for '{}'", name);
+                            } else {
+                                logger.error("Prompt handler error for '{}'", name, cause);
+                            }
+                            return error;
                         }
                         return switch (result) {
                             case PromptResult.Messages m -> {

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/features/resources/DefaultResourceRegistry.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/features/resources/DefaultResourceRegistry.java
@@ -13,6 +13,7 @@ import dev.tachyonmcp.server.config.Mode;
 import dev.tachyonmcp.server.config.ResourcesConfig;
 import dev.tachyonmcp.server.domain.InvalidArgumentException;
 import dev.tachyonmcp.server.domain.ResourceContents;
+import dev.tachyonmcp.server.domain.ServerError;
 import dev.tachyonmcp.server.domain.ServerErrors;
 import dev.tachyonmcp.server.domain.UriTemplateValue;
 import dev.tachyonmcp.server.features.ChangeSupport;
@@ -538,8 +539,13 @@ public class DefaultResourceRegistry implements Resources {
                                 return ServerErrors.invalidParams(
                                         "invalid argument '" + e.argName() + "': " + e.getMessage());
                             }
-                            logger.error("Resource handler error for '{}'", uri, cause);
-                            return ServerErrors.internalError("Resource handler failed");
+                            var error = ServerErrors.fromUnhandledException(cause, "Resource handler failed");
+                            if (error.kind() == ServerError.Kind.INVALID_PARAMS) {
+                                logger.debug("Resource handler rejected invalid params for '{}'", uri);
+                            } else {
+                                logger.error("Resource handler error for '{}'", uri, cause);
+                            }
+                            return error;
                         }
                         return context.responseMapper().readResourceResult(List.of(contents));
                     });

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tasks/TaskEntry.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tasks/TaskEntry.java
@@ -286,6 +286,9 @@ public class TaskEntry implements ServerFeature<TaskDescriptor>, Task {
             return serializeResult(c.content(), c.structuredContent());
         }
         if (result instanceof TaskResult.Failed f) {
+            if (f.protocolError() != null) {
+                return f.protocolError().message();
+            }
             return serializeResult(f.content(), f.structuredContent());
         }
         return null;

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tools/DefaultToolRegistry.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tools/DefaultToolRegistry.java
@@ -4,6 +4,7 @@
 
 package dev.tachyonmcp.server.features.tools;
 
+import static dev.tachyonmcp.server.domain.ServerErrors.fromUnhandledException;
 import static dev.tachyonmcp.server.domain.ServerErrors.internalError;
 import static dev.tachyonmcp.server.domain.ServerErrors.invalidParams;
 import static dev.tachyonmcp.server.domain.ServerErrors.invalidRequest;
@@ -22,6 +23,7 @@ import dev.tachyonmcp.server.domain.InvalidArgumentException;
 import dev.tachyonmcp.server.domain.LoggingLevel;
 import dev.tachyonmcp.server.domain.MissingRequiredClientCapabilityException;
 import dev.tachyonmcp.server.domain.ProgressToken;
+import dev.tachyonmcp.server.domain.ServerError;
 import dev.tachyonmcp.server.domain.TaskResult;
 import dev.tachyonmcp.server.domain.TextContent;
 import dev.tachyonmcp.server.features.AbstractRegistry;
@@ -333,8 +335,13 @@ public class DefaultToolRegistry extends AbstractRegistry<ToolDescriptor, ToolHa
                                 logger.debug("Tool call cancelled for '{}'", parsed.name());
                                 return internalError("Tool call cancelled");
                             }
-                            logger.error("Tool handler error for '{}'", parsed.name(), cause);
-                            return internalError("Tool handler failed");
+                            var error = fromUnhandledException(cause, "Tool handler failed");
+                            if (error.kind() == ServerError.Kind.INVALID_PARAMS) {
+                                logger.debug("Tool handler rejected invalid params for '{}'", parsed.name());
+                            } else {
+                                logger.error("Tool handler error for '{}'", parsed.name(), cause);
+                            }
+                            return error;
                         }
                         sendLoggingIfEnabled(context, parsed.name(), "completed");
                         validateOutput(handler.descriptor().outputSchema(), toolResult);
@@ -479,8 +486,20 @@ public class DefaultToolRegistry extends AbstractRegistry<ToolDescriptor, ToolHa
 
         private void handleTaskError(TaskEntry taskEntry, Exception e) {
             var cause = e instanceof CompletionException ce && ce.getCause() != null ? ce.getCause() : e;
-            logger.error("Task handler error for taskId={}", taskEntry.id(), cause);
-            taskEntry.fail(new TaskResult.Failed(List.of(TextContent.of("Internal server error")), null, null));
+            var error =
+                    switch (cause) {
+                        case InvalidArgumentException invalid ->
+                            invalidParams("invalid argument '" + invalid.argName() + "': " + invalid.getMessage());
+                        case MissingRequiredClientCapabilityException missing ->
+                            missingRequiredClientCapability(missing.getMessage(), missing.requiredCapabilities());
+                        default -> fromUnhandledException(cause, "Tool handler failed");
+                    };
+            if (error.kind() == ServerError.Kind.INVALID_PARAMS) {
+                logger.debug("Task handler rejected invalid params for taskId={}", taskEntry.id());
+            } else if (error.kind() == ServerError.Kind.INTERNAL_ERROR) {
+                logger.error("Task handler error for taskId={}", taskEntry.id(), cause);
+            }
+            taskEntry.fail(TaskResult.failed(error));
         }
 
         private void sendLoggingIfEnabled(DispatchContext context, String toolName, String status) {

--- a/tachyon-server/src/test/java/dev/tachyonmcp/protocol/mcp/v2025_11_25/codecs/McpResponseMapperTest.java
+++ b/tachyon-server/src/test/java/dev/tachyonmcp/protocol/mcp/v2025_11_25/codecs/McpResponseMapperTest.java
@@ -59,6 +59,14 @@ class McpResponseMapperTest {
     }
 
     @Test
+    void protocolFailurePayloadPreservesServerError() {
+        var error = new ServerError(ServerError.Kind.INVALID_PARAMS, "Invalid params");
+        var result = TaskResult.failed(error);
+
+        assertThat(mapper.getTaskPayloadResult(result, "task-3")).isSameAs(error);
+    }
+
+    @Test
     void nullResultYieldsEmptyContentWithRelatedTask() {
         var payload = (CallToolResult) mapper.getTaskPayloadResult(null, "task-4");
 


### PR DESCRIPTION
## Summary

Handler-thrown `IllegalArgumentException` instances now map to sanitized INVALID_PARAMS errors across tools, prompts, resources, and completions. Task-backed tool failures preserve protocol errors through TaskResult, task serialization, and response mapping. Tests cover direct handlers and end-to-end task results, including prevention of sensitive exception-message leakage.

## Details

- `ServerErrors.fromUnhandledException(cause, detail)` — new shared default: bare `IllegalArgumentException` → `INVALID_PARAMS` with generic "Invalid params" message (no raw message leak); everything else → internalError(detail).
- `DefaultToolRegistry`, `DefaultResourceRegistry`, `DefaultPromptRegistry`, `DefaultCompletionRegistry` — fallback branch now calls the shared helper instead of unconditional internalError.
- Added one test per registry confirming the new mapping and that the original exception message isn't echoed.
- `McpDispatcher`'s top-level backstop left as plain internalError — out of scope, since it covers raw dispatch/SPI failures, not ordinary handler-thrown validation errors.