### PR TITLE
feat!: [WIP] Refactor api

### DIFF
--- a/.agents/skills/tachyon-mcp/SKILL.md
+++ b/.agents/skills/tachyon-mcp/SKILL.md
@@ -13,9 +13,9 @@ Make **Java 21+** MCP server. Tachyon lib. Transport = Streamable HTTP (Netty).
 ## Core
 
 - `TachyonServer.builder()` → `ServerBuilder`. Start here.
-- `.start()` (blocking) → builds `TachyonServer` (`AutoCloseable`) with Netty transport bound.
-- `.build()` → `TachyonServer` only, no transport.
-- `TachyonServer`: `.tools()`, `.resources()`, `.prompts()`, `.tasks()` first; then `.port()`, `.close()`, `.config()`.
+- `.build()` (only terminal method) → `TachyonServer` (`AutoCloseable`), no transport bound yet.
+- `TachyonServer.start()` (blocking) → binds the Netty transport.
+- `TachyonServer`: `.tools()`, `.resources()`, `.prompts()`, `.tasks()` first; then `.start()`, `.port()` (throws before `.start()`), `.close()`, `.config()`.
 - Dynamic registration: `.tools().register(handler)`, `.resources().register(...)`, `.prompts().register(...)`.
 - Every handler gets `dev.tachyonmcp.runtime.InteractionContext` → protocol + optional session + notifications.
 - ⚡ **Virtual threads**: All synchronous handlers (`ToolHandler`, `ResourceHandler`, `PromptHandler`) run on a virtual thread per request. Blocking for I/O is fine — never use `synchronized` (pins carrier thread). Use `ReentrantLock` instead. Configure a custom handler executor with `ServerBuilder.executor(...)` when needed.
@@ -26,8 +26,9 @@ Make **Java 21+** MCP server. Tachyon lib. Transport = Streamable HTTP (Netty).
 var server = TachyonServer.builder()
     .info(b -> b.name("my-server").version("1.0"))
     .port(8080)
-    .start();
-// server.port() → real bound port (matters when port=0)
+    .build();
+server.start();
+// server.port() → real bound port (matters when port=0); throws before start()
 ```
 
 ## `ServerBuilder` methods

--- a/.agents/skills/tachyon-mcp/resources/java/ServerBasic.java
+++ b/.agents/skills/tachyon-mcp/resources/java/ServerBasic.java
@@ -24,11 +24,12 @@ import static java.time.Duration.ofSeconds;
 public final class ServerBasic {
 
     public static void main(String... args) {
-        var server = createServer(8080);
+        var server = buildServer(8080);
+        server.start();
         System.out.println("MCP server on http://localhost:" + server.port() + "/mcp");
     }
 
-    static TachyonServer createServer(int port) {
+    static TachyonServer buildServer(int port) {
         var server = TachyonServer.builder()
             .info(it -> it.name("demo-server").version("1.0").description("Demo MCP server"))
             .capabilities(c -> c.tools(true).resources(true, true).prompts(true))
@@ -69,7 +70,6 @@ public final class ServerBasic {
             .register(
                 PromptDescriptor.of("greet", "Generates a greeting"),
                 List.of(PromptMessage.user("Say hello")));
-        server.start();
 
         return server;
     }

--- a/.agents/skills/tachyon-mcp/resources/kotlin/ServerBasic.kt
+++ b/.agents/skills/tachyon-mcp/resources/kotlin/ServerBasic.kt
@@ -8,7 +8,7 @@ import dev.tachyonmcp.server.config.NetworkConfig
 import dev.tachyonmcp.server.domain.Role
 import dev.tachyonmcp.server.features.tools.ToolResult
 import dev.tachyonmcp.server.json.NetworkntJsonSchemaValidator
-import dev.tachyonmcp.kotlin.server.TachyonServer
+import dev.tachyonmcp.kotlin.server.buildServer
 import dev.tachyonmcp.kotlin.server.domain.Icon
 import dev.tachyonmcp.kotlin.server.domain.PromptMessage
 import dev.tachyonmcp.kotlin.server.domain.TextContent
@@ -20,8 +20,9 @@ import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.toKotlinDuration
 
-fun createServer(port: Int = NetworkConfig.UNSET_PORT): TachyonServer =
-    TachyonServer(port = port) {
+fun assembleServer(port: Int = NetworkConfig.UNSET_PORT): TachyonServer {
+    val boundPort = port
+    return buildServer {
         // ── identity ──────────────────────────────────────────────
         info {
             name = "demo-server"
@@ -85,7 +86,7 @@ fun createServer(port: Int = NetworkConfig.UNSET_PORT): TachyonServer =
         // ── network — everything you can set ──────────────────────
         network {
             host = NetworkConfig.DEFAULT_HOST
-            // port = 0 // inherited from createServer(port)
+            this.port = boundPort
             endpointPath = NetworkConfig.DEFAULT_ENDPOINT_PATH
             allowedOrigins.add("*")
             allowedHeaders.add("Authorization")
@@ -138,8 +139,10 @@ fun createServer(port: Int = NetworkConfig.UNSET_PORT): TachyonServer =
         // ── netty pipeline customiser (escape hatch) ──────────────
         pipelineCustomizer { }
     }
+}
 
 fun main() {
-    val server = createServer(8080)
+    val server = assembleServer(8080)
+    server.start()
     println("MCP server on http://localhost:${server.port()}/mcp")
 }

--- a/.agents/skills/tachyon-mcp/resources/kotlin/ToolHandlerExample.kt
+++ b/.agents/skills/tachyon-mcp/resources/kotlin/ToolHandlerExample.kt
@@ -4,7 +4,7 @@ package dev.tachyonmcp.skill
 
 import dev.tachyonmcp.runtime.InteractionContext
 import dev.tachyonmcp.server.TachyonServer
-import dev.tachyonmcp.server.domain.Args
+import dev.tachyonmcp.server.features.tools.ToolRequest
 import dev.tachyonmcp.server.features.tools.AbstractToolHandler
 import dev.tachyonmcp.server.features.tools.ToolResult
 import dev.tachyonmcp.server.json.JsonSchema
@@ -109,9 +109,9 @@ class GreetingTool :
     ) {
     override fun handle(
         ctx: InteractionContext,
-        args: Args,
+        request: ToolRequest,
     ): ToolResult {
-        val name = args.stringValue("name")
+        val name = request.arguments().stringValue("name")
         return ToolResult.text("Hello, $name!")
     }
 }
@@ -129,7 +129,7 @@ class AsyncGreetingTool :
     ) {
     override fun handleAsync(
         ctx: InteractionContext,
-        args: Args,
+        request: ToolRequest,
     ): CompletionStage<out ToolResult> =
         CompletableFuture.completedFuture(ToolResult.text("Hello, Async!"))
 }

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@
 
     public class WeatherMcpServer {
         public static void main(String... args) {
-            TachyonServer.builder()
+            var server = TachyonServer.builder()
                 .name("weather-mcp")
                 .withTools(tools -> tools.register(ToolHandler.of(
                         b -> b.name("get_forecast")
@@ -58,7 +58,8 @@
                             """),
                         (ctx, request) -> ToolResult.text("☀️ 22°C"))))
                 .port(8080)
-                .start();
+                .build();
+            server.start();
         }
     }
     ```
@@ -138,7 +139,8 @@ See [docs/quickstart.md](docs/quickstart.md) for a full walkthrough with Java an
 var server = TachyonServer.builder()
     .extension(TasksExtension.instance())  // exposes create_task tool + task://{id} resource
     .port(8080)
-    .start();
+    .build();
+server.start();
 ```
 
 MCP 2025-11-25 clients that include `"extensions": {"io.modelcontextprotocol/tasks": {}}` in their `initialize` capabilities receive the extension's tool and resource template. Clients that don't negotiate it see standard `tasks/*` methods. See [docs/tasks.md](docs/tasks.md).

--- a/docs/architecture/guidance.md
+++ b/docs/architecture/guidance.md
@@ -57,9 +57,9 @@ Blocking for I/O in `handle`/`read` is intended — handlers run on a server-exe
 
 ## 🏹 When to reach for a heavier dispatch structure
 
-`ToolHandler`/`AbstractToolHandler` deliberately isn't the two-interface pattern — tools have two **independent** override axes (sync vs async, canonical `Args` vs raw `ToolRequest`) funneled into one `handleAsync(ctx, ToolRequest)`. `AbstractToolHandler` detects which of the 4 overrides a handler supplied via a package-private `NotImplemented` sentinel (thrown as control flow, `fillInStackTrace` no-op'd — near-zero cost), so one class covers sync/async × Args/Request without extra supertypes.
-
-Only use this for >1 independent override axis. A single axis always gets the two-interface pattern — don't default to a sentinel/dual-dispatch base for what one interface pair expresses.
+`ToolHandler` carries its descriptor, so it is not a handler SAM. `AbstractToolHandler` keeps one
+request shape with sync and async overrides, both receiving `ToolRequest`. Read parsed arguments via
+`request.arguments()`.
 
 ## 🪶 Descriptor bundling: pair vs self-carrying
 
@@ -80,7 +80,7 @@ those same façade APIs; do not add feature-specific registration overloads to `
 - `XHandler` — the handler type. Also the lambda-entry SAM when the shape is simple: `ResourceHandler`/`PromptHandler` are plain `@FunctionalInterface`s, so the type doubles as both.
 - `AsyncXHandler extends XHandler` — async variant, for single-axis handlers only (`AsyncResourceHandler`, `AsyncPromptHandler`). Abstract `handleAsync`, default `handle` blocks via `HandlerFutures.joinInterruptibly`.
 - `XFn` — companion throwing SAM, only when `XHandler` itself isn't lambda-friendly (carries a descriptor, exposes more than one method). Tools need this because `ToolHandler` isn't a `@FunctionalInterface`; `ToolFn` receives the full `ToolRequest`.
-- Static factory composition on `XHandler.of…`: base verb `of`, then optional `Async` — `ToolHandler.of(...)` / `ToolHandler.ofAsync(...)`. Both tool factories receive `ToolRequest`; class-based handlers may override the `Args` or `ToolRequest` form.
+- Static factory composition on `XHandler.of…`: base verb `of`, then optional `Async` — `ToolHandler.of(...)` / `ToolHandler.ofAsync(...)`. Both tool factories and class-based handlers receive `ToolRequest`.
 
 ## 🪶 Registry/facade API naming
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -3,11 +3,12 @@
 All configuration flows through `TachyonServer.builder()` (Java) or the `TachyonServer { }` DSL (Kotlin). Scopes: `info`, `capabilities`, `network`, `session`, `runtime`, `monitoring`.
 
 ```java
-TachyonServer.builder()
+var server = TachyonServer.builder()
     .info(i -> i.name("my-server").version("1.0"))
     .network(n -> n.port(8080).ioEngine(NettyIoEngine.AUTO))
     .session(s -> s.sessionTtl(Duration.ofMinutes(5)))
-    .start();
+    .build();
+server.start();
 ```
 
 ```kotlin
@@ -240,10 +241,11 @@ Turning `slowRequestLogging` on activates two diagnostics:
 Both share the same threshold and are silenced at default (flag off, zero overhead).
 
 ```java
-TachyonServer.builder()
+var server = TachyonServer.builder()
     .monitoring(m -> m.slowRequestLogging().slowRequestThreshold(Duration.ofSeconds(5)))
     .port(8080)
-    .start();
+    .build();
+server.start();
 ```
 
 ```kotlin
@@ -284,7 +286,7 @@ capability is *also* advertised — regardless of `enabled` — whenever a regis
 task augmentation support (`ToolDescriptor.taskSupport()`).
 
 ```java
-TachyonServer.builder()
+var server = TachyonServer.builder()
     .capabilities(c -> c
         .tools(FeatureConfig.builder().mode(Mode.ON).listChanged(true).build())
         .resources(ResourcesConfig.builder().mode(Mode.ON).subscribe(true).build())
@@ -292,7 +294,8 @@ TachyonServer.builder()
         .completions()
         .logging())
     .port(8080)
-    .start();
+    .build();
+server.start();
 ```
 
 ```kotlin

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -65,10 +65,11 @@ public class AuditExtension implements ServerExtension {
 ## Register an extension
 
 ```java
-TachyonServer.builder()
+var server = TachyonServer.builder()
     .extension(new AuditExtension())
     .port(8080)
-    .start();
+    .build();
+server.start();
 ```
 
 ## How negotiation works

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -27,13 +27,14 @@ import dev.tachyonmcp.server.features.tools.ToolHandler;
 import dev.tachyonmcp.server.features.tools.ToolResult;
 
 void main() {
-    TachyonServer.builder()
+    var server = TachyonServer.builder()
         .name("my-server")
         .version("1.0")
         .withTools(tools -> tools.register(ToolHandler.of("greet", "Say hello",
             (ctx, request) -> ToolResult.text("Hello!"))))
         .port(8080)
-        .start();
+        .build();
+    server.start();
 }
 ```
 

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -7,11 +7,12 @@ Tasks track long-running operations across multiple MCP exchanges. Tachyon imple
 Tasks are enabled automatically when you configure task capabilities:
 
 ```java
-TachyonServer.builder()
+var server = TachyonServer.builder()
     .capabilities(cfg -> cfg
         .tasks(true, true, true))  // list=true, cancel=true, inputRequests=true
     .port(8080)
-    .start();
+    .build();
+server.start();
 ```
 
 ## Task state machine
@@ -36,7 +37,8 @@ import dev.tachyonmcp.server.domain.TextContent;
 import dev.tachyonmcp.server.features.tasks.TaskOptions;
 import java.util.List;
 
-TachyonServer server = TachyonServer.builder().port(8080).start();
+TachyonServer server = TachyonServer.builder().port(8080).build();
+server.start();
 
 // Create — server generates the ID
 Task task = server.tasks().create();
@@ -97,10 +99,11 @@ background — sync, async, and Kotlin suspend handlers all work. The client the
 ```java
 import dev.tachyonmcp.server.features.tasks.TasksExtension;
 
-TachyonServer.builder()
+var server = TachyonServer.builder()
     .extension(TasksExtension.instance())
     .port(8080)
-    .start();
+    .build();
+server.start();
 ```
 
 MCP 2025-11-25 clients that include `"extensions": {"io.modelcontextprotocol/tasks": {}}` in their `initialize` capabilities receive the extension tool and resource. Clients that don't negotiate see standard `tasks/*` methods only.

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -32,14 +32,14 @@ Need an input schema? Configure the descriptor with the builder overload. `.inpu
 
 Prefer the `ToolHandler.of…` factories above — they cover most tools in one call. Reach for a
 class only when the handler needs instance state or shared setup. Then extend
-`AbstractToolHandler`: pass the descriptor to the constructor and override `handle(ctx, Args)`.
+`AbstractToolHandler`: pass the descriptor to the constructor and override `handle(ctx, request)`.
 (`ToolHandler` itself declares only `descriptor()` and `handleAsync(ctx, ToolRequest)`;
-`AbstractToolHandler` supplies the sync/args convenience overrides.)
+`AbstractToolHandler` supplies the synchronous request override.)
 
 ```java
 import dev.tachyonmcp.server.features.tools.AbstractToolHandler;
-import dev.tachyonmcp.server.domain.Args;
 import dev.tachyonmcp.server.features.tools.ToolDescriptor;
+import dev.tachyonmcp.server.features.tools.ToolRequest;
 import dev.tachyonmcp.server.features.tools.ToolResult;
 import dev.tachyonmcp.runtime.InteractionContext;
 
@@ -57,8 +57,8 @@ class WeatherTool extends AbstractToolHandler {
     }
 
     @Override
-    public ToolResult handle(InteractionContext ctx, Args args) {
-        String city = args.stringValue("city");
+    public ToolResult handle(InteractionContext ctx, ToolRequest request) {
+        String city = request.arguments().stringValue("city");
         return ToolResult.text("☀️ 22°C in " + city);
     }
 }
@@ -70,7 +70,7 @@ Register: `server.tools().register(new WeatherTool())`
 
 Blocking handlers run on a virtual thread, so most tools need no async plumbing. When you already
 hold a `CompletionStage` (a non-blocking client, another async service), return it directly:
-lambda via `ToolHandler.ofAsync`, or override `handleAsync(ctx, Args)` on
+lambda via `ToolHandler.ofAsync`, or override `handleAsync(ctx, request)` on
 `AbstractToolHandler`. Async handlers stay async — they are not funneled through the blocking path.
 
 ```java
@@ -84,9 +84,8 @@ import dev.tachyonmcp.server.features.tools.ToolHandler;
 ### Progress token / full request
 
 `ToolHandler.of(...)` and `ToolHandler.ofAsync(...)` lambdas receive `ToolRequest`; call
-`request.arguments()` for parsed arguments. In a class, override `handle(ctx, Args)` for the
-ergonomic path, or `handle(ctx, ToolRequest)` / `handleAsync(ctx, ToolRequest)` when you need
-request `_meta`, progress, cancellation, input responses, or task state.
+`request.arguments()` for parsed arguments. Class-based handlers receive the same request in
+`handle(ctx, ToolRequest)` or `handleAsync(ctx, ToolRequest)`.
 
 ## Read arguments
 

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/AbstractMcpE2eTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/AbstractMcpE2eTest.java
@@ -81,10 +81,9 @@ public abstract class AbstractMcpE2eTest {
         var builder = TachyonServer.builder().port(0);
         configurer.accept(builder);
         builder.session(s -> s.enabled(sessionMode() == SessionMode.STATEFUL));
-        this.server = builder.build();
-        registrar.accept(server);
-        server.start();
-        this.port = server.port();
+        var started = TestServers.startSafely(builder, registrar);
+        this.server = started;
+        this.port = started.port();
         this.usingCustomServer = true;
     }
 

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/CustomSessionIdGeneratorTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/CustomSessionIdGeneratorTest.java
@@ -84,12 +84,14 @@ class CustomSessionIdGeneratorTest {
         // SessionIdGenerator has no fallback by design (see its javadoc): a thrown exception
         // aborts session creation with an internal-error response, it does not fall back to
         // the default generator.
-        try (var failingHandle = TachyonServer.builder()
-                        .session(s -> s.enabled(true).sessionIdGenerator(request -> {
-                            throw new IllegalStateException("boom");
-                        }))
-                        .network(n -> n.host("localhost").port(0))
-                        .start();
+        var failingHandle = TachyonServer.builder()
+                .session(s -> s.enabled(true).sessionIdGenerator(request -> {
+                    throw new IllegalStateException("boom");
+                }))
+                .network(n -> n.host("localhost").port(0))
+                .build();
+        failingHandle.start();
+        try (failingHandle;
                 var client = HttpClient.newHttpClient()) {
             var init = post(
                     client,

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/InputRequiredResultTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/InputRequiredResultTest.java
@@ -5,7 +5,6 @@ import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import dev.tachyonmcp.runtime.InteractionContext;
-import dev.tachyonmcp.server.domain.Args;
 import dev.tachyonmcp.server.domain.FormInputRequest;
 import dev.tachyonmcp.server.domain.InputRequest;
 import dev.tachyonmcp.server.domain.UrlInputRequest;
@@ -276,12 +275,6 @@ class InputRequiredResultTest extends AbstractStatelessMcpE2eTest {
                     .name("test_url_elicitation")
                     .description("Tests URL-mode elicitation flow")
                     .build());
-        }
-
-        @Override
-        public CompletionStage<? extends ToolResult> handleAsync(InteractionContext context, Args args) {
-            return handleAsync(
-                    context, ToolRequest.builder().name(descriptor().name()).build());
         }
 
         @Override

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/SessionJanitorOutboundActivityTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/SessionJanitorOutboundActivityTest.java
@@ -41,7 +41,8 @@ class SessionJanitorOutboundActivityTest {
         serverHandle = TachyonServer.builder()
                 .session(s -> s.enabled(true).sessionTtl(TTL).janitorInterval(JANITOR_INTERVAL))
                 .network(n -> n.host("localhost").port(0).heartbeatInterval(HEARTBEAT_INTERVAL))
-                .start();
+                .build();
+        serverHandle.start();
         port = serverHandle.port();
     }
 
@@ -76,10 +77,12 @@ class SessionJanitorOutboundActivityTest {
     /** Same setup with heartbeats disabled: the silent stream produces no writes, so it is reaped. */
     @Test
     void silentStreamReapedWhenHeartbeatsDisabled() throws Exception {
-        try (var noHbServer = TachyonServer.builder()
+        var noHbServer = TachyonServer.builder()
                 .session(s -> s.enabled(true).sessionTtl(TTL).janitorInterval(JANITOR_INTERVAL))
                 .network(n -> n.host("localhost").port(0).heartbeatInterval(Duration.ZERO))
-                .start()) {
+                .build();
+        noHbServer.start();
+        try (noHbServer) {
             var noHbPort = noHbServer.port();
             var sessionId = initializeAndActivate(noHbPort);
             try (var sseSocket = openRawSse(noHbPort, sessionId);

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/SharedE2eServer.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/SharedE2eServer.java
@@ -16,15 +16,14 @@ final class SharedE2eServer {
         if (started.get()) {
             return handle;
         }
-        handle = TachyonServer.builder()
-                .capabilities(c -> c.tools().logging())
-                .session(s -> s.enabled(true))
-                .network(n -> n.port(0))
-                .build();
-        handle.tools().register(EchoToolHandler.create());
-        handle.start();
-        started.set(true);
+        handle = TestServers.startSafely(
+                TachyonServer.builder()
+                        .capabilities(c -> c.tools().logging())
+                        .session(s -> s.enabled(true))
+                        .network(n -> n.port(0)),
+                s -> s.tools().register(EchoToolHandler.create()));
         Runtime.getRuntime().addShutdownHook(new Thread(handle::close));
+        started.set(true);
         logger.info("Shared E2E server started on port {}", handle.port());
         return handle;
     }

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/SharedStatelessE2eServer.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/SharedStatelessE2eServer.java
@@ -10,21 +10,18 @@ final class SharedStatelessE2eServer {
 
     private static final Logger logger = LoggerFactory.getLogger(SharedStatelessE2eServer.class);
     private static final AtomicBoolean started = new AtomicBoolean();
-    private static volatile TachyonServer handle;
+    private static volatile TachyonServer server;
 
     static synchronized TachyonServer ensureStarted() {
         if (started.get()) {
-            return handle;
+            return server;
         }
-        handle = TachyonServer.builder()
-                .capabilities(c -> c.tools().logging())
-                .network(n -> n.port(0))
-                .build();
-        handle.tools().register(EchoToolHandler.create());
-        handle.start();
+        server = TestServers.startSafely(
+                TachyonServer.builder().capabilities(c -> c.tools().logging()).network(n -> n.port(0)),
+                s -> s.tools().register(EchoToolHandler.create()));
+        Runtime.getRuntime().addShutdownHook(new Thread(server::close));
         started.set(true);
-        Runtime.getRuntime().addShutdownHook(new Thread(handle::close));
-        logger.info("Shared stateless E2E server started on port {}", handle.port());
-        return handle;
+        logger.info("Shared stateless E2E server started on port {}", server.port());
+        return server;
     }
 }

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/TestServers.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/TestServers.java
@@ -1,0 +1,28 @@
+/* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
+package dev.tachyonmcp.e2e;
+
+import dev.tachyonmcp.server.ServerBuilder;
+import dev.tachyonmcp.server.TachyonServer;
+import java.util.function.Consumer;
+
+/** Builds, registers, and starts a server, closing it on failure so it doesn't leak. */
+final class TestServers {
+
+    private TestServers() {}
+
+    static TachyonServer startSafely(ServerBuilder builder, Consumer<TachyonServer> registrar) {
+        var candidate = builder.build();
+        try {
+            registrar.accept(candidate);
+            candidate.start();
+            return candidate;
+        } catch (RuntimeException | Error failure) {
+            try {
+                candidate.close();
+            } catch (RuntimeException | Error closeFailure) {
+                failure.addSuppressed(closeFailure);
+            }
+            throw failure;
+        }
+    }
+}

--- a/examples/echo-kotlin/src/main/kotlin/com/example/echo/EchoServer.kt
+++ b/examples/echo-kotlin/src/main/kotlin/com/example/echo/EchoServer.kt
@@ -2,18 +2,19 @@
 
 package com.example.echo
 
-import dev.tachyonmcp.kotlin.server.TachyonServer
+import dev.tachyonmcp.kotlin.server.buildServer
 import dev.tachyonmcp.kotlin.server.features.tools.registerTool
 import dev.tachyonmcp.server.TachyonServer
 import dev.tachyonmcp.server.config.Mode
 import dev.tachyonmcp.server.features.tools.ToolResult
 import dev.tachyonmcp.server.json.JsonSchema
 
-fun createServer(port: Int = 0): TachyonServer {
+fun assembleServer(port: Int = 0): TachyonServer {
+    val boundPort = port
     val inputSchema = buildEchoSchema()
     val server =
-        TachyonServer(port = port)
-        {
+        buildServer {
+            network { this.port = boundPort }
             info {
                 name = "echo-server"
                 title = "Echo Server"
@@ -64,7 +65,8 @@ private fun buildEchoSchema() =
     )
 
 fun main() {
-    val server = createServer(8080)
+    val server = assembleServer(8080)
+    server.start()
     println("Echo server running. Connect your MCP client to http://localhost:${server.port()}/mcp")
     Thread.sleep(Long.MAX_VALUE)
 }

--- a/examples/echo-kotlin/src/test/kotlin/com/example/echo/EchoServerTest.kt
+++ b/examples/echo-kotlin/src/test/kotlin/com/example/echo/EchoServerTest.kt
@@ -15,7 +15,8 @@ class EchoServerTest {
         @JvmStatic
         @BeforeAll
         fun beforeAll() {
-            handle = createServer(0)
+            handle = assembleServer(0)
+            handle.start()
         }
 
         @JvmStatic

--- a/examples/weather-mcp-kotlin/src/main/kotlin/com/example/weather/WeatherServer.kt
+++ b/examples/weather-mcp-kotlin/src/main/kotlin/com/example/weather/WeatherServer.kt
@@ -7,7 +7,7 @@ import com.example.weather.service.NarrationStyle
 import com.example.weather.service.WeatherService
 import com.example.weather.spi.CityNotFoundException
 import com.example.weather.spi.WeatherObservation
-import dev.tachyonmcp.kotlin.server.TachyonServer
+import dev.tachyonmcp.kotlin.server.buildServer
 import dev.tachyonmcp.kotlin.server.domain.Annotations
 import dev.tachyonmcp.kotlin.server.domain.Icon
 import dev.tachyonmcp.server.domain.InvalidArgumentException
@@ -31,7 +31,8 @@ private val MAPPER = ObjectMapper()
 private val LOGO by lazy { classpathDataUri("/images/logo.png", "image/png") }
 
 fun main() {
-    val server = createServer(8080)
+    val server = assembleServer(8080)
+    server.start()
     log.info("Connect your MCP client to http://localhost:{}/mcp", server.port())
 }
 
@@ -46,10 +47,11 @@ fun createWeatherService(): WeatherService {
     return WeatherService(openMeteoProvider, openMeteoProvider)
 }
 
-fun createServer(
+fun assembleServer(
     port: Int,
     weatherService: WeatherService = createWeatherService(),
 ): TachyonServer {
+    val boundPort = port
     val predictionArticle = weatherService.predictionArticle
     val resourceAnnotations =
         Annotations {
@@ -64,7 +66,8 @@ fun createServer(
             sizes = listOf("256x256")
             theme = "light"
         }
-    return TachyonServer(port = port) {
+    return buildServer {
+        network { this.port = boundPort }
         info {
             name = "weather-server-kotlin"
             title = "Weather Server (Kotlin)"

--- a/examples/weather-mcp-kotlin/src/test/kotlin/com/example/weather/GetWeatherEdgeCasesTest.kt
+++ b/examples/weather-mcp-kotlin/src/test/kotlin/com/example/weather/GetWeatherEdgeCasesTest.kt
@@ -18,7 +18,8 @@ class GetWeatherEdgeCasesTest {
         weatherService: WeatherService,
         elicitationResponse: (McpSchema.ElicitRequest) -> McpSchema.ElicitResult,
     ): McpSchema.CallToolResult {
-        val server = createServer(0, weatherService)
+        val server = assembleServer(0, weatherService)
+        server.start()
         val transport =
             HttpClientStreamableHttpTransport.builder("http://localhost:${server.port()}").build()
         val client = McpClient.sync(transport).elicitation(elicitationResponse).build()

--- a/examples/weather-mcp-kotlin/src/test/kotlin/com/example/weather/WeatherServerTest.kt
+++ b/examples/weather-mcp-kotlin/src/test/kotlin/com/example/weather/WeatherServerTest.kt
@@ -52,7 +52,8 @@ class WeatherServerTest {
         @JvmStatic
         @BeforeAll
         fun beforeAll() {
-            server = createServer(0, weatherService)
+            server = assembleServer(0, weatherService)
+            server.start()
             val port = server.port()
 
             clientTransport =

--- a/examples/weather/src/main/java/com/example/weather/WeatherServer.java
+++ b/examples/weather/src/main/java/com/example/weather/WeatherServer.java
@@ -53,16 +53,17 @@ public final class WeatherServer {
     }
 
     public static void main(String... args) {
-        final var server = createServer(8080);
+        final var server = buildServer(8080);
+        server.start();
         final var port = server.port();
         log.info("Connect your MCP client to http://localhost:{}/mcp", port);
     }
 
-    static TachyonServer createServer(int port) {
-        return createServer(port, weatherService);
+    static TachyonServer buildServer(int port) {
+        return buildServer(port, weatherService);
     }
 
-    static TachyonServer createServer(int port, WeatherService weatherService) {
+    static TachyonServer buildServer(int port, WeatherService weatherService) {
         var predictionArticle = weatherService.predictionArticle();
         var resourceAnnotations =
             Annotations.of(List.of(Role.USER, Role.ASSISTANT), 0.8, "2026-07-23T00:00:00Z");
@@ -129,7 +130,7 @@ public final class WeatherServer {
                                 }))
                 .session(session -> session.enabled(true))
                 .network(network -> network.port(port))
-                .start();
+                .build();
     }
 
     private WeatherServer() {

--- a/examples/weather/src/test/java/com/example/weather/WeatherServerTest.java
+++ b/examples/weather/src/test/java/com/example/weather/WeatherServerTest.java
@@ -37,7 +37,8 @@ class WeatherServerTest {
 
     @BeforeAll
     static void beforeAll() {
-        handle = WeatherServer.createServer(0, weatherService);
+        handle = WeatherServer.buildServer(0, weatherService);
+        handle.start();
         int port = handle.port();
 
         clientTransport = HttpClientStreamableHttpTransport

--- a/tachyon-api/src/main/java/dev/tachyonmcp/server/features/tools/AbstractToolHandler.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/server/features/tools/AbstractToolHandler.java
@@ -4,21 +4,16 @@ package dev.tachyonmcp.server.features.tools;
 import static dev.tachyonmcp.server.features.HandlerFutures.assumeVirtualThread;
 
 import dev.tachyonmcp.runtime.InteractionContext;
-import dev.tachyonmcp.server.domain.Args;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Consumer;
 
 /**
- * Base {@link ToolHandler} implementation. Override exactly one of:
+ * Base {@link ToolHandler} implementation. Override exactly one method:
  * <ul>
- *   <li>{@link #handle(InteractionContext, Args)} — canonical for sync handlers.
- *   <li>{@link #handleAsync(InteractionContext, Args)} — when the tool is already async;
- *       stays async with no virtual-thread detour.
- *   <li>The {@code ToolRequest} variants ({@link #handle(InteractionContext, ToolRequest)} /
- *       {@link #handleAsync(InteractionContext, ToolRequest)}) — only when the raw request is
- *       needed (custom argument deserialization, request metadata).
+ *   <li>{@link #handle(InteractionContext, ToolRequest)} for synchronous handlers.
+ *   <li>{@link #handleAsync(InteractionContext, ToolRequest)} for asynchronous handlers.
  * </ul>
  *
  * @author Konstantin Pavlov
@@ -55,66 +50,23 @@ public abstract class AbstractToolHandler implements ToolHandler {
      * Executes the tool asynchronously with the full request — the single method the dispatcher
      * invokes.
      *
-     * <p>Reaches whichever override the implementation provides: async handlers override
-     * {@link #handleAsync(InteractionContext, Args)} (stays async — no sync detour, no
-     * virtual-thread assertion) or this method; sync handlers override a {@code handle} method
-     * and this falls back to running it (blocking) on the virtual dispatch thread.
+     * <p>Async handlers override this method directly. Sync handlers override {@link
+     * #handle(InteractionContext, ToolRequest)} and this method forwards to it.
      */
     @Override
     public CompletionStage<? extends ToolResult> handleAsync(InteractionContext context, ToolRequest request) {
         try {
-            return handleAsync(context, request.arguments());
-        } catch (NotImplemented noAsyncArgs) {
-            try {
-                return CompletableFuture.completedStage(handle(context, request));
-            } catch (Exception e) {
-                return CompletableFuture.failedFuture(e);
-            }
+            return CompletableFuture.completedStage(handle(context, request));
+        } catch (Exception e) {
+            return CompletableFuture.failedFuture(e);
         }
     }
 
     /**
-     * Executes the tool asynchronously with parsed args. Async handlers override this. The default
-     * signals "not implemented" so {@link #handleAsync(InteractionContext, ToolRequest)} can fall
-     * back to the sync path.
-     */
-    public CompletionStage<? extends ToolResult> handleAsync(InteractionContext context, Args args) {
-        throw NotImplemented.INSTANCE;
-    }
-
-    /**
-     * Executes the tool synchronously with the full request. Default forwards to
-     * {@link #handle(InteractionContext, Args)}.
+     * Executes the tool synchronously with the full request. Sync handlers override this method.
      */
     public ToolResult handle(InteractionContext context, ToolRequest request) throws Exception {
         assumeVirtualThread(); // don't remove this guardrail!
-        return handle(context, request.arguments());
-    }
-
-    /**
-     * Executes the tool synchronously with parsed args. Sync handlers override this.
-     */
-    public ToolResult handle(InteractionContext context, Args args) throws Exception {
-        assumeVirtualThread(); // don't remove this guardrail!
-        throw NotImplemented.INSTANCE;
-    }
-
-    /**
-     * Signals that a {@code handle}/{@code handleAsync} default was not overridden, so
-     * {@link #handleAsync(InteractionContext, ToolRequest)} can probe the args override and fall
-     * back. It is a control flow, not an error, and is thrown on every sync-handler dispatch.
-     */
-    static final class NotImplemented extends UnsupportedOperationException {
-
-        static NotImplemented INSTANCE = new NotImplemented();
-
-        private NotImplemented() {
-            super("Implement one of handle/handleAsync(InteractionContext, Args|ToolRequest)");
-        }
-
-        @Override
-        public synchronized Throwable fillInStackTrace() {
-            return this;
-        }
+        throw new UnsupportedOperationException("Override handle or handleAsync");
     }
 }

--- a/tachyon-api/src/main/java/dev/tachyonmcp/server/features/tools/ToolHandler.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/server/features/tools/ToolHandler.java
@@ -5,7 +5,6 @@ import static dev.tachyonmcp.server.features.HandlerFutures.assumeVirtualThread;
 
 import dev.tachyonmcp.runtime.InteractionContext;
 import dev.tachyonmcp.server.ServerFeature;
-import dev.tachyonmcp.server.domain.Args;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Consumer;
 import org.jspecify.annotations.Nullable;
@@ -15,13 +14,10 @@ import org.jspecify.annotations.Nullable;
  *
  * <p>Override exactly one method in {@link AbstractToolHandler}:
  * <ul>
- *   <li>{@link AbstractToolHandler#handle(InteractionContext, Args)} — canonical for sync
+ *   <li>{@link AbstractToolHandler#handle(InteractionContext, ToolRequest)} for synchronous
  *       handlers.
- *   <li>{@link AbstractToolHandler#handleAsync(InteractionContext, Args)} — when the tool is
- *       already async; stays async with no virtual-thread detour.
- *   <li>The {@code ToolRequest} variants ({@link AbstractToolHandler#handle(InteractionContext,
- *       ToolRequest)} / {@link AbstractToolHandler#handleAsync(InteractionContext, ToolRequest)})
- *       — only when the raw request is needed (progress token, cancellation, task handle).
+ *   <li>{@link AbstractToolHandler#handleAsync(InteractionContext, ToolRequest)} for asynchronous
+ *       handlers.
  * </ul>
  *
  * @author Konstantin Pavlov

--- a/tachyon-api/src/main/java/dev/tachyonmcp/server/json/JsonConfig.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/server/json/JsonConfig.java
@@ -4,19 +4,24 @@ package dev.tachyonmcp.server.json;
 import org.jspecify.annotations.Nullable;
 
 /**
- * JSON payload configuration for the server: serializer, deserializer and schema validators.
+ * JSON payload configuration for the server: serializer, deserializer, schema validators, and
+ * document/schema parsing factories.
  *
  * @param serializer      payload serializer, or {@code null} to keep the server default
  * @param deserializer    payload deserializer, or {@code null} to keep the server default
  * @param inputValidator  input schema validator, or {@code null} to keep the server default
  * @param outputValidator output schema validator, or {@code null} to keep the server default
+ * @param documentFactory parses/validates encoded JSON documents, or {@code null} to keep the server default
+ * @param schemaFactory   parses/validates encoded JSON schemas, or {@code null} to keep the server default
  * @author Konstantin Pavlov
  */
 public record JsonConfig(
         @Nullable PayloadSerializer serializer,
         @Nullable PayloadDeserializer deserializer,
         @Nullable JsonSchemaValidator inputValidator,
-        @Nullable JsonSchemaValidator outputValidator) {
+        @Nullable JsonSchemaValidator outputValidator,
+        @Nullable JsonDocumentFactory<String> documentFactory,
+        @Nullable JsonSchemaFactory<String> schemaFactory) {
 
     public static Builder builder() {
         return new Builder();
@@ -30,6 +35,8 @@ public record JsonConfig(
         private @Nullable PayloadDeserializer deserializer;
         private @Nullable JsonSchemaValidator inputValidator;
         private @Nullable JsonSchemaValidator outputValidator;
+        private @Nullable JsonDocumentFactory<String> documentFactory;
+        private @Nullable JsonSchemaFactory<String> schemaFactory;
 
         private Builder() {}
 
@@ -64,8 +71,19 @@ public record JsonConfig(
             return this;
         }
 
+        public Builder documentFactory(@Nullable JsonDocumentFactory<String> documentFactory) {
+            this.documentFactory = documentFactory;
+            return this;
+        }
+
+        public Builder schemaFactory(@Nullable JsonSchemaFactory<String> schemaFactory) {
+            this.schemaFactory = schemaFactory;
+            return this;
+        }
+
         public JsonConfig build() {
-            return new JsonConfig(serializer, deserializer, inputValidator, outputValidator);
+            return new JsonConfig(
+                    serializer, deserializer, inputValidator, outputValidator, documentFactory, schemaFactory);
         }
     }
 }

--- a/tachyon-api/src/main/java/dev/tachyonmcp/server/json/JsonDocument.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/server/json/JsonDocument.java
@@ -1,6 +1,7 @@
 /* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
 package dev.tachyonmcp.server.json;
 
+import dev.tachyonmcp.annotations.ExperimentalApi;
 import java.util.Optional;
 
 /**
@@ -30,6 +31,7 @@ public interface JsonDocument {
      * @param type the class of the requested representation
      * @return the provider-specific representation, or empty if not available
      */
+    @ExperimentalApi
     default <T> Optional<T> unwrap(Class<T> type) {
         return Optional.empty();
     }

--- a/tachyon-api/src/main/java/dev/tachyonmcp/server/json/JsonDocumentFactory.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/server/json/JsonDocumentFactory.java
@@ -1,0 +1,24 @@
+/* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
+package dev.tachyonmcp.server.json;
+
+/**
+ * Creates a {@link JsonDocument} from a source representation, validating it in the process.
+ *
+ * <p>Unlike {@link JsonDocument#of(String)}, which wraps a string without inspecting it, a
+ * factory implementation parses {@code source} and rejects malformed JSON.
+ *
+ * @param <T> the source representation type
+ * @author Konstantin Pavlov
+ */
+@FunctionalInterface
+public interface JsonDocumentFactory<T> {
+
+    /**
+     * Creates a document from {@code source}.
+     *
+     * @param source the source representation
+     * @return the parsed document
+     * @throws IllegalArgumentException if {@code source} is not valid JSON
+     */
+    JsonDocument toJsonDocument(T source);
+}

--- a/tachyon-api/src/main/java/dev/tachyonmcp/server/json/JsonSchemaFactory.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/server/json/JsonSchemaFactory.java
@@ -1,0 +1,24 @@
+/* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
+package dev.tachyonmcp.server.json;
+
+/**
+ * Creates a {@link JsonSchema} from a source representation, validating it in the process.
+ *
+ * <p>Unlike {@link JsonSchema#of(String)}, which wraps a string without inspecting it, a
+ * factory implementation parses {@code source} and rejects malformed JSON.
+ *
+ * @param <T> the source representation type
+ * @author Konstantin Pavlov
+ */
+@FunctionalInterface
+public interface JsonSchemaFactory<T> {
+
+    /**
+     * Creates a schema from {@code source}.
+     *
+     * @param source the source representation
+     * @return the parsed schema
+     * @throws IllegalArgumentException if {@code source} is not valid JSON
+     */
+    JsonSchema toJsonSchema(T source);
+}

--- a/tachyon-core/src/main/java/dev/tachyonmcp/server/DefaultServerBuilder.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/server/DefaultServerBuilder.java
@@ -13,8 +13,11 @@ import dev.tachyonmcp.server.features.completions.Completions;
 import dev.tachyonmcp.server.features.prompts.Prompts;
 import dev.tachyonmcp.server.features.resources.Resources;
 import dev.tachyonmcp.server.features.tools.Tools;
+import dev.tachyonmcp.server.json.Jackson3JsonFactory;
 import dev.tachyonmcp.server.json.JacksonPayloadSerde;
 import dev.tachyonmcp.server.json.JsonConfig;
+import dev.tachyonmcp.server.json.JsonDocumentFactory;
+import dev.tachyonmcp.server.json.JsonSchemaFactory;
 import dev.tachyonmcp.server.json.JsonSchemaValidator;
 import dev.tachyonmcp.server.json.NetworkntJsonSchemaValidator;
 import dev.tachyonmcp.server.json.PayloadDeserializer;
@@ -50,6 +53,8 @@ final class DefaultServerBuilder implements ServerBuilder {
     private JsonSchemaValidator outputSchemaValidator = new NetworkntJsonSchemaValidator();
     private PayloadSerializer payloadSerializer = new JacksonPayloadSerde();
     private PayloadDeserializer payloadDeserializer = new JacksonPayloadSerde();
+    private JsonDocumentFactory<String> documentFactory = Jackson3JsonFactory.INSTANCE;
+    private JsonSchemaFactory<String> schemaFactory = Jackson3JsonFactory.INSTANCE;
 
     @Nullable
     private Consumer<ChannelPipeline> pipelineCustomizer;
@@ -134,6 +139,12 @@ final class DefaultServerBuilder implements ServerBuilder {
         }
         if (config.outputValidator() != null) {
             outputSchemaValidator = config.outputValidator();
+        }
+        if (config.documentFactory() != null) {
+            documentFactory = config.documentFactory();
+        }
+        if (config.schemaFactory() != null) {
+            schemaFactory = config.schemaFactory();
         }
         return this;
     }
@@ -342,6 +353,7 @@ final class DefaultServerBuilder implements ServerBuilder {
                 outputSchemaValidator,
                 payloadSerializer,
                 payloadDeserializer,
+                schemaFactory,
                 allExtensions,
                 pipelineCustomizer);
         bootstrapRegistrations.forEach(registrar -> registrar.accept(server));

--- a/tachyon-core/src/main/java/dev/tachyonmcp/server/DefaultServerBuilder.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/server/DefaultServerBuilder.java
@@ -306,7 +306,7 @@ final class DefaultServerBuilder implements ServerBuilder {
      *
      * <p>The returned server includes the configured sessions, features, extensions, payload
      * processing, and execution strategy. Transport-dependent host and port values become meaningful
-     * only after {@link #start()}.
+     * only after {@link TachyonServer#start()}.
      *
      * @return the configured server
      */
@@ -345,16 +345,6 @@ final class DefaultServerBuilder implements ServerBuilder {
                 allExtensions,
                 pipelineCustomizer);
         bootstrapRegistrations.forEach(registrar -> registrar.accept(server));
-        return server;
-    }
-
-    /**
-     * Builds the server and starts the Netty transport (blocking). Requires a port to be set.
-     */
-    @Override
-    public TachyonServer start() {
-        var server = build();
-        server.start();
         return server;
     }
 

--- a/tachyon-core/src/main/java/dev/tachyonmcp/server/DefaultTachyonServer.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/server/DefaultTachyonServer.java
@@ -32,7 +32,9 @@ import dev.tachyonmcp.server.handlers.LoggingHandlers;
 import dev.tachyonmcp.server.handlers.PingHandler;
 import dev.tachyonmcp.server.internal.NotificationLogSupport;
 import dev.tachyonmcp.server.internal.ServerEngine;
+import dev.tachyonmcp.server.json.Jackson3JsonFactory;
 import dev.tachyonmcp.server.json.JacksonPayloadSerde;
+import dev.tachyonmcp.server.json.JsonSchemaFactory;
 import dev.tachyonmcp.server.json.JsonSchemaValidator;
 import dev.tachyonmcp.server.json.NetworkntJsonSchemaValidator;
 import dev.tachyonmcp.server.json.PayloadDeserializer;
@@ -224,6 +226,7 @@ final class DefaultTachyonServer implements ServerEngine {
             @Nullable JsonSchemaValidator outputValidator,
             @Nullable PayloadSerializer payloadSerializer,
             @Nullable PayloadDeserializer payloadDeserializer,
+            @Nullable JsonSchemaFactory<String> schemaFactory,
             @Nullable List<ServerExtension> extensions,
             @Nullable Consumer<ChannelPipeline> pipelineCustomizer) {
         this.executor = executor;
@@ -241,9 +244,16 @@ final class DefaultTachyonServer implements ServerEngine {
         final PayloadSerializer payloadSerializer1 = payloadSerializer != null ? payloadSerializer : defaultSerde;
         final PayloadDeserializer payloadDeserializer1 =
                 payloadDeserializer != null ? payloadDeserializer : defaultSerde;
+        final JsonSchemaFactory<String> schemaFactory1 =
+                schemaFactory != null ? schemaFactory : Jackson3JsonFactory.INSTANCE;
         var caps = config.capabilities();
         this.toolRegistry = new DefaultToolRegistry(
-                inputValidator1, outputValidator1, payloadSerializer1, payloadDeserializer1, caps.tools());
+                inputValidator1,
+                outputValidator1,
+                payloadSerializer1,
+                payloadDeserializer1,
+                schemaFactory1,
+                caps.tools());
         this.resourceRegistry = new DefaultResourceRegistry(this, caps.resources());
         this.taskRegistry = new DefaultTaskRegistry(this, caps.tasks());
         this.promptRegistry = new DefaultPromptRegistry(inputValidator1, caps.prompts());

--- a/tachyon-core/src/main/java/dev/tachyonmcp/server/DefaultTachyonServer.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/server/DefaultTachyonServer.java
@@ -300,6 +300,9 @@ final class DefaultTachyonServer implements ServerEngine {
 
     @Override
     public int port() {
+        if (transport == null) {
+            throw new IllegalStateException("Server not started; call start() first");
+        }
         return port;
     }
 

--- a/tachyon-core/src/main/java/dev/tachyonmcp/server/RpcMethodHandler.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/server/RpcMethodHandler.java
@@ -1,6 +1,7 @@
 /* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
 package dev.tachyonmcp.server;
 
+import dev.tachyonmcp.annotations.InternalApi;
 import dev.tachyonmcp.server.session.DispatchContext;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -22,6 +23,7 @@ import org.jspecify.annotations.Nullable;
  * return HandlerFutures.joinInterruptibly(future);
  * }</pre>
  */
+@InternalApi
 public interface RpcMethodHandler {
 
     /** The JSON-RPC method name this handler dispatches to. */

--- a/tachyon-core/src/main/java/dev/tachyonmcp/server/ServerBuilder.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/server/ServerBuilder.java
@@ -56,22 +56,28 @@ public interface ServerBuilder {
     /** Sets the bind host. */
     ServerBuilder host(String host);
 
-    /** Registers tools through the server's tool façade during bootstrap. */
+    /**
+     * Registers tools through the server's tool façade at the end of {@link #build()}.
+     */
     ServerBuilder withTools(Consumer<Tools> registrar);
 
-    /** Registers resources through the server's resource façade during bootstrap. */
+    /** Registers resources through the server's resource façade at the end of {@link #build()}. */
     ServerBuilder withResources(Consumer<Resources> registrar);
 
-    /** Registers prompts through the server's prompt façade during bootstrap. */
+    /** Registers prompts through the server's prompt façade at the end of {@link #build()}. */
     ServerBuilder withPrompts(Consumer<Prompts> registrar);
 
-    /** Registers completions through the server's completion façade during bootstrap. */
+    /** Registers completions through the server's completion façade at the end of {@link #build()}. */
     ServerBuilder withCompletions(Consumer<Completions> registrar);
 
     /** Registers a server extension. */
     ServerBuilder extension(ServerExtension extension);
 
-    /** Sets a caller-owned thread-per-task executor. */
+    /**
+     * Sets a caller-owned thread-per-task executor. The caller must close the executor after the
+     * server is closed. {@link #build()} rejects bounded executors with an
+     * {@link IllegalArgumentException}.
+     */
     ServerBuilder executor(ExecutorService executor);
 
     /** Sets the thread factory used by the server-owned thread-per-task executor. */
@@ -80,10 +86,15 @@ public interface ServerBuilder {
     /** Customizes each Netty channel pipeline. */
     ServerBuilder pipelineCustomizer(@Nullable Consumer<ChannelPipeline> customizer);
 
-    /** Builds the configured server without starting its transport. */
+    /**
+     * Constructs the configured server without starting its transport, then executes the configured
+     * feature-registration callbacks.
+     *
+     * @throws IllegalArgumentException if the configured executor is bounded
+     */
     TachyonServer build();
 
-    /** Builds the configured server and starts its transport. */
+    /** Builds the configured server, executes feature-registration callbacks, and starts its transport. */
     TachyonServer start();
 
     /** Builds the immutable server configuration. */

--- a/tachyon-core/src/main/java/dev/tachyonmcp/server/ServerBuilder.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/server/ServerBuilder.java
@@ -20,7 +20,7 @@ import java.util.concurrent.ThreadFactory;
 import java.util.function.Consumer;
 import org.jspecify.annotations.Nullable;
 
-/** Configures, builds, and optionally starts a {@link TachyonServer}. */
+/** Configures and builds a {@link TachyonServer}; call {@link TachyonServer#start()} to bind its transport. */
 public interface ServerBuilder {
 
     /** Configures server identity. */
@@ -93,9 +93,6 @@ public interface ServerBuilder {
      * @throws IllegalArgumentException if the configured executor is bounded
      */
     TachyonServer build();
-
-    /** Builds the configured server, executes feature-registration callbacks, and starts its transport. */
-    TachyonServer start();
 
     /** Builds the immutable server configuration. */
     ServerConfig buildConfig();

--- a/tachyon-core/src/main/java/dev/tachyonmcp/server/TachyonServer.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/server/TachyonServer.java
@@ -54,8 +54,9 @@ public interface TachyonServer extends AutoCloseable {
     void start();
 
     /**
-     * Returns the port the server is bound to, or 0 if not yet started.
-     * Only meaningful after {@link #start()} or equivalent.
+     * Returns the port the server is bound to.
+     *
+     * @throws IllegalStateException if the server has not been started
      */
     int port();
 

--- a/tachyon-core/src/main/java/dev/tachyonmcp/server/config/ServerConfig.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/server/config/ServerConfig.java
@@ -22,14 +22,6 @@ public record ServerConfig(
         RuntimeConfig runtime,
         MonitoringConfig monitoring) {
 
-    static final ServerConfig DEFAULT = new ServerConfig(
-            ServerIdentity.DEFAULT,
-            CapabilitiesConfig.DEFAULT,
-            SessionConfig.STATELESS,
-            NetworkConfig.DEFAULT,
-            RuntimeConfig.DEFAULT,
-            MonitoringConfig.DEFAULT);
-
     public ServerConfig {
         Objects.requireNonNull(identity, "identity cannot be null");
         Objects.requireNonNull(capabilities, "capabilities cannot be null");

--- a/tachyon-core/src/main/java/dev/tachyonmcp/server/features/tasks/TasksExtension.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/server/features/tasks/TasksExtension.java
@@ -3,12 +3,12 @@ package dev.tachyonmcp.server.features.tasks;
 
 import dev.tachyonmcp.runtime.InteractionContext;
 import dev.tachyonmcp.server.OutboundSseStreamMessageRouter;
-import dev.tachyonmcp.server.domain.Args;
 import dev.tachyonmcp.server.domain.TextResourceContents;
 import dev.tachyonmcp.server.extensions.ServerExtension;
 import dev.tachyonmcp.server.features.resources.ResourceTemplateDescriptor;
 import dev.tachyonmcp.server.features.tools.AbstractToolHandler;
 import dev.tachyonmcp.server.features.tools.ToolDescriptor;
+import dev.tachyonmcp.server.features.tools.ToolRequest;
 import dev.tachyonmcp.server.features.tools.ToolResult;
 import dev.tachyonmcp.server.internal.ServerEngine;
 import dev.tachyonmcp.server.json.JsonSchema;
@@ -86,7 +86,8 @@ public class TasksExtension implements ServerExtension {
         }
 
         @Override
-        public CompletionStage<? extends ToolResult> handleAsync(InteractionContext context, Args args) {
+        public CompletionStage<? extends ToolResult> handleAsync(InteractionContext context, ToolRequest request) {
+            var args = request.arguments();
             var sessionId = OutboundSseStreamMessageRouter.currentSessionId();
             var outboundStream = OutboundSseStreamMessageRouter.currentOutboundSseStream();
             return CompletableFuture.supplyAsync(

--- a/tachyon-core/src/main/java/dev/tachyonmcp/server/features/tools/DefaultToolRegistry.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/server/features/tools/DefaultToolRegistry.java
@@ -30,6 +30,7 @@ import dev.tachyonmcp.server.features.tasks.TaskEntry;
 import dev.tachyonmcp.server.features.tasks.TaskSupport;
 import dev.tachyonmcp.server.json.JsonDocument;
 import dev.tachyonmcp.server.json.JsonSchema;
+import dev.tachyonmcp.server.json.JsonSchemaFactory;
 import dev.tachyonmcp.server.json.JsonSchemaUtils;
 import dev.tachyonmcp.server.json.JsonSchemaValidator;
 import dev.tachyonmcp.server.json.JsonUtils;
@@ -67,6 +68,7 @@ public class DefaultToolRegistry extends AbstractRegistry<ToolDescriptor, ToolHa
     private final JsonSchemaValidator outputValidator;
     private final PayloadSerializer payloadSerializer;
     private final PayloadDeserializer payloadDeserializer;
+    private final JsonSchemaFactory<String> schemaFactory;
     private final FeatureConfig config;
 
     /**
@@ -83,12 +85,14 @@ public class DefaultToolRegistry extends AbstractRegistry<ToolDescriptor, ToolHa
             JsonSchemaValidator outputValidator,
             PayloadSerializer payloadSerializer,
             PayloadDeserializer payloadDeserializer,
+            JsonSchemaFactory<String> schemaFactory,
             FeatureConfig config) {
         super(config.pageSize());
         this.inputValidator = inputValidator;
         this.outputValidator = outputValidator;
         this.payloadSerializer = payloadSerializer;
         this.payloadDeserializer = payloadDeserializer;
+        this.schemaFactory = schemaFactory;
         this.config = config;
     }
 
@@ -111,8 +115,8 @@ public class DefaultToolRegistry extends AbstractRegistry<ToolDescriptor, ToolHa
         }
         var name = descriptor.name();
         validateName(name);
-        validateSchemaRoot("inputSchema", name, descriptor.inputSchema());
-        validateSchemaRoot("outputSchema", name, descriptor.outputSchema());
+        JsonSchemaUtils.validateSchemaRoot(schemaFactory, "inputSchema", name, descriptor.inputSchema());
+        JsonSchemaUtils.validateSchemaRoot(schemaFactory, "outputSchema", name, descriptor.outputSchema());
         var desc = descriptor.description();
         if (desc != null && desc.length() > MAX_DESCRIPTION_LENGTH) {
             logger.warn(
@@ -160,31 +164,6 @@ public class DefaultToolRegistry extends AbstractRegistry<ToolDescriptor, ToolHa
                 .map(ToolHandler::descriptor)
                 .sorted(Comparator.comparing(ToolDescriptor::name))
                 .toList();
-    }
-
-    /**
-     * Validates that a tool schema has an object root declaring {@code "type": "object"}.
-     *
-     * @param schemaKind the kind of schema being validated
-     * @param toolName   the name of the tool owning the schema
-     * @param schema     the schema to validate, or {@code null}
-     * @throws IllegalArgumentException if the schema root is invalid
-     */
-    private static void validateSchemaRoot(String schemaKind, String toolName, @Nullable JsonSchema schemaDocument) {
-        if (schemaDocument == null) return;
-        var schema = JsonUtils.parse(schemaDocument);
-        final String detail;
-        if (!schema.isObject()) {
-            detail = "got: " + schema.getNodeType();
-        } else if (!schema.has("type")) {
-            detail = "missing \"type\"";
-        } else if (!"object".equals(schema.get("type").asString())) {
-            detail = "got: " + schema.get("type");
-        } else {
-            return;
-        }
-        throw new IllegalArgumentException(
-                "Tool '" + toolName + "' " + schemaKind + " root must declare \"type\": \"object\", " + detail);
     }
 
     static void validateName(String name) {

--- a/tachyon-core/src/main/java/dev/tachyonmcp/server/json/Jackson3JsonFactory.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/server/json/Jackson3JsonFactory.java
@@ -1,0 +1,55 @@
+/* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
+package dev.tachyonmcp.server.json;
+
+import tools.jackson.databind.JsonNode;
+
+/**
+ * Jackson 3-backed {@link JsonDocumentFactory} and {@link JsonSchemaFactory}: parses the source
+ * and rejects malformed JSON before wrapping it. Accepts a raw JSON string, an already-parsed
+ * {@link JsonNode}, or a provider-neutral {@link JsonObject} — the latter two are structurally
+ * valid by construction, so they're wrapped without re-validation.
+ *
+ * @author Konstantin Pavlov
+ */
+public final class Jackson3JsonFactory implements JsonDocumentFactory<String>, JsonSchemaFactory<String> {
+
+    public static final Jackson3JsonFactory INSTANCE = new Jackson3JsonFactory();
+
+    private Jackson3JsonFactory() {}
+
+    @Override
+    public JsonDocument toJsonDocument(String json) {
+        validate(json);
+        return JsonDocument.of(json);
+    }
+
+    public JsonDocument toJsonDocument(JsonNode node) {
+        return JsonDocument.of(node.toString());
+    }
+
+    public JsonDocument toJsonDocument(JsonObject object) {
+        return JsonDocument.of(object.json());
+    }
+
+    @Override
+    public JsonSchema toJsonSchema(String json) {
+        validate(json);
+        return JsonSchema.of(json);
+    }
+
+    public JsonSchema toJsonSchema(JsonNode node) {
+        return JsonSchema.of(node.toString());
+    }
+
+    public JsonSchema toJsonSchema(JsonObject object) {
+        return JsonSchema.of(object.json());
+    }
+
+    private static void validate(String json) {
+        try {
+            JsonUtils.parse(json);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Not valid JSON: " + json, e);
+        }
+    }
+}

--- a/tachyon-core/src/main/java/dev/tachyonmcp/server/json/JsonSchemaUtils.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/server/json/JsonSchemaUtils.java
@@ -13,16 +13,32 @@ public class JsonSchemaUtils {
     }
 
     /**
-     * Parses a JSON schema string, returning {@code null} for null input.
+     * Validates that a tool schema is well-formed JSON with an object root declaring
+     * {@code "type": "object"}.
+     *
+     * @param factory    parses and validates the schema's raw JSON
+     * @param schemaKind the kind of schema being validated
+     * @param toolName   the name of the tool owning the schema
+     * @param schema     the schema to validate, or {@code null}
+     * @throws IllegalArgumentException if the schema is not valid JSON, or its root is invalid
      */
-    public static @Nullable JsonSchema parseSchema(@Nullable String json) {
-        if (json == null) return null;
-        try {
-            JsonUtils.parse(json);
-            return JsonSchema.of(json);
-        } catch (Exception e) {
-            throw new IllegalArgumentException("Schema is not valid JSON: " + json, e);
+    public static void validateSchemaRoot(
+            JsonSchemaFactory<String> factory, String schemaKind, String toolName, @Nullable JsonSchema schema) {
+        if (schema == null) return;
+        var validated = factory.toJsonSchema(schema.json());
+        var node = JsonUtils.parse(validated);
+        final String detail;
+        if (!node.isObject()) {
+            detail = "got: " + node.getNodeType();
+        } else if (!node.has("type")) {
+            detail = "missing \"type\"";
+        } else if (!"object".equals(node.get("type").asString())) {
+            detail = "got: " + node.get("type");
+        } else {
+            return;
         }
+        throw new IllegalArgumentException(
+                "Tool '" + toolName + "' " + schemaKind + " root must declare \"type\": \"object\", " + detail);
     }
 
     /**

--- a/tachyon-core/src/test/java/dev/tachyonmcp/server/ServerBuilderTest.java
+++ b/tachyon-core/src/test/java/dev/tachyonmcp/server/ServerBuilderTest.java
@@ -3,6 +3,7 @@ package dev.tachyonmcp.server;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 
 import dev.tachyonmcp.server.domain.PromptMessage;
 import dev.tachyonmcp.server.domain.TextResourceContents;
@@ -187,5 +188,19 @@ class ServerBuilderTest {
                         "asyncPromptCompletion",
                         "resourceCompletion",
                         "asyncResourceCompletion");
+    }
+
+    @Test
+    void builderHasNoStartMethod() {
+        assertThat(ServerBuilder.class.getDeclaredMethods())
+                .extracting(method -> method.getName())
+                .doesNotContain("start");
+    }
+
+    @Test
+    void portThrowsBeforeStart() {
+        try (var server = TachyonServer.builder().build()) {
+            assertThatIllegalStateException().isThrownBy(server::port);
+        }
     }
 }

--- a/tachyon-core/src/test/java/dev/tachyonmcp/server/ServerBuilderTest.java
+++ b/tachyon-core/src/test/java/dev/tachyonmcp/server/ServerBuilderTest.java
@@ -75,8 +75,8 @@ class ServerBuilderTest {
 
             assertThat(server.tools().find("sync-tool")).isPresent();
             assertThat(server.resources().find("sync-resource")).isPresent();
-            assertThat(((DefaultTachyonServer) server).resolveCapabilities().prompts())
-                    .isNotNull();
+            assertThat(server.resources().findTemplate("sync-template")).isPresent();
+            assertThat(server.prompts().find("sync-prompt")).isPresent();
         }
     }
 
@@ -106,8 +106,8 @@ class ServerBuilderTest {
 
             assertThat(server.tools().find("async-tool")).isPresent();
             assertThat(server.resources().find("async-resource")).isPresent();
-            assertThat(((DefaultTachyonServer) server).resolveCapabilities().prompts())
-                    .isNotNull();
+            assertThat(server.resources().findTemplate("async-template")).isPresent();
+            assertThat(server.prompts().find("async-prompt")).isPresent();
         }
     }
 

--- a/tachyon-core/src/test/java/dev/tachyonmcp/server/features/tools/DefaultToolRegistryTest.java
+++ b/tachyon-core/src/test/java/dev/tachyonmcp/server/features/tools/DefaultToolRegistryTest.java
@@ -20,6 +20,7 @@ import dev.tachyonmcp.server.domain.ServerError;
 import dev.tachyonmcp.server.domain.ToolAnnotations;
 import dev.tachyonmcp.server.features.tasks.TaskSupport;
 import dev.tachyonmcp.server.internal.ServerEngine;
+import dev.tachyonmcp.server.json.Jackson3JsonFactory;
 import dev.tachyonmcp.server.json.JacksonPayloadSerde;
 import dev.tachyonmcp.server.json.JsonSchema;
 import dev.tachyonmcp.server.json.JsonSchemaValidator;
@@ -58,6 +59,7 @@ class DefaultToolRegistryTest {
             JsonSchemaValidator.noop(),
             TEST_SERDE,
             TEST_SERDE,
+            Jackson3JsonFactory.INSTANCE,
             FeatureConfig.builder().build());
 
     @Test
@@ -410,6 +412,7 @@ class DefaultToolRegistryTest {
                 JsonSchemaValidator.noop(),
                 TEST_SERDE,
                 TEST_SERDE,
+                Jackson3JsonFactory.INSTANCE,
                 FeatureConfig.builder().pageSize(1).build());
         reg.register(testTool("a", null, null));
         reg.register(testTool("b", null, null));
@@ -425,6 +428,7 @@ class DefaultToolRegistryTest {
                 JsonSchemaValidator.noop(),
                 TEST_SERDE,
                 TEST_SERDE,
+                Jackson3JsonFactory.INSTANCE,
                 FeatureConfig.builder().off().build());
         var changeCount = new AtomicInteger();
         reg.onChange(changeCount::incrementAndGet);
@@ -726,6 +730,7 @@ class DefaultToolRegistryTest {
                 new NetworkntJsonSchemaValidator(),
                 TEST_SERDE,
                 TEST_SERDE,
+                Jackson3JsonFactory.INSTANCE,
                 FeatureConfig.builder().build());
         var handlers = new HashMap<String, RpcMethodHandler>();
         registryVal.registerHandlers(handlers);
@@ -763,6 +768,7 @@ class DefaultToolRegistryTest {
                 new NetworkntJsonSchemaValidator(),
                 TEST_SERDE,
                 TEST_SERDE,
+                Jackson3JsonFactory.INSTANCE,
                 FeatureConfig.builder().build());
         var handlers = new HashMap<String, RpcMethodHandler>();
         registryVal.registerHandlers(handlers);
@@ -798,6 +804,15 @@ class DefaultToolRegistryTest {
                         .inputSchema(schema != null ? schema.toString() : null)
                         .build(),
                 (context, request) -> ToolResult.text("ok"));
+    }
+
+    @Test
+    void shouldRejectRegistrationWithMalformedJsonSchema() {
+        assertThatThrownBy(() -> registry.register(ToolHandler.of(
+                        builder -> builder.name("bad-tool").description("desc").inputSchema("not-json"),
+                        (ctx, request) -> ToolResult.text("x"))))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("not-json");
     }
 
     @Test

--- a/tachyon-core/src/test/java/dev/tachyonmcp/server/features/tools/ToolDescriptorTest.java
+++ b/tachyon-core/src/test/java/dev/tachyonmcp/server/features/tools/ToolDescriptorTest.java
@@ -6,8 +6,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.jupiter.api.Test;
-import org.junitpioneer.jupiter.ExpectedToFail;
-import org.junitpioneer.jupiter.FailAt;
 
 class ToolDescriptorTest {
 
@@ -23,18 +21,6 @@ class ToolDescriptorTest {
         assertThatThrownBy(() -> ToolDescriptor.builder().name("   ").build())
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("name");
-    }
-
-    @Test
-    @ExpectedToFail // fixme: parse schema
-    @FailAt(date = "2026-07-27")
-    void shouldRejectMalformedJsonSchema() {
-        assertThatThrownBy(() -> ToolDescriptor.builder()
-                        .name("bad-tool")
-                        .inputSchema("not-json")
-                        .build())
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("not-json");
     }
 
     @Test

--- a/tachyon-core/src/test/java/dev/tachyonmcp/server/json/Jackson3JsonFactoryTest.java
+++ b/tachyon-core/src/test/java/dev/tachyonmcp/server/json/Jackson3JsonFactoryTest.java
@@ -1,0 +1,68 @@
+/* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
+package dev.tachyonmcp.server.json;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.node.JsonNodeFactory;
+
+class Jackson3JsonFactoryTest {
+
+    private final Jackson3JsonFactory factory = Jackson3JsonFactory.INSTANCE;
+
+    @Test
+    void shouldWrapValidJsonStringAsDocument() {
+        var document = factory.toJsonDocument("{\"a\":1}");
+        assertThat(document.json()).isEqualTo("{\"a\":1}");
+    }
+
+    @Test
+    void shouldRejectMalformedJsonStringAsDocument() {
+        assertThatThrownBy(() -> factory.toJsonDocument("not-json"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("not-json");
+    }
+
+    @Test
+    void shouldWrapValidJsonStringAsSchema() {
+        var schema = factory.toJsonSchema("{\"type\":\"object\"}");
+        assertThat(schema.json()).isEqualTo("{\"type\":\"object\"}");
+    }
+
+    @Test
+    void shouldRejectMalformedJsonStringAsSchema() {
+        assertThatThrownBy(() -> factory.toJsonSchema("not-json"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("not-json");
+    }
+
+    @Test
+    void shouldWrapJsonNodeAsDocument() {
+        var node = JsonNodeFactory.instance.objectNode().put("a", 1);
+        var document = factory.toJsonDocument(node);
+        assertThat(JsonUtils.parse(document)).isEqualTo(node);
+    }
+
+    @Test
+    void shouldWrapJsonNodeAsSchema() {
+        var node = JsonNodeFactory.instance.objectNode().put("type", "object");
+        var schema = factory.toJsonSchema(node);
+        assertThat(JsonUtils.parse(schema.json())).isEqualTo(node);
+    }
+
+    @Test
+    void shouldWrapJsonObjectAsDocument() {
+        var object = JsonObject.of(Map.of("a", 1));
+        var document = factory.toJsonDocument(object);
+        assertThat(document.json()).isEqualTo(object.json());
+    }
+
+    @Test
+    void shouldWrapJsonObjectAsSchema() {
+        var object = JsonObject.of(Map.of("type", "object"));
+        var schema = factory.toJsonSchema(object);
+        assertThat(schema.json()).isEqualTo(object.json());
+    }
+}

--- a/tachyon-core/src/test/java/dev/tachyonmcp/test/TestUtils.java
+++ b/tachyon-core/src/test/java/dev/tachyonmcp/test/TestUtils.java
@@ -23,7 +23,16 @@ public class TestUtils {
         var builder = TachyonServer.builder();
         configurer.accept(builder);
         var server = builder.build();
-        registrar.accept(server);
+        try {
+            registrar.accept(server);
+        } catch (RuntimeException | Error failure) {
+            try {
+                server.close();
+            } catch (RuntimeException | Error closeFailure) {
+                failure.addSuppressed(closeFailure);
+            }
+            throw failure;
+        }
         return (ServerEngine) server;
     }
 

--- a/tachyon-extensions/src/main/java/dev/tachyonmcp/extensions/tools/echo/EchoToolHandler.java
+++ b/tachyon-extensions/src/main/java/dev/tachyonmcp/extensions/tools/echo/EchoToolHandler.java
@@ -2,9 +2,9 @@
 package dev.tachyonmcp.extensions.tools.echo;
 
 import dev.tachyonmcp.runtime.InteractionContext;
-import dev.tachyonmcp.server.domain.Args;
 import dev.tachyonmcp.server.features.tools.AbstractToolHandler;
 import dev.tachyonmcp.server.features.tools.ToolDescriptor;
+import dev.tachyonmcp.server.features.tools.ToolRequest;
 import dev.tachyonmcp.server.features.tools.ToolResult;
 import dev.tachyonmcp.server.json.JsonSchema;
 
@@ -32,7 +32,7 @@ public class EchoToolHandler extends AbstractToolHandler {
     }
 
     @Override
-    public ToolResult handle(InteractionContext context, Args args) {
-        return ToolResult.text(args.stringOr("message", ""));
+    public ToolResult handle(InteractionContext context, ToolRequest request) {
+        return ToolResult.text(request.arguments().stringOr("message", ""));
     }
 }

--- a/tachyon-extensions/src/main/java/dev/tachyonmcp/extensions/tools/youcom/search/YouComSearchTool.java
+++ b/tachyon-extensions/src/main/java/dev/tachyonmcp/extensions/tools/youcom/search/YouComSearchTool.java
@@ -5,6 +5,7 @@ import dev.tachyonmcp.runtime.InteractionContext;
 import dev.tachyonmcp.server.domain.Args;
 import dev.tachyonmcp.server.features.tools.AbstractToolHandler;
 import dev.tachyonmcp.server.features.tools.ToolDescriptor;
+import dev.tachyonmcp.server.features.tools.ToolRequest;
 import dev.tachyonmcp.server.features.tools.ToolResult;
 import java.net.URI;
 import java.net.URLEncoder;
@@ -76,14 +77,15 @@ public class YouComSearchTool extends AbstractToolHandler {
     }
 
     @Override
-    public ToolResult handle(InteractionContext context, Args args) {
-        var request = buildRequest(args);
-        if (request == null) {
+    public ToolResult handle(InteractionContext context, ToolRequest request) {
+        var args = request.arguments();
+        var httpRequest = buildRequest(args);
+        if (httpRequest == null) {
             return ToolResult.error("Query must not be empty");
         }
 
         try {
-            var response = HTTP.send(request, HttpResponse.BodyHandlers.ofString());
+            var response = HTTP.send(httpRequest, HttpResponse.BodyHandlers.ofString());
             var body = response.body();
 
             if (response.statusCode() != 200) {

--- a/tachyon-extensions/src/test/java/dev/tachyonmcp/extensions/tools/echo/EchoToolHandlerTest.java
+++ b/tachyon-extensions/src/test/java/dev/tachyonmcp/extensions/tools/echo/EchoToolHandlerTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import dev.tachyonmcp.runtime.InteractionContext;
 import dev.tachyonmcp.server.domain.Args;
 import dev.tachyonmcp.server.domain.TextContent;
+import dev.tachyonmcp.server.features.tools.ToolRequest;
 import dev.tachyonmcp.server.features.tools.ToolResult;
 import dev.tachyonmcp.server.session.NoopInteractionContext;
 import java.util.Map;
@@ -20,7 +21,8 @@ class EchoToolHandlerTest {
         var handler = new EchoToolHandler();
         var args = Args.of(Map.of("message", "hello"));
 
-        var result = (ToolResult.Success) handler.handle(NOOP_CTX, args);
+        var result = (ToolResult.Success) handler.handle(
+                NOOP_CTX, ToolRequest.builder().name("echo").arguments(args).build());
 
         var text = ((TextContent) result.content().getFirst()).text();
         assertThat(text).isEqualTo("hello");
@@ -31,7 +33,8 @@ class EchoToolHandlerTest {
         var handler = new EchoToolHandler();
         var args = Args.empty();
 
-        var result = (ToolResult.Success) handler.handle(NOOP_CTX, args);
+        var result = (ToolResult.Success) handler.handle(
+                NOOP_CTX, ToolRequest.builder().name("echo").arguments(args).build());
 
         var text = ((TextContent) result.content().getFirst()).text();
         assertThat(text).isEmpty();

--- a/tachyon-extensions/src/test/java/dev/tachyonmcp/extensions/tools/youcom/search/YouComSearchToolTest.java
+++ b/tachyon-extensions/src/test/java/dev/tachyonmcp/extensions/tools/youcom/search/YouComSearchToolTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import dev.tachyonmcp.runtime.InteractionContext;
 import dev.tachyonmcp.server.TachyonServer;
 import dev.tachyonmcp.server.domain.Args;
+import dev.tachyonmcp.server.features.tools.ToolRequest;
 import dev.tachyonmcp.server.features.tools.ToolResult;
 import dev.tachyonmcp.server.session.NoopInteractionContext;
 import java.net.URI;
@@ -97,14 +98,20 @@ public class YouComSearchToolTest {
     void handleReturnsErrorForEmptyQuery() {
         var tool = new YouComSearchTool(YouComSearchConfig.builder().build());
         var args = Args.of(Map.of("query", ""));
-        assertThat(tool.handle(NOOP_CTX, args)).isInstanceOf(ToolResult.Error.class);
+        assertThat(tool.handle(
+                        NOOP_CTX,
+                        ToolRequest.builder().name("you-search").arguments(args).build()))
+                .isInstanceOf(ToolResult.Error.class);
     }
 
     @Test
     void handleReturnsErrorWhenMissingQuery() {
         var tool = new YouComSearchTool(YouComSearchConfig.builder().build());
         var args = Args.of(Map.of());
-        assertThat(tool.handle(NOOP_CTX, args)).isInstanceOf(ToolResult.Error.class);
+        assertThat(tool.handle(
+                        NOOP_CTX,
+                        ToolRequest.builder().name("you-search").arguments(args).build()))
+                .isInstanceOf(ToolResult.Error.class);
     }
 
     @Test

--- a/tachyon-extensions/src/test/java/dev/tachyonmcp/extensions/tools/youcom/search/YouComSearchToolTest.java
+++ b/tachyon-extensions/src/test/java/dev/tachyonmcp/extensions/tools/youcom/search/YouComSearchToolTest.java
@@ -20,14 +20,16 @@ public class YouComSearchToolTest {
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
     public static void main(String[] args) {
-        try (var server = TachyonServer.builder()
+        var server = TachyonServer.builder()
                 .info(it -> it.name("you-search-server").version("1.0"))
                 .session(s -> s.enabled(false))
                 .withTools(tools -> tools.register(new YouComSearchTool(YouComSearchConfig.builder()
                         .apiKey(System.getenv("YDC_API_KEY"))
                         .build())))
                 .port(8080)
-                .start()) {
+                .build();
+        server.start();
+        try (server) {
             System.out.println("Connect your MCP client to http://" + server.host() + ":" + server.port() + "/mcp\n"
                     + "Press Ctrl+C to stop.");
 

--- a/tachyon-kotlin/pom.xml
+++ b/tachyon-kotlin/pom.xml
@@ -71,8 +71,7 @@
 
         <dependency>
             <groupId>io.kotest</groupId>
-            <artifactId>kotest-assertions-core-jvm</artifactId>
-            <version>${kotest.version}</version>
+            <artifactId>kotest-assertions-json-jvm</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/config/ToolScope.kt
+++ b/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/config/ToolScope.kt
@@ -3,7 +3,6 @@ package dev.tachyonmcp.kotlin.server.config
 
 import dev.tachyonmcp.kotlin.server.TachyonDsl
 import dev.tachyonmcp.runtime.InteractionContext
-import dev.tachyonmcp.server.domain.Args
 import dev.tachyonmcp.server.features.tools.ToolRequest
 import dev.tachyonmcp.server.features.tools.ToolResult
 
@@ -11,8 +10,6 @@ import dev.tachyonmcp.server.features.tools.ToolResult
 public class ToolScope
     internal constructor(
         public val ctx: InteractionContext,
-        @Deprecated("Use request instead", ReplaceWith("request.arguments()"))
-        public val args: Args,
         public val request: ToolRequest,
     )
 

--- a/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/features/tools/ToolDescriptorScope.kt
+++ b/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/features/tools/ToolDescriptorScope.kt
@@ -5,8 +5,8 @@ import dev.tachyonmcp.kotlin.server.TachyonDsl
 import dev.tachyonmcp.kotlin.server.json.toJsonSchema
 import dev.tachyonmcp.server.features.tasks.TaskSupport
 import dev.tachyonmcp.server.features.tools.ToolDescriptor
+import dev.tachyonmcp.server.json.Jackson3JsonFactory
 import dev.tachyonmcp.server.json.JsonSchema
-import dev.tachyonmcp.server.json.JsonSchemaUtils.parseSchema
 import kotlinx.serialization.json.JsonObject
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
@@ -27,11 +27,11 @@ public class ToolDescriptorScope
         public var extensionId: String? = null
 
         public fun inputSchema(json: String) {
-            inputSchema = parseSchema(json)
+            inputSchema = Jackson3JsonFactory.INSTANCE.toJsonSchema(json)
         }
 
         public fun outputSchema(json: String) {
-            outputSchema = parseSchema(json)
+            outputSchema = Jackson3JsonFactory.INSTANCE.toJsonSchema(json)
         }
 
         /** Sets the input schema from a kotlinx-serialization [JsonObject]. */

--- a/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/features/tools/ToolHandlerFactory.kt
+++ b/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/features/tools/ToolHandlerFactory.kt
@@ -31,7 +31,6 @@ internal fun toolFn(
         runtime.future(coroutineName) {
             ToolScope(
                 ctx = context,
-                args = request.arguments(),
                 request = request,
             ).block()
         }

--- a/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/json/JsonInterop.kt
+++ b/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/json/JsonInterop.kt
@@ -2,8 +2,8 @@
 package dev.tachyonmcp.kotlin.server.json
 
 import dev.tachyonmcp.server.features.tools.ToolDescriptor
+import dev.tachyonmcp.server.json.Jackson3JsonFactory
 import dev.tachyonmcp.server.json.JsonSchema
-import dev.tachyonmcp.server.json.JsonSchemaUtils.parseSchema
 import dev.tachyonmcp.server.json.JsonUtils
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
@@ -33,10 +33,10 @@ internal fun ToolDescriptor.Builder.schemas(
     outputSchema: String? = null,
 ): ToolDescriptor.Builder {
     if (inputSchema != null) {
-        inputSchema(parseSchema(inputSchema))
+        inputSchema(Jackson3JsonFactory.INSTANCE.toJsonSchema(inputSchema))
     }
     if (outputSchema != null) {
-        outputSchema(parseSchema(outputSchema))
+        outputSchema(Jackson3JsonFactory.INSTANCE.toJsonSchema(outputSchema))
     }
     return this
 }

--- a/tachyon-kotlin/src/test/kotlin/dev/tachyonmcp/kotlin/server/KotlinApiTest.kt
+++ b/tachyon-kotlin/src/test/kotlin/dev/tachyonmcp/kotlin/server/KotlinApiTest.kt
@@ -26,6 +26,7 @@ import dev.tachyonmcp.server.domain.TextContent
 import dev.tachyonmcp.server.features.tools.ToolRequest
 import dev.tachyonmcp.server.features.tools.ToolResult
 import io.kotest.assertions.assertSoftly
+import io.kotest.assertions.json.shouldEqualJson
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
@@ -36,7 +37,12 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import tools.jackson.databind.ObjectMapper
 import java.math.BigDecimal
+import java.util.stream.Stream
 import dev.tachyonmcp.server.json.JsonSchema as JavaJsonSchema
 
 internal class KotlinApiTest {
@@ -50,7 +56,9 @@ internal class KotlinApiTest {
             port = 0,
             {
                 name("test")
-                tool("t1", inputSchema = schema, outputSchema = schema) { ToolResult.text("ok") }
+                tool("t1", inputSchema = schema, outputSchema = schema) {
+                    ToolResult.text("ok")
+                }
             },
         ).use { handle ->
             handle.tools().find("t1").orElse(null) shouldNotBe null
@@ -64,7 +72,9 @@ internal class KotlinApiTest {
             port = 0,
             {
                 name("test")
-                tool("t2", inputSchema = json, outputSchema = json) { ToolResult.text("ok") }
+                tool("t2", inputSchema = json, outputSchema = json) {
+                    ToolResult.text("ok")
+                }
             },
         ).use { handle ->
             handle.tools().find("t2").orElse(null) shouldNotBe null
@@ -78,7 +88,9 @@ internal class KotlinApiTest {
             port = 0,
             {
                 name("test")
-                tool("t3", inputSchema = schema, outputSchema = schema) { ToolResult.text("ok") }
+                tool("t3", inputSchema = schema, outputSchema = schema) {
+                    ToolResult.text("ok")
+                }
             },
         ).use { handle ->
             handle.tools().find("t3").orElse(null) shouldNotBe null
@@ -138,45 +150,90 @@ internal class KotlinApiTest {
         }
     }
 
-    @Test
-    fun `orNull accessors return null when the key is missing or JSON null`() {
-        val args = Args.of(null, null)
-        val nullArgs =
-            Args.of(
-                mapOf<String, Any?>(
-                    "str" to null,
-                    "int" to null,
-                    "long" to null,
-                    "bool" to null,
-                    "double" to null,
-                    "decimal" to null,
-                    "obj" to null,
-                    "arr" to null,
-                ),
-                null,
-            )
-
-        assertSoftly {
-            args.stringOrNull("k") shouldBe null
-            args.intOrNull("k") shouldBe null
-            args.longOrNull("k") shouldBe null
-            args.booleanOrNull("k") shouldBe null
-            args.doubleOrNull("k") shouldBe null
-            args.decimalOrNull("k") shouldBe null
-            args.objectOrNull("k") shouldBe null
-            args.arrayOrNull("k") shouldBe null
-            nullArgs.stringOrNull("str") shouldBe null
-            nullArgs.intOrNull("int") shouldBe null
-            nullArgs.longOrNull("long") shouldBe null
-            nullArgs.booleanOrNull("bool") shouldBe null
-            nullArgs.doubleOrNull("double") shouldBe null
-            nullArgs.decimalOrNull("decimal") shouldBe null
-            nullArgs.objectOrNull("obj") shouldBe null
-            nullArgs.arrayOrNull("arr") shouldBe null
+    @ParameterizedTest(name = "[{index}] {0}")
+    @MethodSource("missingOrJsonNullArguments")
+    fun `orNull and default accessors and decode fold missing and JSON-null arguments the same way`(
+        @Suppress("UnusedParameter") scenario: String,
+        argumentsJson: String,
+    ) {
+        TachyonServer(port = 0) {
+            name("null-accessors-test")
+            session { enabled = true }
+            tool("null-accessors") {
+                val args = request.arguments()
+                val fields =
+                    listOf(
+                        "stringOrNull" to args.stringOrNull("str"),
+                        "intOrNull" to args.intOrNull("int"),
+                        "longOrNull" to args.longOrNull("long"),
+                        "booleanOrNull" to args.booleanOrNull("bool"),
+                        "doubleOrNull" to args.doubleOrNull("double"),
+                        "decimalOrNull" to args.decimalOrNull("decimal"),
+                        "objectOrNull" to args.objectOrNull("obj"),
+                        "arrayOrNull" to args.arrayOrNull("arr"),
+                        "stringDefault" to args.string("str", "default"),
+                        "booleanDefault" to args.boolean("bool", true),
+                        "intDefault" to args.int("int", 7),
+                        "longDefault" to args.long("long", 42L),
+                        "doubleDefault" to args.double("double", 1.5),
+                        "decodeStr" to args.decode<NullableArgs>().str,
+                    )
+                ToolResult.raw(
+                    ObjectMapper().writeValueAsString(fields.toMap()),
+                    "accessors resolved",
+                )
+            }
+        }.use { server ->
+            McpProbe(server.port()).use { probe ->
+                probe.initialize()
+                val response = probe.callTool("null-accessors", argumentsJson)
+                response.statusCode() shouldBe 200
+                response.body() shouldEqualJson """
+                    {
+                      "jsonrpc": "2.0",
+                      "id": 2,
+                      "result": {
+                        "content": [{"type": "text", "text": "accessors resolved"}],
+                        "structuredContent": {
+                          "stringOrNull": null,
+                          "intOrNull": null,
+                          "longOrNull": null,
+                          "booleanOrNull": null,
+                          "doubleOrNull": null,
+                          "decimalOrNull": null,
+                          "objectOrNull": null,
+                          "arrayOrNull": null,
+                          "stringDefault": "default",
+                          "booleanDefault": true,
+                          "intDefault": 7,
+                          "longDefault": 42,
+                          "doubleDefault": 1.5,
+                          "decodeStr": null
+                        }
+                      }
+                    }
+                    """.trimIndent()
+            }
         }
     }
 
     // endregion
+
+    companion object {
+        @JvmStatic
+        fun missingOrJsonNullArguments(): Stream<Arguments> =
+            Stream.of(
+                Arguments.of("missing arguments", "{}"),
+                Arguments.of(
+                    "JSON-null arguments",
+                    // language=json
+                    """
+                    {"str":null,"int":null,"long":null,"bool":null,"double":null,
+                     "decimal":null,"obj":null,"arr":null}
+                    """.trimIndent(),
+                ),
+            )
+    }
 
     @Test
     fun `accessors with default return the value when the key is present`() {
@@ -201,21 +258,10 @@ internal class KotlinApiTest {
         }
     }
 
-    @Test
-    fun `accessors with default return the default when the key is missing or JSON null`() {
-        val args = Args.of(null, null)
-        val nullArgs = Args.of(mapOf<String, Any?>("str" to null, "long" to null), null)
-
-        assertSoftly {
-            args.string("k", "def") shouldBe "def"
-            args.boolean("k", true) shouldBe true
-            args.int("k", 7) shouldBe 7
-            args.long("k", 42L) shouldBe 42L
-            args.double("k", 1.5) shouldBe 1.5
-            nullArgs.string("str", "def") shouldBe "def"
-            nullArgs.long("long", 42L) shouldBe 42L
-        }
-    }
+    @Serializable
+    data class NullableArgs(
+        val str: String? = null,
+    )
 
     @Serializable
     data class GreetingArgs(

--- a/tachyon-kotlin/src/test/kotlin/dev/tachyonmcp/kotlin/server/KotlinApiTest.kt
+++ b/tachyon-kotlin/src/test/kotlin/dev/tachyonmcp/kotlin/server/KotlinApiTest.kt
@@ -188,7 +188,8 @@ internal class KotlinApiTest {
                 probe.initialize()
                 val response = probe.callTool("null-accessors", argumentsJson)
                 response.statusCode() shouldBe 200
-                response.body() shouldEqualJson """
+                response.body() shouldEqualJson
+                    """
                     {
                       "jsonrpc": "2.0",
                       "id": 2,
@@ -351,7 +352,7 @@ internal class KotlinApiTest {
                     .name("greet")
                     .arguments(args)
                     .build()
-            val scope = ToolScope(ctx, args = args, request = request)
+            val scope = ToolScope(ctx, request = request)
             val result = scope.success(value)
             result.shouldBeInstanceOf<ToolResult.Success>()
             result.structured().get() shouldBe value
@@ -369,7 +370,7 @@ internal class KotlinApiTest {
                     .name("greet")
                     .arguments(args)
                     .build()
-            val scope = ToolScope(ctx, args = args, request = request)
+            val scope = ToolScope(ctx, request = request)
             val result = scope.success(value, "custom text")
             result.shouldBeInstanceOf<ToolResult.Success>()
             result.structured().get() shouldBe value


### PR DESCRIPTION
## Summary

1. ServerBuilder API - Removed start() from builder; added TachyonServer.start(); port() throws if not started
2. JsonSchemaFactory/JsonDocumentFactory - New abstractions with Jackson3JsonFactory implementation; schema validation moved to JsonSchemaUtils
3. Tool API - ToolRequest replaces Args in handlers; updated Kotlin DSL to use Jackson3JsonFactory
4. ServerConfig - Removed DEFAULT constant
5. TasksExtension - Updated to use ToolRequest
6. Tests updated across all modules