### PR TITLE
feat(transport): configurable allowedHosts for DNS-rebinding protection

### DIFF
--- a/e2e/src/test/java/dev/tachyonmcp/e2e/ProgressKeepAliveTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/ProgressKeepAliveTest.java
@@ -118,6 +118,7 @@ class ProgressKeepAliveTest {
                 Duration.ofMinutes(5),
                 McpChannelInitializer.DEFAULT_MAX_CONTENT_LENGTH,
                 NettyServerConfig.buildCorsConfig(null, false, false, null),
+                null,
                 NettyIoEngine.AUTO,
                 null);
         nettyServer = new NettyServer(server, config);

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/SseHeartbeatTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/SseHeartbeatTest.java
@@ -48,6 +48,7 @@ class SseHeartbeatTest {
                 Duration.ofMinutes(5),
                 McpChannelInitializer.DEFAULT_MAX_CONTENT_LENGTH,
                 NettyServerConfig.buildCorsConfig(null, false, false, null),
+                null,
                 NettyIoEngine.AUTO,
                 null);
         nettyServer = new NettyServer(server, config);

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/DefaultTachyonServer.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/DefaultTachyonServer.java
@@ -342,6 +342,7 @@ final class DefaultTachyonServer implements ServerEngine, ExtensionContext {
                                 network.allowNullOrigin(),
                                 network.allowPrivateNetworks(),
                                 network.allowedHeaders()),
+                        network.allowedHosts(),
                         network.ioEngine(),
                         pipelineCustomizer));
         transport = netty;

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/config/NetworkConfig.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/config/NetworkConfig.java
@@ -36,6 +36,8 @@ import org.jspecify.annotations.Nullable;
  * @param allowNullOrigin    whether to allow {@code Origin: null}
  * @param allowPrivateNetworks whether to allow private network CORS
  * @param allowedHeaders     additional allowed CORS headers
+ * @param allowedHosts       additional {@code Host} authorities the DNS-rebinding guard accepts
+ *                           beyond localhost ({@code null} = localhost-only)
  * @param ioEngine           Netty I/O engine; defaults to {@link NettyIoEngine#AUTO}
  * @param heartbeatInterval  SSE heartbeat interval that keeps an upgraded stream alive (default
  *                           15s); keep below {@code readerIdleTimeout}; {@code <= 0} disables
@@ -52,6 +54,7 @@ public record NetworkConfig(
         boolean allowNullOrigin,
         boolean allowPrivateNetworks,
         @Nullable List<String> allowedHeaders,
+        @Nullable List<String> allowedHosts,
         NettyIoEngine ioEngine,
         Duration heartbeatInterval) {
 
@@ -61,6 +64,9 @@ public record NetworkConfig(
         }
         if (allowedHeaders != null) {
             allowedHeaders = List.copyOf(allowedHeaders);
+        }
+        if (allowedHosts != null) {
+            allowedHosts = List.copyOf(allowedHosts);
         }
     }
 
@@ -82,6 +88,7 @@ public record NetworkConfig(
             false,
             false,
             null,
+            null,
             NettyIoEngine.AUTO,
             DEFAULT_HEARTBEAT_INTERVAL);
 
@@ -101,6 +108,7 @@ public record NetworkConfig(
         private boolean allowNullOrigin = DEFAULT.allowNullOrigin;
         private boolean allowPrivateNetworks = DEFAULT.allowPrivateNetworks;
         private @Nullable List<String> allowedHeaders = DEFAULT.allowedHeaders;
+        private @Nullable List<String> allowedHosts = DEFAULT.allowedHosts;
         private NettyIoEngine ioEngine = DEFAULT.ioEngine;
         private Duration heartbeatInterval = DEFAULT.heartbeatInterval;
         private boolean hostPortExplicitlySet;
@@ -192,6 +200,17 @@ public record NetworkConfig(
             return this;
         }
 
+        /**
+         * Sets additional {@code Host} authorities the DNS-rebinding guard accepts beyond
+         * {@code localhost}/{@code 127.0.0.1} — e.g. {@code "host.docker.internal:8096"} for a
+         * sanctioned server reached over a Docker bridge. Entries match the request's full authority
+         * ({@code host} or {@code host:port}) and its host part, case-insensitively.
+         */
+        public Builder allowedHosts(String... hosts) {
+            this.allowedHosts = List.of(hosts);
+            return this;
+        }
+
         /** Sets the Netty I/O engine; defaults to {@link NettyIoEngine#AUTO}. */
         public Builder ioEngine(NettyIoEngine ioEngine) {
             this.ioEngine = Objects.requireNonNull(ioEngine, "ioEngine cannot be null");
@@ -222,6 +241,7 @@ public record NetworkConfig(
                     allowNullOrigin,
                     allowPrivateNetworks,
                     allowedHeaders,
+                    allowedHosts,
                     ioEngine,
                     heartbeatInterval);
         }

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/transport/netty/McpChannelInitializer.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/transport/netty/McpChannelInitializer.java
@@ -23,6 +23,7 @@ import io.netty.handler.logging.LogLevel;
 import io.netty.handler.logging.LoggingHandler;
 import io.netty.handler.timeout.IdleStateHandler;
 import java.time.Duration;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import org.jspecify.annotations.Nullable;
@@ -59,7 +60,8 @@ public class McpChannelInitializer extends ChannelInitializer<SocketChannel> {
     private final boolean stateless;
     private final EndpointValidatorHandler endpointValidatorHandler;
     private final InteractionHandler interactionHandler;
-    private static final DnsRebindingProtectionHandler DNS_REBINDING_HANDLER = new DnsRebindingProtectionHandler();
+    // Per-server, not static: carries this server's allowedHosts allowlist (DNS-rebinding protection).
+    private final DnsRebindingProtectionHandler dnsRebindingHandler;
 
     @Nullable
     private final CorsConfig corsConfig;
@@ -88,6 +90,7 @@ public class McpChannelInitializer extends ChannelInitializer<SocketChannel> {
             int maxContentLength,
             ChannelGroup childChannels,
             @Nullable CorsConfig corsConfig,
+            @Nullable List<String> allowedHosts,
             @Nullable Consumer<ChannelPipeline> pipelineCustomizer) {
         this.stateless = stateless;
         this.server = server;
@@ -95,6 +98,9 @@ public class McpChannelInitializer extends ChannelInitializer<SocketChannel> {
         this.writerIdleTimeout = writerIdleTimeout;
         this.maxContentLength = maxContentLength;
         this.corsConfig = corsConfig;
+        this.dnsRebindingHandler = allowedHosts == null
+                ? new DnsRebindingProtectionHandler()
+                : new DnsRebindingProtectionHandler(allowedHosts);
         this.pipelineCustomizer = pipelineCustomizer;
         this.childChannels = childChannels;
         this.dispatcher = new McpDispatcher(server, server.executor());
@@ -125,7 +131,7 @@ public class McpChannelInitializer extends ChannelInitializer<SocketChannel> {
         // Placed right after the codec so it governs responses from ALL downstream handlers
         // (validation handlers write before the aggregator; protocol handlers write after it).
         p.addLast("http-keep-alive", new HttpServerKeepAliveHandler());
-        p.addLast("dns-rebinding", DNS_REBINDING_HANDLER);
+        p.addLast("dns-rebinding", dnsRebindingHandler);
         if (corsConfig != null) {
             p.addLast("cors", new CorsHandler(corsConfig));
         }

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/transport/netty/NettyServer.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/transport/netty/NettyServer.java
@@ -80,6 +80,7 @@ public final class NettyServer implements Closeable {
                         config.maxContentLength(),
                         childChannels,
                         config.corsConfig(),
+                        config.allowedHosts(),
                         config.pipelineCustomizer()));
 
         try {

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/transport/netty/NettyServerConfig.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/transport/netty/NettyServerConfig.java
@@ -20,6 +20,8 @@ import org.jspecify.annotations.Nullable;
  * @param writerIdleTimeout  idle timeout for writing
  * @param maxContentLength   maximum HTTP content length in bytes
  * @param corsConfig         CORS configuration, or {@code null} for defaults
+ * @param allowedHosts       additional {@code Host} authorities the DNS-rebinding guard accepts
+ *                           beyond localhost, or {@code null} for localhost-only
  * @param ioEngine           the Netty I/O engine to use
  * @param pipelineCustomizer optional customizer for the Netty channel pipeline
  */
@@ -31,6 +33,7 @@ public record NettyServerConfig(
         Duration writerIdleTimeout,
         int maxContentLength,
         @Nullable CorsConfig corsConfig,
+        @Nullable List<String> allowedHosts,
         NettyIoEngine ioEngine,
         @Nullable Consumer<ChannelPipeline> pipelineCustomizer) {
 
@@ -68,6 +71,7 @@ public record NettyServerConfig(
                 NetworkConfig.DEFAULT_WRITER_IDLE_TIMEOUT,
                 McpChannelInitializer.DEFAULT_MAX_CONTENT_LENGTH,
                 buildCorsConfig(null, false, false, null),
+                null,
                 NettyIoEngine.AUTO,
                 null);
     }

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/transport/netty/http/DnsRebindingProtectionHandler.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/transport/netty/http/DnsRebindingProtectionHandler.java
@@ -9,6 +9,10 @@ import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponseStatus;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Guards against DNS-rebinding attacks by validating the {@code Host} and {@code Origin} headers.
@@ -16,9 +20,35 @@ import io.netty.handler.codec.http.HttpResponseStatus;
  * <p>Both headers, when present, must resolve to {@code localhost} or {@code 127.0.0.1} (any
  * scheme, any port). Requests without an {@code Origin} header (non-browser clients) are passed
  * through unchanged. Invalid requests receive {@code 403 Forbidden} and the connection is closed.
+ *
+ * <p>An optional {@code allowedHosts} allowlist extends the accepted {@code Host} authorities beyond
+ * localhost — e.g. {@code "host.docker.internal:8096"} so a sanctioned server reached over a Docker
+ * bridge is not rejected. Entries are matched case-insensitively against the request's full
+ * authority ({@code host} or {@code host:port}) and against its host part with the port stripped, so
+ * either {@code "host.docker.internal"} or {@code "host.docker.internal:8096"} accepts a request
+ * whose {@code Host} is {@code host.docker.internal:8096}. The default (empty allowlist) preserves
+ * the localhost-only behaviour.
  */
 @ChannelHandler.Sharable
 public class DnsRebindingProtectionHandler extends ChannelInboundHandlerAdapter {
+
+    private final Set<String> allowedHosts;
+
+    /** Localhost-only protection (no additional allowed hosts). */
+    public DnsRebindingProtectionHandler() {
+        this(List.of());
+    }
+
+    /**
+     * @param allowedHosts additional {@code Host} authorities to accept beyond localhost/127.0.0.1;
+     *     matched case-insensitively against the full authority and its host part
+     */
+    public DnsRebindingProtectionHandler(List<String> allowedHosts) {
+        this.allowedHosts = allowedHosts.stream()
+                .filter(h -> h != null && !h.isEmpty())
+                .map(h -> h.toLowerCase(Locale.ROOT))
+                .collect(Collectors.toUnmodifiableSet());
+    }
 
     @Override
     public void channelRead(ChannelHandlerContext ctx, Object msg) {
@@ -29,12 +59,25 @@ public class DnsRebindingProtectionHandler extends ChannelInboundHandlerAdapter 
                 return;
             }
             var host = req.headers().getAsString(HttpHeaderNames.HOST);
-            if (host != null && !host.isEmpty() && !isLocalhostAuthority(host)) {
+            if (host != null && !host.isEmpty() && !isLocalhostAuthority(host) && !isAllowedHost(host)) {
                 sendPlainTextAndClose(ctx, HttpResponseStatus.FORBIDDEN, "Forbidden");
                 return;
             }
         }
         ctx.fireChannelRead(msg);
+    }
+
+    /** Returns {@code true} when {@code authority} matches a configured allowed host. */
+    private boolean isAllowedHost(String authority) {
+        if (allowedHosts.isEmpty()) {
+            return false;
+        }
+        var lower = authority.toLowerCase(Locale.ROOT);
+        if (allowedHosts.contains(lower)) {
+            return true;
+        }
+        var hostOnly = lower.startsWith("[") ? lower : stripPort(lower);
+        return allowedHosts.contains(hostOnly);
     }
 
     /** Returns {@code true} when the origin's host part is {@code localhost} or {@code 127.0.0.1}. */

--- a/tachyon-core/src/test/java/dev/tachyonmcp/core/server/config/NetworkConfigTest.java
+++ b/tachyon-core/src/test/java/dev/tachyonmcp/core/server/config/NetworkConfigTest.java
@@ -63,6 +63,7 @@ class NetworkConfigTest {
     void directConstructionWithMutableListIsDefended() {
         var origins = new ArrayList<>(List.of("http://example.com"));
         var headers = new ArrayList<>(List.of("X-Foo"));
+        var hosts = new ArrayList<>(List.of("host.docker.internal:8096"));
         var config = new NetworkConfig(
                 "127.0.0.1",
                 8080,
@@ -74,15 +75,18 @@ class NetworkConfigTest {
                 false,
                 false,
                 headers,
+                hosts,
                 NettyIoEngine.AUTO,
                 Duration.ofSeconds(15));
 
         // Mutating the original lists must not affect the config
         origins.add("http://evil.com");
         headers.add("X-Evil");
+        hosts.add("evil.example:1");
 
         assertThat(config.allowedOrigins()).containsExactly("http://example.com");
         assertThat(config.allowedHeaders()).containsExactly("X-Foo");
+        assertThat(config.allowedHosts()).containsExactly("host.docker.internal:8096");
     }
 
     @Test

--- a/tachyon-core/src/test/java/dev/tachyonmcp/core/transport/netty/http/DnsRebindingProtectionHandlerTest.java
+++ b/tachyon-core/src/test/java/dev/tachyonmcp/core/transport/netty/http/DnsRebindingProtectionHandlerTest.java
@@ -1,0 +1,79 @@
+/* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
+package dev.tachyonmcp.core.transport.netty.http;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.http.DefaultFullHttpRequest;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpVersion;
+import java.util.List;
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.Test;
+
+class DnsRebindingProtectionHandlerTest {
+
+    private static HttpRequest requestWithHost(@Nullable String host) {
+        var req = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/mcp");
+        if (host != null) {
+            req.headers().set(HttpHeaderNames.HOST, host);
+        }
+        return req;
+    }
+
+    /** Returns the status of a rejection response written outbound, or {@code null} if none. */
+    private static @Nullable HttpResponseStatus rejectionStatus(EmbeddedChannel channel) {
+        Object out = channel.readOutbound();
+        return out instanceof HttpResponse resp ? resp.status() : null;
+    }
+
+    @Test
+    void allowsLocalhostHostByDefault() {
+        var channel = new EmbeddedChannel(new DnsRebindingProtectionHandler());
+        assertThat(channel.writeInbound(requestWithHost("localhost:8096")))
+                .as("localhost Host must pass through")
+                .isTrue();
+        assertThat(rejectionStatus(channel)).isNull();
+    }
+
+    @Test
+    void rejectsNonLocalhostHostByDefault() {
+        var channel = new EmbeddedChannel(new DnsRebindingProtectionHandler());
+        channel.writeInbound(requestWithHost("host.docker.internal:8096"));
+        assertThat(rejectionStatus(channel)).isEqualTo(HttpResponseStatus.FORBIDDEN);
+    }
+
+    @Test
+    void allowsHostOnTheAllowlist() {
+        var channel = new EmbeddedChannel(new DnsRebindingProtectionHandler(List.of("host.docker.internal:8096")));
+        assertThat(channel.writeInbound(requestWithHost("host.docker.internal:8096")))
+                .as("an allowlisted Host must pass through")
+                .isTrue();
+        assertThat(rejectionStatus(channel)).isNull();
+    }
+
+    @Test
+    void allowlistEntryWithoutPortMatchesAnyPort() {
+        var channel = new EmbeddedChannel(new DnsRebindingProtectionHandler(List.of("host.docker.internal")));
+        assertThat(channel.writeInbound(requestWithHost("host.docker.internal:8096")))
+                .isTrue();
+    }
+
+    @Test
+    void allowlistIsCaseInsensitive() {
+        var channel = new EmbeddedChannel(new DnsRebindingProtectionHandler(List.of("Host.Docker.Internal:8096")));
+        assertThat(channel.writeInbound(requestWithHost("host.docker.internal:8096")))
+                .isTrue();
+    }
+
+    @Test
+    void stillRejectsHostsNotOnTheAllowlist() {
+        var channel = new EmbeddedChannel(new DnsRebindingProtectionHandler(List.of("host.docker.internal:8096")));
+        channel.writeInbound(requestWithHost("evil.example:80"));
+        assertThat(rejectionStatus(channel)).isEqualTo(HttpResponseStatus.FORBIDDEN);
+    }
+}

--- a/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/config/NetworkScope.kt
+++ b/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/config/NetworkScope.kt
@@ -51,6 +51,13 @@ public class NetworkScope
         /** Allowed CORS headers. */
         public val allowedHeaders: MutableList<String> = mutableListOf()
 
+        /**
+         * Additional `Host` authorities the DNS-rebinding guard accepts beyond `localhost`/`127.0.0.1`
+         * — e.g. `"host.docker.internal:8096"` for a sanctioned server reached over a Docker bridge.
+         * Empty (default) keeps the localhost-only behaviour.
+         */
+        public val allowedHosts: MutableList<String> = mutableListOf()
+
         @PublishedApi
         internal fun applyTo(builder: NetworkConfig.Builder) {
             val addr = address
@@ -65,6 +72,7 @@ public class NetworkScope
             allowNullOrigin?.let(builder::allowNullOrigin)
             allowPrivateNetworks?.let(builder::allowPrivateNetworks)
             if (allowedHeaders.isNotEmpty()) builder.allowedHeaders(*allowedHeaders.toTypedArray())
+            if (allowedHosts.isNotEmpty()) builder.allowedHosts(*allowedHosts.toTypedArray())
             readerIdleTimeout?.let { builder.readerIdleTimeout(it.toJavaDuration()) }
             writerIdleTimeout?.let { builder.writerIdleTimeout(it.toJavaDuration()) }
             heartbeatInterval?.let { builder.heartbeatInterval(it.toJavaDuration()) }


### PR DESCRIPTION
## Summary

Adds a configurable `allowedHosts` allowlist to the Netty transport's DNS-rebinding protection, mirroring the official MCP SDK's `StreamableHTTPServerTransport` option.

## Motivation

`DnsRebindingProtectionHandler` validates the `Host` (and `Origin`) header and accepts only `localhost` / `127.0.0.1`, rejecting anything else with `403 Forbidden`. There is currently no way to allow an additional host. This blocks legitimate local setups where a Tachyon server is reached from another origin on the same machine — e.g. from a **Docker sandbox via `host.docker.internal:<port>`**: the container necessarily sends `Host: host.docker.internal`, so every request is rejected.

`NetworkScope`/`NetworkConfig` expose `allowedOrigins`, `allowNullOrigin`, `allowedHeaders`, `allowPrivateNetworks` — but none of those affect the `Host` check.

## What changed

- `DnsRebindingProtectionHandler` gains a constructor taking an `allowedHosts` list. A `Host` is accepted when it is localhost **or** on the list. Entries match the request's full authority (`host` or `host:port`) and its host part, case-insensitively (so either `"host.docker.internal"` or `"host.docker.internal:8096"` accepts a request whose `Host` is `host.docker.internal:8096`). The **no-arg constructor keeps the localhost-only default**, so existing behaviour is unchanged. The `Origin` check is untouched.
- Threaded through `NetworkConfig` (record + Builder `allowedHosts(...)`), `NettyServerConfig`, `NettyServer`, `McpChannelInitializer` (the handler is now a per-server instance carrying that server's allowlist), and the Kotlin `NetworkScope` DSL (`allowedHosts`).

Usage:
```kotlin
buildServer {
    network { allowedHosts.add("host.docker.internal:8096") }
    // ...
}
```
Only a sanctioned local server would set this; the protection stays fully in force for every host not listed.

## Tests

- **New** `DnsRebindingProtectionHandlerTest` (Netty `EmbeddedChannel`): localhost default accept/reject, allowlist accept, port/no-port matching, case-insensitive matching, and continued rejection of unlisted hosts. (Java's `HttpClient` forbids setting a custom `Host` header, so an `EmbeddedChannel` unit test is the clean way to exercise the `Host` path.)
- `NetworkConfigTest` extended to cover `allowedHosts` defensive copying.
- Existing e2e `DnsRebindingTest` (the `Origin` path) still passes — unchanged behaviour.

All green: handler 6/6, config 7/7, e2e 2/2.

## Compatibility

Fully backward-compatible: no config → localhost-only, exactly as before. Two record components (`NetworkConfig`, `NettyServerConfig`) gained a field; all in-tree constructors and tests are updated.
