### PR TITLE
feat: Improve results api

### DIFF
--- a/.agents/skills/tachyon-mcp/SKILL.md
+++ b/.agents/skills/tachyon-mcp/SKILL.md
@@ -107,7 +107,7 @@ Lambda: `ToolHandler.of(name, description, fn)` or `of(configurer, fn)` for a sc
 
 Async: `ToolHandler.ofAsync(name, (ctx, request) -> CompletionStage<ToolResult>)` or override `handleAsync`.
 
-`ToolResult` (not generic): `.text(t)` · `.error(msg)` (isError=true) · `.blocks(ContentBlock...)` · `.of(payload)` (structuredContent; serialized JSON auto-added as text block) · `.of(payload, text)` · `.raw(json, text)` (pre-serialized JSON) · `.inputRequired(reqs, state)` · `.empty()` · `.withMeta(map)` / `.withMeta(key, value)`
+`ToolResult` (not generic): `.text(t)` · `.error(msg)` (isError=true) · `.content(ContentBlock...)` · `.of(payload)` (structuredContent; serialized JSON auto-added as text block) · `.of(payload, text)` · `.raw(json, text)` (pre-serialized JSON) · `.inputRequired(reqs, state)` · `.empty()` · `.withMeta(map)` / `.withMeta(key, value)`
 
 Full: `resources/java/ToolHandlerExample.java`
 

--- a/.agents/skills/tachyon-mcp/resources/kotlin/ToolHandlerExample.kt
+++ b/.agents/skills/tachyon-mcp/resources/kotlin/ToolHandlerExample.kt
@@ -10,7 +10,6 @@ import dev.tachyonmcp.server.features.tools.ToolResult
 import dev.tachyonmcp.json.JsonSchema
 import dev.tachyonmcp.kotlin.server.buildServer
 import dev.tachyonmcp.kotlin.server.config.TachyonServerBuilder
-import dev.tachyonmcp.kotlin.server.config.success
 import dev.tachyonmcp.kotlin.server.domain.decode
 import dev.tachyonmcp.kotlin.server.features.tools.registerTool
 import dev.tachyonmcp.kotlin.server.features.tools.toolDescriptor

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![MCPConformance: 2025-11-25+2026-07-28](https://img.shields.io/badge/MCP%20Conformance-2025.11.25%20+%202026.07.28-grass?logo=modelcontextprotocol)](https://github.com/modelcontextprotocol/conformance)
 [![codecov](https://codecov.io/gh/kpavlov/tachyon/graph/badge.svg?token=WUMD9A8T2T)](https://codecov.io/gh/kpavlov/tachyon)
 [![Docs](https://img.shields.io/badge/Docs-blue?logo=github)](https://github.com/kpavlov/tachyon/blob/main/docs/README.md)
-[![Api](https://img.shields.io/badge/API-blue?logo=github)]([https://github.com/kpavlov/tachyon/blob/main/docs/README.md](https://kpavlov.github.io/tachyon/apidocs))
+[![Api](https://img.shields.io/badge/API-blue?logo=github)](https://kpavlov.github.io/tachyon/apidocs/)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/kpavlov/tachyon)
 <img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=fd923998-7054-4524-b014-cd368cfba9fc" />
 

--- a/conformance/src/test/java/dev/tachyonmcp/conformance/AbstractConformanceServer.java
+++ b/conformance/src/test/java/dev/tachyonmcp/conformance/AbstractConformanceServer.java
@@ -193,14 +193,14 @@ abstract class AbstractConformanceServer {
                         b -> b.name("test_image_content")
                                 .description("Returns image content")
                                 .inputSchema(INPUT_SCHEMA_NO_ARGS),
-                        (ctx, request) -> ToolResult.blocks(ImageContent.of(MINI_PNG_BASE64, "image/png")));
+                        (ctx, request) -> ToolResult.content(ImageContent.base64(MINI_PNG_BASE64, "image/png")));
 
         server.tools()
                 .register(
                         b -> b.name("test_audio_content")
                                 .description("Returns audio content")
                                 .inputSchema(INPUT_SCHEMA_NO_ARGS),
-                        (ctx, request) -> ToolResult.blocks(AudioContent.of(MINI_WAV_BASE64, "audio/wav")));
+                        (ctx, request) -> ToolResult.content(AudioContent.base64(MINI_WAV_BASE64, "audio/wav")));
 
         server.tools()
                 .register(
@@ -210,7 +210,7 @@ abstract class AbstractConformanceServer {
                         (ctx, request) -> {
                             var res = TextResourceContents.of(
                                     "test://embedded-resource", "This is an embedded resource content.", "text/plain");
-                            return ToolResult.blocks(EmbeddedResource.of(res));
+                            return ToolResult.content(EmbeddedResource.of(res));
                         });
 
         server.tools()
@@ -223,9 +223,9 @@ abstract class AbstractConformanceServer {
                                     "test://mixed-content-resource",
                                     "{\"test\":\"data\",\"value\":123}",
                                     "application/json");
-                            return ToolResult.blocks(
+                            return ToolResult.content(
                                     TextContent.of("Multiple content types test:"),
-                                    ImageContent.of(MINI_PNG_BASE64, "image/png"),
+                                    ImageContent.base64(MINI_PNG_BASE64, "image/png"),
                                     EmbeddedResource.of(mixed));
                         });
 
@@ -538,7 +538,7 @@ abstract class AbstractConformanceServer {
         server.prompts()
                 .register(
                         PromptDescriptor.of("test_prompt_with_image", "Prompt with image"),
-                        List.of(PromptMessage.user(ImageContent.of(MINI_PNG_BASE64, "image/png"))));
+                        List.of(PromptMessage.user(ImageContent.base64(MINI_PNG_BASE64, "image/png"))));
 
         registerVersionSpecificPrompts(server);
     }

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -71,7 +71,7 @@ Configure port `0`; the operating system assigns a free port. Exercise the runni
 
 ### Will an MCP protocol upgrade break my handlers?
 
-Tachyon keeps handler and descriptor APIs separate from its internal protocol mappers. A new wire version normally changes the mapper rather than your `ToolHandler`, `ResourceHandler`, or
+Tachyon keeps function, handler, and descriptor APIs separate from its internal protocol mappers. A new wire version normally changes the mapper rather than your `ToolFn`, `ResourceHandler`, or
 `PromptHandler`.
 
 ### Is Kotlin supported?

--- a/docs/kotlin.md
+++ b/docs/kotlin.md
@@ -348,7 +348,7 @@ TachyonServer(port = 8080) {
 |---|---|
 | `ToolResult.text(t)` | Text content block |
 | `ToolResult.error(msg)` | `isError = true` |
-| `ToolResult.blocks(vararg b)` | Multiple content blocks |
+| `ToolResult.content(vararg b)` | Multiple content blocks |
 | `ToolResult.of(payload)` | POJO → `structuredContent` via Jackson |
 | `ToolResult.of(payload, text)` | Structured + human-readable text |
 | `ToolResult.empty()` | No content |

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -114,7 +114,7 @@ hold a `CompletionStage` (a non-blocking client, another async service), return 
 |-----------------------------------------|----------------------------------------|
 | `ToolResult.text(t)`                    | Plain text response                    |
 | `ToolResult.error(msg)`                 | Error (`isError = true`)               |
-| `ToolResult.blocks(blocks...)`          | Multiple content blocks                |
+| `ToolResult.content(blocks...)`         | Multiple content blocks                |
 | `ToolResult.of(payload)`                | POJO → `structuredContent`; serialized JSON auto-added as the text block |
 | `ToolResult.of(payload, text)`          | Structured + explicit human-readable text |
 | `ToolResult.empty()`                    | No content                             |

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/PromptsTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/PromptsTest.java
@@ -194,7 +194,7 @@ class PromptsTest extends AbstractStatelessMcpE2eTest {
         server.prompts()
                 .register(
                         PromptDescriptor.of("image-prompt", "Prompt with image"),
-                        List.of(PromptMessage.user(ImageContent.of("iVBORw0KGgo=", "image/png"))));
+                        List.of(PromptMessage.user(ImageContent.base64("iVBORw0KGgo=", "image/png"))));
 
         try (var client = createTestClient()) {
             client.initialize();

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/ResourceTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/ResourceTest.java
@@ -308,7 +308,7 @@ class ResourceTest extends AbstractStatefulMcpE2eTest {
                                 } else {
                                     resources.unregister("doc");
                                 }
-                                return ToolResult.blocks(TextContent.of("done"));
+                                return ToolResult.content(TextContent.of("done"));
                             });
             if ("remove".equals(action)) {
                 s.resources()
@@ -340,7 +340,7 @@ class ResourceTest extends AbstractStatefulMcpE2eTest {
                             b -> b.name("notify-update").description("Triggers resource updated notification"),
                             (context, request) -> {
                                 server.resources().notifyResourceUpdated("resource://doc");
-                                return ToolResult.blocks(TextContent.of("resource update 'resource://doc' notified "));
+                                return ToolResult.content(TextContent.of("resource update 'resource://doc' notified "));
                             });
         });
 
@@ -373,7 +373,7 @@ class ResourceTest extends AbstractStatefulMcpE2eTest {
                             b -> b.name("notify-update").description("Triggers resource updated notification"),
                             (context, request) -> {
                                 server.resources().notifyResourceUpdated("resource://doc");
-                                return ToolResult.blocks(TextContent.of("resource update 'resource://doc' notified "));
+                                return ToolResult.content(TextContent.of("resource update 'resource://doc' notified "));
                             });
         });
 
@@ -406,7 +406,7 @@ class ResourceTest extends AbstractStatefulMcpE2eTest {
                             b -> b.name("unregister-by-uri").description("Unregisters resource by URI"),
                             (context, request) -> {
                                 server.resources().unregisterByUri("resource://doc");
-                                return ToolResult.blocks(TextContent.of("done"));
+                                return ToolResult.content(TextContent.of("done"));
                             });
             s.resources()
                     .register(

--- a/tachyon-api/src/main/java/dev/tachyonmcp/server/domain/AudioContent.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/server/domain/AudioContent.java
@@ -76,8 +76,21 @@ public non-sealed interface AudioContent extends ContentBlock, HasMeta {
      * @param mimeType the audio MIME type
      * @return a new audio content
      */
-    static AudioContent of(String data, String mimeType) {
+    static AudioContent base64(String data, String mimeType) {
         return DefaultAudioContent.of(data, mimeType, null, null);
+    }
+
+    /**
+     * Creates audio content from base64-encoded data.
+     *
+     * @param data the base64-encoded audio data
+     * @param mimeType the audio MIME type
+     * @return a new audio content
+     * @deprecated use {@link #base64(String, String)}
+     */
+    @Deprecated(since = "1.0.0-beta.15", forRemoval = true)
+    static AudioContent of(String data, String mimeType) {
+        return base64(data, mimeType);
     }
 
     /**
@@ -88,8 +101,22 @@ public non-sealed interface AudioContent extends ContentBlock, HasMeta {
      * @param annotations the annotations, or {@code null}
      * @return a new audio content
      */
-    static AudioContent of(String data, String mimeType, @Nullable Annotations annotations) {
+    static AudioContent base64(String data, String mimeType, @Nullable Annotations annotations) {
         return DefaultAudioContent.of(data, mimeType, annotations, null);
+    }
+
+    /**
+     * Creates audio content from base64-encoded data with annotations.
+     *
+     * @param data the base64-encoded audio data
+     * @param mimeType the audio MIME type
+     * @param annotations the annotations, or {@code null}
+     * @return a new audio content
+     * @deprecated use {@link #base64(String, String, Annotations)}
+     */
+    @Deprecated(since = "1.0.0-beta.15", forRemoval = true)
+    static AudioContent of(String data, String mimeType, @Nullable Annotations annotations) {
+        return base64(data, mimeType, annotations);
     }
 
     /**
@@ -101,9 +128,25 @@ public non-sealed interface AudioContent extends ContentBlock, HasMeta {
      * @param meta        the metadata entries, or {@code null}
      * @return a new audio content
      */
-    static AudioContent of(
+    static AudioContent base64(
             String data, String mimeType, @Nullable Annotations annotations, @Nullable Map<String, Object> meta) {
         return DefaultAudioContent.of(data, mimeType, annotations, meta);
+    }
+
+    /**
+     * Creates audio content from base64-encoded data with annotations and metadata.
+     *
+     * @param data the base64-encoded audio data
+     * @param mimeType the audio MIME type
+     * @param annotations the annotations, or {@code null}
+     * @param meta the metadata entries, or {@code null}
+     * @return a new audio content
+     * @deprecated use {@link #base64(String, String, Annotations, Map)}
+     */
+    @Deprecated(since = "1.0.0-beta.15", forRemoval = true)
+    static AudioContent of(
+            String data, String mimeType, @Nullable Annotations annotations, @Nullable Map<String, Object> meta) {
+        return base64(data, mimeType, annotations, meta);
     }
 
     /**

--- a/tachyon-api/src/main/java/dev/tachyonmcp/server/domain/ImageContent.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/server/domain/ImageContent.java
@@ -18,14 +18,34 @@ import org.jspecify.annotations.Nullable;
         typeImmutable = "Default*")
 public non-sealed interface ImageContent extends ContentBlock {
 
+    /**
+     * Returns the base64-encoded image data.
+     *
+     * @return the image data as a base64 string
+     */
     @Value.Redacted
     String data();
 
+    /**
+     * Returns the MIME type of the image content.
+     *
+     * @return the image MIME type
+     */
     String mimeType();
 
+    /**
+     * Returns the annotations for this content, or {@code null} if none.
+     *
+     * @return the annotations, or {@code null}
+     */
     @Nullable
     Annotations annotations();
 
+    /**
+     * Returns the request-level metadata for this content, or {@code null} if none.
+     *
+     * @return the metadata entries, or {@code null}
+     */
     @Nullable
     Map<String, Object> meta();
 
@@ -34,12 +54,22 @@ public non-sealed interface ImageContent extends ContentBlock {
         return Type.IMAGE;
     }
 
+    /**
+     * Validates that required fields are not blank.
+     *
+     * @throws IllegalArgumentException if {@code data} or {@code mimeType} is blank
+     */
     @Value.Check
     default void check() {
         if (data().isBlank()) throw new IllegalArgumentException("data must not be blank");
         if (mimeType().isBlank()) throw new IllegalArgumentException("mimeType must not be blank");
     }
 
+    /**
+     * Creates a new builder for constructing {@code ImageContent} instances.
+     *
+     * @return a new builder
+     */
     static Builder builder() {
         return DefaultImageContent.builder();
     }
@@ -108,15 +138,47 @@ public non-sealed interface ImageContent extends ContentBlock {
         return base64(data, mimeType, annotations, meta);
     }
 
+    /**
+     * Builder for {@link ImageContent}.
+     */
     interface Builder {
+        /**
+         * Sets the base64-encoded image data.
+         *
+         * @param data the image data
+         * @return this builder
+         */
         Builder data(String data);
 
+        /**
+         * Sets the MIME type of the image content.
+         *
+         * @param mimeType the image MIME type
+         * @return this builder
+         */
         Builder mimeType(String mimeType);
 
+        /**
+         * Sets the annotations.
+         *
+         * @param annotations the annotations, or {@code null}
+         * @return this builder
+         */
         Builder annotations(@Nullable Annotations annotations);
 
+        /**
+         * Sets the metadata entries.
+         *
+         * @param entries the metadata map, or {@code null}
+         * @return this builder
+         */
         Builder meta(@Nullable Map<String, ?> entries);
 
+        /**
+         * Builds the {@code ImageContent} instance.
+         *
+         * @return a new image content
+         */
         ImageContent build();
     }
 }

--- a/tachyon-api/src/main/java/dev/tachyonmcp/server/domain/ImageContent.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/server/domain/ImageContent.java
@@ -44,20 +44,68 @@ public non-sealed interface ImageContent extends ContentBlock {
         return DefaultImageContent.builder();
     }
 
-    /** Creates an image content block with no metadata or annotations. */
-    static ImageContent of(String data, String mimeType) {
+    /**
+     * Creates an image content block from base64-encoded data, with no metadata or annotations.
+     *
+     * @param data     the base64-encoded image data
+     * @param mimeType the image MIME type (e.g. {@code image/png})
+     */
+    static ImageContent base64(String data, String mimeType) {
         return DefaultImageContent.of(data, mimeType, null, null);
     }
 
-    /** Creates an image content block with given annotations and no metadata. */
-    static ImageContent of(String data, String mimeType, @Nullable Annotations annotations) {
+    /**
+     * Creates an image content block from base64-encoded data.
+     *
+     * @param data the base64-encoded image data
+     * @param mimeType the image MIME type
+     * @return a new image content block
+     * @deprecated use {@link #base64(String, String)}
+     */
+    @Deprecated(since = "1.0.0-beta.15", forRemoval = true)
+    static ImageContent of(String data, String mimeType) {
+        return base64(data, mimeType);
+    }
+
+    /** Creates an image content block from base64-encoded data with given annotations and no metadata. */
+    static ImageContent base64(String data, String mimeType, @Nullable Annotations annotations) {
         return DefaultImageContent.of(data, mimeType, annotations, null);
     }
 
-    /** Creates an image content block with metadata and optional annotations. */
-    static ImageContent of(
+    /**
+     * Creates an image content block from base64-encoded data with annotations.
+     *
+     * @param data the base64-encoded image data
+     * @param mimeType the image MIME type
+     * @param annotations the annotations, or {@code null}
+     * @return a new image content block
+     * @deprecated use {@link #base64(String, String, Annotations)}
+     */
+    @Deprecated(since = "1.0.0-beta.15", forRemoval = true)
+    static ImageContent of(String data, String mimeType, @Nullable Annotations annotations) {
+        return base64(data, mimeType, annotations);
+    }
+
+    /** Creates an image content block from base64-encoded data with metadata and optional annotations. */
+    static ImageContent base64(
             String data, String mimeType, @Nullable Annotations annotations, @Nullable Map<String, Object> meta) {
         return DefaultImageContent.of(data, mimeType, annotations, meta);
+    }
+
+    /**
+     * Creates an image content block from base64-encoded data with annotations and metadata.
+     *
+     * @param data the base64-encoded image data
+     * @param mimeType the image MIME type
+     * @param annotations the annotations, or {@code null}
+     * @param meta the metadata, or {@code null}
+     * @return a new image content block
+     * @deprecated use {@link #base64(String, String, Annotations, Map)}
+     */
+    @Deprecated(since = "1.0.0-beta.15", forRemoval = true)
+    static ImageContent of(
+            String data, String mimeType, @Nullable Annotations annotations, @Nullable Map<String, Object> meta) {
+        return base64(data, mimeType, annotations, meta);
     }
 
     interface Builder {

--- a/tachyon-api/src/main/java/dev/tachyonmcp/server/features/tools/ToolResult.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/server/features/tools/ToolResult.java
@@ -1,6 +1,7 @@
 /* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
 package dev.tachyonmcp.server.features.tools;
 
+import dev.tachyonmcp.annotations.ExperimentalApi;
 import dev.tachyonmcp.json.JsonDocument;
 import dev.tachyonmcp.server.domain.ContentBlock;
 import dev.tachyonmcp.server.domain.InputRequest;
@@ -13,6 +14,7 @@ import java.util.Objects;
 import java.util.Optional;
 import org.jspecify.annotations.Nullable;
 
+/** Outcome of a tool invocation: success, error, input-required, or deferred. */
 public sealed interface ToolResult
         permits ToolResult.Success,
                 ToolResult.Error,
@@ -23,19 +25,37 @@ public sealed interface ToolResult
     /** Sentinel returned by a task-augmented handler that defers completion to the caller. */
     record Deferred() implements ToolResult {}
 
+    /**
+     * A successful invocation, carrying an optional structured value and its content blocks.
+     *
+     * @param structuredValue the structured payload, or {@code null} when none was set
+     * @param content         the content blocks, possibly empty
+     */
     record Success(@Nullable Object structuredValue, List<ContentBlock> content) implements ToolResult {
         public Success {
             Objects.requireNonNull(content, "content");
             content = List.copyOf(content);
         }
 
+        /** Returns the structured value, or empty when none was set. */
         public Optional<Object> structured() {
             return Optional.ofNullable(structuredValue);
         }
     }
 
+    /**
+     * A failed invocation carrying a human-readable error message.
+     *
+     * @param message the error message
+     */
     record Error(String message) implements ToolResult {}
 
+    /**
+     * Wraps another result with request-level {@code _meta} entries.
+     *
+     * @param inner the wrapped result
+     * @param meta  the {@code _meta} entries
+     */
     record WithMeta(ToolResult inner, Map<String, Object> meta) implements ToolResult {
         public WithMeta {
             Objects.requireNonNull(inner, "inner");
@@ -44,20 +64,34 @@ public sealed interface ToolResult
         }
     }
 
+    /**
+     * Signals that completing the tool call requires additional input from the caller.
+     *
+     * @param request the requested inputs and opaque state to echo back
+     */
     record InputRequired(InputRequestBundle request) implements ToolResult {
         public InputRequired {
             Objects.requireNonNull(request, "request");
         }
 
+        /** Returns the requested inputs, keyed by request id. */
         public Map<String, ? extends InputRequest> inputRequests() {
             return request.inputRequests();
         }
 
+        /** Returns the opaque state token to echo back with the caller's response, or {@code null}. */
         public @Nullable String requestState() {
             return request.requestState();
         }
     }
 
+    /**
+     * Returns a copy of this result with {@code m} merged into its {@code _meta} entries; returns
+     * this unchanged when {@code m} is empty.
+     *
+     * @param m the {@code _meta} entries to merge in
+     * @return a result carrying the merged metadata
+     */
     default ToolResult withMeta(Map<String, Object> m) {
         if (m.isEmpty()) return this;
         if (this instanceof WithMeta(ToolResult inner, Map<String, Object> meta)) {
@@ -68,14 +102,33 @@ public sealed interface ToolResult
         return new WithMeta(this, m);
     }
 
+    /**
+     * Returns a copy of this result with a single {@code _meta} entry set.
+     *
+     * @param key   the {@code _meta} key
+     * @param value the {@code _meta} value
+     * @return a result carrying the added metadata entry
+     */
     default ToolResult withMeta(String key, Object value) {
         return withMeta(Map.of(key, value));
     }
 
+    /**
+     * Creates a successful result containing a single text content block.
+     *
+     * @param t the text
+     * @return a successful tool result
+     */
     static ToolResult text(String t) {
         return new Success(null, List.of(TextContent.of(t)));
     }
 
+    /**
+     * Creates a successful result containing the given content blocks.
+     *
+     * @param blocks the content blocks
+     * @return a successful tool result
+     */
     static ToolResult content(ContentBlock... blocks) {
         return new Success(null, List.of(blocks));
     }
@@ -92,8 +145,29 @@ public sealed interface ToolResult
         return content(blocks);
     }
 
+    /**
+     * Creates a success result carrying {@code payload} as structured content plus an explicit
+     * human-readable text block.
+     *
+     * @param payload the structured payload
+     * @param text    the text content for the content block
+     * @return a successful tool result
+     */
     static ToolResult of(Object payload, String text) {
         return new Success(payload, List.of(TextContent.of(text)));
+    }
+
+    /**
+     * Alias for {@link #of(Object, String)} with a name that states what the payload becomes
+     * (structured content) rather than how it's constructed.
+     *
+     * @param payload the structured payload
+     * @param text    the text content for the content block
+     * @return a successful tool result
+     */
+    @ExperimentalApi
+    static ToolResult structured(Object payload, String text) {
+        return of(payload, text);
     }
 
     /**
@@ -107,10 +181,29 @@ public sealed interface ToolResult
         return new Success(payload, List.of());
     }
 
+    /**
+     * Alias for {@link #of(Object)} with a name that states what the payload becomes (structured
+     * content) rather than how it's constructed.
+     *
+     * @param payload the structured payload
+     * @return a successful tool result
+     */
+    @ExperimentalApi
+    static ToolResult structured(Object payload) {
+        return of(payload);
+    }
+
+    /**
+     * Creates a failed result with the given error message.
+     *
+     * @param message the error message
+     * @return a failed tool result
+     */
     static ToolResult error(String message) {
         return new Error(message);
     }
 
+    /** Creates a successful result with no structured value and no content. */
     static ToolResult empty() {
         return new Success(null, List.of());
     }
@@ -127,6 +220,14 @@ public sealed interface ToolResult
         return new Success(JsonDocument.of(json), List.of(TextContent.of(text)));
     }
 
+    /**
+     * Creates a result that requests additional input from the caller before the tool call can
+     * complete.
+     *
+     * @param reqs  the requested inputs, keyed by request id
+     * @param state an opaque state token to echo back with the caller's response, or {@code null}
+     * @return a result signaling that input is required
+     */
     static ToolResult inputRequired(Map<String, ? extends InputRequest> reqs, @Nullable String state) {
         return new InputRequired(new InputRequestBundle(reqs, state));
     }

--- a/tachyon-api/src/main/java/dev/tachyonmcp/server/features/tools/ToolResult.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/server/features/tools/ToolResult.java
@@ -76,8 +76,20 @@ public sealed interface ToolResult
         return new Success(null, List.of(TextContent.of(t)));
     }
 
-    static ToolResult blocks(ContentBlock... blocks) {
+    static ToolResult content(ContentBlock... blocks) {
         return new Success(null, List.of(blocks));
+    }
+
+    /**
+     * Creates a successful result containing the given content blocks.
+     *
+     * @param blocks the content blocks
+     * @return a successful tool result
+     * @deprecated use {@link #content(ContentBlock...)}
+     */
+    @Deprecated(since = "1.0.0-beta.15", forRemoval = true)
+    static ToolResult blocks(ContentBlock... blocks) {
+        return content(blocks);
     }
 
     static ToolResult of(Object payload, String text) {

--- a/tachyon-api/src/test/java/dev/tachyonmcp/server/features/tools/ToolResultTest.java
+++ b/tachyon-api/src/test/java/dev/tachyonmcp/server/features/tools/ToolResultTest.java
@@ -14,10 +14,22 @@ import org.junit.jupiter.api.Test;
 class ToolResultTest {
 
     @Test
-    void blocksWithNoArgsIsEmptySuccess() {
-        var r = ToolResult.blocks();
+    void contentWithNoArgsIsEmptySuccess() {
+        var r = ToolResult.content();
         assertThat(r).isInstanceOf(ToolResult.Success.class);
         assertThat(((ToolResult.Success) r).content()).isEmpty();
+    }
+
+    @Test
+    @SuppressWarnings("removal")
+    void deprecatedResponseFactoriesDelegateToCanonicalFactories() {
+        var image = ImageContent.of("aGVsbG8=", "image/png");
+        var audio = AudioContent.of("aGVsbG8=", "audio/wav");
+        var result = ToolResult.blocks(image, audio);
+
+        assertThat(image).isEqualTo(ImageContent.base64("aGVsbG8=", "image/png"));
+        assertThat(audio).isEqualTo(AudioContent.base64("aGVsbG8=", "audio/wav"));
+        assertThat(((ToolResult.Success) result).content()).containsExactly(image, audio);
     }
 
     @Test

--- a/tachyon-api/src/test/java/dev/tachyonmcp/server/features/tools/ToolResultTest.java
+++ b/tachyon-api/src/test/java/dev/tachyonmcp/server/features/tools/ToolResultTest.java
@@ -33,6 +33,12 @@ class ToolResultTest {
     }
 
     @Test
+    void experimentalStructuredAliasesOf() {
+        assertThat(ToolResult.structured(42)).isEqualTo(ToolResult.of(42));
+        assertThat(ToolResult.structured("data", "custom text")).isEqualTo(ToolResult.of("data", "custom text"));
+    }
+
+    @Test
     void successAllowsNullStructuredAndEmptyContent() {
         var r = new ToolResult.Success(null, List.of());
         assertThat(r.structured()).isEmpty();

--- a/tachyon-core/src/main/java/dev/tachyonmcp/protocol/mcp/v2025_11_25/codecs/McpToolMapper.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/protocol/mcp/v2025_11_25/codecs/McpToolMapper.java
@@ -30,7 +30,7 @@ final class McpToolMapper {
     public static ToolResult toDomainResult(Object result) {
         if (result instanceof ToolResult r) return r;
         var text = TextContent.of(result != null ? result.toString() : "");
-        return ToolResult.blocks(text);
+        return ToolResult.content(text);
     }
 
     public static Tool toTool(ToolDescriptor d) {
@@ -83,10 +83,10 @@ final class McpToolMapper {
             case dev.tachyonmcp.protocol.mcp.v2025_11_25.models.TextContent t ->
                 TextContent.of(t.text(), JsonUtils.toObjectMap(t._meta()), toDomainAnnotations(t.annotations()));
             case dev.tachyonmcp.protocol.mcp.v2025_11_25.models.ImageContent i ->
-                ImageContent.of(
+                ImageContent.base64(
                         i.data(), i.mimeType(), toDomainAnnotations(i.annotations()), JsonUtils.toObjectMap(i._meta()));
             case dev.tachyonmcp.protocol.mcp.v2025_11_25.models.AudioContent a ->
-                AudioContent.of(
+                AudioContent.base64(
                         a.data(), a.mimeType(), toDomainAnnotations(a.annotations()), JsonUtils.toObjectMap(a._meta()));
             case dev.tachyonmcp.protocol.mcp.v2025_11_25.models.ResourceLink r ->
                 ResourceLink.builder(r.uri(), r.name())

--- a/tachyon-core/src/test/java/dev/tachyonmcp/protocol/mcp/v2025_11_25/codecs/McpToolMapperTest.java
+++ b/tachyon-core/src/test/java/dev/tachyonmcp/protocol/mcp/v2025_11_25/codecs/McpToolMapperTest.java
@@ -37,7 +37,7 @@ class McpToolMapperTest {
 
     @Test
     void toProtocolImageContentCarriesCorrectType() {
-        var domain = ImageContent.of("data", "image/png");
+        var domain = ImageContent.base64("data", "image/png");
         var protocol = (dev.tachyonmcp.protocol.mcp.v2025_11_25.models.ImageContent)
                 McpToolMapper.toProtocolContentBlock(domain);
         assertThat(protocol.type()).isEqualTo("image");
@@ -47,7 +47,7 @@ class McpToolMapperTest {
 
     @Test
     void toProtocolAudioContentCarriesCorrectType() {
-        var domain = AudioContent.of("data", "audio/wav");
+        var domain = AudioContent.base64("data", "audio/wav");
         var protocol = (dev.tachyonmcp.protocol.mcp.v2025_11_25.models.AudioContent)
                 McpToolMapper.toProtocolContentBlock(domain);
         assertThat(protocol.type()).isEqualTo("audio");
@@ -89,7 +89,7 @@ class McpToolMapperTest {
     @Test
     void metaSurvivesImageContentRoundTrip() {
         var meta = Map.<String, Object>of("key", META_VALUE);
-        var domain = ImageContent.of("data", "image/png", null, meta);
+        var domain = ImageContent.base64("data", "image/png", null, meta);
         var protocol = (dev.tachyonmcp.protocol.mcp.v2025_11_25.models.ImageContent)
                 McpToolMapper.toProtocolContentBlock(domain);
         assertThat(protocol._meta()).containsEntry("key", PROTOCOL_META_VALUE);
@@ -101,7 +101,7 @@ class McpToolMapperTest {
     @Test
     void metaSurvivesAudioContentRoundTrip() {
         var meta = Map.<String, Object>of("key", META_VALUE);
-        var domain = AudioContent.of("data", "audio/wav", null, meta);
+        var domain = AudioContent.base64("data", "audio/wav", null, meta);
         var protocol = (dev.tachyonmcp.protocol.mcp.v2025_11_25.models.AudioContent)
                 McpToolMapper.toProtocolContentBlock(domain);
         assertThat(protocol._meta()).containsEntry("key", PROTOCOL_META_VALUE);
@@ -292,7 +292,7 @@ class McpToolMapperTest {
 
     @Test
     void toDomainResultPreservesToolResult() {
-        var original = ToolResult.blocks(TextContent.of("hello"));
+        var original = ToolResult.content(TextContent.of("hello"));
         var result = McpToolMapper.toDomainResult(original);
         assertThat(result).isSameAs(original);
     }
@@ -308,8 +308,8 @@ class McpToolMapperTest {
     @Test
     void typeDerivesCorrectlyForAllVariants() {
         assertThat(TextContent.of("hello").type()).isEqualTo(ContentBlock.Type.TEXT);
-        assertThat(ImageContent.of("data", "image/png").type()).isEqualTo(ContentBlock.Type.IMAGE);
-        assertThat(AudioContent.of("data", "audio/wav").type()).isEqualTo(ContentBlock.Type.AUDIO);
+        assertThat(ImageContent.base64("data", "image/png").type()).isEqualTo(ContentBlock.Type.IMAGE);
+        assertThat(AudioContent.base64("data", "audio/wav").type()).isEqualTo(ContentBlock.Type.AUDIO);
         assertThat(ResourceLink.of("test://uri", "name").type()).isEqualTo(ContentBlock.Type.RESOURCE_LINK);
         assertThat(EmbeddedResource.of(TextResourceContents.of("u", "c", null)).type())
                 .isEqualTo(ContentBlock.Type.RESOURCE);

--- a/tachyon-core/src/test/java/dev/tachyonmcp/server/domain/BinaryContentToStringTest.java
+++ b/tachyon-core/src/test/java/dev/tachyonmcp/server/domain/BinaryContentToStringTest.java
@@ -12,8 +12,8 @@ class BinaryContentToStringTest {
     @Test
     void binaryResourceContainersDoNotExposePayloads() {
         var icon = Icon.of("data:image/png;base64," + BINARY_PAYLOAD, "image/png", null, null);
-        var image = ImageContent.of(BINARY_PAYLOAD, "image/png");
-        var audio = AudioContent.of(BINARY_PAYLOAD, "audio/wav");
+        var image = ImageContent.base64(BINARY_PAYLOAD, "image/png");
+        var audio = AudioContent.base64(BINARY_PAYLOAD, "audio/wav");
         var blob = BlobResourceContents.of("test://blob", BINARY_PAYLOAD, "application/octet-stream");
 
         assertThat(icon.toString()).doesNotContain(BINARY_PAYLOAD).contains("image/png");

--- a/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/config/ContentScope.kt
+++ b/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/config/ContentScope.kt
@@ -1,0 +1,55 @@
+// Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors.
+@file:JvmSynthetic
+
+package dev.tachyonmcp.kotlin.server.config
+
+import dev.tachyonmcp.kotlin.server.TachyonDsl
+import dev.tachyonmcp.server.domain.AudioContent
+import dev.tachyonmcp.server.domain.ContentBlock
+import dev.tachyonmcp.server.domain.EmbeddedResource
+import dev.tachyonmcp.server.domain.ImageContent
+import dev.tachyonmcp.server.domain.ResourceContents
+import dev.tachyonmcp.server.domain.TextContent
+
+/**
+ * Collects [ContentBlock]s inside a `content { }` result builder.
+ *
+ * Each call appends one block; the enclosing scope turns the collected blocks into a result — a
+ * [dev.tachyonmcp.server.features.tools.ToolResult] for tools, user-role messages for prompts.
+ */
+@TachyonDsl
+public class ContentScope
+    internal constructor() {
+        internal val blocks: MutableList<ContentBlock> = mutableListOf()
+
+        /** Appends a plain-text block. */
+        public fun text(text: String) {
+            blocks += TextContent.of(text)
+        }
+
+        /** Appends a base64-encoded image block. */
+        public fun image(
+            data: String,
+            mimeType: String,
+        ) {
+            blocks += ImageContent.base64(data, mimeType)
+        }
+
+        /** Appends a base64-encoded audio block. */
+        public fun audio(
+            data: String,
+            mimeType: String,
+        ) {
+            blocks += AudioContent.base64(data, mimeType)
+        }
+
+        /** Appends an embedded resource block. */
+        public fun embeddedResource(resource: ResourceContents) {
+            blocks += EmbeddedResource.of(resource)
+        }
+
+        /** Appends a pre-built content block. */
+        public fun add(block: ContentBlock) {
+            blocks += block
+        }
+    }

--- a/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/config/PromptScope.kt
+++ b/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/config/PromptScope.kt
@@ -1,8 +1,11 @@
 // Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors.
+@file:JvmSynthetic
+
 package dev.tachyonmcp.kotlin.server.config
 
 import dev.tachyonmcp.kotlin.server.TachyonDsl
 import dev.tachyonmcp.runtime.InteractionContext
+import dev.tachyonmcp.server.domain.PromptMessage
 import dev.tachyonmcp.server.features.prompts.PromptRequest
 
 @TachyonDsl
@@ -17,3 +20,17 @@ public class PromptScope
         public val arguments: String?
             get() = request.arguments()
     }
+
+/**
+ * Builds a list of user-role [PromptMessage]s from the content blocks collected in [block] — one
+ * message per block. For explicit roles use [dev.tachyonmcp.kotlin.server.domain.PromptMessage].
+ *
+ * ```kotlin
+ * content {
+ *     text("Summarize this")
+ *     image(data, "image/png")
+ * }
+ * ```
+ */
+public fun PromptScope.content(block: ContentScope.() -> Unit): List<PromptMessage> =
+    ContentScope().apply(block).blocks.map { PromptMessage.user(it) }

--- a/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/config/PromptScope.kt
+++ b/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/config/PromptScope.kt
@@ -19,18 +19,19 @@ public class PromptScope
          */
         public val arguments: String?
             get() = request.arguments()
-    }
 
-/**
- * Builds a list of user-role [PromptMessage]s from the content blocks collected in [block] — one
- * message per block. For explicit roles use [dev.tachyonmcp.kotlin.server.domain.PromptMessage].
- *
- * ```kotlin
- * content {
- *     text("Summarize this")
- *     image(data, "image/png")
- * }
- * ```
- */
-public fun PromptScope.content(block: ContentScope.() -> Unit): List<PromptMessage> =
-    ContentScope().apply(block).blocks.map { PromptMessage.user(it) }
+        /**
+         * Builds a list of user-role [PromptMessage]s from the content blocks collected in
+         * [block] — one message per block. For explicit roles use
+         * [dev.tachyonmcp.kotlin.server.domain.PromptMessage].
+         *
+         * ```kotlin
+         * content {
+         *     text("Summarize this")
+         *     image(data, "image/png")
+         * }
+         * ```
+         */
+        public fun content(block: ContentScope.() -> Unit): List<PromptMessage> =
+            ContentScope().apply(block).blocks.map { PromptMessage.user(it) }
+    }

--- a/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/config/ToolScope.kt
+++ b/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/config/ToolScope.kt
@@ -13,39 +13,39 @@ public class ToolScope
     internal constructor(
         public val ctx: InteractionContext,
         public val request: ToolRequest,
-    )
+    ) {
+        /**
+         * Returns a [ToolResult] whose structured value is [value], serialized to
+         * `structuredContent` by the serde configured in server config at encode time
+         * (symmetric with [decode][dev.tachyonmcp.kotlin.server.domain.decode]).
+         *
+         * When [text] is omitted, no text block is attached and the server emits the
+         * serialized JSON as the text content (MCP backwards-compat). Pass [text] to
+         * supply a human-readable text block instead.
+         *
+         * For a pre-serialized JSON payload that skips the configured serde, use
+         * [ToolResult.raw] directly.
+         */
+        public fun <T : Any> success(
+            value: T,
+            text: String? = null,
+        ): ToolResult = if (text != null) ToolResult.of(value, text) else ToolResult.of(value)
 
-/**
- * Returns a [ToolResult] whose structured value is [value], serialized to
- * `structuredContent` by the serde configured in server config at encode time
- * (symmetric with [decode][dev.tachyonmcp.kotlin.server.domain.decode]).
- *
- * When [text] is omitted, no text block is attached and the server emits the
- * serialized JSON as the text content (MCP backwards-compat). Pass [text] to
- * supply a human-readable text block instead.
- *
- * For a pre-serialized JSON payload that skips the configured serde, use
- * [ToolResult.raw] directly.
- */
-public fun <T : Any> ToolScope.success(
-    value: T,
-    text: String? = null,
-): ToolResult = if (text != null) ToolResult.of(value, text) else ToolResult.of(value)
+        /** Returns a [ToolResult] carrying a single plain-text content block. */
+        public fun text(text: String): ToolResult = ToolResult.text(text)
 
-/** Returns a [ToolResult] carrying a single plain-text content block. */
-public fun ToolScope.text(text: String): ToolResult = ToolResult.text(text)
-
-/**
- * Returns a [ToolResult] built from the content blocks collected in [block]:
- *
- * ```kotlin
- * content {
- *     text("Answer")
- *     image(data, "image/png")
- * }
- * ```
- */
-public fun ToolScope.content(block: ContentScope.() -> Unit): ToolResult {
-    val scope = ContentScope().apply(block)
-    return ToolResult.content(*scope.blocks.toTypedArray())
-}
+        /**
+         * Returns a [ToolResult] built from the content blocks collected in [block]:
+         *
+         * ```kotlin
+         * content {
+         *     text("Answer")
+         *     image(data, "image/png")
+         * }
+         * ```
+         */
+        public fun content(block: ContentScope.() -> Unit): ToolResult {
+            val scope = ContentScope().apply(block)
+            return ToolResult.content(*scope.blocks.toTypedArray())
+        }
+    }

--- a/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/config/ToolScope.kt
+++ b/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/config/ToolScope.kt
@@ -1,4 +1,6 @@
 // Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors.
+@file:JvmSynthetic
+
 package dev.tachyonmcp.kotlin.server.config
 
 import dev.tachyonmcp.kotlin.server.TachyonDsl
@@ -29,3 +31,21 @@ public fun <T : Any> ToolScope.success(
     value: T,
     text: String? = null,
 ): ToolResult = if (text != null) ToolResult.of(value, text) else ToolResult.of(value)
+
+/** Returns a [ToolResult] carrying a single plain-text content block. */
+public fun ToolScope.text(text: String): ToolResult = ToolResult.text(text)
+
+/**
+ * Returns a [ToolResult] built from the content blocks collected in [block]:
+ *
+ * ```kotlin
+ * content {
+ *     text("Answer")
+ *     image(data, "image/png")
+ * }
+ * ```
+ */
+public fun ToolScope.content(block: ContentScope.() -> Unit): ToolResult {
+    val scope = ContentScope().apply(block)
+    return ToolResult.content(*scope.blocks.toTypedArray())
+}

--- a/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/domain/ContentFactories.kt
+++ b/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/domain/ContentFactories.kt
@@ -72,13 +72,14 @@ public fun TextContent(
  * @param annotations optional presentation hints
  * @param meta        optional request-level metadata; null to omit
  */
+@JvmSynthetic
 public fun ImageContent(
     data: String,
     mimeType: String,
     annotations: Annotations? = null,
     meta: Map<String, JsonNode>? = null,
 ): ImageContent =
-    ImageContent.of(
+    ImageContent.base64(
         data,
         mimeType,
         annotations,
@@ -96,7 +97,7 @@ public fun ImageContent(
     annotations: Annotations? = null,
     meta: Map<String, JsonObject>?,
 ): ImageContent =
-    ImageContent.of(
+    ImageContent.base64(
         data,
         mimeType,
         annotations,
@@ -117,7 +118,7 @@ public fun AudioContent(
     annotations: Annotations? = null,
     meta: Map<String, JsonNode>? = null,
 ): AudioContent =
-    AudioContent.of(
+    AudioContent.base64(
         data,
         mimeType,
         annotations,
@@ -135,7 +136,7 @@ public fun AudioContent(
     annotations: Annotations? = null,
     meta: Map<String, JsonObject>?,
 ): AudioContent =
-    AudioContent.of(
+    AudioContent.base64(
         data,
         mimeType,
         annotations,

--- a/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/domain/ContentFactories.kt
+++ b/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/domain/ContentFactories.kt
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors.
 @file:Suppress("FunctionName")
 @file:JvmName("ContentBlocks")
+@file:JvmSynthetic
 
 // Copyright (c) 2026 Konstantin Pavlov and contributors.
 
@@ -72,7 +73,6 @@ public fun TextContent(
  * @param annotations optional presentation hints
  * @param meta        optional request-level metadata; null to omit
  */
-@JvmSynthetic
 public fun ImageContent(
     data: String,
     mimeType: String,

--- a/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/domain/StructuredFactoryBuilders.kt
+++ b/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/domain/StructuredFactoryBuilders.kt
@@ -1,4 +1,6 @@
 // Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors.
+@file:JvmSynthetic
+
 package dev.tachyonmcp.kotlin.server.domain
 
 import dev.tachyonmcp.kotlin.server.TachyonDsl
@@ -140,7 +142,7 @@ public class ImageContentBuilder
 
         @PublishedApi
         internal fun build(): ImageContent =
-            ImageContent.of(
+            ImageContent.base64(
                 requireNotNull(data) { "ImageContent.data is required" },
                 requireNotNull(mimeType) { "ImageContent.mimeType is required" },
                 annotations,
@@ -167,7 +169,7 @@ public class AudioContentBuilder
 
         @PublishedApi
         internal fun build(): AudioContent =
-            AudioContent.of(
+            AudioContent.base64(
                 requireNotNull(data) { "AudioContent.data is required" },
                 requireNotNull(mimeType) { "AudioContent.mimeType is required" },
                 annotations,

--- a/tachyon-kotlin/src/test/kotlin/dev/tachyonmcp/kotlin/server/KotlinApiTest.kt
+++ b/tachyon-kotlin/src/test/kotlin/dev/tachyonmcp/kotlin/server/KotlinApiTest.kt
@@ -3,9 +3,6 @@ package dev.tachyonmcp.kotlin.server
 
 import dev.tachyonmcp.kotlin.server.config.PromptScope
 import dev.tachyonmcp.kotlin.server.config.ToolScope
-import dev.tachyonmcp.kotlin.server.config.content
-import dev.tachyonmcp.kotlin.server.config.success
-import dev.tachyonmcp.kotlin.server.config.text
 import dev.tachyonmcp.kotlin.server.domain.arrayOrNull
 import dev.tachyonmcp.kotlin.server.domain.boolean
 import dev.tachyonmcp.kotlin.server.domain.booleanOrNull

--- a/tachyon-kotlin/src/test/kotlin/dev/tachyonmcp/kotlin/server/KotlinApiTest.kt
+++ b/tachyon-kotlin/src/test/kotlin/dev/tachyonmcp/kotlin/server/KotlinApiTest.kt
@@ -1,8 +1,11 @@
 // Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors.
 package dev.tachyonmcp.kotlin.server
 
+import dev.tachyonmcp.kotlin.server.config.PromptScope
 import dev.tachyonmcp.kotlin.server.config.ToolScope
+import dev.tachyonmcp.kotlin.server.config.content
 import dev.tachyonmcp.kotlin.server.config.success
+import dev.tachyonmcp.kotlin.server.config.text
 import dev.tachyonmcp.kotlin.server.domain.arrayOrNull
 import dev.tachyonmcp.kotlin.server.domain.boolean
 import dev.tachyonmcp.kotlin.server.domain.booleanOrNull
@@ -21,13 +24,17 @@ import dev.tachyonmcp.kotlin.server.domain.valuesAs
 import dev.tachyonmcp.kotlin.server.json.KxSerializationSerde
 import dev.tachyonmcp.kotlin.server.json.toJsonNode
 import dev.tachyonmcp.server.domain.Args
+import dev.tachyonmcp.server.domain.ImageContent
 import dev.tachyonmcp.server.domain.InvalidArgumentException
+import dev.tachyonmcp.server.domain.Role
 import dev.tachyonmcp.server.domain.TextContent
+import dev.tachyonmcp.server.features.prompts.PromptRequest
 import dev.tachyonmcp.server.features.tools.ToolRequest
 import dev.tachyonmcp.server.features.tools.ToolResult
 import io.kotest.assertions.assertSoftly
 import io.kotest.assertions.json.shouldEqualJson
 import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.string.shouldContain
@@ -375,6 +382,65 @@ internal class KotlinApiTest {
             result.shouldBeInstanceOf<ToolResult.Success>()
             result.structured().get() shouldBe value
             (result.content().first() as TextContent).text() shouldBe "custom text"
+        }
+    }
+
+    @Test
+    fun `content DSL collects text and image blocks into a ToolResult`() {
+        withStatelessContext { ctx ->
+            val request =
+                ToolRequest
+                    .builder()
+                    .name("render")
+                    .arguments(Args.of(null, null))
+                    .build()
+            val scope = ToolScope(ctx, request = request)
+            val result =
+                scope.content {
+                    text("Answer")
+                    image("aGVsbG8=", "image/png")
+                }
+            result.shouldBeInstanceOf<ToolResult.Success>()
+            assertSoftly {
+                result.content() shouldHaveSize 2
+                (result.content()[0] as TextContent).text() shouldBe "Answer"
+                (result.content()[1] as ImageContent).mimeType() shouldBe "image/png"
+            }
+        }
+    }
+
+    @Test
+    fun `text DSL returns a single-block ToolResult`() {
+        withStatelessContext { ctx ->
+            val request =
+                ToolRequest
+                    .builder()
+                    .name("say")
+                    .arguments(Args.of(null, null))
+                    .build()
+            val scope = ToolScope(ctx, request = request)
+            val result = scope.text("hi")
+            result.shouldBeInstanceOf<ToolResult.Success>()
+            (result.content().single() as TextContent).text() shouldBe "hi"
+        }
+    }
+
+    @Test
+    fun `PromptScope content DSL builds one user message per block`() {
+        withStatelessContext { ctx ->
+            val request = PromptRequest(null, null, null)
+            val scope = PromptScope(ctx, request = request)
+            val messages =
+                scope.content {
+                    text("Summarize this")
+                    image("aGVsbG8=", "image/png")
+                }
+            assertSoftly {
+                messages shouldHaveSize 2
+                messages.forEach { it.role() shouldBe Role.USER }
+                (messages[0].content() as TextContent).text() shouldBe "Summarize this"
+                (messages[1].content() as ImageContent).mimeType() shouldBe "image/png"
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

The update introduces `ImageContent.base64(...)` and `AudioContent.base64(...)`, deprecates their `of(...)` factories, and adds `ToolResult.content(...)` plus experimental structured aliases. Protocol mappers, tests, handlers, and Kotlin factories adopt the new APIs. Kotlin gains `ContentScope`, `ToolScope.content/text`, and `PromptScope.content` DSL methods. Documentation and examples are updated accordingly.

* **New Features**
  * Added Kotlin DSL helpers for creating text, image, audio, embedded-resource, and multi-content results.
  * Added structured result convenience factories.
  * Added dedicated base64 factories for image and audio content.

* **Documentation**
  * Updated API references to recommend `content(...)` for multiple content blocks.
  * Improved guidance and linked directly to published API documentation.

* **Deprecations**
  * Existing `blocks(...)` and binary-content `of(...)` factories are deprecated in favor of the new APIs.
