### PR TITLE
fix(tasks): don't hang task on completion failure; validate structured output on task path

### DIFF
--- a/e2e/src/test/java/dev/tachyonmcp/e2e/TaskAugmentedToolTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/TaskAugmentedToolTest.java
@@ -4,6 +4,7 @@ package dev.tachyonmcp.e2e;
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import dev.tachyonmcp.api.json.JsonSchema;
 import dev.tachyonmcp.api.json.PayloadSerializer;
 import dev.tachyonmcp.api.runtime.InteractionContext;
 import dev.tachyonmcp.api.server.domain.FormInputRequest;
@@ -14,6 +15,7 @@ import dev.tachyonmcp.api.server.features.tools.ToolDescriptor;
 import dev.tachyonmcp.api.server.features.tools.ToolRequest;
 import dev.tachyonmcp.api.server.features.tools.ToolResult;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 import net.javacrumbs.jsonunit.core.Option;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
@@ -141,6 +143,118 @@ class TaskAugmentedToolTest extends AbstractStatelessMcpE2eTest {
                       }
                     }
                     """.formatted(taskId));
+        }
+    }
+
+    @Test
+    void taskResultValidatesStructuredOutput() throws Exception {
+        // language=json
+        var outputSchema = JsonSchema.of("""
+            {"type":"object","properties":{"result":{"type":"string"}},"required":["result"]}
+            """);
+        var validationCalls = new AtomicInteger();
+        startServer(
+                b -> b.json(j -> j.outputSchemaValidator((schema, document) -> {
+                    validationCalls.incrementAndGet();
+                    return java.util.List.of();
+                })),
+                s -> s.tools()
+                        .register(
+                                ToolDescriptor.builder()
+                                        .name("validated-task-output")
+                                        .outputSchema(outputSchema)
+                                        .taskSupport(TaskSupport.OPTIONAL)
+                                        .build(),
+                                (context, request) ->
+                                        ToolResult.structured(Map.of("result", "validated"), "validated")));
+        try (var client = createTestClient()) {
+            client.initialize();
+
+            var response = client.sendRpc("""
+                {"jsonrpc":"2.0","id":2,"method":"tools/call","params":{
+                  "name":"validated-task-output","arguments":{},"task":{}}}
+                """);
+            var taskId = extractTaskId(response);
+            client.awaitTaskStatus(taskId, "completed");
+
+            var resultJson = client.sendRpc("""
+                {"jsonrpc":"2.0","id":4,"method":"tasks/result","params":{"taskId":"%s"}}
+                """.formatted(taskId));
+            assertThatJson(resultJson).isEqualTo("""
+                    {
+                      "jsonrpc": "2.0",
+                      "id": 4,
+                      "result": {
+                        "content": [{"type": "text", "text": "validated"}],
+                        "structuredContent": {"result": "validated"},
+                        "_meta": {
+                          "io.modelcontextprotocol/related-task": {"taskId": "%s"}
+                        }
+                      }
+                    }
+                    """.formatted(taskId));
+            assertThat(validationCalls.get()).isEqualTo(1);
+        }
+    }
+
+    @Test
+    void taskFailsInsteadOfHangingWhenStructuredResultCannotBeSerialized() throws Exception {
+        startServer(
+                b -> b.json(j -> j.serializer(new PayloadSerializer() {
+                    @Override
+                    public <T> String serialize(T value) {
+                        throw new RuntimeException("boom-unserializable");
+                    }
+                })),
+                s -> s.tools()
+                        .register(
+                                b -> b.name("unserializable-task-output").taskSupport(TaskSupport.OPTIONAL),
+                                (context, request) -> ToolResult.structured(new CustomPayload("task"))));
+        try (var client = createTestClient()) {
+            client.initialize();
+
+            var response = client.sendRpc("""
+                {"jsonrpc":"2.0","id":2,"method":"tools/call","params":{
+                  "name":"unserializable-task-output","arguments":{},"task":{}}}
+                """);
+            var taskId = extractTaskId(response);
+
+            // Before the fix, the failure was swallowed by a discarded CompletionStage and the
+            // task stayed in "working" forever; awaitTaskStatus times out if that regresses.
+            client.awaitTaskStatus(taskId, "failed");
+
+            var resultJson = client.sendRpc("""
+                {"jsonrpc":"2.0","id":4,"method":"tasks/result","params":{"taskId":"%s"}}
+                """.formatted(taskId));
+            assertThatJson(resultJson).node("error").isPresent();
+            assertThat(resultJson).doesNotContain("boom-unserializable");
+        }
+    }
+
+    @Test
+    void taskFailsInsteadOfHangingWhenHandlerCompletesWithNullResult() throws Exception {
+        startServerWith(s -> s.tools()
+                .registerAsync(
+                        b -> b.name("null-task-result").taskSupport(TaskSupport.OPTIONAL),
+                        (context, request) ->
+                                java.util.concurrent.CompletableFuture.<ToolResult>completedFuture(null)));
+        try (var client = createTestClient()) {
+            client.initialize();
+
+            var response = client.sendRpc("""
+                {"jsonrpc":"2.0","id":2,"method":"tools/call","params":{
+                  "name":"null-task-result","arguments":{},"task":{}}}
+                """);
+            var taskId = extractTaskId(response);
+
+            // Before the fix, a null result was silently discarded and the task stayed
+            // "working" forever; awaitTaskStatus times out if that regresses.
+            client.awaitTaskStatus(taskId, "failed");
+
+            var resultJson = client.sendRpc("""
+                {"jsonrpc":"2.0","id":4,"method":"tasks/result","params":{"taskId":"%s"}}
+                """.formatted(taskId));
+            assertThatJson(resultJson).node("error").isPresent();
         }
     }
 

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/TestMcpClient.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/TestMcpClient.java
@@ -163,7 +163,8 @@ public abstract class TestMcpClient implements Closeable {
      * Polls {@code tasks/get} until the task reaches {@code status}, then returns the last
      * response body. Fails if {@code status} is not reached within {@code timeout}.
      */
-    public String awaitTaskStatus(@Nullable String sessionId, String taskId, String status, Duration timeout) {
+    public @Nullable String awaitTaskStatus(
+            @Nullable String sessionId, String taskId, String status, Duration timeout) {
         var lastResponse = new AtomicReference<@Nullable String>();
         var nextPollInterval = new AtomicReference<>(DEFAULT_TASK_POLL_INTERVAL);
         await().alias("task %s to reach status %s".formatted(taskId, status))
@@ -183,17 +184,17 @@ public abstract class TestMcpClient implements Closeable {
     }
 
     /** {@link #awaitTaskStatus(String, String, String, Duration)} with a 5s timeout. */
-    public String awaitTaskStatus(String sessionId, String taskId, String status) {
+    public @Nullable String awaitTaskStatus(String sessionId, String taskId, String status) {
         return awaitTaskStatus(sessionId, taskId, status, Duration.ofSeconds(5));
     }
 
     /** {@link #awaitTaskStatus(String, String, String, Duration)} against the stored session. */
-    public String awaitTaskStatus(String taskId, String status, Duration timeout) {
+    public @Nullable String awaitTaskStatus(String taskId, String status, Duration timeout) {
         return awaitTaskStatus(sessionId, taskId, status, timeout);
     }
 
     /** {@link #awaitTaskStatus(String, String, String)} against the stored session, 5s timeout. */
-    public String awaitTaskStatus(String taskId, String status) {
+    public @Nullable String awaitTaskStatus(String taskId, String status) {
         return awaitTaskStatus(taskId, status, Duration.ofSeconds(5));
     }
 

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp20260728/Mcp20260728TestClient.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp20260728/Mcp20260728TestClient.java
@@ -18,7 +18,7 @@ public final class Mcp20260728TestClient extends TestMcpClient {
     }
 
     @Override
-    protected String requestBody(String body) throws Exception {
+    protected String requestBody(String body) {
         var request = MAPPER.readTree(body);
         if (!(request instanceof ObjectNode requestObject)) {
             throw new IllegalArgumentException("MCP request must be a JSON object");
@@ -33,7 +33,7 @@ public final class Mcp20260728TestClient extends TestMcpClient {
     }
 
     @Override
-    protected void configureRequest(HttpRequest.Builder builder, String body) throws Exception {
+    protected void configureRequest(HttpRequest.Builder builder, String body) {
         var request = MAPPER.readTree(body);
         var method = request.path("method").asString(null);
         if (method != null) builder.header(McpHeaderNames.MCP_METHOD, method);

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp20260728/package-info.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp20260728/package-info.java
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2026 Konstantin Pavlov and contributors.
+ */
+
+@NullMarked
+package dev.tachyonmcp.e2e.mcp20260728;
+
+import org.jspecify.annotations.NullMarked;

--- a/tachyon-api/src/main/java/dev/tachyonmcp/api/server/features/HandlerFutures.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/api/server/features/HandlerFutures.java
@@ -76,7 +76,9 @@ public final class HandlerFutures {
      * @return a new stage with the mapped result
      */
     public static <T, R> CompletionStage<R> completeOn(
-            CompletionStage<T> stage, Executor executor, BiFunction<? super T, Throwable, ? extends R> fn) {
+            CompletionStage<T> stage,
+            Executor executor,
+            BiFunction<@Nullable ? super T, @Nullable Throwable, ? extends R> fn) {
         var future = stage.toCompletableFuture();
         return future.isDone() ? future.handle(fn) : future.handleAsync(fn, executor);
     }

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/features/tools/ToolMethodHandlers.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/features/tools/ToolMethodHandlers.java
@@ -92,12 +92,12 @@ public final class ToolMethodHandlers {
         }
 
         @Override
-        public Object handle(DispatchContext context, Object params) throws Exception {
+        public @Nullable Object handle(DispatchContext context, Object params) throws Exception {
             return HandlerFutures.joinInterruptibly(handleAsync(context, params));
         }
 
         @Override
-        public CompletionStage<Object> handleAsync(DispatchContext context, Object params) {
+        public CompletionStage<@Nullable Object> handleAsync(DispatchContext context, Object params) {
             final dev.tachyonmcp.core.protocol.ProtocolRequestMapper.ToolCallRequest mapped;
             try {
                 mapped = context.requestMapper().callTool(params, payloadDeserializer);
@@ -143,13 +143,13 @@ public final class ToolMethodHandlers {
                     (toolResult, cause) -> {
                         if (cause != null) return handlerError(request.name(), cause);
                         sendLogging(context, request.name(), "completed");
-                        validateOutput(handler.descriptor().outputSchema(), toolResult);
                         return context.responseMapper()
-                                .callToolResult(JsonUtils.serializeStructured(toolResult, payloadSerializer));
+                                .callToolResult(
+                                        prepareResult(handler.descriptor().outputSchema(), toolResult));
                     });
         }
 
-        private Object dispatchTaskAugmented(
+        private @Nullable Object dispatchTaskAugmented(
                 DispatchContext context, ToolHandler handler, ToolRequest request, @Nullable Duration taskTtl) {
             sendLogging(context, request.name(), "started");
             var taskRegistry = context.engine().tasksRegistry();
@@ -200,34 +200,47 @@ public final class ToolMethodHandlers {
             });
 
             taskRegistry.registerRunning(task.id(), future);
-            future.thenAccept(toolResult -> completeTask(taskRegistry, task, toolResult));
+            HandlerFutures.completeOn(future, context.engine().executor(), (toolResult, failure) -> {
+                        if (failure == null)
+                            completeTask(
+                                    taskRegistry, task, handler.descriptor().outputSchema(), toolResult);
+                        return null;
+                    })
+                    .exceptionally(throwable -> {
+                        handleFutureFailure(taskRegistry, task, throwable);
+                        return null;
+                    });
             future.exceptionally(throwable -> {
-                var cause = HandlerFutures.unwrap(throwable);
-                if (cause instanceof CancellationException) {
-                    logger.debug("Task handler cancelled for taskId={}", task.id());
-                } else if (cause instanceof Exception exception) {
-                    handleTaskError(task, exception);
-                } else {
-                    logger.error("Non-exception throwable in task handler for taskId={}", task.id(), cause);
-                }
-                taskRegistry.unregisterRunning(task.id());
+                handleFutureFailure(taskRegistry, task, throwable);
                 return null;
             });
             return context.responseMapper().createTaskResult(task);
         }
 
-        private void completeTask(TaskRegistry taskRegistry, TaskEntry task, @Nullable ToolResult result) {
-            if (result == null) return;
-            result = JsonUtils.serializeStructured(result, payloadSerializer);
+        private void completeTask(
+                TaskRegistry taskRegistry,
+                TaskEntry task,
+                @Nullable JsonSchema outputSchema,
+                @Nullable ToolResult result) {
+            if (result == null) {
+                throw new NullPointerException("Tool handler completed task " + task.id() + " with a null result");
+            }
+            result = prepareResult(outputSchema, result);
             var meta = result.meta();
-            if (result instanceof ToolResult.Error error) {
-                task.fail(new TaskResult.Failed(error.content(), null, meta));
-            } else if (result instanceof ToolResult.Success success) {
-                task.complete(new TaskResult.Completed(success.content(), success.structuredValue(), meta));
-            } else if (result instanceof ToolResult.InputRequired inputRequired) {
-                task.requireInput(inputRequired.request(), null);
+            switch (result) {
+                case ToolResult.Error error -> task.fail(new TaskResult.Failed(error.content(), null, meta));
+                case ToolResult.Success success ->
+                    task.complete(new TaskResult.Completed(success.content(), success.structuredValue(), meta));
+                case ToolResult.InputRequired inputRequired ->
+                    task.requireInput(inputRequired.request(), "Input required");
             }
             taskRegistry.unregisterRunning(task.id());
+        }
+
+        private ToolResult prepareResult(@Nullable JsonSchema outputSchema, ToolResult result) {
+            var serialized = JsonUtils.serializeStructured(result, payloadSerializer);
+            validateOutput(outputSchema, serialized);
+            return serialized;
         }
 
         private @Nullable String validateInput(@Nullable JsonSchema schema, ToolRequest request) {
@@ -263,7 +276,17 @@ public final class ToolMethodHandlers {
             return error;
         }
 
-        private void handleTaskError(TaskEntry task, Exception exception) {
+        private void handleFutureFailure(TaskRegistry taskRegistry, TaskEntry task, Throwable throwable) {
+            var cause = HandlerFutures.unwrap(throwable);
+            if (cause instanceof CancellationException) {
+                logger.debug("Task handler cancelled for taskId={}", task.id());
+            } else {
+                handleTaskError(task, cause);
+            }
+            taskRegistry.unregisterRunning(task.id());
+        }
+
+        private void handleTaskError(TaskEntry task, Throwable exception) {
             var cause = HandlerFutures.unwrap(exception);
             var error = fromUnhandledException(cause, "Tool handler failed");
             if (error.kind() == ServerError.Kind.INVALID_PARAMS) {


### PR DESCRIPTION
## Don't hang task on completion failure; validate structured output on task path

Route failures raised while completing a task-augmented tool call (e.g. non-serializable structured output) through the same error path used for handler failures, instead of discarding the CompletionStage and leaving the task stuck in "working" forever. Also extend output-schema validation to the task-augmented tools/call path, which previously only validated the synchronous path, via a shared prepareResult helper. Drop the now-dead default arm on the exhaustive ToolResult switch.


### New Features

- Added structured-output validation for task results.
- Improved handling of task results that require additional input.

### Bug Fixes

- Tasks now fail cleanly when structured results cannot be serialized, without exposing internal error details.
- Standardized result processing and failure handling across regular and task-based tool calls.

### Documentation

- Clarified nullability annotations across task polling and asynchronous result handling.