### PR TITLE
feat!: Resource API migrated to (InteractionContext, ResourceRequest)

### DIFF
--- a/.agents/skills/tachyon-mcp/SKILL.md
+++ b/.agents/skills/tachyon-mcp/SKILL.md
@@ -134,16 +134,17 @@ Template via builder:
         .uriTemplate("myapp://data/{id}")
         .description("Description")
         .mimeType("application/json"),
-    (ctx, uri, params, uriTemplate) -> {
-        var id = ((UriTemplateValue.Scalar) params.get("id")).value();
-        return TextResourceContents.of(uri, data, "application/json");
+    (ctx, request) -> {
+        var id = ((UriTemplateValue.Scalar) request.params().get("id")).value();
+        return TextResourceContents.of(request.uri(), data, "application/json");
     })
 ```
 
-Static resources and templates share `ResourceHandler`. Its full parameters are `(context, uri,
-params, uriTemplate)`; templates receive immutable parsed values and the original template text,
-`UriTemplate` performs matching. Static resources get an empty params map and null template, so
-use `ResourceHandler.of((ctx, uri) -> ...)` to drop the two unused parameters.
+Static resources and templates share `ResourceHandler`. Its canonical shape is
+`(InteractionContext, ResourceRequest)`. `ResourceRequest` carries `uri`, immutable template
+`params`, nullable `uriTemplate`, and request `_meta`. `UriTemplate` performs matching. Static
+resources get an empty params map and null template. Use `ResourceHandler.of((ctx, uri) -> ...)`
+only when a static handler does not need request metadata.
 
 Use explicit async methods. Sync handlers run blocking-first on virtual threads.
 

--- a/.agents/skills/tachyon-mcp/resources/java/ResourceHandlerExample.java
+++ b/.agents/skills/tachyon-mcp/resources/java/ResourceHandlerExample.java
@@ -49,9 +49,10 @@ final class ResourceHandlerExample {
     }
 
     static ResourceHandler userProfileTemplateHandler() {
-        return (ctx, uri, params, uriTemplate) -> {
-            var userId = params.get("userId").scalarValue();
-            return TextResourceContents.of(uri, "{\"userId\":\"" + userId + "\"}", "application/json");
+        return (ctx, request) -> {
+            var userId = request.params().get("userId").scalarValue();
+            return TextResourceContents.of(
+                request.uri(), "{\"userId\":\"" + userId + "\"}", "application/json");
         };
     }
 
@@ -66,8 +67,10 @@ final class ResourceHandlerExample {
     }
 
     static ResourceHandler forecastTemplateHandler() {
-        return (ctx, uri, params, uriTemplate) -> TextResourceContents.of(
-            uri, "{\"city\":\"" + params.get("city").scalarValue() + "\",\"temp\":22}", "application/json"
+        return (ctx, request) -> TextResourceContents.of(
+            request.uri(),
+            "{\"city\":\"" + request.params().get("city").scalarValue() + "\",\"temp\":22}",
+            "application/json"
         );
     }
 

--- a/.agents/skills/tachyon-mcp/resources/java/ServerBasic.java
+++ b/.agents/skills/tachyon-mcp/resources/java/ServerBasic.java
@@ -49,8 +49,8 @@ public final class ServerBasic {
                 ResourceDescriptor.of(
                     "config", "demo://config",
                     "Server configuration", "application/json"),
-                (ctx, uri, params, uriTemplate) ->
-                    TextResourceContents.of(uri, "{\"mode\":\"production\"}", "application/json"))
+                (ctx, request) ->
+                    TextResourceContents.of(request.uri(), "{\"mode\":\"production\"}", "application/json"))
             .prompt(
                 PromptDescriptor.of("greet", "Generates a greeting"),
                 List.of(PromptMessage.user("Say hello")))
@@ -59,10 +59,10 @@ public final class ServerBasic {
                     .uriTemplate("demo://users/{userId}/profile")
                     .description("User profile data")
                     .mimeType("application/json"),
-                (ctx, uri, params, uriTemplate) -> {
-                    var userId = params.get("userId").scalarValue();
+                (ctx, request) -> {
+                    var userId = request.params().get("userId").scalarValue();
                     return TextResourceContents.of(
-                        uri, "{\"userId\":\"" + userId + "\",\"name\":\"User\"}", "application/json");
+                        request.uri(), "{\"userId\":\"" + userId + "\",\"name\":\"User\"}", "application/json");
                 })
             .port(port)
             .start();

--- a/.agents/skills/tachyon-mcp/resources/kotlin/ResourceHandlerExample.kt
+++ b/.agents/skills/tachyon-mcp/resources/kotlin/ResourceHandlerExample.kt
@@ -50,10 +50,10 @@ fun userProfileTemplateDescriptor(): ResourceTemplateDescriptor =
         .build()
 
 fun userProfileTemplateHandler(): ResourceHandler =
-    ResourceHandler { _, uri, params, _ ->
-        val userId = params["userId"]?.scalarValue()
+    ResourceHandler { _, request ->
+        val userId = request.params()["userId"]?.scalarValue()
         TextResourceContents(
-            uri = uri,
+            uri = request.uri(),
             mimeType = "application/json",
             text = """{"userId":"$userId"}""",
         )
@@ -70,10 +70,10 @@ fun forecastTemplateDescriptor(): ResourceTemplateDescriptor =
         .build()
 
 fun forecastTemplateHandler(): ResourceHandler =
-    ResourceHandler { _, uri, params, _ ->
-        val city = params["city"]?.scalarValue()
+    ResourceHandler { _, request ->
+        val city = request.params()["city"]?.scalarValue()
         TextResourceContents(
-            uri = uri,
+            uri = request.uri(),
             mimeType = "application/json",
             text = """{"city":"$city","temp":22}""",
         )

--- a/conformance/src/test/java/dev/tachyonmcp/conformance/AbstractConformanceServer.java
+++ b/conformance/src/test/java/dev/tachyonmcp/conformance/AbstractConformanceServer.java
@@ -16,7 +16,6 @@ import dev.tachyonmcp.server.domain.PromptMessage;
 import dev.tachyonmcp.server.domain.RpcMethodRequest;
 import dev.tachyonmcp.server.domain.TextContent;
 import dev.tachyonmcp.server.domain.TextResourceContents;
-import dev.tachyonmcp.server.domain.UriTemplateValue;
 import dev.tachyonmcp.server.features.prompts.PromptDescriptor;
 import dev.tachyonmcp.server.features.prompts.PromptResult;
 import dev.tachyonmcp.server.features.resources.ResourceDescriptor;
@@ -34,6 +33,7 @@ import java.util.concurrent.TimeUnit;
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 import org.awaitility.Awaitility;
+import org.jspecify.annotations.Nullable;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.node.JsonNodeFactory;
@@ -119,7 +119,7 @@ abstract class AbstractConformanceServer {
         }
     }
 
-    protected static boolean verifyState(String signedState) {
+    protected static boolean verifyState(@Nullable String signedState) {
         if (signedState == null) return false;
         var lastDot = signedState.lastIndexOf('.');
         if (lastDot < 0) return false;
@@ -472,7 +472,7 @@ abstract class AbstractConformanceServer {
                                 var inputResponses = request.inputResponses();
                                 var requestState = request.requestState();
                                 if (inputResponses != null && inputResponses.containsKey("confirm")) {
-                                    if (requestState == null || !verifyState(requestState)) {
+                                    if (!verifyState(requestState)) {
                                         throw new IllegalArgumentException("Invalid or tampered requestState");
                                     }
                                     return ToolResult.text("State verified");
@@ -523,31 +523,30 @@ abstract class AbstractConformanceServer {
         server.resources()
                 .register(
                         ResourceDescriptor.of("hello", "hello://world", "Hello resource", "text/plain"),
-                        (ctx, rawUri, params, uriTemplate) ->
-                                TextResourceContents.of(rawUri, "Hello, World!", "text/plain"));
+                        (ctx, request) -> TextResourceContents.of(request.uri(), "Hello, World!", "text/plain"));
 
         server.resources()
                 .register(
                         ResourceDescriptor.of(
                                 "static-text", "test://static-text", "Static text resource", "text/plain"),
-                        (ctx, rawUri, params, uriTemplate) -> TextResourceContents.of(
-                                rawUri, "This is static text content for testing.", "text/plain"));
+                        (ctx, request) -> TextResourceContents.of(
+                                request.uri(), "This is static text content for testing.", "text/plain"));
 
         server.resources()
                 .register(
                         ResourceDescriptor.of(
                                 "static-binary", "test://static-binary", "Static binary resource", "image/png"),
-                        (ctx, rawUri, params, uriTemplate) ->
-                                BlobResourceContents.of(rawUri, MINI_PNG_BASE64, "image/png"));
+                        (ctx, request) -> BlobResourceContents.of(request.uri(), MINI_PNG_BASE64, "image/png"));
 
         server.resources()
                 .registerTemplate(
                         builder -> builder.name("test-template")
                                 .uriTemplate("test://template/{id}/data")
                                 .description("test-description"),
-                        (ctx, rawUri, params, uriTemplate) -> TextResourceContents.of(
-                                rawUri,
-                                "Resource content for id: " + ((UriTemplateValue.Scalar) params.get("id")).value(),
+                        (ctx, request) -> TextResourceContents.of(
+                                request.uri(),
+                                "Resource content for id: "
+                                        + request.params().get("id").scalarValue(),
                                 "text/plain"));
     }
 

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -12,8 +12,8 @@ import dev.tachyonmcp.server.features.resources.ResourceDescriptor;
 
 .resource(
     ResourceDescriptor.of("config", "app://config", "Server config", "application/json"),
-    (ctx, uri, params, uriTemplate) ->
-        TextResourceContents.of(uri, """{"env":"prod"}""", "application/json"))
+    (ctx, request) ->
+        TextResourceContents.of(request.uri(), """{"env":"prod"}""", "application/json"))
 ```
 
 ## URI template
@@ -32,16 +32,16 @@ server.resources()
             .description("User profile by ID")
             .mimeType("application/json")
             .build(),
-        (ctx, uri, params, uriTemplate) -> {
-            String id = params.get("id").scalarValue();
-            return TextResourceContents.of(uri, loadUser(id), "application/json");
+        (ctx, request) -> {
+            String id = request.params().get("id").scalarValue();
+            return TextResourceContents.of(request.uri(), loadUser(id), "application/json");
         });
 ```
 
-Static resources and templates use the same `ResourceHandler`. `uriTemplate` is null and `params`
-is empty for a static resource. Template handlers receive the original template text and immutable
-parsed values. `UriTemplate` performs matching internally. Values are `UriTemplateValue.Scalar` or
-`UriTemplateValue.Sequence`.
+Static resources and templates use the same `ResourceHandler`. Its `ResourceRequest` contains the
+URI, request `_meta`, immutable template parameters, and the nullable original template text.
+`uriTemplate()` is null and `params()` is empty for a static resource. `UriTemplate` performs
+matching internally. Values are `UriTemplateValue.Scalar` or `UriTemplateValue.Sequence`.
 Exploded lists such as `app://files{/segments*}` produce a sequence. Associative maps are not
 parsed until MCP defines a variable schema that can disambiguate them.
 
@@ -56,11 +56,11 @@ import java.net.URI;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse.BodyHandlers;
 
-AsyncResourceHandler handler = (ctx, uri, params, uriTemplate) ->
+AsyncResourceHandler handler = (ctx, request) ->
     httpClient.sendAsync(
-            HttpRequest.newBuilder(URI.create(uri)).GET().build(),
+            HttpRequest.newBuilder(URI.create(request.uri())).GET().build(),
             BodyHandlers.ofString())
-        .thenApply(rsp -> TextResourceContents.of(uri, rsp.body(), "application/json"));
+        .thenApply(rsp -> TextResourceContents.of(request.uri(), rsp.body(), "application/json"));
 
 .asyncResource(descriptor, handler)
 ```
@@ -75,7 +75,7 @@ Return binary content with `BlobResourceContents`:
 ```java
 import dev.tachyonmcp.server.domain.BlobResourceContents;
 
-(ctx, uri, params, uriTemplate) -> BlobResourceContents.of(uri, base64Image, "image/png")
+(ctx, request) -> BlobResourceContents.of(request.uri(), base64Image, "image/png")
 ```
 
 ## Subscribe to changes
@@ -107,7 +107,7 @@ server.resources().registerTemplate(
         .name("user-profile")
         .uriTemplate("app://users/{id}")
         .build(),
-) { _, uri, params, uriTemplate -> /* ... */ }
+) { _, request -> /* request.uri(), request.params(), request.meta() */ }
 ```
 
 ---

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/ListPaginationE2eTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/ListPaginationE2eTest.java
@@ -18,7 +18,7 @@ class ListPaginationE2eTest extends AbstractStatelessMcpE2eTest {
 
     private static final ObjectMapper MAPPER = new ObjectMapper();
     private static final ResourceHandler EMPTY_RESOURCE =
-            (ctx, rawUri, params, uriTemplate) -> TextResourceContents.of(rawUri, "", "text/plain");
+            (ctx, request) -> TextResourceContents.of(request.uri(), "", "text/plain");
 
     @Test
     void resourcesListReturnsConfiguredPageSize() throws Exception {

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/PostStartRegistrationTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/PostStartRegistrationTest.java
@@ -29,7 +29,7 @@ class PostStartRegistrationTest extends AbstractStatelessMcpE2eTest {
                 .register(
                         ResourceDescriptor.of(
                                 "post-start-res", "test://post-start", "Post-start resource", "text/plain"),
-                        (ctx, rawUri, params, uriTemplate) -> TextResourceContents.of(rawUri, "", "text/plain"));
+                        (ctx, request) -> TextResourceContents.of(request.uri(), "", "text/plain"));
 
         try (var client = createTestClient()) {
             client.initialize();
@@ -66,8 +66,8 @@ class PostStartRegistrationTest extends AbstractStatelessMcpE2eTest {
         server.resources()
                 .register(
                         ResourceDescriptor.of("handled-res", "test://handled", "Handled resource", "text/plain"),
-                        (ctx, rawUri, params, uriTemplate) ->
-                                TextResourceContents.of(rawUri, "post-start data", "text/plain", null));
+                        (ctx, request) ->
+                                TextResourceContents.of(request.uri(), "post-start data", "text/plain", null));
 
         try (var client = createTestClient()) {
             client.initialize();

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/ResourceTemplateTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/ResourceTemplateTest.java
@@ -18,8 +18,10 @@ class ResourceTemplateTest extends AbstractStatelessMcpE2eTest {
                                 .uriTemplate("resource://items/{id}")
                                 .description("An item")
                                 .mimeType("text/plain"),
-                        (ctx, rawUri, params, uriTemplate) -> TextResourceContents.of(
-                                rawUri, "item=" + params.get("id").scalarValue(), "text/plain"));
+                        (ctx, request) -> TextResourceContents.of(
+                                request.uri(),
+                                "item=" + request.params().get("id").scalarValue(),
+                                "text/plain"));
 
         try (var client = createTestClient()) {
             client.initialize();
@@ -54,22 +56,28 @@ class ResourceTemplateTest extends AbstractStatelessMcpE2eTest {
                                 .uriTemplate("resource://items/{id}")
                                 .description("An item")
                                 .mimeType("text/plain"),
-                        (ctx, rawUri, params, uriTemplate) -> TextResourceContents.of(
-                                rawUri, "item=" + params.get("id").scalarValue(), "text/plain"))
+                        (ctx, request) -> TextResourceContents.of(
+                                request.uri(),
+                                "item=" + request.params().get("id").scalarValue(),
+                                "text/plain"))
                 .registerTemplate(
                         builder -> builder.name("orders")
                                 .uriTemplate("resource://orders/{orderId}")
                                 .description("An order")
                                 .mimeType("text/plain"),
-                        (ctx, rawUri, params, uriTemplate) -> TextResourceContents.of(
-                                rawUri, "order=" + params.get("orderId").scalarValue(), "text/plain"))
+                        (ctx, request) -> TextResourceContents.of(
+                                request.uri(),
+                                "order=" + request.params().get("orderId").scalarValue(),
+                                "text/plain"))
                 .registerTemplate(
                         builder -> builder.name("users")
                                 .uriTemplate("resource://users/{userId}")
                                 .description("A user")
                                 .mimeType("text/plain"),
-                        (ctx, rawUri, params, uriTemplate) -> TextResourceContents.of(
-                                rawUri, "user=" + params.get("userId").scalarValue(), "text/plain"));
+                        (ctx, request) -> TextResourceContents.of(
+                                request.uri(),
+                                "user=" + request.params().get("userId").scalarValue(),
+                                "text/plain"));
 
         try (var client = createTestClient()) {
             client.initialize();
@@ -142,10 +150,10 @@ class ResourceTemplateTest extends AbstractStatelessMcpE2eTest {
                                 .uriTemplate("users://{userId}/posts/{postId}")
                                 .description("User's post")
                                 .mimeType("text/plain"),
-                        (ctx, rawUri, params, uriTemplate) -> TextResourceContents.of(
-                                rawUri,
-                                "user=" + params.get("userId").scalarValue() + ",post="
-                                        + params.get("postId").scalarValue(),
+                        (ctx, request) -> TextResourceContents.of(
+                                request.uri(),
+                                "user=" + request.params().get("userId").scalarValue() + ",post="
+                                        + request.params().get("postId").scalarValue(),
                                 "text/plain"));
 
         try (var client = createTestClient()) {
@@ -181,8 +189,10 @@ class ResourceTemplateTest extends AbstractStatelessMcpE2eTest {
                                 .uriTemplate("resource://items/{id}")
                                 .description("An item")
                                 .mimeType("text/plain"),
-                        (ctx, rawUri, params, uriTemplate) -> TextResourceContents.of(
-                                rawUri, "item=" + params.get("id").scalarValue(), "text/plain"));
+                        (ctx, request) -> TextResourceContents.of(
+                                request.uri(),
+                                "item=" + request.params().get("id").scalarValue(),
+                                "text/plain"));
 
         try (var client = createTestClient()) {
             client.initialize();
@@ -214,7 +224,7 @@ class ResourceTemplateTest extends AbstractStatelessMcpE2eTest {
         server.resources()
                 .registerTemplate(
                         builder -> builder.name("item").uriTemplate("resource://items/{id}"),
-                        (ctx, rawUri, params, uriTemplate) -> TextResourceContents.of(rawUri, "item", "text/plain"));
+                        (ctx, request) -> TextResourceContents.of(request.uri(), "item", "text/plain"));
 
         try (var client = createTestClient()) {
             client.initialize();
@@ -244,8 +254,10 @@ class ResourceTemplateTest extends AbstractStatelessMcpE2eTest {
                                 .uriTemplate("resource://items/{id}")
                                 .description("An item")
                                 .mimeType("text/plain"),
-                        (ctx, rawUri, params, uriTemplate) -> TextResourceContents.of(
-                                rawUri, "item=" + params.get("id").scalarValue(), "text/plain"));
+                        (ctx, request) -> TextResourceContents.of(
+                                request.uri(),
+                                "item=" + request.params().get("id").scalarValue(),
+                                "text/plain"));
 
         try (var client = createTestClient()) {
             client.initialize();

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/ResourceTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/ResourceTest.java
@@ -27,10 +27,10 @@ class ResourceTest extends AbstractStatefulMcpE2eTest {
         server.resources()
                 .register(
                         ResourceDescriptor.of("doc", "resource://doc", "A document", "text/plain"),
-                        (ctx, rawUri, params, uriTemplate) -> TextResourceContents.of(rawUri, "Hello", "text/plain"))
+                        (ctx, request) -> TextResourceContents.of(request.uri(), "Hello", "text/plain"))
                 .register(
                         ResourceDescriptor.of("code", "resource://code", "Source code", "text/x-java"),
-                        (ctx, rawUri, params, uriTemplate) ->
+                        (ctx, request) ->
                                 TextResourceContents.of("resource://code", "package com.example;", "text/x-java"));
 
         try (var client = createTestClient()) {
@@ -58,8 +58,7 @@ class ResourceTest extends AbstractStatefulMcpE2eTest {
         server.resources()
                 .register(
                         descriptor,
-                        (ctx, rawUri, params, uriTemplate) ->
-                                TextResourceContents.of(rawUri, "Hello world", "text/plain"));
+                        (ctx, request) -> TextResourceContents.of(request.uri(), "Hello world", "text/plain"));
 
         try (var client = createTestClient()) {
             var sessionId = client.initialize();
@@ -80,8 +79,7 @@ class ResourceTest extends AbstractStatefulMcpE2eTest {
         startEmptyServer();
         server.resources()
                 .register(
-                        ResourceDescriptor.of("bad-arg", "resource://bad-arg", null, "text/plain"),
-                        (ctx, rawUri, params, uriTemplate) -> {
+                        ResourceDescriptor.of("bad-arg", "resource://bad-arg", null, "text/plain"), (ctx, request) -> {
                             throw new IllegalArgumentException("sensitive internal detail");
                         });
 
@@ -109,16 +107,13 @@ class ResourceTest extends AbstractStatefulMcpE2eTest {
         server.resources()
                 .register(
                         ResourceDescriptor.of("alpha", "resource://alpha", "Alpha", "text/plain"),
-                        (ctx, rawUri, params, uriTemplate) ->
-                                TextResourceContents.of(rawUri, "content-alpha", "text/plain"))
+                        (ctx, request) -> TextResourceContents.of(request.uri(), "content-alpha", "text/plain"))
                 .register(
                         ResourceDescriptor.of("beta", "resource://beta", "Beta", "text/plain"),
-                        (ctx, rawUri, params, uriTemplate) ->
-                                TextResourceContents.of(rawUri, "content-beta", "text/plain"))
+                        (ctx, request) -> TextResourceContents.of(request.uri(), "content-beta", "text/plain"))
                 .register(
                         ResourceDescriptor.of("gamma", "resource://gamma", "Gamma", "text/plain"),
-                        (ctx, rawUri, params, uriTemplate) ->
-                                TextResourceContents.of(rawUri, "content-gamma", "text/plain"));
+                        (ctx, request) -> TextResourceContents.of(request.uri(), "content-gamma", "text/plain"));
 
         try (var client = createTestClient()) {
             var sessionId = client.initialize();
@@ -147,7 +142,7 @@ class ResourceTest extends AbstractStatefulMcpE2eTest {
     @Test
     void shouldReadResourceFromAsyncHandler() throws Exception {
         var descriptor = ResourceDescriptor.of("async-doc", "resource://async-doc", "Async document", "text/plain");
-        AsyncResourceHandler handler = (ctx, rawUri, params, uriTemplate) -> CompletableFuture.supplyAsync(
+        AsyncResourceHandler handler = (ctx, request) -> CompletableFuture.supplyAsync(
                 () -> TextResourceContents.of("resource://async-doc", "async content", "text/plain"));
         startEmptyServer();
         server.resources().register(descriptor, handler);
@@ -164,10 +159,47 @@ class ResourceTest extends AbstractStatefulMcpE2eTest {
     }
 
     @Test
+    void shouldPassMetaToResourceHandler() throws Exception {
+        startServer(builder -> builder.resource(
+                resource -> resource.name("meta-doc").uri("resource://meta-doc"),
+                (ctx, request) -> TextResourceContents.of(
+                        request.uri(), request.meta().get("tenant").asString(), "text/plain")));
+
+        try (var client = createTestClient()) {
+            var sessionId = client.initialize();
+            var response = client.post(sessionId, """
+                {"jsonrpc":"2.0","id":2,"method":"resources/read","params":{
+                  "uri":"resource://meta-doc",
+                  "_meta":{"tenant":"acme"}
+                }}
+                """);
+
+            assertThatJson(response.body())
+                    .isEqualTo(
+                            // language=JSON
+                            """
+                    {
+                      "jsonrpc": "2.0",
+                      "id": 2,
+                      "result": {
+                        "contents": [
+                          {
+                            "uri": "resource://meta-doc",
+                            "mimeType": "text/plain",
+                            "text": "acme"
+                          }
+                        ]
+                      }
+                    }
+                    """);
+        }
+    }
+
+    @Test
     void shouldReturnErrorWhenAsyncHandlerFails() throws Exception {
         var descriptor = ResourceDescriptor.of("failing", "resource://failing", "Failing resource", "text/plain");
-        AsyncResourceHandler handler = (ctx, rawUri, params, uriTemplate) ->
-                CompletableFuture.failedFuture(new IllegalStateException("backend down"));
+        AsyncResourceHandler handler =
+                (ctx, request) -> CompletableFuture.failedFuture(new IllegalStateException("backend down"));
         startEmptyServer();
         server.resources().register(descriptor, handler);
 
@@ -230,12 +262,10 @@ class ResourceTest extends AbstractStatefulMcpE2eTest {
         server.resources()
                 .register(
                         ResourceDescriptor.of("alpha", "resource://alpha", "Alpha", "text/plain"),
-                        (ctx, rawUri, params, uriTemplate) ->
-                                TextResourceContents.of(rawUri, "content-alpha", "text/plain"))
+                        (ctx, request) -> TextResourceContents.of(request.uri(), "content-alpha", "text/plain"))
                 .register(
                         ResourceDescriptor.of("beta", "resource://beta", "Beta", "text/plain"),
-                        (ctx, rawUri, params, uriTemplate) ->
-                                TextResourceContents.of(rawUri, "content-beta", "text/plain"));
+                        (ctx, request) -> TextResourceContents.of(request.uri(), "content-beta", "text/plain"));
 
         try (var client = createTestClient()) {
             var sessionId = client.initialize();
@@ -268,7 +298,7 @@ class ResourceTest extends AbstractStatefulMcpE2eTest {
             if ("remove".equals(action)) {
                 builder.resource(
                         ResourceDescriptor.of("doc", "resource://doc", "A document", "text/plain"),
-                        (ctx, rawUri, params, uriTemplate) -> TextResourceContents.of(rawUri, "", "text/plain"));
+                        (ctx, request) -> TextResourceContents.of(request.uri(), "", "text/plain"));
             }
         });
 
@@ -286,7 +316,7 @@ class ResourceTest extends AbstractStatefulMcpE2eTest {
     void shouldNotifyResourceUpdated() throws Exception {
         startServer(it -> it.resource(
                         ResourceDescriptor.of("doc", "resource://doc", "A document", "text/plain"),
-                        (ctx, rawUri, params, uriTemplate) -> TextResourceContents.of(rawUri, "", "text/plain"))
+                        (ctx, request) -> TextResourceContents.of(request.uri(), "", "text/plain"))
                 .tool(notifyUpdatedTool()));
 
         try (var client = createTestClient()) {
@@ -310,7 +340,7 @@ class ResourceTest extends AbstractStatefulMcpE2eTest {
     void shouldNotNotifyAfterUnsubscribe() throws Exception {
         startServer(it -> it.resource(
                         ResourceDescriptor.of("doc", "resource://doc", "A document", "text/plain"),
-                        (ctx, rawUri, params, uriTemplate) -> TextResourceContents.of(rawUri, "", "text/plain"))
+                        (ctx, request) -> TextResourceContents.of(request.uri(), "", "text/plain"))
                 .tool(notifyUpdatedTool()));
 
         try (var client = createTestClient()) {
@@ -340,7 +370,7 @@ class ResourceTest extends AbstractStatefulMcpE2eTest {
             builder.capabilities(c -> c.resourcesListChanged(true)).tool(unregisterByUriTool());
             builder.resource(
                     ResourceDescriptor.of("doc", "resource://doc", "A document", "text/plain"),
-                    (ctx, rawUri, params, uriTemplate) -> TextResourceContents.of(rawUri, "", "text/plain"));
+                    (ctx, request) -> TextResourceContents.of(request.uri(), "", "text/plain"));
         });
 
         try (var client = createTestClient()) {
@@ -364,8 +394,8 @@ class ResourceTest extends AbstractStatefulMcpE2eTest {
                         resources.register(
                                 ResourceDescriptor.of(
                                         "added-resource", "resource://added", "Added by handler", "text/plain"),
-                                (ctx, rawUri, params, uriTemplate) ->
-                                        TextResourceContents.of(rawUri, "content", "text/plain"));
+                                (ctx, resourceRequest) ->
+                                        TextResourceContents.of(resourceRequest.uri(), "content", "text/plain"));
                     } else {
                         resources.unregister("doc");
                     }

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp20260728/CachingHintsTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp20260728/CachingHintsTest.java
@@ -29,13 +29,12 @@ class CachingHintsTest extends AbstractStatelessMcpE2eTest {
         startServer(b -> b.capabilities(c -> c.tools().resources().prompts())
                 .resource(
                         ResourceDescriptor.of("hello", "hello://world", "Hello resource", "text/plain"),
-                        (ctx, rawUri, params, uriTemplate) ->
-                                TextResourceContents.of(rawUri, "Hello, World!", "text/plain"))
+                        (ctx, request) -> TextResourceContents.of(request.uri(), "Hello, World!", "text/plain"))
                 .resourceTemplate(
                         builder -> builder.name("tmpl")
                                 .uriTemplate("test://tmpl/{id}")
                                 .description("d"),
-                        (ctx, rawUri, params, uriTemplate) -> TextResourceContents.of(rawUri, "x", "text/plain"))
+                        (ctx, request) -> TextResourceContents.of(request.uri(), "x", "text/plain"))
                 .prompt(PromptDescriptor.of("greeting", "A greeting"), java.util.List.of()));
     }
 

--- a/examples/weather/src/main/java/com/example/weather/WeatherServer.java
+++ b/examples/weather/src/main/java/com/example/weather/WeatherServer.java
@@ -99,8 +99,8 @@ public final class WeatherServer {
                                 .title("Weather in the city")
                                 .description("Weather forecast for a city")
                                 .mimeType("application/json"),
-                        (ctx, uri, params, uriTemplate) ->
-                                handleWeatherTemplate(weatherService, uri, params))
+                        (ctx, request) ->
+                                handleWeatherTemplate(weatherService, request.uri(), request.params()))
             .asyncResourceCompletion(
                 "weather://current/{city}",
                 (ctx, request) -> {

--- a/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/config/ResourceScope.kt
+++ b/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/config/ResourceScope.kt
@@ -5,12 +5,28 @@ package dev.tachyonmcp.server.config
 import dev.tachyonmcp.runtime.InteractionContext
 import dev.tachyonmcp.server.TachyonDsl
 import dev.tachyonmcp.server.domain.UriTemplateValue
+import dev.tachyonmcp.server.features.resources.ResourceRequest
 
+/**
+ * Receiver for a static or templated resource handler.
+ */
 @TachyonDsl
 public class ResourceScope
     internal constructor(
+        /** Interaction context for the resource read. */
         public val ctx: InteractionContext,
-        public val uri: String,
-        public val params: Map<String, UriTemplateValue>,
-        public val uriTemplate: String?,
-    )
+        /** Full resource request, including URI-template data and request metadata. */
+        public val request: ResourceRequest,
+    ) {
+        /** Requested resource URI. */
+        public val uri: String
+            get() = request.uri()
+
+        /** Parsed URI-template parameters, or an empty map for a static resource. */
+        public val params: Map<String, UriTemplateValue>
+            get() = request.params()
+
+        /** Original URI template, or `null` for a static resource. */
+        public val uriTemplate: String?
+            get() = request.uriTemplate()
+    }

--- a/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/config/TemplateScope.kt
+++ b/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/config/TemplateScope.kt
@@ -5,15 +5,31 @@ package dev.tachyonmcp.server.config
 import dev.tachyonmcp.runtime.InteractionContext
 import dev.tachyonmcp.server.TachyonDsl
 import dev.tachyonmcp.server.domain.UriTemplateValue
+import dev.tachyonmcp.server.features.resources.ResourceRequest
 
+/**
+ * Receiver for a matched resource-template handler.
+ */
 @TachyonDsl
 public class TemplateScope
     internal constructor(
+        /** Interaction context for the resource read. */
         public val ctx: InteractionContext,
-        public val uri: String,
-        public val params: Map<String, UriTemplateValue>,
-        public val uriTemplate: String,
+        /** Full resource request, including URI-template data and request metadata. */
+        public val request: ResourceRequest,
     ) {
+        /** Requested resource URI. */
+        public val uri: String
+            get() = request.uri()
+
+        /** Parsed URI-template parameters for the match. */
+        public val params: Map<String, UriTemplateValue>
+            get() = request.params()
+
+        /** Original URI template, always present for a template match. */
+        public val uriTemplate: String
+            get() = requireNotNull(request.uriTemplate())
+
         /**
          * Retrieves a scalar template variable.
          *

--- a/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/features/resources/ResourceHandlerFactory.kt
+++ b/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/features/resources/ResourceHandlerFactory.kt
@@ -18,9 +18,9 @@ internal fun resourceHandler(
     block: suspend ResourceScope.() -> ResourceContents,
 ): ResourceHandler {
     val coroutineName = CoroutineName("resource:${descriptor.name()}")
-    return ResourceHandler { ctx, uri, params, uriTemplate ->
+    return ResourceHandler { ctx, request ->
         runSuspendHandler(coroutineName) {
-            ResourceScope(ctx, uri, params, uriTemplate).block()
+            ResourceScope(ctx, request).block()
         }
     }
 }

--- a/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/features/resources/TemplateHandlerFactory.kt
+++ b/tachyon-server-kotlin/src/main/kotlin/dev/tachyonmcp/server/features/resources/TemplateHandlerFactory.kt
@@ -15,9 +15,9 @@ internal fun templateHandler(
     block: suspend TemplateScope.() -> ResourceContents,
 ): ResourceHandler {
     val coroutineName = CoroutineName("resource-template:$name")
-    return ResourceHandler { ctx, uri, params, uriTemplate ->
+    return ResourceHandler { ctx, request ->
         runSuspendHandler(coroutineName) {
-            TemplateScope(ctx, uri, params, requireNotNull(uriTemplate)).block()
+            TemplateScope(ctx, request).block()
         }
     }
 }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/RpcMethodHandler.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/RpcMethodHandler.java
@@ -7,6 +7,7 @@ package dev.tachyonmcp.server;
 import dev.tachyonmcp.server.session.DispatchContext;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Handles a single JSON-RPC method. Internal/advanced SPI — receives the rich
@@ -30,13 +31,13 @@ public interface RpcMethodHandler {
     String method();
 
     /** Handles the method and returns the result to serialize as JSON-RPC response. */
-    Object handle(DispatchContext context, Object params) throws Exception;
+    Object handle(DispatchContext context, @Nullable Object params) throws Exception;
 
     /**
      * Handles the method asynchronously. Default delegates to {@link #handle}.
      * Override for async handlers that return a future directly.
      */
-    default CompletionStage<Object> handleAsync(DispatchContext context, Object params) throws Exception {
+    default CompletionStage<Object> handleAsync(DispatchContext context, @Nullable Object params) throws Exception {
         return CompletableFuture.completedFuture(handle(context, params));
     }
 }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/features/HandlerFutures.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/features/HandlerFutures.java
@@ -12,6 +12,7 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.function.BiFunction;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Static utilities for common CompletionStage patterns.
@@ -90,9 +91,9 @@ public final class HandlerFutures {
      */
     public static <R> CompletionStage<Object> invokeAndMap(
             String nullStageMessage,
-            Callable<? extends CompletionStage<? extends R>> invocation,
+            Callable<? extends @Nullable CompletionStage<? extends R>> invocation,
             Executor executor,
-            BiFunction<? super R, Throwable, Object> resultMapper) {
+            BiFunction<? super R, @Nullable Throwable, @Nullable Object> resultMapper) {
         CompletionStage<? extends R> stage;
         try {
             stage = invocation.call();

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/features/resources/AsyncResourceHandler.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/features/resources/AsyncResourceHandler.java
@@ -6,11 +6,8 @@ package dev.tachyonmcp.server.features.resources;
 
 import dev.tachyonmcp.runtime.InteractionContext;
 import dev.tachyonmcp.server.domain.ResourceContents;
-import dev.tachyonmcp.server.domain.UriTemplateValue;
 import dev.tachyonmcp.server.features.HandlerFutures;
-import java.util.Map;
 import java.util.concurrent.CompletionStage;
-import org.jspecify.annotations.Nullable;
 
 /**
  * Convenient base for asynchronous resource handlers. The registry invokes {@link #handleAsync} and
@@ -21,14 +18,11 @@ public interface AsyncResourceHandler extends ResourceHandler {
     /**
      * Reads the resource asynchronously and returns a future of its contents.
      */
-    CompletionStage<? extends ResourceContents> handleAsync(
-            InteractionContext context, String uri, Map<String, UriTemplateValue> params, @Nullable String uriTemplate);
+    CompletionStage<? extends ResourceContents> handleAsync(InteractionContext context, ResourceRequest request);
 
     @Override
-    default ResourceContents handle(
-            InteractionContext context, String uri, Map<String, UriTemplateValue> params, @Nullable String uriTemplate)
-            throws Exception {
+    default ResourceContents handle(InteractionContext context, ResourceRequest request) throws Exception {
         HandlerFutures.assumeVirtualThread();
-        return HandlerFutures.joinInterruptibly(handleAsync(context, uri, params, uriTemplate));
+        return HandlerFutures.joinInterruptibly(handleAsync(context, request));
     }
 }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/features/resources/DefaultResourceRegistry.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/features/resources/DefaultResourceRegistry.java
@@ -5,6 +5,7 @@
 package dev.tachyonmcp.server.features.resources;
 
 import dev.tachyonmcp.annotations.InternalApi;
+import dev.tachyonmcp.protocol.mcp.v2025_11_25.codecs.ProtocolCodecUtil;
 import dev.tachyonmcp.protocol.mcp.v2025_11_25.models.ReadResourceRequestParams;
 import dev.tachyonmcp.protocol.mcp.v2025_11_25.models.SubscribeRequestParams;
 import dev.tachyonmcp.protocol.mcp.v2025_11_25.models.UnsubscribeRequestParams;
@@ -23,6 +24,7 @@ import dev.tachyonmcp.server.features.PaginatedResult;
 import dev.tachyonmcp.server.features.Pagination;
 import dev.tachyonmcp.server.internal.ServerEngine;
 import dev.tachyonmcp.server.session.DispatchContext;
+import dev.tachyonmcp.transport.jsonrpc.JsonRpcCodec;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -41,6 +43,7 @@ import java.util.function.Predicate;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import tools.jackson.databind.JsonNode;
 
 /**
  * Registry for resources, templates, and subscriptions.
@@ -494,33 +497,28 @@ public class DefaultResourceRegistry implements Resources {
         /** Runs resource handlers on the server executor's virtual threads without blocking it. */
         @Override
         public CompletionStage<Object> handleAsync(DispatchContext context, Object params) {
-            var uri = toRawUri(params);
-            if (uri == null) {
+            var parsed = parseRequest(params);
+            if (parsed == null) {
                 return CompletableFuture.completedFuture(ServerErrors.invalidRequest("Missing resource URI"));
             }
+            var uri = parsed.uri();
             var entry = registry.getByUri(uri);
             if (entry != null) {
                 var extId = entry.descriptor().extensionId();
                 if (extId != null && !context.isExtensionEnabled(extId)) {
                     return CompletableFuture.completedFuture(ServerErrors.resourceNotFound("Resource not found"));
                 }
-                return readResult(context, uri, () -> entry.handler().handleAsync(context, uri, Map.of(), null));
+                var request = new ResourceRequest(uri, Map.of(), null, parsed.meta());
+                return readResult(context, uri, () -> entry.handler().handleAsync(context, request));
             }
             var match = registry.matchTemplate(uri);
             if (match == null) {
                 return CompletableFuture.completedFuture(
                         ServerErrors.resourceNotFound("Resource not found", Map.of("uri", uri)));
             }
-            return readResult(
-                    context,
-                    uri,
-                    () -> match.entry()
-                            .handler()
-                            .handleAsync(
-                                    context,
-                                    uri,
-                                    match.params(),
-                                    match.entry().descriptor().uriTemplate()));
+            var request = new ResourceRequest(
+                    uri, match.params(), match.entry().descriptor().uriTemplate(), parsed.meta());
+            return readResult(context, uri, () -> match.entry().handler().handleAsync(context, request));
         }
 
         private CompletionStage<Object> readResult(
@@ -551,15 +549,19 @@ public class DefaultResourceRegistry implements Resources {
                     });
         }
 
-        private static @Nullable String toRawUri(Object params) {
-            if (params instanceof ReadResourceRequestParams p) {
-                return p.uri();
+        private static @Nullable RequestParams parseRequest(Object params) {
+            if (params instanceof ReadResourceRequestParams(Map<String, JsonNode> meta, String uri)) {
+                return uri == null ? null : new RequestParams(uri, meta);
             }
-            if (params instanceof Map<?, ?> map && map.get("uri") instanceof String uri) {
-                return uri;
+            if (params instanceof Map<?, ?> map) {
+                var json = JsonRpcCodec.writeValueAsString(map);
+                var typed = ProtocolCodecUtil.decodeWithCodec(json, ReadResourceRequestParams.class);
+                return typed.uri() == null ? null : new RequestParams(typed.uri(), typed._meta());
             }
             return null;
         }
+
+        private record RequestParams(String uri, @Nullable Map<String, JsonNode> meta) {}
     }
 
     private record ResourcesSubscribeHandler(DefaultResourceRegistry registry) implements RpcMethodHandler {

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/features/resources/ResourceHandler.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/features/resources/ResourceHandler.java
@@ -6,15 +6,11 @@ package dev.tachyonmcp.server.features.resources;
 
 import dev.tachyonmcp.runtime.InteractionContext;
 import dev.tachyonmcp.server.domain.ResourceContents;
-import dev.tachyonmcp.server.domain.UriTemplateValue;
 import dev.tachyonmcp.server.features.HandlerFutures;
-import java.util.Map;
 import java.util.concurrent.CompletionStage;
-import org.jspecify.annotations.Nullable;
 
 /**
- * Reads static and templated resource contents. {@code uriTemplate} is null for static resources;
- * templated requests include the original URI template text and parsed parameters.
+ * Reads static and templated resource contents.
  *
  * <p>{@link #handle} and {@link #handleAsync} run on a server-executor virtual thread. Blocking for I/O
  * is the intended synchronous contract.
@@ -25,9 +21,7 @@ import org.jspecify.annotations.Nullable;
 public interface ResourceHandler {
 
     /** Reads and returns the resource contents. */
-    ResourceContents handle(
-            InteractionContext context, String uri, Map<String, UriTemplateValue> params, @Nullable String uriTemplate)
-            throws Exception;
+    ResourceContents handle(InteractionContext context, ResourceRequest request) throws Exception;
 
     /**
      * Reads asynchronously. Default delegates to {@link #handle}. The registry awaits the returned
@@ -35,12 +29,9 @@ public interface ResourceHandler {
      * Override to integrate async services.
      */
     default CompletionStage<? extends ResourceContents> handleAsync(
-            InteractionContext context,
-            String uri,
-            Map<String, UriTemplateValue> params,
-            @Nullable String uriTemplate) {
+            InteractionContext context, ResourceRequest request) {
         HandlerFutures.assumeVirtualThread();
-        return HandlerFutures.completedOrFailed(() -> handle(context, uri, params, uriTemplate));
+        return HandlerFutures.completedOrFailed(() -> handle(context, request));
     }
 
     /**
@@ -48,7 +39,7 @@ public interface ResourceHandler {
      * fixed-URI resource — no {@code params}/{@code uriTemplate} to ignore.
      */
     static ResourceHandler of(StaticResourceFn fn) {
-        return (context, uri, params, uriTemplate) -> fn.handle(context, uri);
+        return (context, request) -> fn.handle(context, request.uri());
     }
 
     /**
@@ -56,6 +47,6 @@ public interface ResourceHandler {
      * static, fixed-URI resource — no {@code params}/{@code uriTemplate} to ignore.
      */
     static AsyncResourceHandler ofAsync(AsyncStaticResourceFn fn) {
-        return (context, uri, params, uriTemplate) -> fn.handle(context, uri);
+        return (context, request) -> fn.handle(context, request.uri());
     }
 }

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/features/resources/ResourceRequest.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/features/resources/ResourceRequest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2026 Konstantin Pavlov and contributors.
+ */
+
+package dev.tachyonmcp.server.features.resources;
+
+import dev.tachyonmcp.server.domain.HasMeta;
+import dev.tachyonmcp.server.domain.UriTemplateValue;
+import java.util.Map;
+import org.jspecify.annotations.Nullable;
+import tools.jackson.databind.JsonNode;
+
+/**
+ * Request passed to a resource handler.
+ *
+ * @param uri requested resource URI
+ * @param params immutable URI-template parameters; empty for a static resource
+ * @param uriTemplate original URI template; null for a static resource
+ * @param meta optional client request metadata ({@code _meta})
+ */
+public record ResourceRequest(
+        String uri,
+        Map<String, UriTemplateValue> params,
+        @Nullable String uriTemplate,
+        @Nullable Map<String, JsonNode> meta)
+        implements HasMeta {
+
+    public ResourceRequest {
+        params = Map.copyOf(params);
+        meta = meta == null ? null : Map.copyOf(meta);
+    }
+}

--- a/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tasks/TasksExtension.java
+++ b/tachyon-server/src/main/java/dev/tachyonmcp/server/features/tasks/TasksExtension.java
@@ -64,14 +64,12 @@ public class TasksExtension implements ServerExtension {
         server.tools().register(new CreateTaskHandler(descriptor, server));
 
         server.resources()
-                .registerTemplate(
-                        ResourceTemplateDescriptor.of("task-status", "task://{id}"),
-                        (ctx, uri, params, uriTemplate) -> {
-                            var id = params.get("id").scalarValue();
-                            var entry = server.tasks().get(id);
-                            var text = entry != null ? entry.status().name() : "not_found";
-                            return TextResourceContents.of(uri, text, "text/plain", null);
-                        });
+                .registerTemplate(ResourceTemplateDescriptor.of("task-status", "task://{id}"), (ctx, request) -> {
+                    var id = request.params().get("id").scalarValue();
+                    var entry = server.tasks().get(id);
+                    var text = entry != null ? entry.status().name() : "not_found";
+                    return TextResourceContents.of(request.uri(), text, "text/plain", null);
+                });
     }
 
     private static final class CreateTaskHandler extends AbstractToolHandler {

--- a/tachyon-server/src/test/java/dev/tachyonmcp/server/ServerBuilderTest.java
+++ b/tachyon-server/src/test/java/dev/tachyonmcp/server/ServerBuilderTest.java
@@ -60,12 +60,14 @@ class ServerBuilderTest {
                 .tool(tool -> tool.name("sync-tool"), (ToolFn) (ctx, request) -> ToolResult.empty())
                 .resource(
                         resource -> resource.name("sync-resource").uri("test://sync"),
-                        (ctx, rawUri, params, uriTemplate) -> TextResourceContents.of(rawUri, "sync", "text/plain"))
+                        (ctx, request) -> TextResourceContents.of(request.uri(), "sync", "text/plain"))
                 .prompt(prompt -> prompt.name("sync-prompt"), List.of(PromptMessage.user("sync")))
                 .resourceTemplate(
                         template -> template.name("sync-template").uriTemplate("test://sync/{id}"),
-                        (ctx, rawUri, params, uriTemplate) -> TextResourceContents.of(
-                                rawUri, ((UriTemplateValue.Scalar) params.get("id")).value(), "text/plain"))
+                        (ctx, request) -> TextResourceContents.of(
+                                request.uri(),
+                                ((UriTemplateValue.Scalar) request.params().get("id")).value(),
+                                "text/plain"))
                 .build()) {
             assertThat(server.tools().find("sync-tool")).isPresent();
             assertThat(server.resources().find("sync-resource")).isPresent();
@@ -82,16 +84,18 @@ class ServerBuilderTest {
                         (ctx, request) -> CompletableFuture.completedFuture(ToolResult.empty()))
                 .asyncResource(
                         resource -> resource.name("async-resource").uri("test://async"),
-                        (ctx, rawUri, params, uriTemplate) -> CompletableFuture.completedFuture(
-                                TextResourceContents.of(rawUri, "async", "text/plain")))
+                        (ctx, request) -> CompletableFuture.completedFuture(
+                                TextResourceContents.of(request.uri(), "async", "text/plain")))
                 .asyncPrompt(
                         prompt -> prompt.name("async-prompt"),
                         (ctx, request) -> CompletableFuture.completedFuture(
                                 PromptResult.messages(List.of(PromptMessage.user("async")))))
                 .asyncResourceTemplate(
                         template -> template.name("async-template").uriTemplate("test://async/{id}"),
-                        (ctx, rawUri, params, uriTemplate) -> CompletableFuture.completedFuture(TextResourceContents.of(
-                                rawUri, ((UriTemplateValue.Scalar) params.get("id")).value(), "text/plain")))
+                        (ctx, request) -> CompletableFuture.completedFuture(TextResourceContents.of(
+                                request.uri(),
+                                ((UriTemplateValue.Scalar) request.params().get("id")).value(),
+                                "text/plain")))
                 .build()) {
             assertThat(server.tools().find("async-tool")).isPresent();
             assertThat(server.resources().find("async-resource")).isPresent();
@@ -106,7 +110,7 @@ class ServerBuilderTest {
         try (var server = TachyonServer.builder()
                 .resource(
                         resource -> resource.name("sync-resource").uri("test://sync-completed"),
-                        (ctx, rawUri, params, uriTemplate) -> TextResourceContents.of(rawUri, "text", "text/plain"))
+                        (ctx, request) -> TextResourceContents.of(request.uri(), "text", "text/plain"))
                 .resourceCompletion("test://sync-completed", handler)
                 .build()) {
             assertThat(server.completions().findForResource("test://sync-completed"))
@@ -124,7 +128,7 @@ class ServerBuilderTest {
                 .prompt(prompt -> prompt.name("async-completed-prompt"), List.of(PromptMessage.user("prompt")))
                 .resource(
                         resource -> resource.name("async-resource").uri("test://async-completed"),
-                        (ctx, rawUri, params, uriTemplate) -> TextResourceContents.of(rawUri, "text", "text/plain"))
+                        (ctx, request) -> TextResourceContents.of(request.uri(), "text", "text/plain"))
                 .asyncPromptCompletion("async-completed-prompt", promptHandler)
                 .asyncResourceCompletion("test://async-completed", resourceHandler)
                 .build()) {

--- a/tachyon-server/src/test/java/dev/tachyonmcp/server/ServerTest.java
+++ b/tachyon-server/src/test/java/dev/tachyonmcp/server/ServerTest.java
@@ -262,7 +262,7 @@ class ServerTest {
             server.resources()
                     .register(
                             ResourceDescriptor.of("dyn", "test://dyn", "Dyn resource", "text/plain"),
-                            (ctx, rawUri, params, uriTemplate) -> TextResourceContents.of(rawUri, "", "text/plain"));
+                            (ctx, request) -> TextResourceContents.of(request.uri(), "", "text/plain"));
 
             var listChanged = conn.sent.stream()
                     .filter(e -> e.data().contains("notifications/resources/list_changed"))

--- a/tachyon-server/src/test/java/dev/tachyonmcp/server/features/resources/ResourceRegistryTest.java
+++ b/tachyon-server/src/test/java/dev/tachyonmcp/server/features/resources/ResourceRegistryTest.java
@@ -42,7 +42,7 @@ import org.junit.jupiter.api.Test;
 class ResourceRegistryTest {
 
     private static final ResourceHandler EMPTY_HANDLER =
-            (ctx, rawUri, params, uriTemplate) -> TextResourceContents.of(rawUri, "", "text/plain");
+            (ctx, request) -> TextResourceContents.of(request.uri(), "", "text/plain");
 
     private final ServerEngine server = newEngine(b -> {});
     private final DefaultResourceRegistry registry =
@@ -130,7 +130,7 @@ class ResourceRegistryTest {
         reg.register(resource("a"), EMPTY_HANDLER);
         reg.registerTemplate(
                 ResourceTemplateDescriptor.of("template-entry", "test://entry/{id}"),
-                (ctx, rawUri, params, uriTemplate) -> TextResourceContents.of(rawUri, "", "text/plain"));
+                (ctx, request) -> TextResourceContents.of(request.uri(), "", "text/plain"));
 
         assertThat(reg.find("a")).isEmpty();
         assertThat(reg.descriptors()).isEmpty();
@@ -146,16 +146,16 @@ class ResourceRegistryTest {
         api.register(resource -> resource.name("sync").uri("test://sync"), EMPTY_HANDLER)
                 .registerAsync(
                         resource -> resource.name("async").uri("test://async"),
-                        (ctx, rawUri, params, uriTemplate) -> CompletableFuture.completedFuture(
-                                TextResourceContents.of(rawUri, "async", "text/plain")))
+                        (ctx, request) -> CompletableFuture.completedFuture(
+                                TextResourceContents.of(request.uri(), "async", "text/plain")))
                 .registerTemplate(
                         template -> template.name("sync-template").uriTemplate("test://sync/{id}"),
-                        (ctx, rawUri, params, uriTemplate) ->
-                                TextResourceContents.of(rawUri, scalar(params, "id"), "text/plain"))
+                        (ctx, request) ->
+                                TextResourceContents.of(request.uri(), scalar(request.params(), "id"), "text/plain"))
                 .registerTemplateAsync(
                         template -> template.name("async-template").uriTemplate("test://async/{id}"),
-                        (ctx, rawUri, params, uriTemplate) -> CompletableFuture.completedFuture(
-                                TextResourceContents.of(rawUri, scalar(params, "id"), "text/plain")));
+                        (ctx, request) -> CompletableFuture.completedFuture(
+                                TextResourceContents.of(request.uri(), scalar(request.params(), "id"), "text/plain")));
 
         assertThat(api.descriptors()).extracting(ResourceDescriptor::name).containsExactly("async", "sync");
         assertThat(api.find("sync")).isPresent();
@@ -218,7 +218,7 @@ class ResourceRegistryTest {
     void unregisterByUriMakesHandlerUnresolvable() throws Exception {
         registry.register(
                 ResourceDescriptor.of("r1", "test://r1", null, "text/plain"),
-                (ctx, rawUri, params, uriTemplate) -> TextResourceContents.of(rawUri, "content", "text/plain"));
+                (ctx, request) -> TextResourceContents.of(request.uri(), "content", "text/plain"));
 
         registry.unregisterByUri("test://r1");
 
@@ -267,8 +267,7 @@ class ResourceRegistryTest {
     @Test
     void shouldMapInvalidArgumentExceptionToInvalidParams() throws Exception {
         registry.register(
-                ResourceDescriptor.of("bad-input", "test://bad-input", null, "text/plain"),
-                (ctx, rawUri, params, uriTemplate) -> {
+                ResourceDescriptor.of("bad-input", "test://bad-input", null, "text/plain"), (ctx, request) -> {
                     throw new InvalidArgumentException("city", "unknown city");
                 });
 
@@ -283,9 +282,7 @@ class ResourceRegistryTest {
     void shouldReadResourceContentByUri() throws Exception {
         var descriptor = ResourceDescriptor.of("test-resource", "test://resource/1", "Test resource", "text/plain");
         registry.register(
-                descriptor,
-                (ctx, rawUri, params, uriTemplate) ->
-                        TextResourceContents.of("test://resource/1", "content", "text/plain"));
+                descriptor, (ctx, request) -> TextResourceContents.of("test://resource/1", "content", "text/plain"));
 
         var result = runInVirtualThread(() -> handlers.get("resources/read")
                 .handle(DefaultDispatchContext.stateless(server), Map.<String, Object>of("uri", "test://resource/1")));
@@ -301,11 +298,11 @@ class ResourceRegistryTest {
         var capturedUri = new AtomicReference<@Nullable String>();
         var capturedParams = new AtomicReference<@Nullable Map<String, UriTemplateValue>>();
         var capturedTemplate = new AtomicReference<@Nullable String>();
-        registry.register(resource("static-request"), (ctx, rawUri, params, uriTemplate) -> {
-            capturedUri.set(rawUri);
-            capturedParams.set(params);
-            capturedTemplate.set(uriTemplate);
-            return TextResourceContents.of(rawUri, "static", "text/plain");
+        registry.register(resource("static-request"), (ctx, request) -> {
+            capturedUri.set(request.uri());
+            capturedParams.set(request.params());
+            capturedTemplate.set(request.uriTemplate());
+            return TextResourceContents.of(request.uri(), "static", "text/plain");
         });
 
         runInVirtualThread(() -> handlers.get("resources/read")
@@ -322,12 +319,11 @@ class ResourceRegistryTest {
         var capturedParams = new AtomicReference<@Nullable Map<String, UriTemplateValue>>();
         var capturedTemplate = new AtomicReference<@Nullable String>();
         registry.registerTemplate(
-                ResourceTemplateDescriptor.of("template-request", "test://items/{id}"),
-                (ctx, rawUri, params, uriTemplate) -> {
-                    capturedUri.set(rawUri);
-                    capturedParams.set(params);
-                    capturedTemplate.set(uriTemplate);
-                    return TextResourceContents.of(rawUri, "template", "text/plain");
+                ResourceTemplateDescriptor.of("template-request", "test://items/{id}"), (ctx, request) -> {
+                    capturedUri.set(request.uri());
+                    capturedParams.set(request.params());
+                    capturedTemplate.set(request.uriTemplate());
+                    return TextResourceContents.of(request.uri(), "template", "text/plain");
                 });
 
         runInVirtualThread(() -> handlers.get("resources/read")
@@ -341,9 +337,9 @@ class ResourceRegistryTest {
     @Test
     void shouldRunSynchronousResourceHandlerOnCallingVirtualThread() throws Exception {
         var handlerThread = new AtomicReference<Thread>();
-        registry.register(resource("sync-thread"), (ctx, rawUri, params, uriTemplate) -> {
+        registry.register(resource("sync-thread"), (ctx, request) -> {
             handlerThread.set(Thread.currentThread());
-            return TextResourceContents.of(rawUri, "sync", "text/plain");
+            return TextResourceContents.of(request.uri(), "sync", "text/plain");
         });
 
         runInVirtualThread(() -> handlers.get("resources/read")
@@ -358,7 +354,7 @@ class ResourceRegistryTest {
         var callerThread = new AtomicReference<@Nullable Thread>();
         var contents = TextResourceContents.of("test://async-thread", "async", "text/plain");
         var completion = new CompletableFuture<TextResourceContents>();
-        registry.registerAsync(resource("async-thread"), (ctx, rawUri, params, uriTemplate) -> {
+        registry.registerAsync(resource("async-thread"), (ctx, request) -> {
             handlerThread.set(Thread.currentThread());
             return completion;
         });
@@ -506,7 +502,7 @@ class ResourceRegistryTest {
         handlers.get("resources/subscribe").handle(context(sess, server), Map.of("uri", "test://resource/1"));
         registry.register(
                 ResourceDescriptor.of("test-resource", "test://resource/1", "Test resource", "text/plain"),
-                (ctx, rawUri, params, uriTemplate) -> TextResourceContents.of(rawUri, "", "text/plain"));
+                (ctx, request) -> TextResourceContents.of(request.uri(), "", "text/plain"));
 
         registry.notifyResourceUpdated("test://resource/1");
 
@@ -523,7 +519,7 @@ class ResourceRegistryTest {
 
         registry.register(
                 ResourceDescriptor.of("r1", "test://r1", null, null),
-                (ctx, rawUri, params, uriTemplate) -> TextResourceContents.of(rawUri, "", "text/plain"));
+                (ctx, request) -> TextResourceContents.of(request.uri(), "", "text/plain"));
 
         assertThat(callCount).hasValue(1);
     }
@@ -532,7 +528,7 @@ class ResourceRegistryTest {
     void shouldFireOnChangeWhenExistingResourceRemoved() {
         registry.register(
                 ResourceDescriptor.of("r1", "test://r1", null, null),
-                (ctx, rawUri, params, uriTemplate) -> TextResourceContents.of(rawUri, "", "text/plain"));
+                (ctx, request) -> TextResourceContents.of(request.uri(), "", "text/plain"));
 
         var callCount = new AtomicInteger(0);
         registry.onChange(callCount::incrementAndGet);
@@ -574,7 +570,7 @@ class ResourceRegistryTest {
 
         registry.registerTemplate(
                 ResourceTemplateDescriptor.of("tmpl", "test://tmpl/{id}"),
-                (ctx, rawUri, params, uriTemplate) -> TextResourceContents.of(rawUri, "", "text/plain"));
+                (ctx, request) -> TextResourceContents.of(request.uri(), "", "text/plain"));
 
         assertThat(callCount).hasValue(1);
     }
@@ -583,14 +579,14 @@ class ResourceRegistryTest {
     void shouldReplaceHandlerAndFireOnChangeWhenAddedWithSameName() {
         registry.register(
                 ResourceDescriptor.of("doc", "resource://doc-v1", null, "text/plain"),
-                (ctx, rawUri, params, uriTemplate) -> TextResourceContents.of(rawUri, "v1", "text/plain"));
+                (ctx, request) -> TextResourceContents.of(request.uri(), "v1", "text/plain"));
 
         var callCount = new AtomicInteger(0);
         registry.onChange(callCount::incrementAndGet);
 
         registry.register(
                 ResourceDescriptor.of("doc", "resource://doc-v1", null, "text/plain"),
-                (ctx, rawUri, params, uriTemplate) -> TextResourceContents.of(rawUri, "v2", "text/plain"));
+                (ctx, request) -> TextResourceContents.of(request.uri(), "v2", "text/plain"));
 
         assertThat(callCount).hasValue(1);
         assertThat(registry.find("doc")).isPresent();
@@ -601,14 +597,14 @@ class ResourceRegistryTest {
     void shouldEvictOldUriWhenResourceUpdatedWithNewUri() throws Exception {
         registry.register(
                 ResourceDescriptor.of("doc", "resource://doc-v1", null, "text/plain"),
-                (ctx, rawUri, params, uriTemplate) -> TextResourceContents.of(rawUri, "v1", "text/plain"));
+                (ctx, request) -> TextResourceContents.of(request.uri(), "v1", "text/plain"));
 
         var callCount = new AtomicInteger(0);
         registry.onChange(callCount::incrementAndGet);
 
         registry.register(
                 ResourceDescriptor.of("doc", "resource://doc-v2", null, "text/plain"),
-                (ctx, rawUri, params, uriTemplate) -> TextResourceContents.of(rawUri, "v2", "text/plain"));
+                (ctx, request) -> TextResourceContents.of(request.uri(), "v2", "text/plain"));
 
         // updating a resource's URI is a single change
         assertThat(callCount).hasValue(1);
@@ -651,8 +647,7 @@ class ResourceRegistryTest {
                 1024L,
                 List.of(icon));
         registry.register(
-                descriptor,
-                (ctx, rawUri, params, uriTemplate) -> TextResourceContents.of(rawUri, "content", "text/plain"));
+                descriptor, (ctx, request) -> TextResourceContents.of(request.uri(), "content", "text/plain"));
 
         var result = (ListResourcesResult)
                 handlers.get("resources/list").handle(DefaultDispatchContext.stateless(server), null);
@@ -720,10 +715,9 @@ class ResourceRegistryTest {
     void shouldPassExplodedSequenceToTemplateHandler() throws Exception {
         var captured = new AtomicReference<@Nullable Map<String, UriTemplateValue>>();
         registry.registerTemplate(
-                ResourceTemplateDescriptor.of("files", "resource://files{/segments*}"),
-                (ctx, rawUri, params, uriTemplate) -> {
-                    captured.set(params);
-                    return TextResourceContents.of(rawUri, "ok", "text/plain");
+                ResourceTemplateDescriptor.of("files", "resource://files{/segments*}"), (ctx, request) -> {
+                    captured.set(request.params());
+                    return TextResourceContents.of(request.uri(), "ok", "text/plain");
                 });
 
         var result = runInVirtualThread(() -> handlers.get("resources/read")
@@ -740,16 +734,14 @@ class ResourceRegistryTest {
     void shouldPreferMoreSpecificTemplateOnOverlap() throws Exception {
         var matched = new AtomicReference<@Nullable String>();
         registry.registerTemplate(
-                ResourceTemplateDescriptor.of("generic", "resource://{type}/{id}"),
-                (ctx, rawUri, params, uriTemplate) -> {
+                ResourceTemplateDescriptor.of("generic", "resource://{type}/{id}"), (ctx, request) -> {
                     matched.set("generic");
-                    return TextResourceContents.of(rawUri, "generic", "text/plain");
+                    return TextResourceContents.of(request.uri(), "generic", "text/plain");
                 });
         registry.registerTemplate(
-                ResourceTemplateDescriptor.of("specific", "resource://users/{id}"),
-                (ctx, rawUri, params, uriTemplate) -> {
+                ResourceTemplateDescriptor.of("specific", "resource://users/{id}"), (ctx, request) -> {
                     matched.set("specific");
-                    return TextResourceContents.of(rawUri, "specific", "text/plain");
+                    return TextResourceContents.of(request.uri(), "specific", "text/plain");
                 });
 
         runInVirtualThread(() -> handlers.get("resources/read")
@@ -773,8 +765,8 @@ class ResourceRegistryTest {
                         "Template Title",
                         annotations,
                         List.of(icon)),
-                (ctx, rawUri, params, uriTemplate) ->
-                        TextResourceContents.of(rawUri, "content-" + scalar(params, "id"), "text/plain"));
+                (ctx, request) -> TextResourceContents.of(
+                        request.uri(), "content-" + scalar(request.params(), "id"), "text/plain"));
 
         var result = (ListResourceTemplatesResult)
                 handlers.get("resources/templates/list").handle(DefaultDispatchContext.stateless(server), null);
@@ -798,7 +790,7 @@ class ResourceRegistryTest {
         var descriptor = ResourceDescriptor.of(
                 "sized-resource", "test://sized", "A resource", "application/octet-stream", null, null, 4096L, null);
         var contentLoaded = new java.util.concurrent.atomic.AtomicBoolean(false);
-        registry.register(descriptor, (ctx, rawUri, params, uriTemplate) -> {
+        registry.register(descriptor, (ctx, request) -> {
             contentLoaded.set(true);
             return TextResourceContents.of("test://sized", "data", "application/octet-stream");
         });

--- a/tachyon-server/src/test/java/dev/tachyonmcp/server/features/resources/ResourceRequestDispatchTest.java
+++ b/tachyon-server/src/test/java/dev/tachyonmcp/server/features/resources/ResourceRequestDispatchTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2026 Konstantin Pavlov and contributors.
+ */
+
+package dev.tachyonmcp.server.features.resources;
+
+import static dev.tachyonmcp.test.TestUtils.newEngine;
+import static dev.tachyonmcp.test.VirtualThreads.runInVirtualThread;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.tachyonmcp.protocol.mcp.v2025_11_25.models.ReadResourceRequestParams;
+import dev.tachyonmcp.server.RpcMethodHandler;
+import dev.tachyonmcp.server.config.ResourcesConfig;
+import dev.tachyonmcp.server.domain.TextResourceContents;
+import dev.tachyonmcp.server.session.DefaultDispatchContext;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+class ResourceRequestDispatchTest {
+
+    @Test
+    void shouldPassRequestMetaToResourceHandler() throws Exception {
+        var server = newEngine(builder -> {});
+        var registry =
+                new DefaultResourceRegistry(server, ResourcesConfig.builder().build());
+        var handlers = new HashMap<String, RpcMethodHandler>();
+        registry.registerHandlers(handlers);
+        var captured = new AtomicReference<ResourceRequest>();
+        registry.register(
+                ResourceDescriptor.of("meta-request", "test://meta-request", null, "text/plain"), (ctx, request) -> {
+                    captured.set(request);
+                    return TextResourceContents.of(request.uri(), "meta", "text/plain");
+                });
+        Map<String, JsonNode> meta = Map.of("trace-id", new ObjectMapper().readTree("\"trace-42\""));
+
+        runInVirtualThread(() -> handlers.get("resources/read")
+                .handle(
+                        DefaultDispatchContext.stateless(server),
+                        ReadResourceRequestParams.builder()
+                                .uri("test://meta-request")
+                                ._meta(meta)
+                                .build()));
+
+        assertThat(captured.get().uri()).isEqualTo("test://meta-request");
+        assertThat(captured.get().params()).isEmpty();
+        assertThat(captured.get().uriTemplate()).isNull();
+        assertThat(captured.get().meta()).isEqualTo(meta);
+    }
+}


### PR DESCRIPTION
## Resource API migrated to (InteractionContext, ResourceRequest) (#143) 

Resource handlers now receive a unified ResourceRequest containing the URI, template parameters, optional template, and metadata. Resource dispatch parses these fields and forwards them through synchronous and asynchronous handlers. Java and Kotlin factories, scopes, examples, documentation, conformance fixtures, and tests were migrated to the request-based callback form. Additional tests verify metadata propagation and request-field contents. Public nullability annotations were also updated.
