### PR TITLE
fix: accept optional 2026 clientInfo metadata

### DIFF
--- a/conformance/src/test/java/dev/tachyonmcp/conformance/EdgeServerConformanceTest.java
+++ b/conformance/src/test/java/dev/tachyonmcp/conformance/EdgeServerConformanceTest.java
@@ -9,7 +9,7 @@ class EdgeServerConformanceTest extends AbstractServerConformanceTest {
     EdgeServerConformanceTest() {
         super(
                 new EdgeConformanceServer(),
-                "0.2.0-alpha.9",
+                "0.2.0-alpha.10",
                 "conformance-baseline-0.2.yml",
                 "edge",
                 "2026-07-28",

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp20260728/MetaValidationTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp20260728/MetaValidationTest.java
@@ -10,11 +10,10 @@ import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 /**
- * MCP 2026-07-28 requires {@code _meta.io.modelcontextprotocol/protocolVersion},
- * {@code .../clientInfo}, and {@code .../clientCapabilities} on every request (SEP-2575). A request
- * missing any of them is malformed: the server must reject it with JSON-RPC {@code -32602}
- * (Invalid params) and HTTP {@code 400 Bad Request}, and the error response must still carry the
- * original request id.
+ * MCP 2026-07-28 requires {@code _meta.io.modelcontextprotocol/protocolVersion} and
+ * {@code .../clientCapabilities}; {@code .../clientInfo} is optional. A request missing a required
+ * field is malformed: the server must reject it with JSON-RPC {@code -32602} (Invalid params) and
+ * HTTP {@code 400 Bad Request}, and the error response must still carry the original request id.
  */
 class MetaValidationTest extends AbstractStatelessMcpE2eTest {
 
@@ -60,9 +59,20 @@ class MetaValidationTest extends AbstractStatelessMcpE2eTest {
     }
 
     @Test
-    void rejectsMissingClientInfo() throws Exception {
+    void acceptsMissingClientInfo() throws Exception {
+        var response = postToolsCall("""
+                "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+                "io.modelcontextprotocol/clientCapabilities": {}
+                """);
+        assertThat(response.statusCode()).as(response.body()).isEqualTo(200);
+        assertThatJson(response.body()).inPath("$.result.content[0].text").isEqualTo("hi");
+    }
+
+    @Test
+    void rejectsMalformedClientInfo() throws Exception {
         assertRejected(postToolsCall("""
                 "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+                "io.modelcontextprotocol/clientInfo": {},
                 "io.modelcontextprotocol/clientCapabilities": {}
                 """));
     }

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp20260728/MetaValidationTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp20260728/MetaValidationTest.java
@@ -78,6 +78,33 @@ class MetaValidationTest extends AbstractStatelessMcpE2eTest {
     }
 
     @Test
+    void rejectsNonObjectClientInfo() throws Exception {
+        assertRejected(postToolsCall("""
+                "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+                "io.modelcontextprotocol/clientInfo": "string-value",
+                "io.modelcontextprotocol/clientCapabilities": {}
+                """));
+    }
+
+    @Test
+    void rejectsClientInfoWithNonStringName() throws Exception {
+        assertRejected(postToolsCall("""
+                "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+                "io.modelcontextprotocol/clientInfo": {"name": 123, "version": "1"},
+                "io.modelcontextprotocol/clientCapabilities": {}
+                """));
+    }
+
+    @Test
+    void rejectsClientInfoWithNonStringVersion() throws Exception {
+        assertRejected(postToolsCall("""
+                "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+                "io.modelcontextprotocol/clientInfo": {"name": "t", "version": 456},
+                "io.modelcontextprotocol/clientCapabilities": {}
+                """));
+    }
+
+    @Test
     void rejectsMissingClientCapabilities() throws Exception {
         assertRejected(postToolsCall("""
                 "io.modelcontextprotocol/protocolVersion": "2026-07-28",

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/mcp/v2026_07_28/transport/RequestValidationHandler.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/mcp/v2026_07_28/transport/RequestValidationHandler.java
@@ -111,8 +111,11 @@ public final class RequestValidationHandler extends ChannelInboundHandlerAdapter
         if (!(meta.get(PROTOCOL_VERSION_KEY) instanceof String metaProtocolVersion)) {
             return ServerErrors.invalidParams(META + " missing required field: " + PROTOCOL_VERSION_KEY);
         }
-        if (!(meta.get(CLIENT_INFO_KEY) instanceof Map<?, ?>)) {
-            return ServerErrors.invalidParams(META + " missing required field: " + CLIENT_INFO_KEY);
+        if (meta.containsKey(CLIENT_INFO_KEY)
+                && !(meta.get(CLIENT_INFO_KEY) instanceof Map<?, ?> clientInfo
+                        && clientInfo.get("name") instanceof String
+                        && clientInfo.get("version") instanceof String)) {
+            return ServerErrors.invalidParams(META + " invalid field: " + CLIENT_INFO_KEY);
         }
         if (!(meta.get(CLIENT_CAPABILITIES_KEY) instanceof Map<?, ?>)) {
             return ServerErrors.invalidParams(META + " missing required field: " + CLIENT_CAPABILITIES_KEY);

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/handlers/InitializeHandler.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/handlers/InitializeHandler.java
@@ -74,7 +74,6 @@ public final class InitializeHandler implements RpcMethodHandler {
                         extension -> JsonUtils.parse(extension.serverSettings().values())));
     }
 
-    @SuppressWarnings("unchecked")
     private static Map<String, JsonNode> extractClientExtensions(Object params) {
         if (params instanceof InitializeRequestParams initParams) {
             if (initParams.capabilities() == null) {


### PR DESCRIPTION
## Summary

- Accept a missing io.modelcontextprotocol/clientInfo in 2026-07-28 request metadata; the field is a SHOULD, not required.
- Reject supplied clientInfo values that do not contain string name and version fields.
- Cover both cases with stateless 2026 E2E tests.

## Validation

- Not run locally, per request.
- git diff --check passed before commit.

## Scope

2025 initialize clientInfo validation is unchanged.