### PR TITLE
test: Validate percent-encode illegal URI chars in UriTemplate.parse(); Use kt-schema in weather-mcp-kotlin, update docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,7 @@ mvn spotless:apply  # auto-fix
 
 ## Rules
 
+- **Unattended `git commit/push` is prohibited.** Always confirm with user.
 - TDD + SOLID. TachyonServer is SUT in unit tests.
 - **Tests**: JUnit 6 + Kotest (Kotlin) / AssertJ (Java) + Awaitility. `@TempDir` for unit, port 0 for E2E. Prefer E2E, esp. long scenarios; unit only when E2E can't cover, drop unit if E2E already does. No tautologies. Many asserts per test.
 - **Nullability**: JSpecify `@Nullable`/`@NonNull`. `@NullMarked` at package level.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -39,6 +39,12 @@ No. `JsonDocument`, `JsonObject`, `JsonArray`, and `JsonSchema` provide a neutra
 
 Attach JSON Schema to a tool descriptor. Tachyon validates input and structured output, using JSON Schema 2020-12 when the schema doesn't declare another dialect. You can replace or disable either validator through [JSON configuration](json.md#configure-schema-validation).
 
+### How do I keep Kotlin tool schemas in sync with data classes?
+
+Generate input and output schemas from Kotlin model classes instead of maintaining JSON strings.
+The [kt-schema integration guide](kt-schema-json.md) shows the complete request and structured
+response path from the runnable Weather MCP Kotlin example.
+
 ### How do I report a tool failure?
 
 Return `ToolResult.error(message)` for an expected tool-level failure. Reserve thrown exceptions for unexpected failures that the server should map to a JSON-RPC error. See

--- a/docs/json.md
+++ b/docs/json.md
@@ -42,6 +42,9 @@ JsonDocument trusted = JsonDocument.of(jsonLiteral);
 JsonDocument checked = JsonDocument.parse(externalJson);
 ```
 
+**Kotlin developers** — if you're tired of hand-writing schema strings, kt-schema can generate
+them from your data classes. See [kt-schema integration](kt-schema-json.md) for the full guide.
+
 ## Read objects and arrays
 
 Create a provider-neutral object from standard Java collections:

--- a/docs/kt-schema-json.md
+++ b/docs/kt-schema-json.md
@@ -1,0 +1,338 @@
+# Generate JSON Schema from Kotlin classes
+
+[kt-schema](https://github.com/kpavlov/kt-schema) generates
+[JSON Schema 2020-12](https://json-schema.org/draft/2020-12) from Kotlin classes at runtime.
+Use it when Kotlin models should define your tool contract. This removes hand-written schema
+strings that can drift from the handler.
+
+The runnable
+[Weather MCP Kotlin example](https://github.com/kpavlov/tachyon/tree/main/examples/weather-mcp-kotlin)
+uses the reflection generator for tool input, structured output, and elicitation schemas.
+
+## Understand the request and response path
+
+The [MCP 2026-07-28 tool specification](https://modelcontextprotocol.io/specification/2026-07-28/server/tools)
+defines two related contracts: `inputSchema` describes `tools/call` arguments, and
+`outputSchema` describes the result's `structuredContent`. Schemas without `$schema` use
+JSON Schema 2020-12, as defined by the
+[MCP JSON Schema rules](https://modelcontextprotocol.io/specification/2026-07-28/basic#json-schema-usage).
+
+Tachyon implements the contract in this order:
+
+| Phase | MCP data | Tachyon code |
+|---|---|---|
+| Discovery | `tools/list` returns `inputSchema` and `outputSchema` | `ToolDescriptor` |
+| Request | `tools/call.params.arguments` | Validated before the handler, then exposed by `request.arguments()` |
+| Handler | Application logic returns a domain value | `ToolResult.structured(value)` |
+| Response | `result.structuredContent` | Serialized by the configured payload serde, validated against `outputSchema`, then encoded |
+| Compatibility | `result.content` contains serialized JSON text | Tachyon adds the text block when the handler doesn't provide one |
+
+Schema generation doesn't deserialize arguments. The weather handler reads its already-validated
+`Args` through `request.arguments()`. Its `WeatherObservation` result is serialized after the
+handler returns.
+
+## Add the dependencies
+
+The weather example uses kt-schema `0.7.0` with kotlinx.serialization JSON:
+
+```xml
+<properties>
+    <kotlinx-serialization-json.version>1.11.0</kotlinx-serialization-json.version>
+    <kt-schema.version>0.7.0</kt-schema.version>
+</properties>
+
+<dependencies>
+    <dependency>
+        <groupId>org.jetbrains.kotlinx</groupId>
+        <artifactId>kotlinx-serialization-json</artifactId>
+        <version>${kotlinx-serialization-json.version}</version>
+    </dependency>
+    <dependency>
+        <groupId>me.kpavlov.kt.schema</groupId>
+        <artifactId>kt-schema-generator-json-jvm</artifactId>
+        <version>${kt-schema.version}</version>
+    </dependency>
+</dependencies>
+```
+
+Add these dependencies to an existing [`tachyon-kotlin`](kotlin.md#dependency) application.
+
+## Complete weather tool integration
+
+The following code comes from `examples/weather-mcp-kotlin`. The production example keeps each
+model in its own file.
+
+### Define the input and output models
+
+`GetWeatherInput` uses `@Description` for schema descriptions and a default value for the optional
+temperature unit:
+
+```kotlin
+package com.example.weather.model
+
+import me.kpavlov.kt.schema.Description
+
+data class GetWeatherInput(
+    @Description("City name (e.g., London, Tokyo, New York)")
+    val city: String,
+    @Description("Temperature unit (default: Celsius)")
+    val units: TemperatureUnit = TemperatureUnit.Celsius,
+)
+```
+
+The enum supplies the schema values:
+
+```kotlin
+package com.example.weather.model
+
+import me.kpavlov.kt.schema.Description
+
+@Description("Unit used to represent temperature")
+enum class TemperatureUnit {
+    Celsius,
+    Fahrenheit
+}
+```
+
+The handler returns `WeatherObservation` as structured content. The example marks it
+`@Serializable` because its configured Tachyon serde is kotlinx.serialization:
+
+```kotlin
+package com.example.weather.spi
+
+import com.example.weather.model.TemperatureUnit
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class WeatherObservation(
+    val city: String,
+    val condition: String,
+    val temperature: Double,
+    val temperatureUnit: TemperatureUnit,
+    val humidity: Int,
+    val windSpeed: Double,
+)
+```
+
+### Generate both tool schemas
+
+Create one generator and use the same source models as the handler:
+
+```kotlin
+import com.example.weather.model.GetWeatherInput
+import com.example.weather.spi.WeatherObservation
+import dev.tachyonmcp.kotlin.server.features.tools.ToolDescriptor
+import me.kpavlov.kt.schema.generator.json.JsonSchemaConfig
+import me.kpavlov.kt.schema.generator.json.ReflectionClassJsonSchemaGenerator
+
+private val schemaGenerator =
+    ReflectionClassJsonSchemaGenerator(
+        json = kotlinx.serialization.json.Json { encodeDefaults = false },
+        config = JsonSchemaConfig.Default,
+    )
+
+val getWeatherToolDescriptor =
+    ToolDescriptor {
+        name = "get-weather"
+        title = "Current Weather"
+        description = "Get current weather for a city"
+        inputSchema(schemaGenerator.generateSchemaString(GetWeatherInput::class))
+        outputSchema(schemaGenerator.generateSchemaString(WeatherObservation::class))
+    }
+```
+
+`generateSchemaString` returns encoded JSON Schema. The `ToolDescriptor` builder accepts that
+string directly and Tachyon validates the schema when the tool is registered.
+
+The running weather server publishes both generated schemas through `tools/list`:
+
+<details>
+<summary>Show the complete <code>tools/list</code> JSON response</summary>
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "tools": [
+      {
+        "description": "Get current weather for a city",
+        "inputSchema": {
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
+          "$id": "com.example.weather.model.GetWeatherInput",
+          "type": "object",
+          "properties": {
+            "city": {
+              "type": "string",
+              "description": "City name (e.g., London, Tokyo, New York)"
+            },
+            "units": {
+              "$ref": "#/$defs/com.example.weather.model.TemperatureUnit",
+              "description": "Temperature unit (default: Celsius)"
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "city"
+          ],
+          "$defs": {
+            "com.example.weather.model.TemperatureUnit": {
+              "type": "string",
+              "description": "Unit used to represent temperature",
+              "enum": [
+                "Celsius",
+                "Fahrenheit"
+              ]
+            }
+          }
+        },
+        "outputSchema": {
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
+          "$id": "com.example.weather.spi.WeatherObservation",
+          "type": "object",
+          "properties": {
+            "city": {
+              "type": "string"
+            },
+            "condition": {
+              "type": "string"
+            },
+            "temperature": {
+              "type": "number"
+            },
+            "temperatureUnit": {
+              "$ref": "#/$defs/com.example.weather.model.TemperatureUnit"
+            },
+            "humidity": {
+              "type": "integer"
+            },
+            "windSpeed": {
+              "type": "number"
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "city",
+            "condition",
+            "temperature",
+            "temperatureUnit",
+            "humidity",
+            "windSpeed"
+          ],
+          "$defs": {
+            "com.example.weather.model.TemperatureUnit": {
+              "type": "string",
+              "description": "Unit used to represent temperature",
+              "enum": [
+                "Celsius",
+                "Fahrenheit"
+              ]
+            }
+          }
+        },
+        "name": "get-weather",
+        "title": "Current Weather"
+      }
+    ]
+  }
+}
+```
+
+</details>
+
+### Return the output model and register the tool
+
+The weather handler passes a `WeatherObservation` to `ToolResult.structured`:
+
+```kotlin
+fun attempt(city: String): ToolResult =
+    try {
+        ToolResult.structured(
+            fetchWithProgress(
+                ctx, progressToken, weatherService, city, temperatureUnit
+            )
+        )
+    } catch (e: Exception) {
+        if (e is CityNotFoundException) throw e
+        internalError(e)
+    }
+```
+
+The configured payload serde serializes this value. Tachyon validates the serialized value against
+the generated `outputSchema` before writing the MCP response.
+
+The server selects kotlinx.serialization and registers the generated descriptor with the handler:
+
+```kotlin
+return buildServer {
+    network { this.port = port }
+    json { serde = KxSerializationSerde.Default }
+
+    tool(getWeatherToolDescriptor) { getWeather(weatherService) }
+}
+```
+
+This gives one end-to-end contract:
+
+| Stage | Source of truth |
+|---|---|
+| Tool input schema | `GetWeatherInput` |
+| Handler arguments | `request.arguments()` |
+| Tool output schema | `WeatherObservation` |
+| Structured result | `WeatherObservation` returned through `ToolResult.structured` |
+| Payload encoding | `KxSerializationSerde.Default` |
+
+The MCP 2026-07-28 specification permits any JSON value in `structuredContent`. Tachyon currently
+accepts object-root tool output schemas and object-shaped structured results, so use a data class
+as the top-level result rather than a list or primitive.
+
+See the exact
+[`GetWeatherTool.kt`](https://github.com/kpavlov/tachyon/blob/main/examples/weather-mcp-kotlin/src/main/kotlin/com/example/weather/GetWeatherTool.kt)
+and
+[`WeatherServer.kt`](https://github.com/kpavlov/tachyon/blob/main/examples/weather-mcp-kotlin/src/main/kotlin/com/example/weather/WeatherServer.kt)
+sources for progress notifications, elicitation, resources, prompts, and error handling.
+
+## Generate other schema types
+
+The same generator creates the weather example's elicitation and prompt input schemas. APIs that
+take `JsonSchema` instead of an encoded string use `JsonSchema.parse`:
+
+```kotlin
+private val CITY_SCHEMA =
+    JsonSchema.parse(
+        schemaGenerator.generateSchemaString(CityElicitationInput::class),
+    )
+
+private data class CityElicitationInput(val city: String)
+```
+
+The generator configuration determines how Kotlin types map to JSON Schema:
+
+| Kotlin declaration | Generated schema |
+|---|---|
+| `@Description("...")` | `description` |
+| `val city: String` | Required string property |
+| `val units: TemperatureUnit = Celsius` | Optional enum property |
+| `val value: T?` | Optional nullable property |
+| `enum class` | `enum` values |
+| Nested type | `$defs` and `$ref` |
+
+The weather example uses `JsonSchemaConfig.Default`, the general-purpose JSON Schema preset.
+
+## Run the source example
+
+From the repository root:
+
+```shell
+cd examples/weather-mcp-kotlin
+./mvnw package
+java -jar target/weather-mcp-kotlin-example.jar
+```
+
+Connect an MCP client to `http://localhost:8080/mcp`, then inspect `get-weather` through
+`tools/list` or call it through `tools/call`.
+
+Next, see [JSON and JSON Schema](json.md) for validation and provider behavior,
+[Tools](tools.md) for tool contracts, the [Kotlin DSL](kotlin.md) for handler APIs, or the
+[MCP 2026-07-28 schema reference](https://modelcontextprotocol.io/specification/2026-07-28/schema)
+for wire types.

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/ResourceTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/ResourceTest.java
@@ -237,6 +237,32 @@ class ResourceTest extends AbstractStatefulMcpE2eTest {
     }
 
     @Test
+    void shouldRejectInvalidResourceUri() throws Exception {
+        startEmptyServer();
+
+        try (var client = createTestClient()) {
+            var sessionId = client.initialize();
+            var response = client.post(sessionId, """
+                {"jsonrpc":"2.0","id":2,"method":"resources/read","params":{"uri":"resource://bad uri"}}
+                """);
+
+            assertThat(response.statusCode()).isEqualTo(200);
+            // language=JSON
+            var expected = """
+                {
+                  "jsonrpc": "2.0",
+                  "id": 2,
+                  "error": {
+                    "code": -32602,
+                    "message": "Invalid resource URI"
+                  }
+                }
+                """;
+            assertThatJson(response.body()).isEqualTo(expected);
+        }
+    }
+
+    @Test
     void shouldReturnEmptyListWhenNoResources() throws Exception {
         startEmptyServer();
 

--- a/examples/weather-mcp-kotlin/README.md
+++ b/examples/weather-mcp-kotlin/README.md
@@ -19,5 +19,5 @@ Kotlin builder (`tachyon-kotlin`) with the MCP Java SDK 2.0 client in tests.
 
 ```shell
 ./mvnw package && \
-java -jar target/weather-mcp-kotlin-example-1.0-SNAPSHOT.jar
+java -jar target/weather-mcp-kotlin-example.jar
 ```

--- a/examples/weather-mcp-kotlin/pom.xml
+++ b/examples/weather-mcp-kotlin/pom.xml
@@ -18,8 +18,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>21</java.version>
         <kotlin.version>2.2.21</kotlin.version>
-<!--        <tachyon.version>1.0.0-beta.16</tachyon.version>-->
-        <tachyon.version>1.0.0-SNAPSHOT</tachyon.version>
+        <tachyon.version>1.0.0-beta.15</tachyon.version>
+<!--        <tachyon.version>1.0.0-SNAPSHOT</tachyon.version>-->
         <junit.version>6.1.2</junit.version>
         <kotest.version>6.2.1</kotest.version>
         <jackson.version>3.2.0</jackson.version>
@@ -85,21 +85,6 @@
         <dependency>
             <groupId>me.kpavlov.kt.schema</groupId>
             <artifactId>kt-schema-generator-json-jvm</artifactId>
-            <version>${kt-schema.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>me.kpavlov.kt.schema</groupId>
-            <artifactId>kt-schema-generator-core-jvm</artifactId>
-            <version>${kt-schema.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>me.kpavlov.kt.schema</groupId>
-            <artifactId>kt-schema-json-jvm</artifactId>
-            <version>${kt-schema.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>me.kpavlov.kt.schema</groupId>
-            <artifactId>kt-schema-annotations</artifactId>
             <version>${kt-schema.version}</version>
         </dependency>
 

--- a/examples/weather-mcp-kotlin/pom.xml
+++ b/examples/weather-mcp-kotlin/pom.xml
@@ -18,8 +18,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>21</java.version>
         <kotlin.version>2.2.21</kotlin.version>
-        <tachyon.version>1.0.0-beta.15</tachyon.version>
-<!--        <tachyon.version>1.0.0-SNAPSHOT</tachyon.version>-->
+<!--        <tachyon.version>1.0.0-beta.16</tachyon.version>-->
+        <tachyon.version>1.0.0-SNAPSHOT</tachyon.version>
         <junit.version>6.1.2</junit.version>
         <kotest.version>6.2.1</kotest.version>
         <jackson.version>3.2.0</jackson.version>
@@ -28,6 +28,7 @@
         <mcp-sdk.version>2.0.0</mcp-sdk.version>
         <awaitility.version>4.3.0</awaitility.version>
         <kotlinx-serialization-json.version>1.11.0</kotlinx-serialization-json.version>
+        <kt-schema.version>0.7.0</kt-schema.version>
     </properties>
 
     <dependencyManagement>
@@ -43,6 +44,13 @@
                 <groupId>org.junit</groupId>
                 <artifactId>junit-bom</artifactId>
                 <version>${junit.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-bom</artifactId>
+                <version>${kotlin.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -72,6 +80,27 @@
             <artifactId>slf4j-simple</artifactId>
             <version>${slf4j.version}</version>
             <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>me.kpavlov.kt.schema</groupId>
+            <artifactId>kt-schema-generator-json-jvm</artifactId>
+            <version>${kt-schema.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>me.kpavlov.kt.schema</groupId>
+            <artifactId>kt-schema-generator-core-jvm</artifactId>
+            <version>${kt-schema.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>me.kpavlov.kt.schema</groupId>
+            <artifactId>kt-schema-json-jvm</artifactId>
+            <version>${kt-schema.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>me.kpavlov.kt.schema</groupId>
+            <artifactId>kt-schema-annotations</artifactId>
+            <version>${kt-schema.version}</version>
         </dependency>
 
         <!-- Test -->
@@ -132,7 +161,20 @@
                 <configuration>
                     <jvmTarget>${java.version}</jvmTarget>
                     <javaParameters>true</javaParameters>
+                    <args>
+                        <arg>-Xannotation-default-target=param-property</arg>
+                    </args>
+                    <compilerPlugins>
+                        <plugin>kotlinx-serialization</plugin>
+                    </compilerPlugins>
                 </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.jetbrains.kotlin</groupId>
+                        <artifactId>kotlin-maven-serialization</artifactId>
+                        <version>${kotlin.version}</version>
+                    </dependency>
+                </dependencies>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/examples/weather-mcp-kotlin/src/main/kotlin/com/example/weather/GetWeatherTool.kt
+++ b/examples/weather-mcp-kotlin/src/main/kotlin/com/example/weather/GetWeatherTool.kt
@@ -56,21 +56,19 @@ fun ToolScope.getWeather(weatherService: WeatherService): ToolResult {
     val units = args.stringOrNull("units")
     val progressToken = request.progressToken()
     val temperatureUnit = when (units?.lowercase(Locale.getDefault())) {
-        "celsius" -> TemperatureUnit.Celsius
-        "fahrenheit" -> TemperatureUnit.Fahrenheit
+        "celsius" -> Celsius
+        "fahrenheit" -> Fahrenheit
         else -> {
-            TemperatureUnit.Celsius
+            Celsius
         }
     }
 
     fun attempt(city: String): ToolResult =
         try {
-            ToolResult.text(
-                format(
-                    fetchWithProgress(
-                        ctx, progressToken, weatherService, city, temperatureUnit
-                    ),
-                ),
+            ToolResult.structured(
+                fetchWithProgress(
+                    ctx, progressToken, weatherService, city, temperatureUnit
+                )
             )
         } catch (e: Exception) {
             if (e is CityNotFoundException) throw e

--- a/examples/weather-mcp-kotlin/src/main/kotlin/com/example/weather/GetWeatherTool.kt
+++ b/examples/weather-mcp-kotlin/src/main/kotlin/com/example/weather/GetWeatherTool.kt
@@ -2,6 +2,10 @@
 
 package com.example.weather
 
+import com.example.weather.model.GetWeatherInput
+import com.example.weather.model.TemperatureUnit
+import com.example.weather.model.TemperatureUnit.Celsius
+import com.example.weather.model.TemperatureUnit.Fahrenheit
 import com.example.weather.service.WeatherService
 import com.example.weather.spi.CityNotFoundException
 import com.example.weather.spi.WeatherObservation
@@ -10,10 +14,12 @@ import dev.tachyonmcp.api.runtime.ElicitationRequest
 import dev.tachyonmcp.api.runtime.ElicitationResult
 import dev.tachyonmcp.api.runtime.InteractionContext
 import dev.tachyonmcp.api.server.domain.ProgressToken
-import dev.tachyonmcp.api.server.features.tools.ToolDescriptor
 import dev.tachyonmcp.api.server.features.tools.ToolResult
 import dev.tachyonmcp.kotlin.server.config.ToolScope
+import dev.tachyonmcp.kotlin.server.domain.stringOrNull
 import dev.tachyonmcp.kotlin.server.features.tools.ToolDescriptor
+import me.kpavlov.kt.schema.generator.json.JsonSchemaConfig
+import me.kpavlov.kt.schema.generator.json.ReflectionClassJsonSchemaGenerator
 import org.slf4j.LoggerFactory
 import java.util.Locale
 import java.util.concurrent.TimeUnit
@@ -21,47 +27,51 @@ import java.util.concurrent.TimeoutException
 
 private val log = LoggerFactory.getLogger("com.example.weather.GetWeatherTool")
 private const val ELICITATION_TIMEOUT_SECONDS = 600L
-private val CITY_SCHEMA =
-    JsonSchema.of(
-        """{"type":"object","properties":{"city":{"type":"string","title":"City"}},"required":["city"]}""",
+
+private val schemaGenerator =
+    ReflectionClassJsonSchemaGenerator(
+        json = kotlinx.serialization.json.Json { encodeDefaults = false },
+        config = JsonSchemaConfig.Default,
     )
 
-// language=json
-private const val INPUT_SCHEMA = """
-{
-  "type": "object",
-  "properties": {
-    "city": {
-      "type": "string",
-      "description": "City name (e.g., London, Tokyo, New York)"
-    },
-    "units": {
-      "type": "string",
-      "enum": ["celsius", "fahrenheit"],
-      "description": "Temperature unit (default: celsius)"
-    }
-  },
-  "required": ["city"]
-}
-"""
+private val CITY_SCHEMA =
+    JsonSchema.parse(
+        schemaGenerator.generateSchemaString(CityElicitationInput::class),
+    )
+
+private data class CityElicitationInput(val city: String)
 
 val getWeatherToolDescriptor =
     ToolDescriptor {
         name = "get-weather"
         title = "Current Weather"
         description = "Get current weather for a city"
-        inputSchema(INPUT_SCHEMA)
+        inputSchema(schemaGenerator.generateSchemaString(GetWeatherInput::class))
+        outputSchema(schemaGenerator.generateSchemaString(WeatherObservation::class))
     }
 
 fun ToolScope.getWeather(weatherService: WeatherService): ToolResult {
     val args = request.arguments()
     val city = args.stringValue("city")
-    val units = args.stringOr("units", "celsius")
+    val units = args.stringOrNull("units")
     val progressToken = request.progressToken()
+    val temperatureUnit = when (units?.lowercase(Locale.getDefault())) {
+        "celsius" -> TemperatureUnit.Celsius
+        "fahrenheit" -> TemperatureUnit.Fahrenheit
+        else -> {
+            TemperatureUnit.Celsius
+        }
+    }
 
     fun attempt(city: String): ToolResult =
         try {
-            ToolResult.text(format(fetchWithProgress(ctx, progressToken, weatherService, city), units))
+            ToolResult.text(
+                format(
+                    fetchWithProgress(
+                        ctx, progressToken, weatherService, city, temperatureUnit
+                    ),
+                ),
+            )
         } catch (e: Exception) {
             if (e is CityNotFoundException) throw e
             internalError(e)
@@ -84,10 +94,12 @@ private fun fetchWithProgress(
     progressToken: ProgressToken?,
     weatherService: WeatherService,
     city: String,
+    temperatureUnit: TemperatureUnit,
 ): WeatherObservation {
     ctx.notifications().progress(progressToken, 0.1, 1.0, "Fetching weather for $city")
-    val weather = weatherService.currentWeather(city)
-    ctx.notifications().progress(progressToken, 1.0, 1.0, "Weather retrieved for $city")
+    val weather = weatherService.currentWeather(city, temperatureUnit)
+    ctx.notifications()
+        .progress(progressToken, 1.0, 1.0, "Weather retrieved for $city")
     return weather
 }
 
@@ -126,13 +138,16 @@ private fun elicitCity(
 
 private fun format(
     weather: WeatherObservation,
-    units: String,
 ): String {
     val temperature =
-        if (units == "celsius") {
-            "%.1f°C".format(Locale.ROOT, weather.temperatureCelsius)
-        } else {
-            "%.1f°F".format(Locale.ROOT, weather.temperatureCelsius * 9 / 5 + 32)
+        when (weather.temperatureUnit) {
+            Celsius -> {
+                "%.1f°C".format(Locale.ROOT, weather.temperature)
+            }
+
+            Fahrenheit -> {
+                "%.1f°F".format(Locale.ROOT, weather.temperature * 9 / 5 + 32)
+            }
         }
     return """
         Weather in ${weather.city}:

--- a/examples/weather-mcp-kotlin/src/main/kotlin/com/example/weather/WeatherServer.kt
+++ b/examples/weather-mcp-kotlin/src/main/kotlin/com/example/weather/WeatherServer.kt
@@ -3,6 +3,7 @@
 package com.example.weather
 
 import com.example.weather.integration.OpenMeteoProvider
+import com.example.weather.model.TemperatureUnit
 import com.example.weather.service.NarrationStyle
 import com.example.weather.service.WeatherService
 import com.example.weather.spi.CityNotFoundException
@@ -20,6 +21,8 @@ import dev.tachyonmcp.kotlin.server.domain.Annotations
 import dev.tachyonmcp.kotlin.server.domain.Icon
 import dev.tachyonmcp.kotlin.server.features.prompts.PromptDescriptor
 import dev.tachyonmcp.kotlin.server.json.KxSerializationSerde
+import me.kpavlov.kt.schema.generator.json.JsonSchemaConfig
+import me.kpavlov.kt.schema.generator.json.ReflectionClassJsonSchemaGenerator
 import org.slf4j.LoggerFactory
 import tools.jackson.databind.ObjectMapper
 import java.net.http.HttpClient
@@ -31,6 +34,14 @@ import java.util.concurrent.Executors
 private val log = LoggerFactory.getLogger("com.example.weather.WeatherServer")
 private val MAPPER = ObjectMapper()
 private val LOGO by lazy { classpathDataUri("/images/logo.png", "image/png") }
+
+private val schemaGenerator =
+    ReflectionClassJsonSchemaGenerator(
+        json = kotlinx.serialization.json.Json { encodeDefaults = false },
+        config = JsonSchemaConfig.Default,
+    )
+
+private data class NarrationStyleInput(val forecast: String, val style: NarrationStyle)
 
 fun main() {
     val server = assembleServer(8080)
@@ -106,7 +117,7 @@ fun assembleServer(
             icons = listOf(resourceIcon),
         ) {
             TextResourceContents {
-                text = asJson(weatherService.currentWeather("Tallinn"))
+                text = asJson(weatherService.currentWeather("Tallinn", TemperatureUnit.Celsius))
             }
         }
 
@@ -128,7 +139,10 @@ fun assembleServer(
             description = "Weather forecast for a city",
             mimeType = "application/json",
         ) {
-            TextResourceContents { text = handleWeatherTemplate(weatherService, param("city")) }
+            TextResourceContents {
+                text =
+                    handleWeatherTemplate(weatherService, param("city"))
+            }
         }
 
         resourceCompletion("weather://current/{city}") {
@@ -157,7 +171,8 @@ private fun rewriteForecastPromptDescriptor(): PromptDescriptor =
             description = "plain, concise, or pirate"
             required = true
         }
-        inputSchema = JsonSchema.parse(NarrationStyle.inputSchema())
+        inputSchema =
+            JsonSchema.parse(schemaGenerator.generateSchemaString(NarrationStyleInput::class))
     }
 
 private fun rewriteForecast(
@@ -184,7 +199,7 @@ private fun handleWeatherTemplate(
     city: String,
 ): String =
     try {
-        asJson(weatherService.currentWeather(city))
+        asJson(weatherService.currentWeather(city, TemperatureUnit.Celsius))
     } catch (e: CityNotFoundException) {
         throw InvalidArgumentException("city", e.message ?: "City not found: $city", e)
     } catch (e: Exception) {

--- a/examples/weather-mcp-kotlin/src/main/kotlin/com/example/weather/integration/OpenMeteoProvider.kt
+++ b/examples/weather-mcp-kotlin/src/main/kotlin/com/example/weather/integration/OpenMeteoProvider.kt
@@ -2,6 +2,7 @@
 
 package com.example.weather.integration
 
+import com.example.weather.model.TemperatureUnit
 import com.example.weather.spi.CityNotFoundException
 import com.example.weather.spi.CityProvider
 import com.example.weather.spi.WeatherCondition
@@ -21,10 +22,13 @@ class OpenMeteoProvider(
     private val httpClient: HttpClient,
 ) : WeatherProvider,
     CityProvider {
-    override fun currentWeather(city: String): WeatherObservation {
+    override fun currentWeather(
+        city: String,
+        temperatureUnit: TemperatureUnit
+    ): WeatherObservation {
         val location = location(city, get(geocodingRequest(city, count = 1)))
-        val forecast = get(forecastRequest(location))
-        return weather(city, forecast)
+        val forecast = get(forecastRequest(location, temperatureUnit))
+        return weather(city, temperatureUnit, forecast)
     }
 
     override fun searchCities(query: String): List<String> {
@@ -53,13 +57,15 @@ class OpenMeteoProvider(
 
     private fun weather(
         city: String,
+        temperatureUnit: TemperatureUnit,
         response: String,
     ): WeatherObservation {
         val current = parse(response).path("current")
         return WeatherObservation(
             city = city,
             condition = condition(current.path("weather_code").asInt()).displayName,
-            temperatureCelsius = current.path("temperature_2m").asDouble(),
+            temperature = current.path("temperature_2m").asDouble(),
+            temperatureUnit = temperatureUnit,
             humidity = current.path("relative_humidity_2m").asInt(),
             windSpeed = current.path("wind_speed_10m").asDouble(),
         )
@@ -94,11 +100,14 @@ class OpenMeteoProvider(
                 .build()
         }
 
-        private fun forecastRequest(location: Location): HttpRequest {
+        private fun forecastRequest(
+            location: Location,
+            temperatureUnit: TemperatureUnit
+        ): HttpRequest {
             val uri =
                 "$FORECAST_URL?latitude=${location.latitude}&longitude=${location.longitude}" +
                     "&current=temperature_2m,relative_humidity_2m,weather_code,wind_speed_10m" +
-                    "&wind_speed_unit=kmh"
+                    "&wind_speed_unit=kmh&temperature_unit=${temperatureUnit.name.lowercase()}"
             return HttpRequest
                 .newBuilder(URI.create(uri))
                 .timeout(REQUEST_TIMEOUT)

--- a/examples/weather-mcp-kotlin/src/main/kotlin/com/example/weather/model/GetWeatherInput.kt
+++ b/examples/weather-mcp-kotlin/src/main/kotlin/com/example/weather/model/GetWeatherInput.kt
@@ -1,0 +1,14 @@
+package com.example.weather.model
+
+import me.kpavlov.kt.schema.Description
+
+enum class TemperatureUnit {
+    celsius, fahrenheit
+}
+
+data class GetWeatherInput(
+    @Description("City name (e.g., London, Tokyo, New York)")
+    val city: String,
+    @Description("Temperature unit (default: celsius)")
+    val units: TemperatureUnit? = null,
+)

--- a/examples/weather-mcp-kotlin/src/main/kotlin/com/example/weather/model/GetWeatherInput.kt
+++ b/examples/weather-mcp-kotlin/src/main/kotlin/com/example/weather/model/GetWeatherInput.kt
@@ -2,13 +2,9 @@ package com.example.weather.model
 
 import me.kpavlov.kt.schema.Description
 
-enum class TemperatureUnit {
-    celsius, fahrenheit
-}
-
 data class GetWeatherInput(
     @Description("City name (e.g., London, Tokyo, New York)")
     val city: String,
-    @Description("Temperature unit (default: celsius)")
-    val units: TemperatureUnit? = null,
+    @Description("Temperature unit (default: Celsius)")
+    val units: TemperatureUnit = TemperatureUnit.Celsius,
 )

--- a/examples/weather-mcp-kotlin/src/main/kotlin/com/example/weather/model/TemperatureUnit.kt
+++ b/examples/weather-mcp-kotlin/src/main/kotlin/com/example/weather/model/TemperatureUnit.kt
@@ -1,0 +1,2 @@
+package com.example.weather.model
+

--- a/examples/weather-mcp-kotlin/src/main/kotlin/com/example/weather/model/TemperatureUnit.kt
+++ b/examples/weather-mcp-kotlin/src/main/kotlin/com/example/weather/model/TemperatureUnit.kt
@@ -1,2 +1,9 @@
 package com.example.weather.model
 
+import me.kpavlov.kt.schema.Description
+
+@Description("Unit used to represent temperature")
+enum class TemperatureUnit {
+    Celsius,
+    Fahrenheit
+}

--- a/examples/weather-mcp-kotlin/src/main/kotlin/com/example/weather/service/NarrationStyle.kt
+++ b/examples/weather-mcp-kotlin/src/main/kotlin/com/example/weather/service/NarrationStyle.kt
@@ -5,9 +5,9 @@ package com.example.weather.service
 enum class NarrationStyle(
     val value: String,
 ) {
-    PLAIN("plain"),
-    CONCISE("concise"),
-    PIRATE("pirate"),
+    plain("plain"),
+    concise("concise"),
+    pirate("pirate"),
     ;
 
     companion object {
@@ -16,20 +16,5 @@ enum class NarrationStyle(
         fun from(value: String): NarrationStyle =
             entries.firstOrNull { it.value == value }
                 ?: throw IllegalArgumentException("Unsupported style: $value")
-
-        fun inputSchema(): String {
-            val values = entries.joinToString(", ") { "\"${it.value}\"" }
-            // language=json
-            return """
-                {
-                  "type": "object",
-                  "properties": {
-                    "forecast": {"type": "string"},
-                    "style": {"type": "string", "enum": [$values]}
-                  },
-                  "required": ["forecast", "style"]
-                }
-                """.trimIndent()
-        }
     }
 }

--- a/examples/weather-mcp-kotlin/src/main/kotlin/com/example/weather/service/WeatherService.kt
+++ b/examples/weather-mcp-kotlin/src/main/kotlin/com/example/weather/service/WeatherService.kt
@@ -2,6 +2,7 @@
 
 package com.example.weather.service
 
+import com.example.weather.model.TemperatureUnit
 import com.example.weather.spi.CityProvider
 import com.example.weather.spi.WeatherObservation
 import com.example.weather.spi.WeatherProvider
@@ -10,7 +11,11 @@ class WeatherService(
     private val weatherProvider: WeatherProvider,
     private val cityProvider: CityProvider,
 ) {
-    fun currentWeather(city: String): WeatherObservation = weatherProvider.currentWeather(city)
+    fun currentWeather(city: String, temperatureUnit: TemperatureUnit): WeatherObservation =
+        weatherProvider.currentWeather(
+            city = city,
+            temperatureUnit = temperatureUnit
+        )
 
     fun searchCities(query: String): List<String> = cityProvider.searchCities(query)
 

--- a/examples/weather-mcp-kotlin/src/main/kotlin/com/example/weather/spi/WeatherObservation.kt
+++ b/examples/weather-mcp-kotlin/src/main/kotlin/com/example/weather/spi/WeatherObservation.kt
@@ -2,10 +2,15 @@
 
 package com.example.weather.spi
 
+import com.example.weather.model.TemperatureUnit
+import kotlinx.serialization.Serializable
+
+@Serializable
 data class WeatherObservation(
     val city: String,
     val condition: String,
-    val temperatureCelsius: Double,
+    val temperature: Double,
+    val temperatureUnit: TemperatureUnit,
     val humidity: Int,
     val windSpeed: Double,
 )

--- a/examples/weather-mcp-kotlin/src/main/kotlin/com/example/weather/spi/WeatherProvider.kt
+++ b/examples/weather-mcp-kotlin/src/main/kotlin/com/example/weather/spi/WeatherProvider.kt
@@ -2,6 +2,10 @@
 
 package com.example.weather.spi
 
+import com.example.weather.model.TemperatureUnit
+
 fun interface WeatherProvider {
-    fun currentWeather(city: String): WeatherObservation
+    fun currentWeather(city: String,
+                       temperatureUnit: TemperatureUnit
+    ): WeatherObservation
 }

--- a/examples/weather-mcp-kotlin/src/test/kotlin/com/example/weather/GetWeatherEdgeCasesTest.kt
+++ b/examples/weather-mcp-kotlin/src/test/kotlin/com/example/weather/GetWeatherEdgeCasesTest.kt
@@ -2,6 +2,7 @@
 
 package com.example.weather
 
+import com.example.weather.model.TemperatureUnit
 import com.example.weather.service.WeatherService
 import com.example.weather.spi.WeatherProvider
 import io.kotest.matchers.shouldBe
@@ -67,7 +68,7 @@ class GetWeatherEdgeCasesTest {
     @Test
     fun `returns fixed error when provider fails without leaking details`() {
         val failingProvider =
-            WeatherProvider { throw IOException("connection refused to internal-host:6443") }
+            WeatherProvider { _, _ -> throw IOException("connection refused to internal-host:6443") }
 
         val result =
             callGetWeather(WeatherService(failingProvider, TestCityProvider())) {

--- a/examples/weather-mcp-kotlin/src/test/kotlin/com/example/weather/TestWeatherProvider.kt
+++ b/examples/weather-mcp-kotlin/src/test/kotlin/com/example/weather/TestWeatherProvider.kt
@@ -2,13 +2,24 @@
 
 package com.example.weather
 
+import com.example.weather.model.TemperatureUnit
 import com.example.weather.spi.CityNotFoundException
 import com.example.weather.spi.WeatherObservation
 import com.example.weather.spi.WeatherProvider
 
 class TestWeatherProvider : WeatherProvider {
-    override fun currentWeather(city: String): WeatherObservation {
+    override fun currentWeather(
+        city: String,
+        temperatureUnit: TemperatureUnit
+    ): WeatherObservation {
         if (city == "Unknown") throw CityNotFoundException(city)
-        return WeatherObservation(city, "Clear sky", 18.5, 52, 12.0)
+        return WeatherObservation(
+            city = city,
+            condition = "Clear sky",
+            temperature = 18.5,
+            temperatureUnit = temperatureUnit,
+            humidity = 52,
+            windSpeed = 12.0
+        )
     }
 }

--- a/examples/weather-mcp-kotlin/src/test/kotlin/com/example/weather/WeatherServerTest.kt
+++ b/examples/weather-mcp-kotlin/src/test/kotlin/com/example/weather/WeatherServerTest.kt
@@ -104,7 +104,7 @@ class WeatherServerTest {
             name() shouldBe "get-weather"
             title() shouldBe "Current Weather"
             description() shouldBe "Get current weather for a city"
-            outputSchema() shouldBe null
+            outputSchema() shouldNotBe null
         }
     }
 
@@ -114,7 +114,7 @@ class WeatherServerTest {
             client.callTool(
                 CallToolRequest
                     .builder("get-weather")
-                    .arguments(mapOf("city" to "London", "units" to "celsius"))
+                    .arguments(mapOf("city" to "London", "units" to "Celsius"))
                     .build(),
             )
 

--- a/examples/weather-mcp-kotlin/src/test/kotlin/com/example/weather/WeatherServerTest.kt
+++ b/examples/weather-mcp-kotlin/src/test/kotlin/com/example/weather/WeatherServerTest.kt
@@ -118,14 +118,18 @@ class WeatherServerTest {
                     .build(),
             )
 
-        val content = result.content().first()
-        content.shouldBeInstanceOf<TextContent>()
-        val text = content.text()
-        text shouldStartWith "Weather in London:"
-        text shouldContain "Temperature:"
-        text shouldContain "°C"
-        text shouldContain "Humidity:"
-        text shouldContain "Wind:"
+        result.isError shouldNotBe true
+        result.structuredContent() shouldBe
+            mapOf(
+                "city" to "London",
+                "condition" to "Clear sky",
+                "temperature" to 18.5,
+                "temperatureUnit" to "Celsius",
+                "humidity" to 52,
+                "windSpeed" to 12.0,
+            )
+        result.content().single().shouldBeInstanceOf<TextContent>().text() shouldBe
+            """{"city":"London","condition":"Clear sky","temperature":18.5,"temperatureUnit":"Celsius","humidity":52,"windSpeed":12.0}"""
     }
 
     @Test
@@ -160,9 +164,18 @@ class WeatherServerTest {
                     .build(),
             )
 
-        val content = result.content().first()
-        content.shouldBeInstanceOf<TextContent>()
-        content.text() shouldStartWith "Weather in Tallinn:"
+        result.isError shouldNotBe true
+        result.structuredContent() shouldBe
+            mapOf(
+                "city" to "Tallinn",
+                "condition" to "Clear sky",
+                "temperature" to 18.5,
+                "temperatureUnit" to "Celsius",
+                "humidity" to 52,
+                "windSpeed" to 12.0,
+            )
+        result.content().single().shouldBeInstanceOf<TextContent>().text() shouldBe
+            """{"city":"Tallinn","condition":"Clear sky","temperature":18.5,"temperatureUnit":"Celsius","humidity":52,"windSpeed":12.0}"""
     }
 
     @Test

--- a/tachyon-api/src/main/java/dev/tachyonmcp/api/server/domain/UriTemplate.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/api/server/domain/UriTemplate.java
@@ -90,9 +90,13 @@ public final class UriTemplate {
             throw noMatch(rawUri);
         }
 
-        final var normalizedUri = normalizeUri(rawUri);
+        try {
+            new URI(rawUri);
+        } catch (URISyntaxException exception) {
+            throw noMatch(rawUri);
+        }
 
-        Matcher matcher = pattern.matcher(normalizedUri);
+        Matcher matcher = pattern.matcher(rawUri);
         if (!matcher.matches()) {
             throw noMatch(rawUri);
         }
@@ -335,64 +339,6 @@ public final class UriTemplate {
             index += Character.charCount(codePoint);
         }
         regex.append(Pattern.quote(encoded.toString()));
-    }
-
-    /**
-     * Normalizes a raw URI by encoding characters that are illegal in
-     * URIs (spaces, control characters, non-ASCII, forbidden chars) and
-     * validates the result.
-     *
-     * @param rawUri the raw URI string
-     * @return the normalized URI string with illegal characters percent-encoded
-     * @throws IllegalArgumentException if the URI is invalid
-     */
-    private static String normalizeUri(String rawUri) {
-        String normalized = encodeIllegalCharacters(rawUri);
-        try {
-            new URI(normalized);
-            return normalized;
-        } catch (URISyntaxException exception) {
-            throw noMatch(rawUri);
-        }
-    }
-
-    /**
-     * Percent-encodes characters that are illegal in URIs (spaces,
-     * control characters, non-ASCII, and characters forbidden by RFC 3986).
-     *
-     * @param rawUri the raw URI string
-     * @return the repaired URI string with illegal characters percent-encoded
-     */
-    private static String encodeIllegalCharacters(String rawUri) {
-        var result = new StringBuilder(rawUri.length() + 16);
-        for (int index = 0; index < rawUri.length(); ) {
-            int codePoint = rawUri.codePointAt(index);
-            if (codePoint <= 0x20 || codePoint == 0x7F || isForbiddenInUri(codePoint) || codePoint > 0x7F) {
-                appendPercentEncoded(result, codePoint);
-            } else {
-                result.appendCodePoint(codePoint);
-            }
-            index += Character.charCount(codePoint);
-        }
-        return result.toString();
-    }
-
-    /**
-     * Determines whether a code point is forbidden in URIs per RFC 3986.
-     *
-     * @param codePoint the Unicode code point to check
-     * @return {@code true} if the code point is forbidden, {@code false} otherwise
-     */
-    private static boolean isForbiddenInUri(int codePoint) {
-        return codePoint == '"'
-                || codePoint == '<'
-                || codePoint == '>'
-                || codePoint == '\\'
-                || codePoint == '^'
-                || codePoint == '`'
-                || codePoint == '{'
-                || codePoint == '|'
-                || codePoint == '}';
     }
 
     /**

--- a/tachyon-api/src/main/java/dev/tachyonmcp/api/server/domain/UriTemplate.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/api/server/domain/UriTemplate.java
@@ -90,13 +90,9 @@ public final class UriTemplate {
             throw noMatch(rawUri);
         }
 
-        try {
-            new URI(rawUri);
-        } catch (URISyntaxException exception) {
-            throw noMatch(rawUri);
-        }
+        final var normalizedUri = normalizeUri(rawUri);
 
-        Matcher matcher = pattern.matcher(rawUri);
+        Matcher matcher = pattern.matcher(normalizedUri);
         if (!matcher.matches()) {
             throw noMatch(rawUri);
         }
@@ -339,6 +335,64 @@ public final class UriTemplate {
             index += Character.charCount(codePoint);
         }
         regex.append(Pattern.quote(encoded.toString()));
+    }
+
+    /**
+     * Normalizes a raw URI by encoding characters that are illegal in
+     * URIs (spaces, control characters, non-ASCII, forbidden chars) and
+     * validates the result.
+     *
+     * @param rawUri the raw URI string
+     * @return the normalized URI string with illegal characters percent-encoded
+     * @throws IllegalArgumentException if the URI is invalid
+     */
+    private static String normalizeUri(String rawUri) {
+        String normalized = encodeIllegalCharacters(rawUri);
+        try {
+            new URI(normalized);
+            return normalized;
+        } catch (URISyntaxException exception) {
+            throw noMatch(rawUri);
+        }
+    }
+
+    /**
+     * Percent-encodes characters that are illegal in URIs (spaces,
+     * control characters, non-ASCII, and characters forbidden by RFC 3986).
+     *
+     * @param rawUri the raw URI string
+     * @return the repaired URI string with illegal characters percent-encoded
+     */
+    private static String encodeIllegalCharacters(String rawUri) {
+        var result = new StringBuilder(rawUri.length() + 16);
+        for (int index = 0; index < rawUri.length(); ) {
+            int codePoint = rawUri.codePointAt(index);
+            if (codePoint <= 0x20 || codePoint == 0x7F || isForbiddenInUri(codePoint) || codePoint > 0x7F) {
+                appendPercentEncoded(result, codePoint);
+            } else {
+                result.appendCodePoint(codePoint);
+            }
+            index += Character.charCount(codePoint);
+        }
+        return result.toString();
+    }
+
+    /**
+     * Determines whether a code point is forbidden in URIs per RFC 3986.
+     *
+     * @param codePoint the Unicode code point to check
+     * @return {@code true} if the code point is forbidden, {@code false} otherwise
+     */
+    private static boolean isForbiddenInUri(int codePoint) {
+        return codePoint == '"'
+                || codePoint == '<'
+                || codePoint == '>'
+                || codePoint == '\\'
+                || codePoint == '^'
+                || codePoint == '`'
+                || codePoint == '{'
+                || codePoint == '|'
+                || codePoint == '}';
     }
 
     /**

--- a/tachyon-api/src/test/java/dev/tachyonmcp/api/server/domain/UriTemplateTest.java
+++ b/tachyon-api/src/test/java/dev/tachyonmcp/api/server/domain/UriTemplateTest.java
@@ -182,38 +182,7 @@ class UriTemplateTest {
                 sequenceArguments("empty exploded path list", "X{/colors*}", "X", "colors"),
                 sequenceArguments("empty exploded matrix list", "X{;colors*}", "X", "colors"),
                 sequenceArguments("empty exploded query list", "X{?colors*}", "X", "colors"),
-                sequenceArguments("empty exploded continuation list", "X{&colors*}", "X", "colors"),
-                arguments(
-                        "percent-encoded space and unicode in weather URI",
-                        "weather://current/{city}",
-                        "weather://current/Los%20%C3%81ngeles",
-                        Map.of("city", "Los Ángeles")),
-                arguments(
-                        "raw space and raw unicode in weather URI",
-                        "weather://current/{city}",
-                        "weather://current/Los Ángeles",
-                        Map.of("city", "Los Ángeles")),
-                arguments(
-                        "raw space in path variable",
-                        "/users/{name}/profile",
-                        "/users/John Doe/profile",
-                        Map.of("name", "John Doe")),
-                arguments(
-                        "percent-encoded space in path variable",
-                        "/users/{name}/profile",
-                        "/users/John%20Doe/profile",
-                        Map.of("name", "John Doe")),
-                arguments("raw unicode city name", "/weather/{city}", "/weather/México", Map.of("city", "México")),
-                arguments(
-                        "special chars in query value",
-                        "search?q={query}",
-                        "search?q=New%20York%20%26%20LA",
-                        Map.of("query", "New York & LA")),
-                arguments(
-                        "raw space in query value",
-                        "search?q={query}",
-                        "search?q=hello world",
-                        Map.of("query", "hello world")));
+                sequenceArguments("empty exploded continuation list", "X{&colors*}", "X", "colors"));
     }
 
     private static Stream<Arguments> invalidRfc6570Templates() {

--- a/tachyon-api/src/test/java/dev/tachyonmcp/api/server/domain/UriTemplateTest.java
+++ b/tachyon-api/src/test/java/dev/tachyonmcp/api/server/domain/UriTemplateTest.java
@@ -182,7 +182,38 @@ class UriTemplateTest {
                 sequenceArguments("empty exploded path list", "X{/colors*}", "X", "colors"),
                 sequenceArguments("empty exploded matrix list", "X{;colors*}", "X", "colors"),
                 sequenceArguments("empty exploded query list", "X{?colors*}", "X", "colors"),
-                sequenceArguments("empty exploded continuation list", "X{&colors*}", "X", "colors"));
+                sequenceArguments("empty exploded continuation list", "X{&colors*}", "X", "colors"),
+                arguments(
+                        "percent-encoded space and unicode in weather URI",
+                        "weather://current/{city}",
+                        "weather://current/Los%20%C3%81ngeles",
+                        Map.of("city", "Los Ángeles")),
+                arguments(
+                        "raw space and raw unicode in weather URI",
+                        "weather://current/{city}",
+                        "weather://current/Los Ángeles",
+                        Map.of("city", "Los Ángeles")),
+                arguments(
+                        "raw space in path variable",
+                        "/users/{name}/profile",
+                        "/users/John Doe/profile",
+                        Map.of("name", "John Doe")),
+                arguments(
+                        "percent-encoded space in path variable",
+                        "/users/{name}/profile",
+                        "/users/John%20Doe/profile",
+                        Map.of("name", "John Doe")),
+                arguments("raw unicode city name", "/weather/{city}", "/weather/México", Map.of("city", "México")),
+                arguments(
+                        "special chars in query value",
+                        "search?q={query}",
+                        "search?q=New%20York%20%26%20LA",
+                        Map.of("query", "New York & LA")),
+                arguments(
+                        "raw space in query value",
+                        "search?q={query}",
+                        "search?q=hello world",
+                        Map.of("query", "hello world")));
     }
 
     private static Stream<Arguments> invalidRfc6570Templates() {

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/features/resources/DefaultResourceRegistry.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/features/resources/DefaultResourceRegistry.java
@@ -30,6 +30,8 @@ import dev.tachyonmcp.core.server.internal.ServerEngine;
 import dev.tachyonmcp.core.server.json.JsonUtils;
 import dev.tachyonmcp.core.server.session.DispatchContext;
 import dev.tachyonmcp.core.transport.jsonrpc.JsonRpcCodec;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -56,6 +58,7 @@ import tools.jackson.databind.JsonNode;
 @InternalApi
 public class DefaultResourceRegistry implements Resources {
 
+    private static final int MAX_RESOURCE_URI_LENGTH = 8_192;
     private static final Logger logger = LoggerFactory.getLogger(DefaultResourceRegistry.class);
 
     /**
@@ -101,6 +104,18 @@ public class DefaultResourceRegistry implements Resources {
      */
     private void fireOnChange() {
         changes.fireOnChange();
+    }
+
+    private static boolean isValidResourceUri(String uri) {
+        if (uri.isBlank() || uri.length() > MAX_RESOURCE_URI_LENGTH) {
+            return false;
+        }
+        try {
+            new URI(uri);
+            return true;
+        } catch (URISyntaxException ignored) {
+            return false;
+        }
     }
 
     /**
@@ -526,6 +541,9 @@ public class DefaultResourceRegistry implements Resources {
                 return CompletableFuture.completedFuture(ServerErrors.invalidRequest("Missing resource URI"));
             }
             var uri = parsed.uri();
+            if (!isValidResourceUri(uri)) {
+                return CompletableFuture.completedFuture(ServerErrors.invalidParams("Invalid resource URI"));
+            }
             var entry = registry.getByUri(uri);
             if (entry != null) {
                 var extId = entry.descriptor().extensionId();
@@ -608,6 +626,9 @@ public class DefaultResourceRegistry implements Resources {
             if (uri == null) {
                 return ServerErrors.invalidRequest("Missing resource URI");
             }
+            if (!isValidResourceUri(uri)) {
+                return ServerErrors.invalidParams("Invalid resource URI");
+            }
             var session = context.session();
             if (session == null) {
                 return ServerErrors.invalidRequest("resources/subscribe requires a session");
@@ -642,6 +663,9 @@ public class DefaultResourceRegistry implements Resources {
             var uri = extractUri(params);
             if (uri == null) {
                 return ServerErrors.invalidRequest("Missing resource URI");
+            }
+            if (!isValidResourceUri(uri)) {
+                return ServerErrors.invalidParams("Invalid resource URI");
             }
             var session = context.session();
             if (session == null) {

--- a/tachyon-core/src/test/java/dev/tachyonmcp/core/server/features/resources/DefaultResourceRegistryTest.java
+++ b/tachyon-core/src/test/java/dev/tachyonmcp/core/server/features/resources/DefaultResourceRegistryTest.java
@@ -39,6 +39,8 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class DefaultResourceRegistryTest {
 
@@ -263,6 +265,34 @@ class DefaultResourceRegistryTest {
         var result = handlers.get("resources/read").handle(DefaultDispatchContext.stateless(server), Map.of());
 
         assertThat(result).isInstanceOf(ServerError.class);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", " ", "test://bad path", "test://bad%2", "test://bad\npath"})
+    void shouldRejectInvalidReadResourceUri(String uri) throws Exception {
+        var result = handlers.get("resources/read")
+                .handle(DefaultDispatchContext.stateless(server), Map.<String, Object>of("uri", uri));
+
+        assertThat(result).isEqualTo(new ServerError(ServerError.Kind.INVALID_PARAMS, "Invalid resource URI"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"resources/subscribe", "resources/unsubscribe"})
+    void shouldRejectInvalidSubscriptionUri(String method) throws Exception {
+        var result =
+                handlers.get(method).handle(DefaultDispatchContext.stateless(server), Map.of("uri", "test://bad uri"));
+
+        assertThat(result).isEqualTo(new ServerError(ServerError.Kind.INVALID_PARAMS, "Invalid resource URI"));
+    }
+
+    @Test
+    void shouldRejectOversizedResourceUri() throws Exception {
+        var result = handlers.get("resources/read")
+                .handle(
+                        DefaultDispatchContext.stateless(server),
+                        Map.<String, Object>of("uri", "test://" + "a".repeat(8_192)));
+
+        assertThat(result).isEqualTo(new ServerError(ServerError.Kind.INVALID_PARAMS, "Invalid resource URI"));
     }
 
     @Test


### PR DESCRIPTION
### Tests

Validate percent-encode illegal URI chars in UriTemplate.parse(), added more tests.

### Examples

Use kt-schema 0.7.0 to generate JSON Schema from POJOs in weather-mcp-kotlin

- Add kt-schema dependencies (generator-json, generator-core, json, annotations)
- Create TemperatureUnit enum + GetWeatherInput data class with @description
- Replace hand-crafted INPUT_SCHEMA with schema generated from GetWeatherInput::class
- Add outputSchema generated from WeatherObservation::class
- Replace NarrationStyle.inputSchema() with generated schema from NarrationStyleInput
- Rename NarrationStyle entries to lowercase for schema-compatible enum values
- Refactor WeatherObservation to @serializable with temperatureUnit field
- Update WeatherProvider/WeatherService to pass TemperatureUnit through
- Update tests for capitalized TemperatureUnit values and ToolResult.text()

## Documentation

add kt-schema-json.md guide for generating JSON Schema from Kotlin data classes

- New guide: docs/kt-schema-json.md — tutorial covering reflection-based
  JSON Schema generation with the weather-mcp-kotlin example
- docs/json.md: add cross-reference to kt-schema-json.md in schema section