### PR TITLE
Hide binary payloads from resource toString()

### DIFF
--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/domain/AudioContent.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/domain/AudioContent.java
@@ -22,6 +22,7 @@ import tools.jackson.databind.JsonNode;
         visibility = Value.Style.ImplementationVisibility.PACKAGE)
 public non-sealed interface AudioContent extends ContentBlock, HasMeta {
 
+    @Value.Redacted
     String data();
 
     String mimeType();

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/domain/BlobResourceContents.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/domain/BlobResourceContents.java
@@ -30,6 +30,7 @@ public non-sealed interface BlobResourceContents extends ResourceContents {
     String mimeType();
 
     @Value.Parameter(order = 3)
+    @Value.Redacted
     String blob();
 
     @Override

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/domain/Icon.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/domain/Icon.java
@@ -22,6 +22,7 @@ import org.jspecify.annotations.Nullable;
         visibility = Value.Style.ImplementationVisibility.PACKAGE)
 public interface Icon {
 
+    @Value.Redacted
     String src();
 
     @Nullable

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/domain/ImageContent.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/domain/ImageContent.java
@@ -22,6 +22,7 @@ import tools.jackson.databind.JsonNode;
         typeImmutable = "Default*")
 public non-sealed interface ImageContent extends ContentBlock {
 
+    @Value.Redacted
     String data();
 
     String mimeType();

--- a/tachyon-server/src/test/java/dev/tachyonmcp/server/domain/BinaryContentToStringTest.java
+++ b/tachyon-server/src/test/java/dev/tachyonmcp/server/domain/BinaryContentToStringTest.java
@@ -22,8 +22,6 @@ class BinaryContentToStringTest {
         assertThat(icon.toString()).doesNotContain(BINARY_PAYLOAD).contains("image/png");
         assertThat(image.toString()).doesNotContain(BINARY_PAYLOAD).contains("image/png");
         assertThat(audio.toString()).doesNotContain(BINARY_PAYLOAD).contains("audio/wav");
-        assertThat(blob.toString())
-                .doesNotContain(BINARY_PAYLOAD)
-                .contains("test://blob", "application/octet-stream");
+        assertThat(blob.toString()).doesNotContain(BINARY_PAYLOAD).contains("test://blob", "application/octet-stream");
     }
 }

--- a/tachyon-server/src/test/java/dev/tachyonmcp/server/domain/BinaryContentToStringTest.java
+++ b/tachyon-server/src/test/java/dev/tachyonmcp/server/domain/BinaryContentToStringTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 Konstantin Pavlov and contributors.
+ */
+
+package dev.tachyonmcp.server.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class BinaryContentToStringTest {
+
+    private static final String BINARY_PAYLOAD = "c2Vuc2l0aXZlLWJpbmFyeS1wYXlsb2Fk";
+
+    @Test
+    void binaryResourceContainersDoNotExposePayloads() {
+        var icon = Icon.of("data:image/png;base64," + BINARY_PAYLOAD, "image/png", null, null);
+        var image = ImageContent.of(BINARY_PAYLOAD, "image/png");
+        var audio = AudioContent.of(BINARY_PAYLOAD, "audio/wav");
+        var blob = BlobResourceContents.of("test://blob", BINARY_PAYLOAD, "application/octet-stream");
+
+        assertThat(icon.toString()).doesNotContain(BINARY_PAYLOAD).contains("image/png");
+        assertThat(image.toString()).doesNotContain(BINARY_PAYLOAD).contains("image/png");
+        assertThat(audio.toString()).doesNotContain(BINARY_PAYLOAD).contains("audio/wav");
+        assertThat(blob.toString())
+                .doesNotContain(BINARY_PAYLOAD)
+                .contains("test://blob", "application/octet-stream");
+    }
+}


### PR DESCRIPTION
## Summary
- mark binary payload fields as redacted in generated immutable `toString()` methods
- cover icons, image/audio content, and blob resources
- add regression tests that preserve useful metadata without exposing payloads

## Verification
- `./mvnw -q -pl tachyon-server -Dtest=BinaryContentToStringTest test`
- `./mvnw -q spotless:check`

Closes #145