### PR TITLE
fix(mcp): per-request extension negotiation for 2026-07-28, SPI-driven pipeline wiring

### DIFF
--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp20260728/ExtensionNegotiationTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp20260728/ExtensionNegotiationTest.java
@@ -1,0 +1,74 @@
+/* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
+package dev.tachyonmcp.e2e.mcp20260728;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.tachyonmcp.api.runtime.InteractionContext;
+import dev.tachyonmcp.api.server.extensions.ExtensionSettings;
+import dev.tachyonmcp.api.server.extensions.ServerExtension;
+import dev.tachyonmcp.e2e.AbstractStatelessMcpE2eTest;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.Test;
+
+/**
+ * 2026-07-28 has no {@code initialize} handshake, so extension negotiation happens per request via
+ * {@code ExtensionNegotiationHandler} rather than {@code InitializeHandler}. Both now share
+ * {@code ExtensionNegotiator}, so a negotiated extension's {@link ServerExtension#onConnectionInit}
+ * fires under 2026-07-28 too, not just 2025-11-25.
+ */
+class ExtensionNegotiationTest extends AbstractStatelessMcpE2eTest {
+
+    private static final String EXT_ID = "com.example/onconnectinit-test";
+
+    @Test
+    void onConnectionInitFiresForPerRequestDeclaration() throws Exception {
+        var extension = new RecordingExtension();
+        startServer(builder -> builder.extension(extension), registrar -> {});
+
+        try (var client = createModernTestClient()) {
+            var response = client.post("""
+                    {"jsonrpc":"2.0","id":1,"method":"tools/list","params":{\
+                    "_meta":{"io.modelcontextprotocol/clientCapabilities":\
+                    {"extensions":{"%s":{"client":"test"}}}}}}
+                    """.formatted(EXT_ID));
+
+            assertThat(response.statusCode()).as(response.body()).isEqualTo(200);
+        }
+
+        assertThat(extension.initCalled.get()).isTrue();
+        assertThat(extension.clientSettings.values().stringValue("client")).isEqualTo("test");
+    }
+
+    @Test
+    void onConnectionInitNotCalledWhenNotDeclared() throws Exception {
+        var extension = new RecordingExtension();
+        startServer(builder -> builder.extension(extension), registrar -> {});
+
+        try (var client = createModernTestClient()) {
+            var response = client.post("""
+                    {"jsonrpc":"2.0","id":1,"method":"tools/list"}
+                    """);
+
+            assertThat(response.statusCode()).as(response.body()).isEqualTo(200);
+        }
+
+        assertThat(extension.initCalled.get()).isFalse();
+    }
+
+    private static final class RecordingExtension implements ServerExtension {
+
+        final AtomicBoolean initCalled = new AtomicBoolean();
+        volatile ExtensionSettings clientSettings = ExtensionSettings.empty();
+
+        @Override
+        public String extensionId() {
+            return EXT_ID;
+        }
+
+        @Override
+        public void onConnectionInit(InteractionContext context, ExtensionSettings clientSettings) {
+            initCalled.set(true);
+            this.clientSettings = clientSettings;
+        }
+    }
+}

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp20260728/TasksExtensionTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp20260728/TasksExtensionTest.java
@@ -5,6 +5,8 @@ import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import dev.tachyonmcp.api.server.domain.TaskResult;
+import dev.tachyonmcp.api.server.features.tasks.TaskSupport;
+import dev.tachyonmcp.api.server.features.tools.ToolResult;
 import dev.tachyonmcp.core.server.features.tasks.TasksExtension;
 import dev.tachyonmcp.core.server.json.JsonUtils;
 import dev.tachyonmcp.e2e.AbstractStatelessMcpE2eTest;
@@ -29,8 +31,9 @@ class TasksExtensionTest extends AbstractStatelessMcpE2eTest {
 
         try (var client = createModernTestClient()) {
             var response = client.post("""
-                    {"jsonrpc":"2.0","id":1,"method":"tasks/get","params":{"taskId":"%s"}}
-                    """.formatted(task.id()));
+                    {"jsonrpc":"2.0","id":1,"method":"tasks/get","params":{"taskId":"%s",\
+                    "_meta":{"io.modelcontextprotocol/clientCapabilities":{"extensions":{"%s":{}}}}}}
+                    """.formatted(task.id(), TasksExtension.ID));
 
             assertThat(response.statusCode()).as(response.body()).isEqualTo(200);
             assertThatJson(response.body())
@@ -53,8 +56,9 @@ class TasksExtensionTest extends AbstractStatelessMcpE2eTest {
 
         try (var client = createModernTestClient()) {
             var response = client.post("""
-                    {"jsonrpc":"2.0","id":2,"method":"tasks/get","params":{"taskId":"%s"}}
-                    """.formatted(task.id()));
+                    {"jsonrpc":"2.0","id":2,"method":"tasks/get","params":{"taskId":"%s",\
+                    "_meta":{"io.modelcontextprotocol/clientCapabilities":{"extensions":{"%s":{}}}}}}
+                    """.formatted(task.id(), TasksExtension.ID));
 
             assertThat(response.statusCode()).as(response.body()).isEqualTo(200);
             assertThatJson(response.body())
@@ -66,6 +70,116 @@ class TasksExtensionTest extends AbstractStatelessMcpE2eTest {
                               "result":{"taskId":"%s","status":"completed","ttl":null}
                             }
                             """.formatted(task.id()));
+        }
+    }
+
+    @Test
+    void rejectsTasksGetWithoutDeclaredExtension() throws Exception {
+        startTasksServer();
+        var task = server.tasks().create();
+
+        try (var client = createModernTestClient()) {
+            var response = client.post("""
+                    {"jsonrpc":"2.0","id":1,"method":"tasks/get","params":{"taskId":"%s"}}
+                    """.formatted(task.id()));
+
+            assertThat(response.statusCode()).as(response.body()).isEqualTo(400);
+            assertThatJson(response.body()).inPath("$.error.code").isEqualTo(-32021);
+            assertThatJson(response.body())
+                    .inPath("$.error.data.requiredCapabilities.extensions")
+                    .isObject()
+                    .containsKey(TasksExtension.ID);
+        }
+    }
+
+    @Test
+    void doesNotRetainTasksExtensionAcrossRequestsOnSameConnection() throws Exception {
+        startTasksServer();
+        var task = server.tasks().create();
+
+        try (var client = createModernTestClient()) {
+            var declared = client.post("""
+                    {"jsonrpc":"2.0","id":1,"method":"tasks/get","params":{"taskId":"%s",\
+                    "_meta":{"io.modelcontextprotocol/clientCapabilities":{"extensions":{"%s":{}}}}}}
+                    """.formatted(task.id(), TasksExtension.ID));
+            assertThat(declared.statusCode()).as(declared.body()).isEqualTo(200);
+
+            // 2026-07-28 has no session: declaring the extension on request 1 must not leave it
+            // enabled for request 2 on the same (likely pooled/reused) HTTP connection.
+            var undeclared = client.post("""
+                    {"jsonrpc":"2.0","id":2,"method":"tasks/get","params":{"taskId":"%s"}}
+                    """.formatted(task.id()));
+            assertThat(undeclared.statusCode()).as(undeclared.body()).isEqualTo(400);
+            assertThatJson(undeclared.body()).inPath("$.error.code").isEqualTo(-32021);
+        }
+    }
+
+    @Test
+    void rejectsTasksCancelWithoutDeclaredExtension() throws Exception {
+        startTasksServer();
+        var task = server.tasks().create();
+
+        try (var client = createModernTestClient()) {
+            var response = client.post("""
+                    {"jsonrpc":"2.0","id":1,"method":"tasks/cancel","params":{"taskId":"%s"}}
+                    """.formatted(task.id()));
+
+            assertThat(response.statusCode()).as(response.body()).isEqualTo(400);
+            assertThatJson(response.body()).inPath("$.error.code").isEqualTo(-32021);
+        }
+    }
+
+    @Test
+    void rejectsTaskAugmentedToolCallWithoutDeclaredExtension() throws Exception {
+        startServer(
+                builder -> {},
+                registrar -> registrar
+                        .tools()
+                        .register(
+                                b -> b.name("sleep").taskSupport(TaskSupport.OPTIONAL),
+                                (context, request) -> ToolResult.text("done")));
+
+        try (var client = createModernTestClient()) {
+            var response = client.post("""
+                    {"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"sleep","arguments":{},"task":{}}}
+                    """);
+
+            assertThat(response.statusCode()).as(response.body()).isEqualTo(400);
+            assertThatJson(response.body()).inPath("$.error.code").isEqualTo(-32021);
+            assertThatJson(response.body())
+                    .inPath("$.error.data.requiredCapabilities.extensions")
+                    .isObject()
+                    .containsKey(TasksExtension.ID);
+        }
+    }
+
+    @Test
+    void rejectsExtensionGatedToolWithoutPerRequestDeclaration() throws Exception {
+        startTasksServer();
+
+        try (var client = createModernTestClient()) {
+            var response = client.post("""
+                    {"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"create_task","arguments":{"name":"my-task"}}}
+                    """);
+
+            assertThat(response.statusCode()).as(response.body()).isEqualTo(400);
+            assertThatJson(response.body()).inPath("$.error.code").isEqualTo(-32602);
+            assertThatJson(response.body()).inPath("$.error.message").isEqualTo("Unknown tool: create_task");
+        }
+    }
+
+    @Test
+    void acceptsExtensionGatedToolWhenDeclaredPerRequest() throws Exception {
+        startTasksServer();
+
+        try (var client = createModernTestClient()) {
+            var response = client.post("""
+                    {"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"create_task","arguments":{"name":"my-task"},\
+                    "_meta":{"io.modelcontextprotocol/clientCapabilities":{"extensions":{"%s":{}}}}}}
+                    """.formatted(TasksExtension.ID));
+
+            assertThat(response.statusCode()).as(response.body()).isEqualTo(200);
+            assertThatJson(response.body()).inPath("$.result.content[0].text").isString();
         }
     }
 }

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/Protocol.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/Protocol.java
@@ -4,7 +4,10 @@ package dev.tachyonmcp.core.protocol;
 import dev.tachyonmcp.core.runtime.ChannelContext;
 import dev.tachyonmcp.core.runtime.DefaultChannelContext;
 import dev.tachyonmcp.core.server.ServerBuilder;
+import dev.tachyonmcp.core.server.internal.ServerEngine;
+import io.netty.channel.ChannelHandler;
 import io.netty.handler.codec.http.HttpRequest;
+import java.util.List;
 
 /**
  * SPI for protocol versions, loadable via {@link java.util.ServiceLoader}.
@@ -62,5 +65,19 @@ public interface Protocol {
 
     default ChannelContext createInteractionContext() {
         return new DefaultChannelContext(this);
+    }
+
+    /**
+     * Per-request Netty pipeline handlers this protocol version needs, in the order they must run
+     * (e.g. request-shape validation before extension negotiation). Added once per channel alongside
+     * every other registered protocol's handlers — a channel's negotiated protocol isn't fixed at
+     * construction time (a single keep-alive connection can carry requests for different negotiated
+     * versions, e.g. behind a proxy that pools upstream connections across unrelated clients), so
+     * each handler must recognize and no-op for a request that didn't negotiate this version.
+     * Returned handlers are shared across every channel for this server, so each must be
+     * {@code @Sharable}. Empty by default.
+     */
+    default List<ChannelHandler> requestHandlers(ServerEngine server) {
+        return List.of();
     }
 }

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/ProtocolRequestMapper.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/ProtocolRequestMapper.java
@@ -55,6 +55,15 @@ public interface ProtocolRequestMapper {
     /** Maps {@code initialize} params into the client's requested extensions. */
     InitializeRequest initialize(@Nullable Object params);
 
+    /**
+     * Extracts the extensions the client declares support for on this request (ID to client settings),
+     * from {@code _meta."io.modelcontextprotocol/clientCapabilities".extensions} (2026-07-28, SEP-2575) —
+     * same shape as {@link InitializeRequest#extensions()}, so both feed the same negotiator. Protocols
+     * negotiated once via {@code initialize} (e.g. 2025-11-25) carry no such per-request declaration and
+     * return an empty map.
+     */
+    Map<String, JsonObject> declaredExtensions(@Nullable Object params);
+
     /** Extracts the client's permitted {@link LoggingLevel}, or {@code null} if unset. */
     @Nullable
     LoggingLevel permittedLogLevel(@Nullable Object params);

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/mcp/v2025_11_25/McpProtocol.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/mcp/v2025_11_25/McpProtocol.java
@@ -6,8 +6,12 @@ import dev.tachyonmcp.core.protocol.ProtocolRequestMapper;
 import dev.tachyonmcp.core.protocol.ProtocolResponseMapper;
 import dev.tachyonmcp.core.protocol.mcp.McpHeaderNames;
 import dev.tachyonmcp.core.protocol.mcp.v2025_11_25.codecs.McpResponseMapper;
+import dev.tachyonmcp.core.protocol.mcp.v2025_11_25.transport.RequestValidationHandler;
+import dev.tachyonmcp.core.server.internal.ServerEngine;
+import io.netty.channel.ChannelHandler;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpRequest;
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -70,5 +74,10 @@ public final class McpProtocol implements Protocol {
     @Override
     public ProtocolRequestMapper requestMapper() {
         return REQUEST_MAPPER;
+    }
+
+    @Override
+    public List<ChannelHandler> requestHandlers(ServerEngine server) {
+        return List.of(new RequestValidationHandler());
     }
 }

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/mcp/v2025_11_25/codecs/McpRequestMapper.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/mcp/v2025_11_25/codecs/McpRequestMapper.java
@@ -31,6 +31,7 @@ import tools.jackson.databind.json.JsonMapper;
 public class McpRequestMapper implements ProtocolRequestMapper {
 
     private static final String META_LOG_LEVEL_KEY = "io.modelcontextprotocol/logLevel";
+    private static final String META_CLIENT_CAPABILITIES_KEY = "io.modelcontextprotocol/clientCapabilities";
     private static final JsonMapper JSON = new JsonMapper();
 
     @Override
@@ -144,11 +145,26 @@ public class McpRequestMapper implements ProtocolRequestMapper {
     public InitializeRequest initialize(@Nullable Object params) {
         var capabilities = optionalMap(asMap(params), "capabilities", "Invalid capabilities");
         var extensions = capabilities != null ? optionalMap(capabilities, "extensions", "Invalid extensions") : null;
-        if (extensions == null || extensions.isEmpty()) return new InitializeRequest(Map.of());
+        return new InitializeRequest(mapExtensions(extensions));
+    }
+
+    @Override
+    public Map<String, JsonObject> declaredExtensions(@Nullable Object params) {
+        var map = asMap(params);
+        if (!(map.get("_meta") instanceof Map<?, ?> meta)) return Map.of();
+        if (!(meta.get(META_CLIENT_CAPABILITIES_KEY) instanceof Map<?, ?> capabilities)) return Map.of();
+        if (!(capabilities.get("extensions") instanceof Map<?, ?> extensions)) return Map.of();
+        return mapExtensions(extensions);
+    }
+
+    /** Maps a raw {@code extensions} object (id -> settings) to the domain {@code Map<String, JsonObject>} shape. */
+    private static Map<String, JsonObject> mapExtensions(@Nullable Map<?, ?> extensions) {
+        if (extensions == null || extensions.isEmpty()) return Map.of();
         var mapped = new LinkedHashMap<String, JsonObject>();
-        extensions.forEach((key, value) ->
-                mapped.put(key, value instanceof Map<?, ?> map ? JsonObject.of(stringKeyed(map)) : JsonObject.empty()));
-        return new InitializeRequest(Map.copyOf(mapped));
+        stringKeyed(extensions)
+                .forEach((key, value) -> mapped.put(
+                        key, value instanceof Map<?, ?> map ? JsonObject.of(stringKeyed(map)) : JsonObject.empty()));
+        return Map.copyOf(mapped);
     }
 
     @Override

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/mcp/v2026_07_28/McpProtocol.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/mcp/v2026_07_28/McpProtocol.java
@@ -6,8 +6,14 @@ import dev.tachyonmcp.core.protocol.ProtocolRequestMapper;
 import dev.tachyonmcp.core.protocol.ProtocolResponseMapper;
 import dev.tachyonmcp.core.protocol.mcp.McpHeaderNames;
 import dev.tachyonmcp.core.protocol.mcp.v2026_07_28.codecs.McpResponseMapper;
+import dev.tachyonmcp.core.protocol.mcp.v2026_07_28.transport.ExtensionNegotiationHandler;
+import dev.tachyonmcp.core.protocol.mcp.v2026_07_28.transport.RequestValidationHandler;
+import dev.tachyonmcp.core.server.handlers.ExtensionNegotiator;
+import dev.tachyonmcp.core.server.internal.ServerEngine;
+import io.netty.channel.ChannelHandler;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpRequest;
+import java.util.List;
 
 /** MCP protocol implementation for the modern, per-request 2026-07-28 revision. */
 public final class McpProtocol implements Protocol {
@@ -54,5 +60,11 @@ public final class McpProtocol implements Protocol {
     @Override
     public boolean supportsSessions() {
         return false;
+    }
+
+    @Override
+    public List<ChannelHandler> requestHandlers(ServerEngine server) {
+        var negotiator = new ExtensionNegotiator(server.extensions());
+        return List.of(new RequestValidationHandler(server), new ExtensionNegotiationHandler(negotiator));
     }
 }

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/mcp/v2026_07_28/transport/ExtensionNegotiationHandler.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/mcp/v2026_07_28/transport/ExtensionNegotiationHandler.java
@@ -1,0 +1,69 @@
+/* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
+package dev.tachyonmcp.core.protocol.mcp.v2026_07_28.transport;
+
+import dev.tachyonmcp.core.protocol.mcp.v2026_07_28.McpProtocol;
+import dev.tachyonmcp.core.server.handlers.ExtensionNegotiator;
+import dev.tachyonmcp.core.transport.jsonrpc.JsonRpcCodec;
+import dev.tachyonmcp.core.transport.jsonrpc.JsonRpcMessage;
+import dev.tachyonmcp.core.transport.netty.ChannelHandlerUtils;
+import io.netty.channel.ChannelHandler.Sharable;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.HttpMethod;
+
+/**
+ * Negotiates MCP extensions for 2026-07-28: this revision removed {@code initialize} (no session to
+ * negotiate once and persist), so every request self-describes the extensions it wants via {@code
+ * _meta."io.modelcontextprotocol/clientCapabilities".extensions} (SEP-2575). {@code
+ * ProtocolVersionHandler} binds a brand-new, empty interaction context to the channel before every
+ * 2026-07-28 request (see its {@code interaction.set(...)} call), so enabling extensions on it here is
+ * already correctly scoped to this one request — no session or channel-level bookkeeping needed.
+ *
+ * <p>Delegates the actual matching/enabling to {@link ExtensionNegotiator}, shared with 2025-11-25's
+ * {@code InitializeHandler} — both fire {@code ServerExtension.onConnectionInit} for a negotiated
+ * extension, not just this handler's own {@code enableExtension} bookkeeping.
+ *
+ * <p>Per-server instance (not shared/static), added to every pipeline unconditionally and no-ops for
+ * any request that didn't negotiate 2026-07-28 — see the sibling {@link RequestValidationHandler}, run
+ * first so this only negotiates extensions for requests that already passed the required {@code _meta}
+ * shape checks.
+ */
+@Sharable
+public final class ExtensionNegotiationHandler extends ChannelInboundHandlerAdapter {
+
+    private final ExtensionNegotiator negotiator;
+
+    public ExtensionNegotiationHandler(ExtensionNegotiator negotiator) {
+        this.negotiator = negotiator;
+    }
+
+    @Override
+    public void channelRead(ChannelHandlerContext ctx, Object msg) {
+        if (!(msg instanceof FullHttpRequest req) || req.method() != HttpMethod.POST) {
+            ctx.fireChannelRead(msg);
+            return;
+        }
+        var interaction = ChannelHandlerUtils.getInteractionContext(ctx);
+        if (interaction == null || !McpProtocol.VERSION.equals(interaction.protocolVersion())) {
+            ctx.fireChannelRead(msg);
+            return;
+        }
+
+        JsonRpcMessage message;
+        try {
+            // A duplicate view shares the backing memory but has its own reader index, so peeking
+            // here doesn't disturb what the operation handler reads from req.content() next.
+            message = JsonRpcCodec.parseRequest(req.content().duplicate());
+        } catch (RuntimeException e) {
+            // Malformed JSON: let the normal parse-error path downstream handle it.
+            ctx.fireChannelRead(msg);
+            return;
+        }
+        if (message instanceof JsonRpcMessage.Request<?> request) {
+            var declared = interaction.protocol().requestMapper().declaredExtensions(request.params());
+            negotiator.negotiate(interaction, declared);
+        }
+        ctx.fireChannelRead(msg);
+    }
+}

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/DefaultTachyonServer.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/DefaultTachyonServer.java
@@ -42,6 +42,7 @@ import dev.tachyonmcp.core.server.features.tasks.TaskRegistry;
 import dev.tachyonmcp.core.server.features.tools.DefaultToolRegistry;
 import dev.tachyonmcp.core.server.features.tools.ToolMethodHandlers;
 import dev.tachyonmcp.core.server.handlers.DiscoverHandler;
+import dev.tachyonmcp.core.server.handlers.ExtensionNegotiator;
 import dev.tachyonmcp.core.server.handlers.InitializeHandler;
 import dev.tachyonmcp.core.server.handlers.LoggingHandlers;
 import dev.tachyonmcp.core.server.handlers.PingHandler;
@@ -419,7 +420,7 @@ final class DefaultTachyonServer implements ServerEngine, ExtensionContext {
     }
 
     private void registerDefaults() {
-        methodHandlers.put("initialize", new InitializeHandler(this, extensions));
+        methodHandlers.put("initialize", new InitializeHandler(this, new ExtensionNegotiator(extensions)));
         methodHandlers.put("server/discover", new DiscoverHandler(this));
         methodHandlers.put("ping", new PingHandler());
         ToolMethodHandlers.register(

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/features/tasks/TaskMethodHandlers.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/features/tasks/TaskMethodHandlers.java
@@ -1,12 +1,14 @@
 /* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
 package dev.tachyonmcp.core.server.features.tasks;
 
+import dev.tachyonmcp.api.server.domain.ServerError;
 import dev.tachyonmcp.api.server.features.tasks.TaskState;
 import dev.tachyonmcp.core.protocol.RequestMappingException;
 import dev.tachyonmcp.core.server.RpcMethodHandler;
 import dev.tachyonmcp.core.server.domain.ServerErrors;
 import dev.tachyonmcp.core.server.session.DispatchContext;
 import java.util.Map;
+import org.jspecify.annotations.Nullable;
 
 /** JSON-RPC adapters for task operations. */
 public final class TaskMethodHandlers {
@@ -18,6 +20,22 @@ public final class TaskMethodHandlers {
         handlers.put("tasks/get", new TasksGetHandler(registry));
         handlers.put("tasks/cancel", new TasksCancelHandler(registry));
         handlers.put("tasks/result", new TasksResultHandler(registry));
+    }
+
+    /**
+     * 2026-07-28 requires every {@code tasks/get}/{@code tasks/cancel} request to declare the {@code
+     * io.modelcontextprotocol/tasks} extension capability (SEP-2663) or be rejected with {@code
+     * -32021}. 2025-11-25's legacy, session-negotiated task support predates that extension and isn't
+     * gated by it (SEP-2663's protocol-version compatibility table: "this extension does not apply"
+     * under 2025-11-25) — {@code protocol().supportsSessions()} is exactly that version boundary.
+     */
+    private static @Nullable ServerError requireTasksExtension(DispatchContext context) {
+        if (context.protocol().supportsSessions() || context.isExtensionEnabled(TasksExtension.ID)) {
+            return null;
+        }
+        return ServerErrors.missingRequiredClientCapability(
+                "Requires the '" + TasksExtension.ID + "' extension",
+                Map.of("extensions", Map.of(TasksExtension.ID, Map.of())));
     }
 
     private record TasksListHandler(DefaultTaskRegistry registry) implements RpcMethodHandler {
@@ -45,6 +63,8 @@ public final class TaskMethodHandlers {
 
         @Override
         public Object handle(DispatchContext context, Object params) {
+            var missingCapability = requireTasksExtension(context);
+            if (missingCapability != null) return missingCapability;
             final String taskId;
             try {
                 taskId = context.requestMapper().taskId(params);
@@ -66,6 +86,8 @@ public final class TaskMethodHandlers {
 
         @Override
         public Object handle(DispatchContext context, Object params) {
+            var missingCapability = requireTasksExtension(context);
+            if (missingCapability != null) return missingCapability;
             final String taskId;
             try {
                 taskId = context.requestMapper().taskId(params);

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/features/tools/ToolMethodHandlers.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/features/tools/ToolMethodHandlers.java
@@ -4,6 +4,7 @@ package dev.tachyonmcp.core.server.features.tools;
 import static dev.tachyonmcp.core.server.domain.ServerErrors.fromUnhandledException;
 import static dev.tachyonmcp.core.server.domain.ServerErrors.internalError;
 import static dev.tachyonmcp.core.server.domain.ServerErrors.invalidParams;
+import static dev.tachyonmcp.core.server.domain.ServerErrors.missingRequiredClientCapability;
 
 import dev.tachyonmcp.api.json.JsonDocument;
 import dev.tachyonmcp.api.json.JsonSchema;
@@ -25,6 +26,7 @@ import dev.tachyonmcp.core.server.OutboundSseStreamMessageRouter;
 import dev.tachyonmcp.core.server.RpcMethodHandler;
 import dev.tachyonmcp.core.server.features.tasks.TaskEntry;
 import dev.tachyonmcp.core.server.features.tasks.TaskRegistry;
+import dev.tachyonmcp.core.server.features.tasks.TasksExtension;
 import dev.tachyonmcp.core.server.json.JsonUtils;
 import dev.tachyonmcp.core.server.session.DispatchContext;
 import java.time.Duration;
@@ -97,7 +99,7 @@ public final class ToolMethodHandlers {
         }
 
         @Override
-        public CompletionStage<@Nullable Object> handleAsync(DispatchContext context, Object params) {
+        public CompletionStage<Object> handleAsync(DispatchContext context, Object params) {
             final dev.tachyonmcp.core.protocol.ProtocolRequestMapper.ToolCallRequest mapped;
             try {
                 mapped = context.requestMapper().callTool(params, payloadDeserializer);
@@ -130,6 +132,16 @@ public final class ToolMethodHandlers {
             if (taskSupport == TaskSupport.REQUIRED && !mapped.taskAugmented()) {
                 return CompletableFuture.completedFuture(invalidParams("Task augmentation required for this tool"));
             }
+            // 2026-07-28 (no session) requires the client to declare the tasks extension per request
+            // (SEP-2663) before the server may return a CreateTaskResult; 2025-11-25's legacy,
+            // session-negotiated task augmentation predates that extension and isn't gated by it.
+            if (mapped.taskAugmented()
+                    && !context.protocol().supportsSessions()
+                    && !context.isExtensionEnabled(TasksExtension.ID)) {
+                return CompletableFuture.completedFuture(missingRequiredClientCapability(
+                        "Requires the '" + TasksExtension.ID + "' extension",
+                        Map.of("extensions", Map.of(TasksExtension.ID, Map.of()))));
+            }
             if (mapped.taskAugmented()) {
                 return CompletableFuture.completedFuture(
                         dispatchTaskAugmented(context, handler, request, mapped.taskTtl()));
@@ -152,7 +164,8 @@ public final class ToolMethodHandlers {
         private @Nullable Object dispatchTaskAugmented(
                 DispatchContext context, ToolHandler handler, ToolRequest request, @Nullable Duration taskTtl) {
             sendLogging(context, request.name(), "started");
-            var taskRegistry = context.engine().tasksRegistry();
+            final var engine = context.engine();
+            var taskRegistry = engine.tasksRegistry();
             var task = taskRegistry.createSessionTask(
                     taskTtl,
                     request.meta(),
@@ -172,7 +185,7 @@ public final class ToolMethodHandlers {
 
             var future = new CompletableFuture<ToolResult>();
             var handlerFuture = new AtomicReference<@Nullable CompletableFuture<? extends ToolResult>>();
-            var dispatchFuture = context.engine().executor().submit(() -> {
+            var dispatchFuture = engine.executor().submit(() -> {
                 if (future.isCancelled()) return;
                 try {
                     var stage = Objects.requireNonNull(
@@ -200,7 +213,7 @@ public final class ToolMethodHandlers {
             });
 
             taskRegistry.registerRunning(task.id(), future);
-            HandlerFutures.completeOn(future, context.engine().executor(), (toolResult, failure) -> {
+            HandlerFutures.completeOn(future, engine.executor(), (toolResult, failure) -> {
                         if (failure == null)
                             completeTask(
                                     taskRegistry, task, handler.descriptor().outputSchema(), toolResult);

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/handlers/ExtensionNegotiator.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/handlers/ExtensionNegotiator.java
@@ -1,0 +1,53 @@
+/* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
+package dev.tachyonmcp.core.server.handlers;
+
+import dev.tachyonmcp.api.json.JsonObject;
+import dev.tachyonmcp.api.runtime.Extension;
+import dev.tachyonmcp.api.server.extensions.ExtensionSettings;
+import dev.tachyonmcp.api.server.extensions.ServerExtension;
+import dev.tachyonmcp.core.runtime.ChannelContext;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Matches a client's declared extensions (ID to client settings) against the server's registered
+ * {@link ServerExtension}s, enabling each match on the given {@link ChannelContext} and firing its
+ * {@link ServerExtension#onConnectionInit}. Takes the minimal type it needs (just
+ * {@code enableExtension}/{@code isExtensionEnabled}, both on {@code ChannelContext}) rather than the
+ * wider {@code DispatchContext}, since 2026-07-28's negotiation runs in the Netty pipeline, before a
+ * {@code DispatchContext} exists.
+ *
+ * <p>Shared by 2025-11-25's {@link InitializeHandler} (declared once via {@code initialize}, matches
+ * {@link dev.tachyonmcp.core.protocol.ProtocolRequestMapper.InitializeRequest#extensions()}) and
+ * 2026-07-28's {@code ExtensionNegotiationHandler} (declared per request, matches {@link
+ * dev.tachyonmcp.core.protocol.ProtocolRequestMapper#declaredExtensions}) — both produce the same
+ * {@code Map<String, JsonObject>} shape.
+ */
+public final class ExtensionNegotiator {
+
+    private final List<ServerExtension> extensions;
+
+    public ExtensionNegotiator(List<ServerExtension> extensions) {
+        this.extensions = extensions;
+    }
+
+    /** Enables each registered extension the client declared, and fires its {@code onConnectionInit}. */
+    public void negotiate(ChannelContext context, Map<String, JsonObject> declared) {
+        for (var ext : extensions) {
+            var clientSettings = declared.get(ext.extensionId());
+            if (clientSettings != null) {
+                context.enableExtension(ext.extensionId());
+                ext.onConnectionInit(context, ExtensionSettings.of(clientSettings.asMap()));
+            }
+        }
+    }
+
+    /** Returns the currently-enabled subset of registered extensions, for echoing back in a response. */
+    public Map<String, JsonObject> negotiatedExtensions(ChannelContext context) {
+        return extensions.stream()
+                .filter(e -> context.isExtensionEnabled(e.extensionId()))
+                .collect(Collectors.toMap(
+                        Extension::extensionId, e -> e.serverSettings().values()));
+    }
+}

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/handlers/InitializeHandler.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/handlers/InitializeHandler.java
@@ -1,29 +1,29 @@
 /* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
 package dev.tachyonmcp.core.server.handlers;
 
-import dev.tachyonmcp.api.json.JsonObject;
-import dev.tachyonmcp.api.runtime.Extension;
-import dev.tachyonmcp.api.server.extensions.ExtensionSettings;
-import dev.tachyonmcp.api.server.extensions.ServerExtension;
+import dev.tachyonmcp.core.protocol.ProtocolRequestMapper;
 import dev.tachyonmcp.core.protocol.RequestMappingException;
 import dev.tachyonmcp.core.protocol.mcp.v2025_11_25.McpProtocol;
 import dev.tachyonmcp.core.server.RpcMethodHandler;
 import dev.tachyonmcp.core.server.domain.InitializeResponse;
 import dev.tachyonmcp.core.server.internal.ServerEngine;
 import dev.tachyonmcp.core.server.session.DispatchContext;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 
+/**
+ * Handles MCP 2025-11-25's {@code initialize} handshake: maps the request, resolves server
+ * capabilities, negotiates extensions once via {@link ExtensionNegotiator} (unlike 2026-07-28,
+ * which redeclares extensions per request through {@code ExtensionNegotiationHandler}), and maps
+ * the result back through the negotiated protocol's response mapper.
+ */
 public final class InitializeHandler implements RpcMethodHandler {
 
     private static final String MCP_VERSION = McpProtocol.VERSION;
     private final ServerEngine server;
-    private final List<ServerExtension> extensions;
+    private final ExtensionNegotiator negotiator;
 
-    public InitializeHandler(ServerEngine server, List<ServerExtension> extensions) {
+    public InitializeHandler(ServerEngine server, ExtensionNegotiator negotiator) {
         this.server = server;
-        this.extensions = extensions;
+        this.negotiator = negotiator;
     }
 
     @Override
@@ -33,17 +33,19 @@ public final class InitializeHandler implements RpcMethodHandler {
 
     @Override
     public Object handle(DispatchContext context, Object params) {
-        var capabilities = server.resolveCapabilities();
-
+        final ProtocolRequestMapper.InitializeRequest initializeRequest;
         try {
-            negotiateExtensions(context, params);
+            initializeRequest = context.requestMapper().initialize(params);
         } catch (RequestMappingException e) {
             return e.error();
         }
-        var negotiatedExtensions = buildNegotiatedExtensions(context);
+
+        var capabilities = server.resolveCapabilities();
+
+        negotiator.negotiate(context, initializeRequest.extensions());
+        var negotiatedExtensions = negotiator.negotiatedExtensions(context);
 
         final var serverConfig = server.config();
-
         var domainResponse = new InitializeResponse(
                 MCP_VERSION,
                 capabilities,
@@ -52,24 +54,5 @@ public final class InitializeHandler implements RpcMethodHandler {
                 negotiatedExtensions.isEmpty() ? null : negotiatedExtensions);
 
         return context.responseMapper().initializeResult(domainResponse);
-    }
-
-    private void negotiateExtensions(DispatchContext context, Object params) {
-        var clientExtensions = context.requestMapper().initialize(params).extensions();
-        for (var ext : extensions) {
-            if (clientExtensions.containsKey(ext.extensionId())) {
-                context.enableExtension(ext.extensionId());
-                var clientSettings = clientExtensions.get(ext.extensionId());
-                ext.onConnectionInit(context, ExtensionSettings.of(clientSettings.asMap()));
-            }
-        }
-    }
-
-    private Map<String, JsonObject> buildNegotiatedExtensions(DispatchContext context) {
-        return extensions.stream()
-                .filter(e -> context.isExtensionEnabled(e.extensionId()))
-                .collect(Collectors.toMap(
-                        Extension::extensionId,
-                        extension -> extension.serverSettings().values()));
     }
 }

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/session/NoopInteractionContext.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/session/NoopInteractionContext.java
@@ -27,10 +27,11 @@ public class NoopInteractionContext implements DispatchContext {
             new dev.tachyonmcp.core.protocol.mcp.v2025_11_25.codecs.McpRequestMapper();
     private static final ProtocolResponseMapper RESPONSE_MAPPER =
             Objects.requireNonNull(ProtocolMappers.getMapper("mcp", McpProtocol.VERSION));
+    private static final Protocol PROTOCOL = new McpProtocol();
 
     @Override
     public Protocol protocol() {
-        throw new UnsupportedOperationException("No interaction context available");
+        return PROTOCOL;
     }
 
     @Override

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/transport/netty/McpChannelInitializer.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/transport/netty/McpChannelInitializer.java
@@ -1,7 +1,7 @@
 /* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
 package dev.tachyonmcp.core.transport.netty;
 
-import dev.tachyonmcp.core.protocol.mcp.v2025_11_25.transport.RequestValidationHandler;
+import dev.tachyonmcp.core.protocol.Protocols;
 import dev.tachyonmcp.core.server.McpDispatcher;
 import dev.tachyonmcp.core.server.internal.ServerEngine;
 import dev.tachyonmcp.core.transport.netty.http.AcceptValidationHandler;
@@ -23,7 +23,9 @@ import io.netty.handler.logging.LogLevel;
 import io.netty.handler.logging.LoggingHandler;
 import io.netty.handler.timeout.IdleStateHandler;
 import java.time.Duration;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import org.jspecify.annotations.Nullable;
@@ -31,7 +33,9 @@ import org.jspecify.annotations.Nullable;
 /**
  * Assembles the Netty pipeline for each new MCP channel: validation handlers
  * (endpoint, origin, protocol version, accept header, stateless guard),
- * {@link InteractionHandler}, HTTP aggregation, idle timeout, the
+ * {@link InteractionHandler}, HTTP aggregation, idle timeout, each registered
+ * {@link dev.tachyonmcp.core.protocol.Protocol}'s own
+ * {@link dev.tachyonmcp.core.protocol.Protocol#requestHandlers request handlers}, the
  * initialization-phase handler ({@link McpInitializationHandler}), and the
  * {@link LifecyclePipelineCoordinator}.
  *
@@ -67,11 +71,11 @@ public class McpChannelInitializer extends ChannelInitializer<SocketChannel> {
     private final CorsConfig corsConfig;
 
     private static final ChannelHandler statelessValidator = new StatelessValidatorHandler();
-    private static final ChannelHandler MCP_2025_11_25_REQUEST_VALIDATOR = new RequestValidationHandler();
 
-    // Per-server, not static: Mcp-Param-* validation resolves x-mcp-header tool-schema annotations
-    // via this server's own tool registry.
-    private final ChannelHandler mcp20260728RequestValidator;
+    // Built once per server from every registered Protocol's own requestHandlers(server) — see
+    // Protocol#requestHandlers. Per-server, not static: several of these handlers are bound to this
+    // server's own tool registry / registered extensions.
+    private final Map<String, ChannelHandler> protocolRequestHandlers;
 
     private final ServerEngine server;
     private final McpDispatcher dispatcher;
@@ -105,8 +109,17 @@ public class McpChannelInitializer extends ChannelInitializer<SocketChannel> {
         this.childChannels = childChannels;
         this.dispatcher = new McpDispatcher(server, server.executor());
         this.interactionHandler = new InteractionHandler();
-        this.mcp20260728RequestValidator =
-                new dev.tachyonmcp.core.protocol.mcp.v2026_07_28.transport.RequestValidationHandler(server);
+
+        var handlers = new LinkedHashMap<String, ChannelHandler>();
+        for (var protocol : Protocols.list()) {
+            for (var handler : protocol.requestHandlers(server)) {
+                handlers.put(
+                        protocol.familyName() + "-" + protocol.versionString() + "-"
+                                + handler.getClass().getSimpleName(),
+                        handler);
+            }
+        }
+        this.protocolRequestHandlers = handlers;
 
         protocolVersionHandler = new ProtocolVersionHandler(endpointPath);
         acceptHeaderValidator = new AcceptValidationHandler(endpointPath);
@@ -168,13 +181,15 @@ public class McpChannelInitializer extends ChannelInitializer<SocketChannel> {
                             readerIdleTimeout.toMillis(), writerIdleTimeout.toMillis(), 0, TimeUnit.MILLISECONDS));
         }
 
-        // Protocol-bound request validation, one handler per protocol version (see each handler's
-        // own package). Each checks the negotiated protocol on the interaction context and no-ops
-        // for any other version, so both can sit unconditionally ahead of dispatch — no dynamic
-        // pipeline surgery. Needs the aggregated body (peeked read-only), so it must run after
-        // http-aggregator and before the phase handlers below.
-        p.addLast("mcp-request-validation-2025-11-25", MCP_2025_11_25_REQUEST_VALIDATOR);
-        p.addLast("mcp-request-validation-2026-07-28", mcp20260728RequestValidator);
+        // Every registered Protocol's own request handlers (see Protocol#requestHandlers), e.g.
+        // request-shape validation and, for 2026-07-28, per-request extension negotiation. Each
+        // checks the negotiated protocol on the interaction context and no-ops for any other
+        // version, so all of them can sit unconditionally ahead of dispatch — no dynamic pipeline
+        // surgery, since a channel's negotiated protocol isn't fixed at construction time (a
+        // keep-alive connection can carry requests for different negotiated versions, e.g. behind a
+        // proxy that pools upstream connections across unrelated clients). Needs the aggregated body
+        // (peeked read-only), so it must run after http-aggregator and before the phase handlers below.
+        protocolRequestHandlers.forEach(p::addLast);
 
         // Both stateless and stateful modes go through the initialization phase handler.
         // It negotiates the protocol, fires InteractionEvent.OperationStarted, then the

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/transport/netty/McpInitializationHandler.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/transport/netty/McpInitializationHandler.java
@@ -25,6 +25,7 @@ import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.timeout.IdleStateEvent;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
+import java.util.function.Consumer;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -170,30 +171,50 @@ public class McpInitializationHandler extends ChannelInboundHandlerAdapter {
                                 origin);
                         return;
                     }
-                    if (result instanceof McpDispatcher.DispatchResult.Accepted) {
-                        postStream.terminate();
-                        sendAccepted(ctx, origin);
-                        return;
-                    }
-                    if (result instanceof McpDispatcher.DispatchResult.Status(int code, String statusMessage)) {
-                        postStream.terminate();
-                        sendPlainTextAndClose(ctx, HttpResponseStatus.valueOf(code), statusMessage, origin);
-                        return;
-                    }
-                    var response = (McpDispatcher.DispatchResult.Response) result;
-                    if (postStream.started()) {
-                        postStream.writeEvent(server.nextEventId(), response.responseBody(), null);
-                        postStream.terminate();
-                        return;
-                    }
-                    postStream.terminate();
-                    sendJsonResponse(
-                            ctx,
-                            response.responseBody(),
-                            HttpResponseStatus.valueOf(response.httpStatus()),
-                            response.sessionId(),
-                            origin);
+                    completeDispatch(ctx, postStream, result, origin, null);
                 }));
+    }
+
+    /**
+     * Terminates {@code postStream} and writes the response for a completed {@link
+     * McpDispatcher.DispatchResult}, handling all three outcomes (accepted/status/response). Shared
+     * by {@link #dispatchPreSessionRequest} and {@link #handleInitialize} — the only difference
+     * between the two call sites is that {@code initialize} must fire the OPERATION-phase lifecycle
+     * transition once the {@link McpDispatcher.DispatchResult.Response} is known, before the response
+     * is written; {@code onResponseReady} carries that (a no-op for every other pre-session request).
+     */
+    private void completeDispatch(
+            ChannelHandlerContext ctx,
+            PostSseStream postStream,
+            McpDispatcher.DispatchResult result,
+            @Nullable String origin,
+            @Nullable Consumer<McpDispatcher.DispatchResult.Response> onResponseReady) {
+        if (result instanceof McpDispatcher.DispatchResult.Accepted) {
+            postStream.terminate();
+            sendAccepted(ctx, origin);
+            return;
+        }
+        if (result instanceof McpDispatcher.DispatchResult.Status(int code, String statusMessage)) {
+            postStream.terminate();
+            sendPlainTextAndClose(ctx, HttpResponseStatus.valueOf(code), statusMessage, origin);
+            return;
+        }
+        var response = (McpDispatcher.DispatchResult.Response) result;
+        if (onResponseReady != null) {
+            onResponseReady.accept(response);
+        }
+        if (postStream.started()) {
+            postStream.writeEvent(server.nextEventId(), response.responseBody(), null);
+            postStream.terminate();
+            return;
+        }
+        postStream.terminate();
+        sendJsonResponse(
+                ctx,
+                response.responseBody(),
+                HttpResponseStatus.valueOf(response.httpStatus()),
+                response.sessionId(),
+                origin);
     }
 
     private void handleInitialize(ChannelHandlerContext ctx, RequestId id, Object params, @Nullable String origin) {
@@ -212,10 +233,8 @@ public class McpInitializationHandler extends ChannelInboundHandlerAdapter {
                         ChannelHandlerUtils.requireInteractionContext(ctx))
                 .whenComplete((result, ex) -> ctx.executor().execute(() -> {
                     var elapsedMs = (System.nanoTime() - startNs) / 1_000_000;
-                    // initialize never emits server→client messages, but neutralize defensively so
-                    // the keep-alive JSON response below can never be preceded by an SSE upgrade.
-                    postStream.terminate();
                     if (ex != null) {
+                        postStream.terminate();
                         logger.error("Initialize dispatch failed: id={}, elapsed={}ms", id, elapsedMs, ex);
                         sendResponseAndClose(
                                 ctx,
@@ -226,20 +245,17 @@ public class McpInitializationHandler extends ChannelInboundHandlerAdapter {
                         return;
                     }
                     logger.debug("Initialize response: id={}, elapsed={}ms", id, elapsedMs);
-
-                    var response = (McpDispatcher.DispatchResult.Response) result;
-                    var resultSessionId = response.sessionId();
-
-                    // Fire event with the live Session — InteractionHandler binds it into
-                    // InteractionContext, and LifecyclePipelineCoordinator replaces this handler
-                    // with McpOperationHandler.
-                    var mcpSession = resultSessionId != null
-                            ? server.getSession(resultSessionId).orElse(null)
-                            : null;
-                    ctx.pipeline().fireUserEventTriggered(new InteractionEvent.OperationStarted(mcpSession));
-                    logger.debug("Pipeline transitioned to OPERATION phase for session: {}", resultSessionId);
-
-                    sendJsonResponse(ctx, response.responseBody(), resultSessionId, origin);
+                    completeDispatch(ctx, postStream, result, origin, response -> {
+                        var resultSessionId = response.sessionId();
+                        // Fire event with the live Session — InteractionHandler binds it into
+                        // InteractionContext, and LifecyclePipelineCoordinator replaces this handler
+                        // with McpOperationHandler.
+                        var mcpSession = resultSessionId != null
+                                ? server.getSession(resultSessionId).orElse(null)
+                                : null;
+                        ctx.pipeline().fireUserEventTriggered(new InteractionEvent.OperationStarted(mcpSession));
+                        logger.debug("Pipeline transitioned to OPERATION phase for session: {}", resultSessionId);
+                    });
                 }));
     }
 

--- a/tachyon-core/src/test/java/dev/tachyonmcp/core/transport/netty/ProtocolVersionHandlerTest.java
+++ b/tachyon-core/src/test/java/dev/tachyonmcp/core/transport/netty/ProtocolVersionHandlerTest.java
@@ -88,6 +88,32 @@ class ProtocolVersionHandlerTest {
     }
 
     @Test
+    void latestVersionRebindsFreshInteractionOnEveryRequest() {
+        // 2026-07-28 is stateless/per-request: a keep-alive connection carrying two requests must
+        // never let the second one see state (e.g. negotiated extensions) left on the interaction
+        // context by the first. A fresh EmbeddedChannel per request can't catch a regression to
+        // setIfAbsent here — there'd be nothing yet to overwrite either way — so this reuses one
+        // channel across both requests, the same way a real keep-alive connection would.
+        var negotiationChannel = new EmbeddedChannel(new ProtocolVersionHandler("/mcp"), new InteractionHandler());
+        var firstRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/mcp");
+        firstRequest.headers().set("MCP-Protocol-Version", McpProtocol.VERSION);
+        negotiationChannel.writeInbound(firstRequest);
+        var firstContext = negotiationChannel
+                .attr(InteractionHandler.INTERACTION_CONTEXT_KEY)
+                .get();
+
+        var secondRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/mcp");
+        secondRequest.headers().set("MCP-Protocol-Version", McpProtocol.VERSION);
+        negotiationChannel.writeInbound(secondRequest);
+        var secondContext = negotiationChannel
+                .attr(InteractionHandler.INTERACTION_CONTEXT_KEY)
+                .get();
+
+        assertThat(secondContext).isNotSameAs(firstContext);
+        negotiationChannel.finishAndReleaseAll();
+    }
+
+    @Test
     void missingVersionPassesThrough() {
         var body = "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{}}";
         var request = new DefaultFullHttpRequest(


### PR DESCRIPTION
## Summary
- 2026-07-28 removed protocol-level sessions, so extensions must be negotiated per request via `_meta.clientCapabilities.extensions` (SEP-2575) instead of once at `initialize`. Adds `ExtensionNegotiator` (shared with 2025-11-25's `InitializeHandler`) and a 2026-07-28 `ExtensionNegotiationHandler`, and gates the tasks extension's task-augmented tool calls / `tasks/get`/`tasks/cancel` behind it per SEP-2663.
- `Protocol` gains a `requestHandlers(ServerEngine)` SPI method so each protocol version contributes its own ordered Netty handler list, instead of `McpChannelInitializer` hardcoding imports of every protocol-family's transport package.
- `McpInitializationHandler`'s duplicated dispatch-completion logic (`handleInitialize`/`dispatchPreSessionRequest`) is deduplicated into one helper — also fixes an unsafe unchecked cast and a hardcoded HTTP 200 that ignored the mapped error status.


### New Features

- Added per-request extension negotiation, allowing client-declared settings to be applied before request processing.
- Added support for dynamically registering request handling across supported protocol versions.

### Bug Fixes

- Task operations now return clear capability errors when the required task extension is not declared.
- Task-augmented tool calls are correctly blocked unless the necessary capability is enabled.
- Extension initialization now consistently reflects the client’s declared settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)