### PR TITLE
chore: cleanups, javadoc, codecov

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,9 @@ jobs:
           - 21
           - 25
           - 26
+        include:
+          - java: 21
+            codecov: true
     runs-on: ubuntu-latest
     timeout-minutes: 7
 
@@ -68,7 +71,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload results to Codecov
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && matrix.codecov }}
         uses: codecov/codecov-action@v7
         with:
           name: codecov-jdk${{ matrix.java }}
@@ -77,7 +80,7 @@ jobs:
           slug: kpavlov/tachyon
 
       - name: Upload test results to Codecov
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && matrix.codecov }}
         uses: codecov/codecov-action@v7
         with:
           report_type: test_results

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -1,0 +1,39 @@
+comment:
+  layout: "header, diff, flags, components"
+
+component_management:
+  default_rules:
+    statuses:
+      - type: project
+        target: auto
+        branches:
+          - "!main"
+  individual_components:
+    - component_id: tachyon-api
+      name: API
+      paths:
+        - tachyon-api/**
+    - component_id: tachyon-core
+      name: Core
+      paths:
+        - tachyon-core/**
+    - component_id: tachyon-kotlin
+      name: Kotlin DSL
+      paths:
+        - tachyon-kotlin/**
+    - component_id: tachyon-extensions
+      name: Extensions
+      paths:
+        - tachyon-extensions/**
+    - component_id: e2e
+      name: E2E Tests
+      paths:
+        - e2e/**
+    - component_id: conformance
+      name: Conformance Tests
+      paths:
+        - conformance/**
+    - component_id: examples
+      name: Examples
+      paths:
+        - examples/**

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/ProtocolRequestMapper.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/ProtocolRequestMapper.java
@@ -14,60 +14,139 @@ import java.time.Duration;
 import java.util.Map;
 import org.jspecify.annotations.Nullable;
 
-/** Maps protocol-specific request parameters to protocol-neutral domain requests. */
+/**
+ * Maps protocol-specific request parameters to protocol-neutral domain requests.
+ *
+ * <p>Each protocol version (e.g. MCP 2025-11-25) provides its own implementation, mirroring
+ * {@link ProtocolResponseMapper} on the response side.
+ */
 public interface ProtocolRequestMapper {
 
+    /**
+     * Maps pagination params ({@code cursor}, and an optional {@code limit}) into a {@link PageRequest}.
+     */
     PageRequest page(@Nullable Object params);
 
+    /**
+     * Maps {@code tools/call} params, deserializing arguments with the given {@link PayloadDeserializer}.
+     */
     ToolCallRequest callTool(@Nullable Object params, PayloadDeserializer payloadDeserializer);
 
+    /**
+     * Maps {@code prompts/get} params into a prompt name and its argument request.
+     */
     PromptCallRequest getPrompt(@Nullable Object params);
 
+    /** Maps {@code resources/read} params into a resource request. */
     ResourceRequest readResource(@Nullable Object params);
 
+    /** Maps {@code completion/complete} params into a completion reference and its request. */
     CompletionCallRequest complete(@Nullable Object params);
 
+    /** Extracts the resource {@code uri} from params. */
     String resourceUri(@Nullable Object params);
 
+    /** Extracts the {@code taskId} from params. */
     String taskId(@Nullable Object params);
 
+    /** Extracts the requested {@link LoggingLevel} from {@code logging/setLevel} params. */
     LoggingLevel loggingLevel(@Nullable Object params);
 
+    /** Maps {@code initialize} params into the client's requested extensions. */
     InitializeRequest initialize(@Nullable Object params);
 
+    /** Extracts the client's permitted {@link LoggingLevel}, or {@code null} if unset. */
     @Nullable
     LoggingLevel permittedLogLevel(@Nullable Object params);
 
+    /** Returns {@code true} when params carry a {@code _meta} entry under the given key. */
     boolean hasMetaKey(@Nullable Object params, String key);
 
+    /** Maps {@code notifications/cancelled} params, or {@code null} if the request cannot be identified. */
     @Nullable
     CancellationRequest cancellation(@Nullable Object params);
 
+    /** Maps {@code tasks/status} notification params, or {@code null} if unparseable. */
     @Nullable
     TaskStatusRequest taskStatus(@Nullable Object params);
 
+    /**
+     * A page request.
+     *
+     * @param limit  maximum number of items to return
+     * @param cursor opaque continuation token from a prior page, or {@code null} for the first page
+     */
     record PageRequest(int limit, @Nullable String cursor) {}
 
+    /**
+     * A tool call request.
+     *
+     * @param request the tool name and deserialized arguments
+     * @param taskAugmented whether the client requested task-augmented (async) execution
+     * @param taskTtl requested task retention duration, or {@code null} to use the server default
+     */
     record ToolCallRequest(
             ToolRequest request,
             boolean taskAugmented,
             @Nullable Duration taskTtl) {}
 
+    /**
+     * A prompt call request.
+     *
+     * @param name    the prompt's registered name
+     * @param request the prompt's argument request
+     */
     record PromptCallRequest(String name, PromptRequest request) {}
 
+    /**
+     * A completion request.
+     *
+     * @param reference the prompt or resource being completed
+     * @param request   the completion argument request
+     */
     record CompletionCallRequest(CompletionReference reference, CompletionRequest request) {}
 
+    /** Identifies what a completion request is completing against. */
     sealed interface CompletionReference {
+
+        /**
+         * Completion against a prompt's argument.
+         *
+         * @param name the prompt's registered name
+         */
         record Prompt(String name) implements CompletionReference {}
 
+        /**
+         * Completion against a resource template's URI variable.
+         *
+         * @param uri the resource template URI
+         */
         record Resource(String uri) implements CompletionReference {}
     }
 
+    /**
+     * An initialize request.
+     *
+     * @param extensions client-requested protocol extensions, keyed by extension name
+     */
     record InitializeRequest(Map<String, JsonObject> extensions) {}
 
+    /**
+     * A cancellation notification.
+     *
+     * @param requestId the ID of the request being cancelled
+     * @param reason optional human-readable cancellation reason, or {@code null}
+     */
     record CancellationRequest(
             RequestId requestId, @Nullable String reason) {}
 
+    /**
+     * A task status update.
+     *
+     * @param taskId the task's ID
+     * @param state the task's new state
+     * @param message optional human-readable status message, or {@code null}
+     */
     record TaskStatusRequest(
             String taskId, TaskState state, @Nullable String message) {}
 }

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/session/NoopInteractionContext.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/session/NoopInteractionContext.java
@@ -25,7 +25,7 @@ public class NoopInteractionContext implements DispatchContext {
     public static final NoopInteractionContext INSTANCE = new NoopInteractionContext();
     private static final dev.tachyonmcp.core.protocol.mcp.v2025_11_25.codecs.McpRequestMapper REQUEST_MAPPER =
             new dev.tachyonmcp.core.protocol.mcp.v2025_11_25.codecs.McpRequestMapper();
-    public static final @Nullable ProtocolResponseMapper RESPONSE_MAPPER =
+    private static final ProtocolResponseMapper RESPONSE_MAPPER =
             Objects.requireNonNull(ProtocolMappers.getMapper("mcp", McpProtocol.VERSION));
 
     @Override

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/session/NoopInteractionContext.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/session/NoopInteractionContext.java
@@ -23,6 +23,10 @@ import org.jspecify.annotations.Nullable;
 public class NoopInteractionContext implements DispatchContext {
 
     public static final NoopInteractionContext INSTANCE = new NoopInteractionContext();
+    private static final dev.tachyonmcp.core.protocol.mcp.v2025_11_25.codecs.McpRequestMapper REQUEST_MAPPER =
+            new dev.tachyonmcp.core.protocol.mcp.v2025_11_25.codecs.McpRequestMapper();
+    public static final @Nullable ProtocolResponseMapper RESPONSE_MAPPER =
+            Objects.requireNonNull(ProtocolMappers.getMapper("mcp", McpProtocol.VERSION));
 
     @Override
     public Protocol protocol() {
@@ -101,12 +105,12 @@ public class NoopInteractionContext implements DispatchContext {
 
     @Override
     public ProtocolResponseMapper responseMapper() {
-        return Objects.requireNonNull(ProtocolMappers.getMapper("mcp", McpProtocol.VERSION));
+        return RESPONSE_MAPPER;
     }
 
     @Override
     public ProtocolRequestMapper requestMapper() {
-        return new dev.tachyonmcp.core.protocol.mcp.v2025_11_25.codecs.McpRequestMapper();
+        return REQUEST_MAPPER;
     }
 
     @Override


### PR DESCRIPTION
## Summary

The build matrix now marks Java 21 for Codecov uploads, while other JDK variants skip those steps. A new Codecov configuration defines component attribution and reporting layout. Protocol request mapper documentation and formatting are expanded without changing public shapes. `NoopInteractionContext` now reuse static request and response mapper instances.

### Documentation

  * Expanded protocol mapping documentation and standardized formatting for improved maintainability.

### Chores

  * Streamlined coverage reporting to publish results from the designated Java build variant.
  * Added component-based coverage reporting configuration for clearer project and module-level insights.