### PR TITLE
fix(kotlin): align DSL with byte[]-canonical content API, fix stale docs

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -124,6 +124,30 @@ Guidance:
 | `allowPrivateNetworks` | `false` | Allow private-network CORS preflight |
 | `allowedHeaders` | — | Extra allowed request headers |
 
+### DNS-rebinding protection
+
+Every request's `Host` (and, when present, `Origin`) header must resolve to
+`localhost`/`127.0.0.1`, or the connection is rejected with `403 Forbidden`. `allowedHosts`
+extends the `Host` check with additional authorities — e.g. a container reaching the server
+via `host.docker.internal`. It does **not** widen the `Origin` check: a browser page on a
+non-local origin is still rejected even if `Host` is allowlisted.
+
+| Option | Default | Description |
+|---|---|---|
+| `allowedHosts` | — (localhost-only) | Extra `Host` authorities (`host` or `host:port`) accepted beyond localhost |
+
+```java
+.network(n -> n.allowedHosts("host.docker.internal:8096"))
+```
+
+```kotlin
+network { allowedHosts += "host.docker.internal:8096" }
+```
+
+Entries are bare authorities, not URLs, matched case-insensitively; an entry without a port
+matches that host on any port. See `DnsRebindingProtectionHandler`'s class docs for exact
+matching rules (bracketed IPv6, multiple/missing `Host` headers, HTTP/1.0 exemption).
+
 ## I/O engine
 
 `NettyIoEngine` selects the Netty transport:

--- a/docs/kotlin.md
+++ b/docs/kotlin.md
@@ -309,7 +309,7 @@ tool(name = "greet", inputSchema = ..., outputSchema = ...) {
 |---|---|---|
 | `ServerInfoScope` | `info { }` | `name`, `version`, `description`, `title`, `instructions` |
 | `CapabilitiesScope` | `capabilities { }` | `tools()`, `resources()`, `prompts()`, `tasks()`, `logging()`, `completions()` |
-| `NetworkScope` | `network { }` | `host`, `port`, `endpointPath`, `allowedOrigins`, `maxContentLength` |
+| `NetworkScope` | `network { }` | `host`, `port`, `endpointPath`, `allowedOrigins`, `allowedHeaders`, `allowedHosts`, `maxContentLength` |
 | `SessionScope` | `session { }` | `enabled`, `sessionTtl`, `sessionIdGenerator` |
 | `RuntimeScope` | `runtime { }` | `shutdownGracePeriod` |
 | `ToolScope` | tool lambda | `ctx`, `request` |
@@ -350,8 +350,8 @@ TachyonServer(port = 8080) {
 | `ToolResult.text(t)` | Text content block |
 | `ToolResult.error(msg)` | `isError = true` |
 | `ToolResult.content(vararg b)` | Multiple content blocks |
-| `ToolResult.of(payload)` | POJO → `structuredContent` via Jackson |
-| `ToolResult.of(payload, text)` | Structured + human-readable text |
+| `ToolResult.structured(payload)` | POJO → `structuredContent` via Jackson |
+| `ToolResult.structured(payload, text)` | Structured + human-readable text |
 | `ToolResult.empty()` | No content |
 
 `structuredContent` requires a JSON object shape. Tachyon rejects primitives and arrays at runtime.

--- a/docs/migrate-from-kotlin-mcp-to-tachyon.md
+++ b/docs/migrate-from-kotlin-mcp-to-tachyon.md
@@ -139,7 +139,7 @@ CallToolResult(content = listOf(TextContent(json)))               → ToolResult
 CallToolResult(content = listOf(TextContent(json)), isError=true) → ToolResult.error(json)
 ToolResult.raw(structuredJson, textFallback)                    // pre-serialized JSON, skips serde
 success(EchoReply(...))                                         // configured serde → structuredContent
-ToolResult.of(pojo)                                             // Jackson: POJO → structuredContent
+ToolResult.structured(pojo)                                     // Jackson: POJO → structuredContent
 ```
 
 ## 6. Schemas — three shapes, one gotcha

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -98,9 +98,7 @@ Return binary content with `BlobResourceContents`:
 ```java
 import dev.tachyonmcp.api.server.domain.BlobResourceContents;
 
-(ctx,request)->BlobResourceContents.
-
-of(request.uri(),base64Image, "image/png")
+(ctx, request) -> BlobResourceContents.of(request.uri(), imageBytes, "image/png")
 ```
 
 ## Subscribe to changes

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -115,8 +115,8 @@ hold a `CompletionStage` (a non-blocking client, another async service), return 
 | `ToolResult.text(t)`                    | Plain text response                    |
 | `ToolResult.error(msg)`                 | Error (`isError = true`)               |
 | `ToolResult.content(blocks...)`         | Multiple content blocks                |
-| `ToolResult.of(payload)`                | POJO → `structuredContent`; serialized JSON auto-added as the text block |
-| `ToolResult.of(payload, text)`          | Structured + explicit human-readable text |
+| `ToolResult.structured(payload)`        | POJO → `structuredContent`; serialized JSON auto-added as the text block |
+| `ToolResult.structured(payload, text)`  | Structured + explicit human-readable text |
 | `ToolResult.empty()`                    | No content                             |
 | `ToolResult.inputRequired(reqs, state)` | Elicitation request                    |
 

--- a/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/config/ContentScope.kt
+++ b/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/config/ContentScope.kt
@@ -28,7 +28,19 @@ public class ContentScope
             blocks += TextContent.of(text)
         }
 
-        /** Appends a base64-encoded image block. */
+        /** Appends an image block. */
+        public fun image(
+            data: ByteArray,
+            mimeType: String,
+        ) {
+            blocks += ImageContent.of(data, mimeType)
+        }
+
+        /** Appends an image block from base64-encoded data. */
+        @Deprecated(
+            "Base64-encoded String input is deprecated; pass raw bytes instead.",
+            ReplaceWith("image(Base64.getDecoder().decode(data), mimeType)", "java.util.Base64"),
+        )
         public fun image(
             data: String,
             mimeType: String,
@@ -36,7 +48,19 @@ public class ContentScope
             blocks += ImageContent.of(Base64.getDecoder().decode(data), mimeType)
         }
 
-        /** Appends a base64-encoded audio block. */
+        /** Appends an audio block. */
+        public fun audio(
+            data: ByteArray,
+            mimeType: String,
+        ) {
+            blocks += AudioContent.of(data, mimeType)
+        }
+
+        /** Appends an audio block from base64-encoded data. */
+        @Deprecated(
+            "Base64-encoded String input is deprecated; pass raw bytes instead.",
+            ReplaceWith("audio(Base64.getDecoder().decode(data), mimeType)", "java.util.Base64"),
+        )
         public fun audio(
             data: String,
             mimeType: String,

--- a/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/domain/ContentFactories.kt
+++ b/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/domain/ContentFactories.kt
@@ -112,7 +112,6 @@ public fun ImageContent(
  * @param mimeType    image format (e.g. "image/png")
  * @param annotations optional presentation hints
  * @param meta        optional request-level metadata; null to omit
- * @deprecated base64-encoded String input is deprecated since 1.0.0-beta.17; use the [ByteArray] overload
  */
 @Deprecated(
     message = "Base64-encoded String input is deprecated; pass raw bytes instead.",
@@ -138,7 +137,6 @@ public fun ImageContent(
 /**
  * Creates an [ImageContent] block from base64-encoded data using a kotlinx-serialization
  * metadata map. Requires kotlinx-serialization-json on the classpath.
- * @deprecated base64-encoded String input is deprecated since 1.0.0-beta.17; use the [ByteArray] overload
  */
 @JvmName("imageContentWithKxMeta")
 @Deprecated(
@@ -208,7 +206,6 @@ public fun AudioContent(
  * @param mimeType    audio format (e.g. "audio/mp3")
  * @param annotations optional presentation hints
  * @param meta        optional request-level metadata; null to omit
- * @deprecated base64-encoded String input is deprecated since 1.0.0-beta.17; use the [ByteArray] overload
  */
 @Deprecated(
     message = "Base64-encoded String input is deprecated; pass raw bytes instead.",
@@ -234,7 +231,6 @@ public fun AudioContent(
 /**
  * Creates an [AudioContent] block from base64-encoded data using a kotlinx-serialization
  * metadata map. Requires kotlinx-serialization-json on the classpath.
- * @deprecated base64-encoded String input is deprecated since 1.0.0-beta.17; use the [ByteArray] overload
  */
 @JvmName("audioContentWithKxMeta")
 @Deprecated(

--- a/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/domain/ResourceFactories.kt
+++ b/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/domain/ResourceFactories.kt
@@ -126,7 +126,6 @@ public fun BlobResourceContents(
  * @param mimeType MIME type of the binary data; null to omit
  * @param meta     optional request-level metadata; defaults to empty map
  * @author Konstantin Pavlov
- * @deprecated base64-encoded String input is deprecated; use the [ByteArray] overload
  */
 @Deprecated(
     message = "Base64-encoded String input is deprecated; pass raw bytes instead.",
@@ -154,7 +153,6 @@ public fun BlobResourceContents(
  * metadata map. Requires kotlinx-serialization-json on the classpath.
  *
  * @author Konstantin Pavlov
- * @deprecated base64-encoded String input is deprecated; use the [ByteArray] overload
  */
 @JvmName("blobResourceContentsWithKxMeta")
 @Deprecated(

--- a/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/domain/StructuredFactoryBuilders.kt
+++ b/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/domain/StructuredFactoryBuilders.kt
@@ -132,11 +132,7 @@ public class ImageContentBuilder
         /** Raw image bytes. */
         public var data: ByteArray? = null
 
-        /**
-         * Base64-encoded image bytes.
-         *
-         * @deprecated base64-encoded String input is deprecated; assign raw bytes to [data] instead
-         */
+        /** Base64-encoded image bytes. */
         @Deprecated(
             "Base64-encoded String input is deprecated; assign raw bytes to `data` instead.",
         )
@@ -173,11 +169,7 @@ public class AudioContentBuilder
         /** Raw audio bytes. */
         public var data: ByteArray? = null
 
-        /**
-         * Base64-encoded audio bytes.
-         *
-         * @deprecated base64-encoded String input is deprecated; assign raw bytes to [data] instead
-         */
+        /** Base64-encoded audio bytes. */
         @Deprecated(
             "Base64-encoded String input is deprecated; assign raw bytes to `data` instead.",
         )
@@ -219,11 +211,11 @@ public class BlobResourceContentsBuilder
         /** Raw resource bytes. */
         public var data: ByteArray? = null
 
-        /**
-         * Base64-encoded resource bytes.
-         *
-         * @deprecated base64-encoded String input is deprecated; assign raw bytes to [data] instead
-         */
+        /** Alias for [data]; kept for the pre-rename `blob` property name. */
+        @Deprecated("Renamed to `data`.", ReplaceWith("data"))
+        public var blob: ByteArray? by ::data
+
+        /** Base64-encoded resource bytes. */
         @Deprecated(
             "Base64-encoded String input is deprecated; assign raw bytes to `data` instead.",
         )

--- a/tachyon-kotlin/src/test/kotlin/dev/tachyonmcp/kotlin/server/KotlinApiTest.kt
+++ b/tachyon-kotlin/src/test/kotlin/dev/tachyonmcp/kotlin/server/KotlinApiTest.kt
@@ -2,6 +2,7 @@
 package dev.tachyonmcp.kotlin.server
 
 import dev.tachyonmcp.api.server.domain.Args
+import dev.tachyonmcp.api.server.domain.AudioContent
 import dev.tachyonmcp.api.server.domain.ImageContent
 import dev.tachyonmcp.api.server.domain.InvalidArgumentException
 import dev.tachyonmcp.api.server.domain.Role
@@ -383,6 +384,7 @@ internal class KotlinApiTest {
     }
 
     @Test
+    @Suppress("DEPRECATION")
     fun `content DSL collects text and image blocks into a ToolResult`() {
         withStatelessContext { ctx ->
             val request =
@@ -407,6 +409,30 @@ internal class KotlinApiTest {
     }
 
     @Test
+    fun `content DSL accepts raw byte array image and audio blocks`() {
+        withStatelessContext { ctx ->
+            val request =
+                ToolRequest
+                    .builder()
+                    .name("render")
+                    .arguments(Args.of(null, null))
+                    .build()
+            val scope = ToolScope(ctx, request = request)
+            val result =
+                scope.content {
+                    image(byteArrayOf(1, 2, 3), "image/png")
+                    audio(byteArrayOf(4, 5, 6), "audio/wav")
+                }
+            result.shouldBeInstanceOf<ToolResult.Success>()
+            assertSoftly {
+                result.content() shouldHaveSize 2
+                (result.content()[0] as ImageContent).data().toList() shouldBe listOf<Byte>(1, 2, 3)
+                (result.content()[1] as AudioContent).data().toList() shouldBe listOf<Byte>(4, 5, 6)
+            }
+        }
+    }
+
+    @Test
     fun `text DSL returns a single-block ToolResult`() {
         withStatelessContext { ctx ->
             val request =
@@ -423,6 +449,7 @@ internal class KotlinApiTest {
     }
 
     @Test
+    @Suppress("DEPRECATION")
     fun `PromptScope content DSL builds one user message per block`() {
         withStatelessContext { ctx ->
             val request = PromptRequest(Args.empty(), null, null)

--- a/tachyon-kotlin/src/test/kotlin/dev/tachyonmcp/kotlin/server/TachyonServerTest.kt
+++ b/tachyon-kotlin/src/test/kotlin/dev/tachyonmcp/kotlin/server/TachyonServerTest.kt
@@ -101,6 +101,7 @@ internal class TachyonServerTest {
                     port = 0
                     endpointPath = "/mcp"
                     allowedOrigins.add("*")
+                    allowedHosts.add("host.docker.internal:8096")
                     allowNullOrigin = true
                     allowPrivateNetworks = true
                     readerIdleTimeout = 124.seconds
@@ -184,6 +185,7 @@ internal class TachyonServerTest {
             with(config.network) {
                 host shouldBe "127.0.0.1"
                 endpointPath shouldBe "/mcp"
+                allowedHosts shouldBe listOf("host.docker.internal:8096")
                 allowNullOrigin shouldBe true
                 readerIdleTimeout shouldBe 124.seconds.toJavaDuration()
                 writerIdleTimeout shouldBe 60.seconds.toJavaDuration()


### PR DESCRIPTION
## Summary

- `ContentScope.image()`/`.audio()` were the one Kotlin DSL entry point (used inside every `ToolScope.content { }` / `PromptScope.content { }` block) left on base64 `String` after #190 made binary content `byte[]`-canonical everywhere else. Added `ByteArray` overloads as primary, deprecated the base64 `String` ones to match.
- Restored `BlobResourceContentsBuilder.blob` as a deprecated alias for the renamed `data` property, so old code gets a compile-time warning instead of a hard break — `ImageContentBuilder`/`AudioContentBuilder` already had this cushion via `dataBase64`.
- Dropped non-standard `@deprecated` KDoc tags (Kotlin/Dokka doesn't recognize the Javadoc-style tag; the real `@Deprecated` annotations already carry the message).
- Fixed docs (`kotlin.md`, `tools.md`, `resources.md`, `migrate-from-kotlin-mcp-to-tachyon.md`) still referencing the removed `ToolResult.of(...)` and base64-`String` `BlobResourceContents` factory.
- Documented `allowedHosts` (DNS-rebinding allowlist, #192) in `configuration.md` and the Kotlin scope reference table, and covered its DSL wiring in `TachyonServerTest`.


🤖 Generated with [Claude Code](https://claude.com/claude-code)