### PR TITLE
fix!: refactor prompt requests, add typed client APIs for elicitation and sampling

### DIFF
--- a/.agents/skills/tachyon-mcp/resources/java/PromptHandlerExample.java
+++ b/.agents/skills/tachyon-mcp/resources/java/PromptHandlerExample.java
@@ -40,10 +40,10 @@ final class PromptHandlerExample {
                 null);
     }
 
-    /** Handler that reads the argument string. */
+    /** Handler that reads a typed argument. */
     static PromptHandler argHandler() {
         return (ctx, request) -> {
-            var text = request.arguments() != null ? request.arguments() : "default text";
+            var text = request.arguments().stringOr("text", "default text");
             return PromptResult.messages(List.of(PromptMessage.user("Rewrite this: " + text)));
         };
     }
@@ -61,6 +61,6 @@ final class PromptHandlerExample {
     /** Async handler — returns a CompletionStage for non-blocking backends. */
     static AsyncPromptHandler asyncHandler() {
         return (ctx, request) -> CompletableFuture.supplyAsync(
-                () -> PromptResult.messages(List.of(PromptMessage.user("Rewrite: " + request.arguments()))));
+                () -> PromptResult.messages(List.of(PromptMessage.user("Rewrite: " + request.arguments().json()))));
     }
 }

--- a/conformance/src/test/java/dev/tachyonmcp/conformance/AbstractConformanceServer.java
+++ b/conformance/src/test/java/dev/tachyonmcp/conformance/AbstractConformanceServer.java
@@ -524,8 +524,8 @@ abstract class AbstractConformanceServer {
                         List.of(PromptMessage.user("This is a simple test prompt.")))
                 .register(
                         PromptDescriptor.of("test_prompt_with_arguments", "A parameterized prompt"),
-                        (ctx, request) -> PromptResult.messages(
-                                List.of(PromptMessage.user("Prompt with arguments: " + request.arguments()))));
+                        (ctx, request) -> PromptResult.messages(List.of(PromptMessage.user(
+                                "Prompt with arguments: " + request.arguments().json()))));
 
         server.prompts()
                 .register(

--- a/conformance/src/test/java/dev/tachyonmcp/conformance/DefaultConformanceServer.java
+++ b/conformance/src/test/java/dev/tachyonmcp/conformance/DefaultConformanceServer.java
@@ -1,12 +1,16 @@
 /* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
 package dev.tachyonmcp.conformance;
 
+import dev.tachyonmcp.api.json.JsonSchema;
+import dev.tachyonmcp.api.runtime.ElicitationRequest;
+import dev.tachyonmcp.api.server.domain.Args;
 import dev.tachyonmcp.api.server.features.tools.ToolResult;
 import dev.tachyonmcp.core.server.TachyonServer;
 import dev.tachyonmcp.core.server.internal.ServerEngine;
 import dev.tachyonmcp.core.transport.jsonrpc.JsonRpcCodec;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
@@ -52,21 +56,19 @@ class DefaultConformanceServer extends AbstractConformanceServer {
                             if (promptOpt.isPresent()) {
                                 var prompt = promptOpt.get();
                                 try {
-                                    Map<String, Object> paramsMap = Map.of(
+                                    var params = Args.of(Map.of(
                                             "messages",
                                             List.of(Map.of(
                                                     "role", "user", "content", Map.of("type", "text", "text", prompt))),
                                             "maxTokens",
-                                            100);
-                                    var responseJson = ctx.sendRequest(
-                                                    "sampling/createMessage",
-                                                    JsonRpcCodec.writeValueAsString(paramsMap))
+                                            100));
+                                    var result = ctx.client()
+                                            .sampling()
+                                            .createMessage(params)
                                             .get(2, TimeUnit.SECONDS);
-                                    var responseObj = (Map<String, Object>) JsonRpcCodec.readValue(responseJson);
-                                    var content = responseObj.get("content");
-                                    var text = content instanceof Map<?, ?> cm && "text".equals(cm.get("type"))
-                                            ? (String) cm.get("text")
-                                            : "";
+                                    var text = result.objectOpt("content")
+                                            .flatMap(c -> c.stringOpt("text"))
+                                            .orElse("");
                                     return ToolResult.text(text);
                                 } catch (Exception e) {
                                     return ToolResult.error("Sampling request failed");
@@ -85,29 +87,23 @@ class DefaultConformanceServer extends AbstractConformanceServer {
                             if (messageOpt.isPresent()) {
                                 var message = messageOpt.get();
                                 try {
-                                    var paramsMap = Map.of(
-                                            "mode",
-                                            "form",
-                                            "message",
-                                            message,
-                                            "requestedSchema",
+                                    var schema = JsonSchema.of(JsonRpcCodec.writeValueAsString(Map.of(
+                                            "type",
+                                            "object",
+                                            "properties",
                                             Map.of(
-                                                    "type",
-                                                    "object",
-                                                    "properties",
-                                                    Map.of(
-                                                            "username", Map.of("type", "string"),
-                                                            "email", Map.of("type", "string")),
-                                                    "required",
-                                                    List.of("username", "email")));
-                                    var responseJson = ctx.sendRequest(
-                                                    "elicitation/create", JsonRpcCodec.writeValueAsString(paramsMap))
+                                                    "username", Map.of("type", "string"),
+                                                    "email", Map.of("type", "string")),
+                                            "required",
+                                            List.of("username", "email"))));
+                                    var result = ctx.client()
+                                            .elicitation()
+                                            .create(new ElicitationRequest(message, schema))
                                             .get(2, TimeUnit.SECONDS);
-                                    var responseObj = (Map<String, Object>) JsonRpcCodec.readValue(responseJson);
-                                    var action = responseObj.get("action");
-                                    var content = responseObj.get("content");
-                                    var text = "User response: " + (action != null ? action : "unknown");
-                                    if (content instanceof Map<?, ?> cm) text += ", " + cm;
+                                    var text = "User response: "
+                                            + result.action().name().toLowerCase(Locale.ROOT);
+                                    if (result.content() != null)
+                                        text += ", " + result.content().asMap();
                                     return ToolResult.text(text);
                                 } catch (Exception e) {
                                     return ToolResult.error("Elicitation request failed");
@@ -123,41 +119,35 @@ class DefaultConformanceServer extends AbstractConformanceServer {
                                 .inputSchema(INPUT_SCHEMA_NO_ARGS),
                         (ctx, request) -> {
                             try {
-                                var paramsMap = Map.of(
-                                        "mode",
-                                        "form",
-                                        "message",
-                                        "Please provide your details with defaults",
-                                        "requestedSchema",
-                                        Map.of(
-                                                "type",
-                                                "object",
-                                                "properties",
-                                                Map.<String, Object>of(
-                                                        "name",
-                                                        Map.of("type", "string", "default", "John Doe"),
-                                                        "age",
-                                                        Map.of("type", "integer", "default", 30),
-                                                        "score",
-                                                        Map.of("type", "number", "default", 95.5),
-                                                        "status",
-                                                        Map.of(
-                                                                "type",
-                                                                "string",
-                                                                "enum",
-                                                                List.of("active", "inactive"),
-                                                                "default",
-                                                                "active"),
-                                                        "verified",
-                                                        Map.of("type", "boolean", "default", true))));
-                                var responseJson = ctx.sendRequest(
-                                                "elicitation/create", JsonRpcCodec.writeValueAsString(paramsMap))
+                                var schema = JsonSchema.of(JsonRpcCodec.writeValueAsString(Map.of(
+                                        "type",
+                                        "object",
+                                        "properties",
+                                        Map.<String, Object>of(
+                                                "name",
+                                                Map.of("type", "string", "default", "John Doe"),
+                                                "age",
+                                                Map.of("type", "integer", "default", 30),
+                                                "score",
+                                                Map.of("type", "number", "default", 95.5),
+                                                "status",
+                                                Map.of(
+                                                        "type",
+                                                        "string",
+                                                        "enum",
+                                                        List.of("active", "inactive"),
+                                                        "default",
+                                                        "active"),
+                                                "verified",
+                                                Map.of("type", "boolean", "default", true)))));
+                                var result = ctx.client()
+                                        .elicitation()
+                                        .create(new ElicitationRequest(
+                                                "Please provide your details with defaults", schema))
                                         .get(2, TimeUnit.SECONDS);
-                                var responseObj = (Map<String, Object>) JsonRpcCodec.readValue(responseJson);
-                                var action = responseObj.get("action");
-                                var content = responseObj.get("content");
-                                var text = "Defaults " + (action != null ? action : "unknown");
-                                if (content instanceof Map<?, ?> cm) text += ", " + cm;
+                                var text = "Defaults " + result.action().name().toLowerCase(Locale.ROOT);
+                                if (result.content() != null)
+                                    text += ", " + result.content().asMap();
                                 return ToolResult.text(text);
                             } catch (Exception e) {
                                 return ToolResult.error("Error: " + e.getMessage());
@@ -213,18 +203,15 @@ class DefaultConformanceServer extends AbstractConformanceServer {
                                                         List.of(
                                                                 Map.of("const", "item1", "title", "Item One"),
                                                                 Map.of("const", "item2", "title", "Item Two")))));
-                                var paramsMap = Map.of(
-                                        "mode", "form",
-                                        "message", "Please select your preferences",
-                                        "requestedSchema", Map.of("type", "object", "properties", props));
-                                var responseJson = ctx.sendRequest(
-                                                "elicitation/create", JsonRpcCodec.writeValueAsString(paramsMap))
+                                var schema = JsonSchema.of(
+                                        JsonRpcCodec.writeValueAsString(Map.of("type", "object", "properties", props)));
+                                var result = ctx.client()
+                                        .elicitation()
+                                        .create(new ElicitationRequest("Please select your preferences", schema))
                                         .get(2, TimeUnit.SECONDS);
-                                var responseObj = (Map<String, Object>) JsonRpcCodec.readValue(responseJson);
-                                var action = responseObj.get("action");
-                                var content = responseObj.get("content");
-                                var text = "Enums " + (action != null ? action : "unknown");
-                                if (content instanceof Map<?, ?> cm) text += ", " + cm;
+                                var text = "Enums " + result.action().name().toLowerCase(Locale.ROOT);
+                                if (result.content() != null)
+                                    text += ", " + result.content().asMap();
                                 return ToolResult.text(text);
                             } catch (Exception e) {
                                 return ToolResult.error("Error: " + e.getMessage());

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/PromptsTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/PromptsTest.java
@@ -68,8 +68,8 @@ class PromptsTest extends AbstractStatelessMcpE2eTest {
         server.prompts()
                 .register(
                         PromptDescriptor.of("test_prompt_with_arguments", "A parameterized prompt"),
-                        (ctx, request) -> PromptResult.messages(
-                                List.of(PromptMessage.user("Hello, " + request.arguments() + "!"))));
+                        (ctx, request) -> PromptResult.messages(List.of(PromptMessage.user(
+                                "Hello, " + request.arguments().json() + "!"))));
 
         try (var client = createTestClient()) {
             client.initialize();

--- a/examples/weather-mcp-kotlin/src/main/kotlin/com/example/weather/GetWeatherTool.kt
+++ b/examples/weather-mcp-kotlin/src/main/kotlin/com/example/weather/GetWeatherTool.kt
@@ -45,7 +45,7 @@ private const val INPUT_SCHEMA = """
 }
 """
 
-fun getWeatherToolDescriptor(): ToolDescriptor =
+val getWeatherToolDescriptor =
     ToolDescriptor {
         name = "get-weather"
         title = "Current Weather"
@@ -56,25 +56,26 @@ fun getWeatherToolDescriptor(): ToolDescriptor =
 fun ToolScope.getWeather(weatherService: WeatherService): ToolResult {
     val args = request.arguments()
     val city = args.stringValue("city")
-    val units = args.stringOr("units", "celsius") ?: "celsius"
+    val units = args.stringOr("units", "celsius")
     val progressToken = request.progressToken()
 
-    fun render(city: String) =
-        ToolResult.text(format(fetchWithProgress(ctx, progressToken, weatherService, city), units))
+    fun attempt(city: String): ToolResult =
+        try {
+            ToolResult.text(format(fetchWithProgress(ctx, progressToken, weatherService, city), units))
+        } catch (e: Exception) {
+            if (e is CityNotFoundException) throw e
+            internalError(e)
+        }
 
     return try {
-        render(city)
+        attempt(city)
     } catch (_: CityNotFoundException) {
         val elicitedCity = elicitCity(ctx, city) ?: return ToolResult.error("City not found")
         try {
-            render(elicitedCity)
+            attempt(elicitedCity)
         } catch (_: CityNotFoundException) {
             ToolResult.error("City not found")
-        } catch (x: Exception) {
-            internalError(x)
         }
-    } catch (e: Exception) {
-        internalError(e)
     }
 }
 
@@ -114,7 +115,7 @@ private fun elicitCity(
         try {
             future.get(ELICITATION_TIMEOUT_SECONDS, TimeUnit.SECONDS)
         } catch (e: InterruptedException) {
-            Thread.currentThread().interrupt()
+            restoreInterruptStatus(e)
             throw e
         } catch (_: TimeoutException) {
             return null

--- a/examples/weather-mcp-kotlin/src/main/kotlin/com/example/weather/GetWeatherTool.kt
+++ b/examples/weather-mcp-kotlin/src/main/kotlin/com/example/weather/GetWeatherTool.kt
@@ -5,6 +5,9 @@ package com.example.weather
 import com.example.weather.service.WeatherService
 import com.example.weather.spi.CityNotFoundException
 import com.example.weather.spi.WeatherObservation
+import dev.tachyonmcp.api.json.JsonSchema
+import dev.tachyonmcp.api.runtime.ElicitationRequest
+import dev.tachyonmcp.api.runtime.ElicitationResult
 import dev.tachyonmcp.api.runtime.InteractionContext
 import dev.tachyonmcp.api.server.domain.ProgressToken
 import dev.tachyonmcp.api.server.features.tools.ToolDescriptor
@@ -12,14 +15,16 @@ import dev.tachyonmcp.api.server.features.tools.ToolResult
 import dev.tachyonmcp.kotlin.server.config.ToolScope
 import dev.tachyonmcp.kotlin.server.features.tools.ToolDescriptor
 import org.slf4j.LoggerFactory
-import tools.jackson.databind.ObjectMapper
 import java.util.Locale
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
 
 private val log = LoggerFactory.getLogger("com.example.weather.GetWeatherTool")
-private val MAPPER = ObjectMapper()
 private const val ELICITATION_TIMEOUT_SECONDS = 600L
+private val CITY_SCHEMA =
+    JsonSchema.of(
+        """{"type":"object","properties":{"city":{"type":"string","title":"City"}},"required":["city"]}""",
+    )
 
 // language=json
 private const val INPUT_SCHEMA = """
@@ -102,27 +107,10 @@ private fun elicitCity(
     city: String,
 ): String? {
     val future =
-        ctx.sendRequest(
-            "elicitation/create",
-            mapOf(
-                "mode" to "form",
-                "message" to "City '$city' was not found. Enter another city.",
-                "requestedSchema" to
-                    mapOf(
-                        "type" to "object",
-                        "properties" to
-                            mapOf(
-                                "city" to
-                                    mapOf(
-                                        "type" to "string",
-                                        "title" to "City",
-                                    ),
-                            ),
-                        "required" to listOf("city"),
-                    ),
-            ),
+        ctx.client().elicitation().create(
+            ElicitationRequest("City '$city' was not found. Enter another city.", CITY_SCHEMA),
         )
-    val response =
+    val result =
         try {
             future.get(ELICITATION_TIMEOUT_SECONDS, TimeUnit.SECONDS)
         } catch (e: InterruptedException) {
@@ -131,13 +119,8 @@ private fun elicitCity(
         } catch (_: TimeoutException) {
             return null
         }
-    val result = MAPPER.readTree(response)
-    if (result.path("action").asString() != "accept") return null
-    return result
-        .path("content")
-        .path("city")
-        .asString()
-        .takeIf(String::isNotBlank)
+    if (result.action() != ElicitationResult.Action.ACCEPT) return null
+    return result.content()?.stringOr("city", "")?.takeIf(String::isNotBlank)
 }
 
 private fun format(

--- a/examples/weather-mcp-kotlin/src/main/kotlin/com/example/weather/WeatherServer.kt
+++ b/examples/weather-mcp-kotlin/src/main/kotlin/com/example/weather/WeatherServer.kt
@@ -8,6 +8,7 @@ import com.example.weather.service.WeatherService
 import com.example.weather.spi.CityNotFoundException
 import com.example.weather.spi.WeatherObservation
 import dev.tachyonmcp.api.json.JsonSchema
+import dev.tachyonmcp.api.server.domain.Args
 import dev.tachyonmcp.api.server.domain.InvalidArgumentException
 import dev.tachyonmcp.api.server.domain.PromptMessage
 import dev.tachyonmcp.api.server.domain.Role
@@ -52,7 +53,6 @@ fun assembleServer(
     port: Int,
     weatherService: WeatherService = createWeatherService(),
 ): TachyonServer {
-    val boundPort = port
     val predictionArticle = weatherService.predictionArticle
     val resourceAnnotations =
         Annotations {
@@ -68,7 +68,7 @@ fun assembleServer(
             theme = "light"
         }
     return buildServer {
-        network { this.port = boundPort }
+        network { this.port = port }
         json { serde = KxSerializationSerde.Default }
         info {
             name = "weather-server-kotlin"
@@ -81,7 +81,7 @@ fun assembleServer(
         }
         session { enabled = true }
 
-        tool(getWeatherToolDescriptor()) { getWeather(weatherService) }
+        tool(getWeatherToolDescriptor) { getWeather(weatherService) }
 
         resource(
             name = "prediction-article",
@@ -93,7 +93,7 @@ fun assembleServer(
             size = predictionArticle.toByteArray().size.toLong(),
             icons = listOf(resourceIcon),
         ) {
-            TextResourceContents { text = predictionArticle }
+            TextResourceContents { text = weatherService.predictionArticle }
         }
 
         resource(
@@ -162,11 +162,10 @@ private fun rewriteForecastPromptDescriptor(): PromptDescriptor =
 
 private fun rewriteForecast(
     weatherService: WeatherService,
-    argumentsJson: String?,
+    arguments: Args,
 ): List<PromptMessage> {
-    val arguments = MAPPER.readTree(argumentsJson ?: "{}")
-    val forecast = arguments.path("forecast").asString()
-    val style = NarrationStyle.from(arguments.path("style").asString())
+    val forecast = arguments.stringValue("forecast")
+    val style = NarrationStyle.from(arguments.stringValue("style"))
     return listOf(PromptMessage.user(weatherService.rewriteForecastInstruction(forecast, style)))
 }
 

--- a/examples/weather/src/main/java/com/example/weather/GetWeatherTool.java
+++ b/examples/weather/src/main/java/com/example/weather/GetWeatherTool.java
@@ -6,6 +6,9 @@ package com.example.weather;
 import com.example.weather.service.WeatherService;
 import com.example.weather.spi.CityNotFoundException;
 import com.example.weather.spi.WeatherObservation;
+import dev.tachyonmcp.api.json.JsonSchema;
+import dev.tachyonmcp.api.runtime.ElicitationRequest;
+import dev.tachyonmcp.api.runtime.ElicitationResult;
 import dev.tachyonmcp.api.runtime.InteractionContext;
 import dev.tachyonmcp.api.server.domain.ProgressToken;
 import dev.tachyonmcp.api.server.features.tools.ToolDescriptor;
@@ -13,15 +16,14 @@ import dev.tachyonmcp.api.server.features.tools.ToolFn;
 import dev.tachyonmcp.api.server.features.tools.ToolResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import tools.jackson.databind.ObjectMapper;
 
-import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 class GetWeatherTool {
     private static final Logger log = LoggerFactory.getLogger(GetWeatherTool.class);
-    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final JsonSchema CITY_SCHEMA = JsonSchema.of("""
+        {"type":"object","properties":{"city":{"type":"string","title":"City"}},"required":["city"]}
+        """);
     // language=json
     private static final String INPUT_SCHEMA = """
         {
@@ -91,28 +93,19 @@ class GetWeatherTool {
     }
 
     private static Optional<String> elicitCity(InteractionContext ctx, String city) throws Exception {
-        var future = ctx.sendRequest(
-            "elicitation/create",
-            Map.of(
-                "mode", "form",
-                "message", "City '%s' was not found. Enter another city.".formatted(city),
-                "requestedSchema",
-                Map.of(
-                    "type", "object",
-                    "properties", Map.of("city", Map.of("type", "string", "title", "City")),
-                    "required", List.of("city"))));
-        String response;
+        var request = new ElicitationRequest(
+            "City '%s' was not found. Enter another city.".formatted(city), CITY_SCHEMA);
+        ElicitationResult result;
         try {
-            response = future.get();
+            result = ctx.client().elicitation().create(request).get();
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw e;
         }
-        var result = MAPPER.readTree(response);
-        if (!"accept".equals(result.path("action").asString())) {
+        if (result.action() != ElicitationResult.Action.ACCEPT || result.content() == null) {
             return Optional.empty();
         }
-        var correctedCity = result.path("content").path("city").asString();
+        var correctedCity = result.content().stringOr("city", "");
         return correctedCity.isBlank() ? Optional.empty() : Optional.of(correctedCity);
     }
 

--- a/examples/weather/src/main/java/com/example/weather/WeatherServer.java
+++ b/examples/weather/src/main/java/com/example/weather/WeatherServer.java
@@ -148,9 +148,9 @@ public final class WeatherServer {
     }
 
     private static PromptResult rewriteForecast(WeatherService weatherService, PromptRequest request) {
-        var arguments = MAPPER.readTree(request.arguments() != null ? request.arguments() : "{}");
-        var forecast = arguments.path("forecast").asString();
-        var style = NarrationStyle.from(arguments.path("style").asString());
+        var arguments = request.arguments();
+        var forecast = arguments.stringOr("forecast", "");
+        var style = NarrationStyle.from(arguments.stringOr("style", ""));
         return PromptResult.messages(List.of(PromptMessage.user(weatherService.rewriteForecastInstruction(forecast, style))));
     }
 

--- a/tachyon-api/src/main/java/dev/tachyonmcp/api/runtime/ClientContext.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/api/runtime/ClientContext.java
@@ -19,7 +19,10 @@ public interface ClientContext {
     /**
      * Returns the sampling service for requesting an LLM completion from the client.
      *
+     * @deprecated Sampling is deprecated as of protocol version 2026-07-28 (SEP-2577)
+     *
      * @return the sampling service
      */
+    @Deprecated(forRemoval = false)
     SamplingService sampling();
 }

--- a/tachyon-api/src/main/java/dev/tachyonmcp/api/runtime/ClientContext.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/api/runtime/ClientContext.java
@@ -1,0 +1,25 @@
+/* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
+package dev.tachyonmcp.api.runtime;
+
+/**
+ * Typed access to the client-facing collaboration channels a handler may invoke:
+ * elicitation and sampling round-trips.
+ *
+ * @see InteractionContext#client()
+ */
+public interface ClientContext {
+
+    /**
+     * Returns the elicitation service for requesting additional information from the user.
+     *
+     * @return the elicitation service
+     */
+    ElicitationService elicitation();
+
+    /**
+     * Returns the sampling service for requesting an LLM completion from the client.
+     *
+     * @return the sampling service
+     */
+    SamplingService sampling();
+}

--- a/tachyon-api/src/main/java/dev/tachyonmcp/api/runtime/ElicitationRequest.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/api/runtime/ElicitationRequest.java
@@ -1,0 +1,12 @@
+/* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
+package dev.tachyonmcp.api.runtime;
+
+import dev.tachyonmcp.api.json.JsonSchema;
+
+/**
+ * A request to elicit additional information from the user via the client, in form mode.
+ *
+ * @param message the message to present to the user describing what information is being requested
+ * @param requestedSchema a restricted JSON Schema (top-level primitive properties only) describing the requested form
+ */
+public record ElicitationRequest(String message, JsonSchema requestedSchema) {}

--- a/tachyon-api/src/main/java/dev/tachyonmcp/api/runtime/ElicitationResult.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/api/runtime/ElicitationResult.java
@@ -1,0 +1,24 @@
+/* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
+package dev.tachyonmcp.api.runtime;
+
+import dev.tachyonmcp.api.server.domain.Args;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * The client's response to an elicitation request.
+ *
+ * @param action the user's action in response to the elicitation
+ * @param content the submitted form data, present only when {@code action} is {@link Action#ACCEPT}
+ */
+public record ElicitationResult(Action action, @Nullable Args content) {
+
+    /** The user action in response to an elicitation request. */
+    public enum Action {
+        /** The user submitted the form. */
+        ACCEPT,
+        /** The user explicitly declined the action. */
+        DECLINE,
+        /** The user dismissed the request without making an explicit choice. */
+        CANCEL
+    }
+}

--- a/tachyon-api/src/main/java/dev/tachyonmcp/api/runtime/ElicitationService.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/api/runtime/ElicitationService.java
@@ -1,0 +1,21 @@
+/* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
+package dev.tachyonmcp.api.runtime;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Requests additional information from the user via the client ({@code elicitation/create}).
+ *
+ * @see ClientContext#elicitation()
+ */
+@FunctionalInterface
+public interface ElicitationService {
+
+    /**
+     * Sends an elicitation request to the client and returns a future completed with the user's response.
+     *
+     * @param request the elicitation request
+     * @return a future that completes with the client's response
+     */
+    CompletableFuture<ElicitationResult> create(ElicitationRequest request);
+}

--- a/tachyon-api/src/main/java/dev/tachyonmcp/api/runtime/InteractionContext.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/api/runtime/InteractionContext.java
@@ -1,6 +1,7 @@
 /* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
 package dev.tachyonmcp.api.runtime;
 
+import dev.tachyonmcp.api.annotations.ExperimentalApi;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import org.jspecify.annotations.Nullable;
@@ -70,13 +71,26 @@ public interface InteractionContext {
     ContextNotifications notifications();
 
     /**
+     * Returns typed access to the client-facing elicitation and sampling services.
+     *
+     * <p>Prefer this over {@link #sendRequest(String, Object)} for sampling/elicitation
+     * round-trips — it returns domain results instead of raw JSON.
+     *
+     * @return the client context
+     */
+    ClientContext client();
+
+    /**
      * Sends a request to the client and returns a future that completes with the raw JSON response.
-     * Used for sampling/elicitation roundtrips.
+     *
+     * <p>Experimental escape hatch for client requests not covered by {@link #client()}, such as
+     * URL-mode elicitation or sampling parameters beyond what {@link SamplingService} models.
      *
      * @param method the request method name
      * @param params the request parameters
      * @return a future that completes with the raw JSON response
      */
+    @ExperimentalApi
     CompletableFuture<String> sendRequest(String method, Object params);
 
     /**

--- a/tachyon-api/src/main/java/dev/tachyonmcp/api/runtime/SamplingService.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/api/runtime/SamplingService.java
@@ -1,0 +1,29 @@
+/* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
+package dev.tachyonmcp.api.runtime;
+
+import dev.tachyonmcp.api.annotations.ExperimentalApi;
+import dev.tachyonmcp.api.server.domain.Args;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Requests an LLM completion from the client ({@code sampling/createMessage}).
+ *
+ * <p>Sampling was deprecated in MCP protocol version 2026-07-28 (SEP-2577) and may be removed from
+ * a future protocol revision. Request and response are kept as raw {@link Args} rather than a
+ * per-field domain model, since the wire shape isn't a stable long-term contract to model against.
+ *
+ * @see ClientContext#sampling()
+ */
+@ExperimentalApi
+@FunctionalInterface
+public interface SamplingService {
+
+    /**
+     * Sends a {@code sampling/createMessage} request to the client and returns a future completed
+     * with the raw result.
+     *
+     * @param params the request parameters, matching {@code CreateMessageRequestParams}
+     * @return a future that completes with the client's result
+     */
+    CompletableFuture<Args> createMessage(Args params);
+}

--- a/tachyon-api/src/main/java/dev/tachyonmcp/api/runtime/SamplingService.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/api/runtime/SamplingService.java
@@ -12,10 +12,12 @@ import java.util.concurrent.CompletableFuture;
  * a future protocol revision. Request and response are kept as raw {@link Args} rather than a
  * per-field domain model, since the wire shape isn't a stable long-term contract to model against.
  *
+ * @deprecated SEP-2577 explicitly deprecates sampling.
  * @see ClientContext#sampling()
  */
 @ExperimentalApi
 @FunctionalInterface
+@Deprecated(forRemoval = false)
 public interface SamplingService {
 
     /**

--- a/tachyon-api/src/main/java/dev/tachyonmcp/api/server/domain/Args.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/api/server/domain/Args.java
@@ -139,6 +139,18 @@ public final class Args implements JsonObject {
     }
 
     /**
+     * Returns the JSON representation, so an accidental string concatenation of {@code Args}
+     * (e.g. in a log line or a prompt/tool message) produces readable JSON instead of an opaque
+     * object identity.
+     *
+     * @return the JSON string
+     */
+    @Override
+    public String toString() {
+        return json();
+    }
+
+    /**
      * Returns the full arguments as a JSON string.
      *
      * @return the JSON string

--- a/tachyon-api/src/main/java/dev/tachyonmcp/api/server/features/prompts/PromptRequest.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/api/server/features/prompts/PromptRequest.java
@@ -1,17 +1,23 @@
 /* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
 package dev.tachyonmcp.api.server.features.prompts;
 
+import dev.tachyonmcp.api.server.domain.Args;
 import java.util.Map;
 import org.jspecify.annotations.Nullable;
 
 /**
  * Request parameters for a prompt invocation.
  *
- * @param arguments JSON-serialized argument string, or null
+ * @param arguments the prompt arguments, or empty if none were provided
  * @param inputResponses client's input responses for input-required prompts, or null
  * @param requestState opaque state token for input-required prompts, or null
  */
 public record PromptRequest(
-        @Nullable String arguments,
+        Args arguments,
         @Nullable Map<String, Object> inputResponses,
-        @Nullable String requestState) {}
+        @Nullable String requestState) {
+
+    public PromptRequest {
+        if (arguments == null) arguments = Args.empty();
+    }
+}

--- a/tachyon-api/src/test/java/dev/tachyonmcp/api/server/features/prompts/PromptRequestTest.java
+++ b/tachyon-api/src/test/java/dev/tachyonmcp/api/server/features/prompts/PromptRequestTest.java
@@ -1,0 +1,17 @@
+/* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
+package dev.tachyonmcp.api.server.features.prompts;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.tachyonmcp.api.server.domain.Args;
+import org.junit.jupiter.api.Test;
+
+class PromptRequestTest {
+
+    @Test
+    void shouldNormalizeNullArgumentsToEmpty() {
+        var request = new PromptRequest(null, null, null);
+
+        assertThat(request.arguments()).isEqualTo(Args.empty());
+    }
+}

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/runtime/DefaultChannelContext.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/runtime/DefaultChannelContext.java
@@ -3,8 +3,10 @@ package dev.tachyonmcp.core.runtime;
 
 import dev.tachyonmcp.api.annotations.InternalApi;
 import dev.tachyonmcp.api.runtime.AttributeKey;
+import dev.tachyonmcp.api.runtime.ClientContext;
 import dev.tachyonmcp.api.runtime.ContextNotifications;
 import dev.tachyonmcp.core.protocol.Protocol;
+import dev.tachyonmcp.core.server.session.WireClientContext;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -74,6 +76,11 @@ public class DefaultChannelContext implements ChannelContext {
     public CompletableFuture<String> sendRequest(String method, Object params) {
         return CompletableFuture.failedFuture(
                 new UnsupportedOperationException("sendRequest is not supported in this context"));
+    }
+
+    @Override
+    public ClientContext client() {
+        return new WireClientContext(this);
     }
 
     @Override

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/features/prompts/DefaultPromptRegistry.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/features/prompts/DefaultPromptRegistry.java
@@ -172,20 +172,21 @@ public class DefaultPromptRegistry extends AbstractRegistry<PromptDescriptor, Pr
             if (extId != null && !context.isExtensionEnabled(extId)) {
                 return CompletableFuture.completedFuture(ServerErrors.invalidRequest("Prompt not found"));
             }
+            Map<String, JsonNode> argsMap;
+            try {
+                argsMap = extractArgumentsMap(params);
+            } catch (RuntimeException e) {
+                return CompletableFuture.completedFuture(ServerErrors.invalidParams("Invalid arguments"));
+            }
+
             var inputSchema = entry.descriptor().inputSchema();
             if (inputSchema != null) {
-                Map<String, JsonNode> argsMap;
-                try {
-                    argsMap = extractArgumentsMap(params);
-                } catch (RuntimeException e) {
-                    return CompletableFuture.completedFuture(ServerErrors.invalidParams("Invalid arguments"));
-                }
                 var error = JsonSchemaUtils.validateArguments(validator, inputSchema, argsMap);
                 if (error != null) return CompletableFuture.completedFuture(ServerErrors.invalidParams(error));
             }
 
             var request = new PromptRequest(
-                    extractArguments(params),
+                    argsMap != null ? Args.of(JsonUtils.toObjectMap(argsMap)) : Args.empty(),
                     extractInputResponsesFromParams(params),
                     extractRequestStateFromParams(params));
 
@@ -217,11 +218,6 @@ public class DefaultPromptRegistry extends AbstractRegistry<PromptDescriptor, Pr
                                 context.responseMapper().inputRequiredResult(ir.inputRequests(), ir.requestState());
                         };
                     });
-        }
-
-        private static Args extractArguments(Object params) {
-            var argsMap = extractArgumentsMap(params);
-            return argsMap != null ? Args.of(JsonUtils.toObjectMap(argsMap)) : Args.empty();
         }
 
         private static @Nullable Map<String, JsonNode> extractArgumentsMap(Object params) {

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/features/prompts/DefaultPromptRegistry.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/features/prompts/DefaultPromptRegistry.java
@@ -4,6 +4,7 @@ package dev.tachyonmcp.core.server.features.prompts;
 import dev.tachyonmcp.api.annotations.InternalApi;
 import dev.tachyonmcp.api.json.JsonSchemaValidator;
 import dev.tachyonmcp.api.server.config.Mode;
+import dev.tachyonmcp.api.server.domain.Args;
 import dev.tachyonmcp.api.server.domain.PromptMessage;
 import dev.tachyonmcp.api.server.domain.ServerError;
 import dev.tachyonmcp.api.server.features.HandlerFutures;
@@ -218,14 +219,9 @@ public class DefaultPromptRegistry extends AbstractRegistry<PromptDescriptor, Pr
                     });
         }
 
-        private static @Nullable String extractArguments(Object params) {
-            if (params instanceof GetPromptRequestParams p && p.arguments() != null) {
-                return JsonRpcCodec.writeValueAsString(p.arguments());
-            }
-            if (params instanceof Map<?, ?> map && map.get("arguments") instanceof Map<?, ?> args) {
-                return JsonRpcCodec.writeValueAsString(args);
-            }
-            return null;
+        private static Args extractArguments(Object params) {
+            var argsMap = extractArgumentsMap(params);
+            return argsMap != null ? Args.of(JsonUtils.toObjectMap(argsMap)) : Args.empty();
         }
 
         private static @Nullable Map<String, JsonNode> extractArgumentsMap(Object params) {

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/package-info.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/package-info.java
@@ -6,8 +6,6 @@
  * Server classes
  */
 @NullMarked
-@InternalApi
 package dev.tachyonmcp.core.server;
 
-import dev.tachyonmcp.api.annotations.InternalApi;
 import org.jspecify.annotations.NullMarked;

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/session/DefaultDispatchContext.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/session/DefaultDispatchContext.java
@@ -3,6 +3,7 @@ package dev.tachyonmcp.core.server.session;
 
 import dev.tachyonmcp.api.annotations.InternalApi;
 import dev.tachyonmcp.api.runtime.AttributeKey;
+import dev.tachyonmcp.api.runtime.ClientContext;
 import dev.tachyonmcp.api.runtime.ContextNotifications;
 import dev.tachyonmcp.api.server.domain.LoggingLevel;
 import dev.tachyonmcp.api.server.domain.ProgressToken;
@@ -150,6 +151,11 @@ public class DefaultDispatchContext implements DispatchContext {
                     new IllegalStateException("Server-to-client requests require a session (stateless mode)"));
         }
         return server.sendRequest(s, method, params, outboundStream);
+    }
+
+    @Override
+    public ClientContext client() {
+        return new WireClientContext(this);
     }
 
     @Override

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/session/NoopInteractionContext.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/session/NoopInteractionContext.java
@@ -3,6 +3,7 @@ package dev.tachyonmcp.core.server.session;
 
 import dev.tachyonmcp.api.annotations.InternalApi;
 import dev.tachyonmcp.api.runtime.AttributeKey;
+import dev.tachyonmcp.api.runtime.ClientContext;
 import dev.tachyonmcp.api.runtime.ContextNotifications;
 import dev.tachyonmcp.api.server.domain.LoggingLevel;
 import dev.tachyonmcp.core.protocol.Protocol;
@@ -67,6 +68,11 @@ public class NoopInteractionContext implements DispatchContext {
     @Override
     public CompletableFuture<String> sendRequest(String method, Object params) {
         return CompletableFuture.failedFuture(new UnsupportedOperationException("sendRequest"));
+    }
+
+    @Override
+    public ClientContext client() {
+        return new WireClientContext(this);
     }
 
     @Override

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/session/WireClientContext.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/session/WireClientContext.java
@@ -1,0 +1,70 @@
+/* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
+package dev.tachyonmcp.core.server.session;
+
+import dev.tachyonmcp.api.annotations.InternalApi;
+import dev.tachyonmcp.api.runtime.ClientContext;
+import dev.tachyonmcp.api.runtime.ElicitationRequest;
+import dev.tachyonmcp.api.runtime.ElicitationResult;
+import dev.tachyonmcp.api.runtime.ElicitationService;
+import dev.tachyonmcp.api.runtime.InteractionContext;
+import dev.tachyonmcp.api.runtime.SamplingService;
+import dev.tachyonmcp.api.server.domain.Args;
+import dev.tachyonmcp.core.transport.jsonrpc.JsonRpcCodec;
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Adapts {@link InteractionContext#sendRequest(String, Object)} into the typed {@link
+ * ElicitationService}/{@link SamplingService} surface, building wire-shaped params and parsing raw
+ * JSON responses back into domain types.
+ */
+@InternalApi
+public final class WireClientContext implements ClientContext, ElicitationService, SamplingService {
+
+    private final InteractionContext ctx;
+
+    public WireClientContext(InteractionContext ctx) {
+        this.ctx = ctx;
+    }
+
+    @Override
+    public ElicitationService elicitation() {
+        return this;
+    }
+
+    @Override
+    public SamplingService sampling() {
+        return this;
+    }
+
+    @Override
+    public CompletableFuture<ElicitationResult> create(ElicitationRequest request) {
+        var params = new LinkedHashMap<String, Object>();
+        params.put("mode", "form");
+        params.put("message", request.message());
+        params.put(
+                "requestedSchema",
+                JsonRpcCodec.readValue(request.requestedSchema().json()));
+        return ctx.sendRequest("elicitation/create", params).thenApply(WireClientContext::toElicitationResult);
+    }
+
+    @Override
+    public CompletableFuture<Args> createMessage(Args params) {
+        return ctx.sendRequest("sampling/createMessage", params.asMap()).thenApply(WireClientContext::toArgs);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static ElicitationResult toElicitationResult(String json) {
+        var map = (Map<String, Object>) JsonRpcCodec.readValue(json);
+        var action = ElicitationResult.Action.valueOf(((String) map.get("action")).toUpperCase(Locale.ROOT));
+        var content = map.get("content");
+        return new ElicitationResult(action, content instanceof Map<?, ?> cm ? Args.of((Map<String, ?>) cm) : null);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Args toArgs(String json) {
+        return Args.of((Map<String, Object>) JsonRpcCodec.readValue(json));
+    }
+}

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/session/WireClientContext.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/session/WireClientContext.java
@@ -1,6 +1,7 @@
 /* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
 package dev.tachyonmcp.core.server.session;
 
+import dev.tachyonmcp.api.annotations.ExperimentalApi;
 import dev.tachyonmcp.api.annotations.InternalApi;
 import dev.tachyonmcp.api.runtime.ClientContext;
 import dev.tachyonmcp.api.runtime.ElicitationRequest;
@@ -35,6 +36,7 @@ public final class WireClientContext implements ClientContext, ElicitationServic
     }
 
     @Override
+    @ExperimentalApi
     public SamplingService sampling() {
         return this;
     }
@@ -60,6 +62,10 @@ public final class WireClientContext implements ClientContext, ElicitationServic
         var map = (Map<String, Object>) JsonRpcCodec.readValue(json);
         var action = ElicitationResult.Action.valueOf(((String) map.get("action")).toUpperCase(Locale.ROOT));
         var content = map.get("content");
+        if (action == ElicitationResult.Action.ACCEPT && !(content instanceof Map<?, ?>)) {
+            throw new IllegalArgumentException(
+                    "elicitation/create response with action=ACCEPT must include an object 'content', got: " + content);
+        }
         return new ElicitationResult(action, content instanceof Map<?, ?> cm ? Args.of((Map<String, ?>) cm) : null);
     }
 

--- a/tachyon-core/src/test/java/dev/tachyonmcp/core/server/features/prompts/DefaultPromptRegistryTest.java
+++ b/tachyon-core/src/test/java/dev/tachyonmcp/core/server/features/prompts/DefaultPromptRegistryTest.java
@@ -239,6 +239,19 @@ class DefaultPromptRegistryTest {
     }
 
     @Test
+    void shouldReturnInvalidParamsForBadArgumentsWithoutSchema() throws Exception {
+        registry.register(PromptDescriptor.of("no-schema", "No schema prompt"), List.of(PromptMessage.user("Hi")));
+
+        var result = handlers.get("prompts/get")
+                .handle(
+                        DefaultDispatchContext.stateless(server),
+                        Map.of("name", "no-schema", "arguments", List.of(1, 2, 3)));
+
+        assertThat(result).isInstanceOf(ServerError.class);
+        assertThat(((ServerError) result).kind()).isEqualTo(ServerError.Kind.INVALID_PARAMS);
+    }
+
+    @Test
     void shouldUseDynamicHandlerForMessages() throws Exception {
         registry.register(
                 PromptDescriptor.of("dynamic", "Dynamic prompt"),

--- a/tachyon-core/src/test/java/dev/tachyonmcp/core/server/features/prompts/DefaultPromptRegistryTest.java
+++ b/tachyon-core/src/test/java/dev/tachyonmcp/core/server/features/prompts/DefaultPromptRegistryTest.java
@@ -242,7 +242,8 @@ class DefaultPromptRegistryTest {
     void shouldUseDynamicHandlerForMessages() throws Exception {
         registry.register(
                 PromptDescriptor.of("dynamic", "Dynamic prompt"),
-                (ctx, request) -> PromptResult.messages(List.of(PromptMessage.user("args=" + request.arguments()))));
+                (ctx, request) -> PromptResult.messages(
+                        List.of(PromptMessage.user("args=" + request.arguments().json()))));
 
         var result = (GetPromptResult)
                 handlers.get("prompts/get").handle(DefaultDispatchContext.stateless(server), Map.of("name", "dynamic"));

--- a/tachyon-core/src/test/java/dev/tachyonmcp/core/server/session/WireClientContextTest.java
+++ b/tachyon-core/src/test/java/dev/tachyonmcp/core/server/session/WireClientContextTest.java
@@ -1,0 +1,147 @@
+/* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
+package dev.tachyonmcp.core.server.session;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import dev.tachyonmcp.api.json.JsonSchema;
+import dev.tachyonmcp.api.runtime.AttributeKey;
+import dev.tachyonmcp.api.runtime.ContextNotifications;
+import dev.tachyonmcp.api.runtime.ElicitationRequest;
+import dev.tachyonmcp.api.runtime.ElicitationResult;
+import dev.tachyonmcp.api.runtime.InteractionContext;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import org.junit.jupiter.api.Test;
+
+class WireClientContextTest {
+
+    private static WireClientContext contextReturning(String rawJsonResponse) {
+        return new WireClientContext(new StubInteractionContext(rawJsonResponse));
+    }
+
+    private static CompletableFuture<ElicitationResult> create(WireClientContext ctx) {
+        return ctx.elicitation().create(new ElicitationRequest("please fill this in", JsonSchema.objectSchema()));
+    }
+
+    @Test
+    void acceptWithObjectContent_returnsElicitationResultWithContent() throws Exception {
+        var ctx = contextReturning("""
+            {"action":"accept","content":{"name":"Ada"}}""");
+
+        var result = create(ctx).get();
+
+        assertThat(result.action()).isEqualTo(ElicitationResult.Action.ACCEPT);
+        assertThat(result.content()).isNotNull();
+        assertThat(result.content().asMap()).containsEntry("name", "Ada");
+    }
+
+    @Test
+    void acceptWithMissingContent_failsInsteadOfReturningNullContent() {
+        var ctx = contextReturning("""
+            {"action":"accept"}""");
+
+        assertThatThrownBy(() -> create(ctx).get())
+                .isInstanceOf(ExecutionException.class)
+                .cause()
+                .isInstanceOfAny(IllegalArgumentException.class, IllegalStateException.class);
+    }
+
+    @Test
+    void acceptWithNullContent_failsInsteadOfReturningNullContent() {
+        var ctx = contextReturning("""
+            {"action":"accept","content":null}""");
+
+        assertThatThrownBy(() -> create(ctx).get())
+                .isInstanceOf(ExecutionException.class)
+                .cause()
+                .isInstanceOfAny(IllegalArgumentException.class, IllegalStateException.class);
+    }
+
+    @Test
+    void acceptWithNonObjectContent_failsInsteadOfReturningNullContent() {
+        var ctx = contextReturning("""
+            {"action":"accept","content":"not-an-object"}""");
+
+        assertThatThrownBy(() -> create(ctx).get())
+                .isInstanceOf(ExecutionException.class)
+                .cause()
+                .isInstanceOfAny(IllegalArgumentException.class, IllegalStateException.class);
+    }
+
+    @Test
+    void decline_returnsResultWithNullContentWithoutValidation() throws Exception {
+        var ctx = contextReturning("""
+            {"action":"decline"}""");
+
+        var result = create(ctx).get();
+
+        assertThat(result.action()).isEqualTo(ElicitationResult.Action.DECLINE);
+        assertThat(result.content()).isNull();
+    }
+
+    @Test
+    void cancel_returnsResultWithNullContentWithoutValidation() throws Exception {
+        var ctx = contextReturning("""
+            {"action":"cancel"}""");
+
+        var result = create(ctx).get();
+
+        assertThat(result.action()).isEqualTo(ElicitationResult.Action.CANCEL);
+        assertThat(result.content()).isNull();
+    }
+
+    private static final class StubInteractionContext implements InteractionContext {
+        private final String response;
+
+        StubInteractionContext(String response) {
+            this.response = response;
+        }
+
+        @Override
+        public String protocolVersion() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Lifecycle lifecycle() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String sessionId() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean isExtensionEnabled(String extensionId) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ContextNotifications notifications() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public dev.tachyonmcp.api.runtime.ClientContext client() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public CompletableFuture<String> sendRequest(String method, Object params) {
+            return CompletableFuture.completedFuture(response);
+        }
+
+        @Override
+        public <T> Optional<T> get(AttributeKey<T> key) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public <T> void set(AttributeKey<T> key, T value) {
+            throw new UnsupportedOperationException();
+        }
+    }
+}

--- a/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/config/PromptScope.kt
+++ b/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/config/PromptScope.kt
@@ -4,6 +4,7 @@
 package dev.tachyonmcp.kotlin.server.config
 
 import dev.tachyonmcp.api.runtime.InteractionContext
+import dev.tachyonmcp.api.server.domain.Args
 import dev.tachyonmcp.api.server.domain.PromptMessage
 import dev.tachyonmcp.api.server.features.prompts.PromptRequest
 import dev.tachyonmcp.kotlin.server.TachyonDsl
@@ -15,9 +16,9 @@ public class PromptScope
         public val request: PromptRequest,
     ) {
         /**
-         * Convenience access to the prompt arguments string or null.
+         * Convenience access to the prompt arguments.
          */
-        public val arguments: String?
+        public val arguments: Args
             get() = request.arguments()
 
         /**

--- a/tachyon-kotlin/src/test/kotlin/dev/tachyonmcp/kotlin/server/KotlinApiTest.kt
+++ b/tachyon-kotlin/src/test/kotlin/dev/tachyonmcp/kotlin/server/KotlinApiTest.kt
@@ -425,7 +425,7 @@ internal class KotlinApiTest {
     @Test
     fun `PromptScope content DSL builds one user message per block`() {
         withStatelessContext { ctx ->
-            val request = PromptRequest(null, null, null)
+            val request = PromptRequest(Args.empty(), null, null)
             val scope = PromptScope(ctx, request = request)
             val messages =
                 scope.content {

--- a/tachyon-kotlin/src/test/kotlin/dev/tachyonmcp/kotlin/server/TachyonServerTest.kt
+++ b/tachyon-kotlin/src/test/kotlin/dev/tachyonmcp/kotlin/server/TachyonServerTest.kt
@@ -132,7 +132,7 @@ internal class TachyonServerTest {
                     listOf(
                         PromptMessage(
                             role = Role.USER,
-                            TextContent("Hello, ${arguments ?: "world"}!"),
+                            TextContent("Hello, ${arguments.stringOr("name", "world")}!"),
                         ),
                     )
                 }
@@ -431,7 +431,7 @@ internal class TachyonServerTest {
                 listOf(
                     PromptMessage(
                         role = Role.USER,
-                        TextContent("styled: ${arguments ?: "none"}"),
+                        TextContent("styled: ${arguments.stringOr("style", "none")}"),
                     ),
                 )
             }


### PR DESCRIPTION
## Summary

The PR adds typed client APIs for elicitation and sampling, backed by JSON-RPC wire handling. Prompt requests and Kotlin prompt scopes now expose `Args`, with null normalization and typed accessors. Conformance servers and weather examples migrate from manual JSON construction/parsing to typed services. Prompt handlers and tests now use explicit JSON or named argument serialization.


* **New Features**
  * Added typed client capabilities for elicitation and sampling interactions.
  * Added structured requests and results for collecting user-provided information, including acceptance, decline, and cancellation states.
  * Prompt arguments are now available as structured data across Java and Kotlin APIs.
* **Bug Fixes**
  * Improved prompt argument serialization and default-value handling for consistent generated messages.
  * Weather examples now reliably process elicited city information and handle declined or incomplete responses.

