### PR TITLE
fix: extension registrations and tasks

### DIFF
--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -94,6 +94,10 @@ background — sync, async, and Kotlin suspend handlers all work. The client the
 `tasks/get` and fetches the outcome via `tasks/result`.
 
 - `taskSupport = REQUIRED` rejects plain calls; `FORBIDDEN` (default) rejects task-augmented calls.
+- MCP 2026-07-28 has no session, so it additionally requires the client to declare the
+  `io.modelcontextprotocol/tasks` extension on the request itself (SEP-2663) — a task-augmented
+  call without that declaration is rejected with `-32021`, regardless of `taskSupport`. 2025-11-25's
+  session-negotiated task support predates the extension and isn't gated by it.
 - `task.ttl` (milliseconds) bounds retention; expired tasks transition to `FAILED`.
 - `tasks/cancel` interrupts synchronous handlers running on virtual threads and cancels the
   `CompletionStage` returned by asynchronous handlers. Kotlin suspend handlers receive coroutine

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -70,7 +70,7 @@ state, overriding the server-wide default (`TasksConfig.keepAlive`, 5 minutes).
 
 Status notifications are broadcast automatically on each transition.
 
-## Task-augmented tool calls
+## MCP 2025-11-25 task-augmented tool calls
 
 Declare `taskSupport` on a tool descriptor and clients can run the tool as a background task
 by adding a `task` field to `tools/call`:
@@ -94,18 +94,48 @@ background — sync, async, and Kotlin suspend handlers all work. The client the
 `tasks/get` and fetches the outcome via `tasks/result`.
 
 - `taskSupport = REQUIRED` rejects plain calls; `FORBIDDEN` (default) rejects task-augmented calls.
-- MCP 2026-07-28 has no session, so it additionally requires the client to declare the
-  `io.modelcontextprotocol/tasks` extension on the request itself (SEP-2663) — a task-augmented
-  call without that declaration is rejected with `-32021`, regardless of `taskSupport`. 2025-11-25's
-  session-negotiated task support predates the extension and isn't gated by it.
 - `task.ttl` (milliseconds) bounds retention; expired tasks transition to `FAILED`.
 - `tasks/cancel` interrupts synchronous handlers running on virtual threads and cancels the
   `CompletionStage` returned by asynchronous handlers. Kotlin suspend handlers receive coroutine
   cancellation.
 
-## TasksExtension (SEP-1686)
+## MCP 2026-07-28 tasks (SEP-2663)
 
-`TasksExtension` is a negotiable protocol extension. It exposes a `create_task` tool and a `task://{id}` resource template only to clients that opt in during `initialize`.
+MCP 2026-07-28 has no session, so task creation moved from a client-requested opt-in to a
+**server-directed** extension: the legacy `task` field on `tools/call` is ignored outright (any
+value, well-formed or not), and clients instead declare readiness to receive a task per request via
+`_meta."io.modelcontextprotocol/clientCapabilities".extensions."io.modelcontextprotocol/tasks"`.
+
+- A `taskSupport = REQUIRED` tool always creates a task under 2026-07-28 (it can't run
+  synchronously) — the server returns `CreateTaskResult` immediately if the caller declared the
+  extension, or a `-32021` (Missing Required Client Capability) error if it didn't.
+  `OPTIONAL`/`FORBIDDEN` tools run synchronously, same as always.
+- `tasks/get` and `tasks/cancel` remain, gated by the same per-request declaration (`-32021` if
+  undeclared). `tasks/list` and `tasks/result` are removed outright (`-32601`) — `tasks/list` has
+  no caller-scoping mechanism under a sessionless protocol, and `tasks/result` is replaced by the
+  outcome inlined directly into `tasks/get`'s `result`/`error` fields once the task reaches a
+  terminal state.
+- Wire shape differs from 2025-11-25's experimental fields: `ttlMs`/`pollIntervalMs` (not
+  `ttl`/`pollInterval`), a `resultType` discriminator (`"task"` on task creation, `"complete"` on
+  `tasks/get`), a flat `CreateTaskResult` (no `{"task": {...}}` wrapper), and `tasks/cancel`
+  returning a bare `{"resultType": "complete"}` acknowledgement rather than the task's full state.
+- A tool result that completes with `isError: true` reports task status `completed` (with the
+  error content inlined into `result`), not `failed` — `failed` is reserved for genuine JSON-RPC
+  protocol errors.
+
+Not yet implemented: `tasks/update` (SEP-2663's replacement for submitting `inputResponses` to a
+task in `input_required` state), inlining `inputRequests` into `tasks/get` for that same state, and
+server-to-client `notifications/tasks` push (needs `subscriptions/listen` over the stateless
+2026-07-28 transport, which doesn't exist yet).
+
+## TasksExtension
+
+`TasksExtension` (`io.modelcontextprotocol/tasks`) serves double duty. Under 2025-11-25 it's a
+negotiable extension example: it exposes a `create_task` tool and a `task://{id}` resource
+template only to clients that opt in during `initialize`. Under 2026-07-28, its ID is exactly the
+SEP-2663 capability gate described above — registering it (`.extension(TasksExtension.instance())`)
+is what makes `context.isExtensionEnabled(TasksExtension.ID)` satisfiable for a client that
+declares it per request.
 
 ```java
 import dev.tachyonmcp.core.server.features.tasks.TasksExtension;
@@ -128,19 +158,21 @@ A background janitor sweeps every 30s and does two independent things:
   `keepAlive` has elapsed since they entered the terminal state — default 5 minutes, configurable
   server-wide via `TasksConfig.keepAlive`/`CapabilitiesConfig.Builder.tasksKeepAlive(...)`
   (Kotlin DSL: `tasks { keepAlive = 10.minutes }`), or per task via `TaskOptions.keepAlive(...)`.
-  Once dropped, `tasks/get`/`tasks/result` return "Task not found", same as an ID that never
+  Once dropped, `tasks/get` (2025-11-25 and 2026-07-28) and `tasks/result` (2025-11-25 only —
+  removed outright under 2026-07-28, see below) return "Task not found", same as an ID that never
   existed.
 
 ## MCP methods
 
-| Method | Description |
-|---|---|
-| `tasks/list` | List tasks, paginated |
-| `tasks/get` | Get a task by ID |
-| `tasks/cancel` | Cancel a running task |
-| `tasks/result` | Get the task payload result |
+| Method | Description | 2026-07-28 |
+|---|---|---|
+| `tasks/list` | List tasks, paginated | removed (`-32601`) |
+| `tasks/get` | Get a task by ID | kept, gated by the tasks extension |
+| `tasks/cancel` | Cancel a running task | kept, gated by the tasks extension |
+| `tasks/result` | Get the task payload result | removed (`-32601`) unconditionally, even for a valid, unexpired task ID — outcome inlined into `tasks/get` instead |
 
-Notifications: `notifications/tasks/list_changed`, `notifications/tasks/status`
+Notifications: `notifications/tasks/list_changed`, `notifications/tasks/status` — 2025-11-25 only.
+Not implemented for 2026-07-28 (no session to push to; see "Not yet implemented" above).
 
 ---
 

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp20260728/TasksExtensionTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp20260728/TasksExtensionTest.java
@@ -4,19 +4,26 @@ package dev.tachyonmcp.e2e.mcp20260728;
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import dev.tachyonmcp.api.server.domain.ServerError;
 import dev.tachyonmcp.api.server.domain.TaskResult;
+import dev.tachyonmcp.api.server.domain.TextContent;
 import dev.tachyonmcp.api.server.features.tasks.TaskSupport;
 import dev.tachyonmcp.api.server.features.tools.ToolResult;
 import dev.tachyonmcp.core.server.features.tasks.TasksExtension;
 import dev.tachyonmcp.core.server.json.JsonUtils;
 import dev.tachyonmcp.e2e.AbstractStatelessMcpE2eTest;
+import java.util.List;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 /**
- * MCP 2026-07-28 tasks (<a href="https://modelcontextprotocol.io/seps/1686-tasks">SEP-1686</a>):
- * this revision exposes the wider seven-state workflow, so a freshly created task reports
- * {@code "submitted"} on the wire — where 2025-11-25 folds the same internal {@code SUBMITTED}
- * state down to {@code "working"} (see {@code TasksExtensionTest} in the default package).
+ * MCP 2026-07-28 tasks (<a href="https://modelcontextprotocol.io/seps/2663-tasks-extension">SEP-2663</a>):
+ * task creation is server-directed and gated on the client declaring {@code
+ * io.modelcontextprotocol/tasks} per request (there's no session to negotiate it once, and no
+ * client-side {@code task} field to opt in with — that legacy 2025-11-25 field is ignored
+ * entirely). {@code tasks/list} and {@code tasks/result} are removed outright; {@code tasks/get}
+ * and {@code tasks/cancel} remain, gated the same way as task-augmented {@code tools/call}.
  */
 class TasksExtensionTest extends AbstractStatelessMcpE2eTest {
 
@@ -25,51 +32,56 @@ class TasksExtensionTest extends AbstractStatelessMcpE2eTest {
     }
 
     @Test
-    void freshTaskReportsSubmittedStatus() throws Exception {
-        startTasksServer();
-        var task = server.tasks().create();
+    void ignoresLegacyTaskAugmentation() throws Exception {
+        startServer(
+                builder -> {},
+                registrar -> registrar
+                        .tools()
+                        .register(
+                                b -> b.name("sleep").taskSupport(TaskSupport.OPTIONAL),
+                                (context, request) -> ToolResult.text("done")));
 
         try (var client = createModernTestClient()) {
             var response = client.post("""
-                    {"jsonrpc":"2.0","id":1,"method":"tasks/get","params":{"taskId":"%s",\
-                    "_meta":{"io.modelcontextprotocol/clientCapabilities":{"extensions":{"%s":{}}}}}}
-                    """.formatted(task.id(), TasksExtension.ID));
+                    {"jsonrpc":"2.0","id":1,"method":"tools/call","params":{
+                    "name":"sleep","arguments":{},"task":"ignored",
+                    "_meta":{"io.modelcontextprotocol/clientCapabilities":{"extensions":{
+                    "io.modelcontextprotocol/tasks":{}}}}}}
+                    """);
 
             assertThat(response.statusCode()).as(response.body()).isEqualTo(200);
-            assertThatJson(response.body())
-                    .whenIgnoringPaths("$.result.createdAt", "$.result.lastUpdatedAt")
-                    .isEqualTo("""
-                            {
-                              "jsonrpc":"2.0",
-                              "id":1,
-                              "result":{"taskId":"%s","status":"submitted","ttl":null}
-                            }
-                            """.formatted(task.id()));
+            assertThatJson(response.body()).isEqualTo("""
+                    {
+                      "jsonrpc": "2.0",
+                      "id": 1,
+                      "result": {
+                        "content": [{"type": "text", "text": "done"}],
+                        "resultType": "complete"
+                      }
+                    }
+                    """);
         }
     }
 
-    @Test
-    void completedTaskReportsCompletedStatus() throws Exception {
-        startTasksServer();
-        var task = server.tasks().create();
-        task.complete(TaskResult.completed(JsonUtils.parse("{\"output\":\"done\"}")));
+    @ParameterizedTest
+    @ValueSource(strings = {"tasks/list", "tasks/result"})
+    void doesNotExposeMethodsRemovedBySep2663(String method) throws Exception {
+        startServer(builder -> {}, registrar -> {});
 
         try (var client = createModernTestClient()) {
+            var params = "tasks/list".equals(method) ? "{}" : "{\"taskId\":\"task-1\"}";
             var response = client.post("""
-                    {"jsonrpc":"2.0","id":2,"method":"tasks/get","params":{"taskId":"%s",\
-                    "_meta":{"io.modelcontextprotocol/clientCapabilities":{"extensions":{"%s":{}}}}}}
-                    """.formatted(task.id(), TasksExtension.ID));
+                    {"jsonrpc":"2.0","id":1,"method":"%s","params":%s}
+                    """.formatted(method, params));
 
-            assertThat(response.statusCode()).as(response.body()).isEqualTo(200);
-            assertThatJson(response.body())
-                    .whenIgnoringPaths("$.result.createdAt", "$.result.lastUpdatedAt")
-                    .isEqualTo("""
-                            {
-                              "jsonrpc":"2.0",
-                              "id":2,
-                              "result":{"taskId":"%s","status":"completed","ttl":null}
-                            }
-                            """.formatted(task.id()));
+            assertThat(response.statusCode()).as(response.body()).isEqualTo(404);
+            assertThatJson(response.body()).isEqualTo("""
+                    {
+                      "jsonrpc": "2.0",
+                      "id": 1,
+                      "error": {"code": -32601, "message": "Method not found"}
+                    }
+                    """);
         }
     }
 
@@ -115,6 +127,131 @@ class TasksExtensionTest extends AbstractStatelessMcpE2eTest {
     }
 
     @Test
+    void freshTaskReportsSubmittedStatus() throws Exception {
+        startTasksServer();
+        var task = server.tasks().create();
+
+        try (var client = createModernTestClient()) {
+            var response = client.post("""
+                    {"jsonrpc":"2.0","id":1,"method":"tasks/get","params":{"taskId":"%s",\
+                    "_meta":{"io.modelcontextprotocol/clientCapabilities":{"extensions":{"%s":{}}}}}}
+                    """.formatted(task.id(), TasksExtension.ID));
+
+            assertThat(response.statusCode()).as(response.body()).isEqualTo(200);
+            assertThatJson(response.body())
+                    .whenIgnoringPaths("$.result.createdAt", "$.result.lastUpdatedAt")
+                    .isEqualTo("""
+                            {
+                              "jsonrpc":"2.0",
+                              "id":1,
+                              "result":{"taskId":"%s","status":"submitted","ttlMs":null,"resultType":"complete"}
+                            }
+                            """.formatted(task.id()));
+        }
+    }
+
+    @Test
+    void completedTaskInlinesItsResult() throws Exception {
+        startTasksServer();
+        var task = server.tasks().create();
+        task.complete(TaskResult.completed(JsonUtils.parse("{\"output\":\"done\"}")));
+
+        try (var client = createModernTestClient()) {
+            var response = client.post("""
+                    {"jsonrpc":"2.0","id":2,"method":"tasks/get","params":{"taskId":"%s",\
+                    "_meta":{"io.modelcontextprotocol/clientCapabilities":{"extensions":{"%s":{}}}}}}
+                    """.formatted(task.id(), TasksExtension.ID));
+
+            assertThat(response.statusCode()).as(response.body()).isEqualTo(200);
+            assertThatJson(response.body())
+                    .whenIgnoringPaths("$.result.createdAt", "$.result.lastUpdatedAt")
+                    .isEqualTo("""
+                            {
+                              "jsonrpc":"2.0",
+                              "id":2,
+                              "result":{
+                                "taskId":"%s",
+                                "status":"completed",
+                                "ttlMs":null,
+                                "resultType":"complete",
+                                "result":{
+                                  "content":[{"type":"text","text":"{\\"output\\":\\"done\\"}"}],
+                                  "structuredContent":{"output":"done"},
+                                  "resultType":"complete"
+                                }
+                              }
+                            }
+                            """.formatted(task.id()));
+        }
+    }
+
+    @Test
+    void toolLevelErrorInlinesResultAndReportsCompletedNotFailed() throws Exception {
+        startTasksServer();
+        var task = server.tasks().create();
+        task.fail(new TaskResult.Failed(List.of(TextContent.of("bad input")), null, null));
+
+        try (var client = createModernTestClient()) {
+            var response = client.post("""
+                    {"jsonrpc":"2.0","id":2,"method":"tasks/get","params":{"taskId":"%s",\
+                    "_meta":{"io.modelcontextprotocol/clientCapabilities":{"extensions":{"%s":{}}}}}}
+                    """.formatted(task.id(), TasksExtension.ID));
+
+            assertThat(response.statusCode()).as(response.body()).isEqualTo(200);
+            assertThatJson(response.body())
+                    .whenIgnoringPaths("$.result.createdAt", "$.result.lastUpdatedAt")
+                    .isEqualTo("""
+                            {
+                              "jsonrpc":"2.0",
+                              "id":2,
+                              "result":{
+                                "taskId":"%s",
+                                "status":"completed",
+                                "ttlMs":null,
+                                "resultType":"complete",
+                                "result":{
+                                  "content":[{"type":"text","text":"bad input"}],
+                                  "isError":true,
+                                  "resultType":"complete"
+                                }
+                              }
+                            }
+                            """.formatted(task.id()));
+        }
+    }
+
+    @Test
+    void protocolFailureInlinesErrorAndReportsFailedStatus() throws Exception {
+        startTasksServer();
+        var task = server.tasks().create();
+        task.fail(TaskResult.failed(new ServerError(ServerError.Kind.INVALID_PARAMS, "bad request")));
+
+        try (var client = createModernTestClient()) {
+            var response = client.post("""
+                    {"jsonrpc":"2.0","id":2,"method":"tasks/get","params":{"taskId":"%s",\
+                    "_meta":{"io.modelcontextprotocol/clientCapabilities":{"extensions":{"%s":{}}}}}}
+                    """.formatted(task.id(), TasksExtension.ID));
+
+            assertThat(response.statusCode()).as(response.body()).isEqualTo(200);
+            assertThatJson(response.body())
+                    .whenIgnoringPaths("$.result.createdAt", "$.result.lastUpdatedAt")
+                    .isEqualTo("""
+                            {
+                              "jsonrpc":"2.0",
+                              "id":2,
+                              "result":{
+                                "taskId":"%s",
+                                "status":"failed",
+                                "ttlMs":null,
+                                "resultType":"complete",
+                                "error":{"code":-32602,"message":"bad request"}
+                              }
+                            }
+                            """.formatted(task.id()));
+        }
+    }
+
+    @Test
     void rejectsTasksCancelWithoutDeclaredExtension() throws Exception {
         startTasksServer();
         var task = server.tasks().create();
@@ -130,18 +267,48 @@ class TasksExtensionTest extends AbstractStatelessMcpE2eTest {
     }
 
     @Test
+    void acceptsTasksCancelWhenDeclared() throws Exception {
+        startTasksServer();
+        var task = server.tasks().create();
+
+        try (var client = createModernTestClient()) {
+            var response = client.post("""
+                    {"jsonrpc":"2.0","id":1,"method":"tasks/cancel","params":{"taskId":"%s",\
+                    "_meta":{"io.modelcontextprotocol/clientCapabilities":{"extensions":{"%s":{}}}}}}
+                    """.formatted(task.id(), TasksExtension.ID));
+
+            assertThat(response.statusCode()).as(response.body()).isEqualTo(200);
+            assertThatJson(response.body()).isEqualTo("""
+                    {
+                      "jsonrpc": "2.0",
+                      "id": 1,
+                      "result": {"resultType": "complete"}
+                    }
+                    """);
+
+            var getResponse = client.post("""
+                    {"jsonrpc":"2.0","id":2,"method":"tasks/get","params":{"taskId":"%s",\
+                    "_meta":{"io.modelcontextprotocol/clientCapabilities":{"extensions":{"%s":{}}}}}}
+                    """.formatted(task.id(), TasksExtension.ID));
+
+            assertThat(getResponse.statusCode()).as(getResponse.body()).isEqualTo(200);
+            assertThatJson(getResponse.body()).inPath("$.result.status").isEqualTo("cancelled");
+        }
+    }
+
+    @Test
     void rejectsTaskAugmentedToolCallWithoutDeclaredExtension() throws Exception {
         startServer(
                 builder -> {},
                 registrar -> registrar
                         .tools()
                         .register(
-                                b -> b.name("sleep").taskSupport(TaskSupport.OPTIONAL),
+                                b -> b.name("sleep").taskSupport(TaskSupport.REQUIRED),
                                 (context, request) -> ToolResult.text("done")));
 
         try (var client = createModernTestClient()) {
             var response = client.post("""
-                    {"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"sleep","arguments":{},"task":{}}}
+                    {"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"sleep","arguments":{}}}
                     """);
 
             assertThat(response.statusCode()).as(response.body()).isEqualTo(400);
@@ -166,24 +333,19 @@ class TasksExtensionTest extends AbstractStatelessMcpE2eTest {
         try (var client = createModernTestClient()) {
             var response = client.post("""
                     {"jsonrpc":"2.0","id":1,"method":"tools/call","params":{\
-                    "name":"sleep","arguments":{},"task":{},\
+                    "name":"sleep","arguments":{},\
                     "_meta":{"io.modelcontextprotocol/clientCapabilities":{"extensions":{"%s":{}}}}}}
                     """.formatted(TasksExtension.ID));
 
             assertThat(response.statusCode()).as(response.body()).isEqualTo(200);
             assertThatJson(response.body())
                     .whenIgnoringPaths(
-                            "$.result.task.taskId",
-                            "$.result.task.createdAt",
-                            "$.result.task.lastUpdatedAt",
-                            "$.result._meta")
+                            "$.result.taskId", "$.result.createdAt", "$.result.lastUpdatedAt", "$.result._meta")
                     .isEqualTo("""
                             {
                               "jsonrpc": "2.0",
                               "id": 1,
-                              "result": {
-                                "task": {"status": "working", "ttl": null}
-                              }
+                              "result": {"status": "working", "ttlMs": null, "resultType": "task"}
                             }
                             """);
         }

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp20260728/TasksExtensionTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp20260728/TasksExtensionTest.java
@@ -154,6 +154,42 @@ class TasksExtensionTest extends AbstractStatelessMcpE2eTest {
     }
 
     @Test
+    void acceptsTaskAugmentedRequiredToolWhenDeclaredPerRequest() throws Exception {
+        startServer(
+                builder -> builder.extension(TasksExtension.instance()),
+                registrar -> registrar
+                        .tools()
+                        .register(
+                                b -> b.name("sleep").taskSupport(TaskSupport.REQUIRED),
+                                (context, request) -> ToolResult.text("done")));
+
+        try (var client = createModernTestClient()) {
+            var response = client.post("""
+                    {"jsonrpc":"2.0","id":1,"method":"tools/call","params":{\
+                    "name":"sleep","arguments":{},"task":{},\
+                    "_meta":{"io.modelcontextprotocol/clientCapabilities":{"extensions":{"%s":{}}}}}}
+                    """.formatted(TasksExtension.ID));
+
+            assertThat(response.statusCode()).as(response.body()).isEqualTo(200);
+            assertThatJson(response.body())
+                    .whenIgnoringPaths(
+                            "$.result.task.taskId",
+                            "$.result.task.createdAt",
+                            "$.result.task.lastUpdatedAt",
+                            "$.result._meta")
+                    .isEqualTo("""
+                            {
+                              "jsonrpc": "2.0",
+                              "id": 1,
+                              "result": {
+                                "task": {"status": "working", "ttl": null}
+                              }
+                            }
+                            """);
+        }
+    }
+
+    @Test
     void rejectsExtensionGatedToolWithoutPerRequestDeclaration() throws Exception {
         startTasksServer();
 

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/ProtocolRequestMapper.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/ProtocolRequestMapper.java
@@ -33,6 +33,16 @@ public interface ProtocolRequestMapper {
     ToolCallRequest callTool(@Nullable Object params, PayloadDeserializer payloadDeserializer);
 
     /**
+     * Whether this protocol supports MCP 2025-11-25's legacy {@code tools/call.task} augmentation.
+     *
+     * <p>MCP 2026-07-28 ignores that field; task creation is server-directed through the tasks
+     * extension instead.
+     */
+    default boolean supportsLegacyTaskAugmentation() {
+        return true;
+    }
+
+    /**
      * Maps {@code prompts/get} params into a prompt name and its argument request.
      */
     PromptCallRequest getPrompt(@Nullable Object params);

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/mcp/v2025_11_25/codecs/McpRequestMapper.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/mcp/v2025_11_25/codecs/McpRequestMapper.java
@@ -26,7 +26,7 @@ import tools.jackson.databind.json.JsonMapper;
  *
  * <p>Also parses the 2026-07-28 {@code inputResponses}/{@code requestState} fields (SEP-2322)
  * unconditionally: they're simply absent on 2025-11-25 wire payloads, so this is a no-op for that
- * version. The 2026-07-28 mapper reuses this class as-is (no override needed).
+ * version.
  */
 public class McpRequestMapper implements ProtocolRequestMapper {
 
@@ -44,13 +44,19 @@ public class McpRequestMapper implements ProtocolRequestMapper {
 
     @Override
     public ToolCallRequest callTool(@Nullable Object params, PayloadDeserializer payloadDeserializer) {
+        return callTool(params, payloadDeserializer, true);
+    }
+
+    /** Maps a tool call, optionally preserving MCP 2025-11-25's legacy task augmentation fields. */
+    protected final ToolCallRequest callTool(
+            @Nullable Object params, PayloadDeserializer payloadDeserializer, boolean legacyTaskAugmentation) {
         var map = asMap(params);
         var name = requiredString(map, "name", "Missing tool name");
         var arguments = optionalMap(map, "arguments", "Invalid arguments");
         var meta = optionalMap(map, "_meta", "Invalid _meta");
         var inputResponses = optionalMap(map, "inputResponses", "Invalid inputResponses");
         var requestState = optionalString(map, "requestState", "Invalid requestState");
-        var task = optionalMap(map, "task", "Invalid task metadata");
+        var task = legacyTaskAugmentation ? optionalMap(map, "task", "Invalid task metadata") : null;
         var ttl = task != null && task.get("ttl") instanceof Number value ? Duration.ofMillis(value.longValue()) : null;
         var request = ToolRequest.builder()
                 .name(name)
@@ -61,7 +67,7 @@ public class McpRequestMapper implements ProtocolRequestMapper {
                 .inputResponses(inputResponses)
                 .requestState(requestState)
                 .build();
-        return new ToolCallRequest(request, task != null, ttl);
+        return new ToolCallRequest(request, legacyTaskAugmentation && task != null, ttl);
     }
 
     @Override

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/mcp/v2026_07_28/codecs/McpRequestMapper.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/mcp/v2026_07_28/codecs/McpRequestMapper.java
@@ -1,38 +1,25 @@
 /* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
 package dev.tachyonmcp.core.protocol.mcp.v2026_07_28.codecs;
 
-import dev.tachyonmcp.api.server.features.tasks.TaskState;
+import dev.tachyonmcp.api.json.PayloadDeserializer;
+import dev.tachyonmcp.core.protocol.ProtocolRequestMapper.ToolCallRequest;
 import org.jspecify.annotations.Nullable;
 
 /**
  * Request mapper for MCP 2026-07-28.
  *
- * <p>Task status uses the wider 2026-07-28 workflow (SEP-1686): it adds the {@code submitted}
- * (initial pre-{@code working}) and {@code unknown} (terminal fallback) states on top of the five
- * 2025-11-25 states. {@link #taskStatus(Object)} is overridden to parse those two extra strings;
- * everything else is inherited from the 2025-11-25 mapper unchanged.
+ * <p>MCP 2026-07-28 ignores the legacy {@code tools/call.task} parameter. Task creation is
+ * server-directed through the tasks extension (SEP-2663).
  */
 public final class McpRequestMapper extends dev.tachyonmcp.core.protocol.mcp.v2025_11_25.codecs.McpRequestMapper {
 
     @Override
-    public @Nullable TaskStatusRequest taskStatus(@Nullable Object params) {
-        var map = asMap(params);
-        if (!(map.get("taskId") instanceof String taskId)) return null;
-        var state = toTaskState(map.get("status"));
-        var message = map.get("statusMessage") instanceof String text ? text : null;
-        return new TaskStatusRequest(taskId, state, message);
+    public ToolCallRequest callTool(@Nullable Object params, PayloadDeserializer payloadDeserializer) {
+        return callTool(params, payloadDeserializer, false);
     }
 
-    private static TaskState toTaskState(@Nullable Object status) {
-        if (!(status instanceof String text)) return TaskState.WORKING;
-        return switch (text) {
-            case "submitted" -> TaskState.SUBMITTED;
-            case "input_required" -> TaskState.INPUT_REQUIRED;
-            case "completed" -> TaskState.COMPLETED;
-            case "failed" -> TaskState.FAILED;
-            case "cancelled" -> TaskState.CANCELLED;
-            case "unknown" -> TaskState.UNKNOWN;
-            default -> TaskState.WORKING;
-        };
+    @Override
+    public boolean supportsLegacyTaskAugmentation() {
+        return false;
     }
 }

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/mcp/v2026_07_28/codecs/McpResponseMapper.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/mcp/v2026_07_28/codecs/McpResponseMapper.java
@@ -9,6 +9,7 @@ import dev.tachyonmcp.api.server.domain.ContentBlock;
 import dev.tachyonmcp.api.server.domain.PromptMessage;
 import dev.tachyonmcp.api.server.domain.ServerCapabilities;
 import dev.tachyonmcp.api.server.domain.ServerError;
+import dev.tachyonmcp.api.server.domain.TaskResult;
 import dev.tachyonmcp.api.server.domain.TextContent;
 import dev.tachyonmcp.api.server.domain.ToolAnnotations;
 import dev.tachyonmcp.api.server.features.completions.CompletionResult;
@@ -113,13 +114,13 @@ public final class McpResponseMapper extends dev.tachyonmcp.core.protocol.mcp.v2
     public Object discoverResult(
             List<String> supportedVersions, ServerCapabilities capabilities, ServerIdentity serverIdentity) {
         var implementation = ServerInfoMapper.toImplementation(serverIdentity);
-        var meta = Map.of("io.modelcontextprotocol/serverInfo", encodeToTree(implementation));
+        var meta = Map.of("io.modelcontextprotocol/serverInfo", encodeToTree(Implementation.class, implementation));
         // The schema models server identity only via the optional
         // _meta["io.modelcontextprotocol/serverInfo"] key (see `meta` above), but the pinned
         // conformance suite still requires a top-level `serverInfo` field too. `Result` permits
         // arbitrary extra keys (`[key: string]: unknown`), so mirror it there via
         // additionalProperties for conformance, in addition to the spec-correct `_meta` location.
-        var additionalProperties = Map.of("serverInfo", encodeToTree(implementation));
+        var additionalProperties = Map.of("serverInfo", encodeToTree(Implementation.class, implementation));
         return new DiscoverResult(
                 supportedVersions,
                 ServerInfoMapper.toServerCapabilities(capabilities).build(),
@@ -198,19 +199,9 @@ public final class McpResponseMapper extends dev.tachyonmcp.core.protocol.mcp.v2
     }
 
     @Override
-    public Object listTasksResult(List<TaskEntry> entries, @Nullable String nextCursor) {
-        var tasks = entries.stream().map(McpTaskMapper::toTaskProto).toList();
-        var result = new LinkedHashMap<String, Object>();
-        result.put("tasks", tasks);
-        if (nextCursor != null) {
-            result.put("nextCursor", nextCursor);
-        }
-        return JsonUtils.toObjectNode(result);
-    }
-
-    @Override
     public Object getTaskResult(dev.tachyonmcp.api.server.domain.Task entry) {
-        return McpTaskMapper.toGetTaskResult((TaskEntry) entry);
+        var taskEntry = (TaskEntry) entry;
+        return McpTaskMapper.toGetTaskResult(taskEntry, taskResultNode(taskEntry), taskErrorNode(taskEntry));
     }
 
     @Override
@@ -220,12 +211,50 @@ public final class McpResponseMapper extends dev.tachyonmcp.core.protocol.mcp.v2
 
     @Override
     public Object cancelTaskResult(TaskEntry entry) {
-        return McpTaskMapper.toCancelTaskResult(entry);
+        return McpTaskMapper.toCancelTaskResult();
     }
 
     @Override
     public Object taskStatusNotificationParams(TaskEntry entry) {
         return McpTaskMapper.toStatusNotification(entry);
+    }
+
+    /**
+     * Inlines a completed task's outcome (or a tool-level {@code isError: true} failure — see
+     * {@link TaskResult.Failed#protocolError()}) into {@code tasks/get}'s {@code result} field, in
+     * the same shape a synchronous {@code tools/call} would have returned. {@code null} while the
+     * task hasn't reached a result-bearing state.
+     */
+    private @Nullable JsonNode taskResultNode(TaskEntry entry) {
+        return switch (entry.result()) {
+            case TaskResult.Completed c ->
+                encodeToTree(
+                        CallToolResult.class,
+                        buildCallToolResult(
+                                c.content(), c.structuredContent(), null, JsonUtils.toJsonNodeMap(c.meta())));
+            case TaskResult.Failed f
+            when f.protocolError() == null ->
+                encodeToTree(
+                        CallToolResult.class,
+                        buildCallToolResult(
+                                f.content(), f.structuredContent(), true, JsonUtils.toJsonNodeMap(f.meta())));
+            case null, default -> null;
+        };
+    }
+
+    /** Inlines a genuine JSON-RPC protocol failure into {@code tasks/get}'s {@code error} field. */
+    private @Nullable JsonNode taskErrorNode(TaskEntry entry) {
+        if (!(entry.result() instanceof TaskResult.Failed f) || f.protocolError() == null) {
+            return null;
+        }
+        var mapped = error(f.protocolError());
+        var fields = new LinkedHashMap<String, Object>();
+        fields.put("code", mapped.code());
+        fields.put("message", mapped.message());
+        if (mapped.data() != null) {
+            fields.put("data", mapped.data());
+        }
+        return JsonUtils.toObjectNode(fields);
     }
 
     private static Tool toTool(ToolDescriptor d) {
@@ -396,14 +425,14 @@ public final class McpResponseMapper extends dev.tachyonmcp.core.protocol.mcp.v2
                         .toList();
     }
 
-    private static JsonNode encodeToTree(Implementation implementation) {
+    private static <T> JsonNode encodeToTree(Class<T> type, T value) {
         try (var out = new ByteArrayOutputStream(256);
                 var gen = JsonUtils.FACTORY.createGenerator(ObjectWriteContext.empty(), out, JsonEncoding.UTF8)) {
-            CodecRegistry.<Implementation>codecFor(Implementation.class).encode(gen, implementation);
+            CodecRegistry.<T>codecFor(type).encode(gen, value);
             gen.flush();
             return JsonUtils.parseJsonNode(out.toString(StandardCharsets.UTF_8));
         } catch (IOException e) {
-            throw new UncheckedIOException("Failed to encode Implementation", e);
+            throw new UncheckedIOException("Failed to encode " + type.getSimpleName(), e);
         }
     }
 

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/mcp/v2026_07_28/codecs/McpTaskMapper.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/mcp/v2026_07_28/codecs/McpTaskMapper.java
@@ -1,6 +1,7 @@
 /* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
 package dev.tachyonmcp.core.protocol.mcp.v2026_07_28.codecs;
 
+import dev.tachyonmcp.api.server.domain.TaskResult;
 import dev.tachyonmcp.api.server.features.tasks.TaskState;
 import dev.tachyonmcp.core.server.features.tasks.TaskEntry;
 import dev.tachyonmcp.core.server.json.JsonUtils;
@@ -11,17 +12,22 @@ import org.jspecify.annotations.Nullable;
 import tools.jackson.databind.JsonNode;
 
 /**
- * Task wire mapping for MCP 2026-07-28 (SEP-1686). Unlike 2025-11-25, this version exposes the
- * full seven-state workflow: {@code SUBMITTED} maps to {@code "submitted"} (rather than folding to
- * {@code "working"}) and {@code UNKNOWN} maps to {@code "unknown"} (rather than throwing).
+ * Task wire mapping for MCP 2026-07-28's tasks extension (SEP-2663). Field names and shapes
+ * follow the extension spec rather than 2025-11-25's experimental tasks feature: {@code ttlMs}/
+ * {@code pollIntervalMs} (not {@code ttl}/{@code pollInterval}), a {@code resultType}
+ * discriminator ({@code "task"} on task creation, {@code "complete"} on {@code tasks/get}), a
+ * flat {@code CreateTaskResult} shape (@code CreateTaskResult = Result & Task} — no nesting under
+ * a {@code "task"} key), and {@code tasks/cancel} returning an empty acknowledgement rather than
+ * the full task state.
  *
- * <p>The 2026-07-28 schema does not generate task wire records, so results are shaped as ordered
- * field maps and rendered to JSON via {@link JsonUtils#toObjectNode(Map)}. The shape mirrors the
- * 2025-11-25 generated codecs exactly: {@code statusMessage}, {@code pollInterval} and
- * {@code _meta} are omitted when absent; {@code ttl} is always present ({@code null} when
- * unlimited).
+ * <p>{@code SUBMITTED} maps to {@code "submitted"} and {@code UNKNOWN} to {@code "unknown"} — two
+ * states 2025-11-25 cannot express on the wire (it folds {@code SUBMITTED} to {@code "working"}
+ * and throws on {@code UNKNOWN}).
  */
 final class McpTaskMapper {
+
+    private static final String RESULT_TYPE_TASK = "task";
+    private static final String RESULT_TYPE_COMPLETE = "complete";
 
     private McpTaskMapper() {}
 
@@ -37,48 +43,56 @@ final class McpTaskMapper {
         };
     }
 
-    static Map<String, Object> toTaskProto(TaskEntry entry) {
-        var task = new LinkedHashMap<String, Object>();
-        task.put("taskId", entry.id());
-        task.put("status", toWireStatus(entry.status()));
-        putIfPresent(task, "statusMessage", entry.statusMessage());
-        task.put("createdAt", entry.createdAtIso());
-        task.put("lastUpdatedAt", entry.lastUpdatedAtIso());
-        task.put("ttl", entry.ttl());
-        putIfPresent(task, "pollInterval", pollIntervalMillis(entry.pollInterval()));
-        return task;
+    static JsonNode toCreateTaskResult(TaskEntry entry) {
+        var fields = taskFields(entry, toWireStatus(entry.status()));
+        fields.put("resultType", RESULT_TYPE_TASK);
+        return JsonUtils.toObjectNode(fields);
     }
 
-    static JsonNode toGetTaskResult(TaskEntry entry) {
-        return JsonUtils.toObjectNode(toTaskResult(entry));
+    static JsonNode toGetTaskResult(TaskEntry entry, @Nullable JsonNode inlineResult, @Nullable JsonNode inlineError) {
+        var fields = taskFields(entry, effectiveWireStatus(entry));
+        putIfPresent(fields, "result", inlineResult);
+        putIfPresent(fields, "error", inlineError);
+        fields.put("resultType", RESULT_TYPE_COMPLETE);
+        return JsonUtils.toObjectNode(fields);
     }
 
-    static JsonNode toCancelTaskResult(TaskEntry entry) {
-        return JsonUtils.toObjectNode(toTaskResult(entry));
+    /** {@code tasks/cancel}'s response is an empty acknowledgement, not the task's state. */
+    static JsonNode toCancelTaskResult() {
+        return JsonUtils.toObjectNode(Map.of("resultType", RESULT_TYPE_COMPLETE));
     }
 
     static JsonNode toStatusNotification(TaskEntry entry) {
-        return JsonUtils.toObjectNode(toTaskResult(entry));
+        return JsonUtils.toObjectNode(taskFields(entry, effectiveWireStatus(entry)));
     }
 
-    static JsonNode toCreateTaskResult(TaskEntry entry) {
-        var result = new LinkedHashMap<String, Object>();
-        result.put("task", toTaskProto(entry));
-        putMeta(result, entry);
-        return JsonUtils.toObjectNode(result);
+    /**
+     * A tool result that completed with {@code isError: true} is a normal {@code completed}
+     * outcome, not a task failure: "This status MUST NOT be used for non-JSON-RPC errors ...
+     * errors within the context of a protocol method result MUST use the completed status." Only
+     * a {@link TaskResult.Failed} carrying a {@code protocolError} is a genuine JSON-RPC failure.
+     */
+    private static String effectiveWireStatus(TaskEntry entry) {
+        if (entry.result() instanceof TaskResult.Failed failed && failed.protocolError() == null) {
+            return "completed";
+        }
+        return toWireStatus(entry.status());
     }
 
-    private static Map<String, Object> toTaskResult(TaskEntry entry) {
-        var result = new LinkedHashMap<String, Object>();
-        putMeta(result, entry);
-        result.put("taskId", entry.id());
-        result.put("status", toWireStatus(entry.status()));
-        putIfPresent(result, "statusMessage", entry.statusMessage());
-        result.put("createdAt", entry.createdAtIso());
-        result.put("lastUpdatedAt", entry.lastUpdatedAtIso());
-        result.put("ttl", entry.ttl());
-        putIfPresent(result, "pollInterval", pollIntervalMillis(entry.pollInterval()));
-        return result;
+    private static Map<String, Object> taskFields(TaskEntry entry, String wireStatus) {
+        var fields = new LinkedHashMap<String, Object>();
+        putMeta(fields, entry);
+        fields.put("taskId", entry.id());
+        fields.put("status", wireStatus);
+        putIfPresent(fields, "statusMessage", entry.statusMessage());
+        fields.put("createdAt", entry.createdAtIso());
+        fields.put("lastUpdatedAt", entry.lastUpdatedAtIso());
+        // SEP-2663 types Task.ttlMs as `number | null` (required, nullable) but
+        // Task.pollIntervalMs as `number?` (optional) -- ttlMs is always written, even when null;
+        // pollIntervalMs is omitted rather than written as null.
+        fields.put("ttlMs", entry.ttl());
+        putIfPresent(fields, "pollIntervalMs", pollIntervalMillis(entry.pollInterval()));
+        return fields;
     }
 
     private static void putMeta(Map<String, Object> target, TaskEntry entry) {

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/features/tasks/TaskMethodHandlers.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/features/tasks/TaskMethodHandlers.java
@@ -1,14 +1,12 @@
 /* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
 package dev.tachyonmcp.core.server.features.tasks;
 
-import dev.tachyonmcp.api.server.domain.ServerError;
 import dev.tachyonmcp.api.server.features.tasks.TaskState;
 import dev.tachyonmcp.core.protocol.RequestMappingException;
 import dev.tachyonmcp.core.server.RpcMethodHandler;
 import dev.tachyonmcp.core.server.domain.ServerErrors;
 import dev.tachyonmcp.core.server.session.DispatchContext;
 import java.util.Map;
-import org.jspecify.annotations.Nullable;
 
 /** JSON-RPC adapters for task operations. */
 public final class TaskMethodHandlers {
@@ -20,22 +18,6 @@ public final class TaskMethodHandlers {
         handlers.put("tasks/get", new TasksGetHandler(registry));
         handlers.put("tasks/cancel", new TasksCancelHandler(registry));
         handlers.put("tasks/result", new TasksResultHandler(registry));
-    }
-
-    /**
-     * 2026-07-28 requires every {@code tasks/get}/{@code tasks/cancel} request to declare the {@code
-     * io.modelcontextprotocol/tasks} extension capability (SEP-2663) or be rejected with {@code
-     * -32021}. 2025-11-25's legacy, session-negotiated task support predates that extension and isn't
-     * gated by it (SEP-2663's protocol-version compatibility table: "this extension does not apply"
-     * under 2025-11-25) — {@code protocol().supportsSessions()} is exactly that version boundary.
-     */
-    private static @Nullable ServerError requireTasksExtension(DispatchContext context) {
-        if (context.protocol().supportsSessions() || context.isExtensionEnabled(TasksExtension.ID)) {
-            return null;
-        }
-        return ServerErrors.missingRequiredClientCapability(
-                "Requires the '" + TasksExtension.ID + "' extension",
-                Map.of("extensions", Map.of(TasksExtension.ID, Map.of())));
     }
 
     private record TasksListHandler(DefaultTaskRegistry registry) implements RpcMethodHandler {
@@ -63,7 +45,7 @@ public final class TaskMethodHandlers {
 
         @Override
         public Object handle(DispatchContext context, Object params) {
-            var missingCapability = requireTasksExtension(context);
+            var missingCapability = TasksExtension.requireDeclared(context);
             if (missingCapability != null) return missingCapability;
             final String taskId;
             try {
@@ -86,7 +68,7 @@ public final class TaskMethodHandlers {
 
         @Override
         public Object handle(DispatchContext context, Object params) {
-            var missingCapability = requireTasksExtension(context);
+            var missingCapability = TasksExtension.requireDeclared(context);
             if (missingCapability != null) return missingCapability;
             final String taskId;
             try {

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/features/tasks/TaskMethodHandlers.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/features/tasks/TaskMethodHandlers.java
@@ -1,12 +1,14 @@
 /* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
 package dev.tachyonmcp.core.server.features.tasks;
 
+import dev.tachyonmcp.api.server.domain.ServerError;
 import dev.tachyonmcp.api.server.features.tasks.TaskState;
 import dev.tachyonmcp.core.protocol.RequestMappingException;
 import dev.tachyonmcp.core.server.RpcMethodHandler;
 import dev.tachyonmcp.core.server.domain.ServerErrors;
 import dev.tachyonmcp.core.server.session.DispatchContext;
 import java.util.Map;
+import org.jspecify.annotations.Nullable;
 
 /** JSON-RPC adapters for task operations. */
 public final class TaskMethodHandlers {
@@ -20,6 +22,18 @@ public final class TaskMethodHandlers {
         handlers.put("tasks/result", new TasksResultHandler(registry));
     }
 
+    /**
+     * MCP 2026-07-28 (SEP-2663) reserves no scoping mechanism for {@code tasks/list} (a poorly-
+     * scoped list could leak one caller's tasks to another) and replaces {@code tasks/result} with
+     * the outcome inlined into {@code tasks/get} -- both methods are removed under that protocol
+     * version. MCP 2025-11-25's legacy task model predates the extension and keeps both.
+     */
+    private static @Nullable ServerError legacyTasksUnavailable(DispatchContext context) {
+        return context.requestMapper().supportsLegacyTaskAugmentation()
+                ? null
+                : ServerErrors.methodNotFound("Method not found");
+    }
+
     private record TasksListHandler(DefaultTaskRegistry registry) implements RpcMethodHandler {
         @Override
         public String method() {
@@ -28,6 +42,8 @@ public final class TaskMethodHandlers {
 
         @Override
         public Object handle(DispatchContext context, Object params) {
+            var unavailable = legacyTasksUnavailable(context);
+            if (unavailable != null) return unavailable;
             var page = context.requestMapper().page(params);
             var paginated = registry.listEntries(page.limit(), page.cursor());
             if (!paginated.cursorValid()) {
@@ -95,6 +111,8 @@ public final class TaskMethodHandlers {
 
         @Override
         public Object handle(DispatchContext context, Object params) {
+            var unavailable = legacyTasksUnavailable(context);
+            if (unavailable != null) return unavailable;
             final String taskId;
             try {
                 taskId = context.requestMapper().taskId(params);

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/features/tasks/TasksExtension.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/features/tasks/TasksExtension.java
@@ -30,10 +30,10 @@ public class TasksExtension implements ServerExtension {
     public static final String ID = "io.modelcontextprotocol/tasks";
 
     /**
-     * 2026-07-28 requires every task-augmented request (task-augmented {@code tools/call},
-     * {@code tasks/get}, {@code tasks/cancel}) to declare this extension per request (SEP-2663) or be
-     * rejected with {@code -32021}; 2025-11-25's legacy, session-negotiated task support predates the
-     * extension and isn't gated by it.
+     * MCP 2026-07-28 (SEP-2663) requires every task-augmented request (task-augmented
+     * {@code tools/call}, {@code tasks/get}, {@code tasks/cancel}) to declare this extension per
+     * request or be rejected with {@code -32021}; MCP 2025-11-25's legacy, session-negotiated task
+     * support predates the extension and isn't gated by it.
      */
     public static @Nullable ServerError requireDeclared(DispatchContext context) {
         if (context.protocol().supportsSessions() || context.isExtensionEnabled(ID)) {

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/features/tasks/TasksExtension.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/features/tasks/TasksExtension.java
@@ -3,6 +3,7 @@ package dev.tachyonmcp.core.server.features.tasks;
 
 import dev.tachyonmcp.api.json.JsonSchema;
 import dev.tachyonmcp.api.runtime.InteractionContext;
+import dev.tachyonmcp.api.server.domain.ServerError;
 import dev.tachyonmcp.api.server.domain.TextResourceContents;
 import dev.tachyonmcp.api.server.extensions.ExtensionContext;
 import dev.tachyonmcp.api.server.extensions.ServerExtension;
@@ -14,15 +15,33 @@ import dev.tachyonmcp.api.server.features.tools.ToolDescriptor;
 import dev.tachyonmcp.api.server.features.tools.ToolRequest;
 import dev.tachyonmcp.api.server.features.tools.ToolResult;
 import dev.tachyonmcp.core.server.OutboundSseStreamMessageRouter;
+import dev.tachyonmcp.core.server.domain.ServerErrors;
+import dev.tachyonmcp.core.server.session.DispatchContext;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
+import org.jspecify.annotations.Nullable;
 
 public class TasksExtension implements ServerExtension {
 
     public static final String ID = "io.modelcontextprotocol/tasks";
+
+    /**
+     * 2026-07-28 requires every task-augmented request (task-augmented {@code tools/call},
+     * {@code tasks/get}, {@code tasks/cancel}) to declare this extension per request (SEP-2663) or be
+     * rejected with {@code -32021}; 2025-11-25's legacy, session-negotiated task support predates the
+     * extension and isn't gated by it.
+     */
+    public static @Nullable ServerError requireDeclared(DispatchContext context) {
+        if (context.protocol().supportsSessions() || context.isExtensionEnabled(ID)) {
+            return null;
+        }
+        return ServerErrors.missingRequiredClientCapability(
+                "Requires the '" + ID + "' extension", Map.of("extensions", Map.of(ID, Map.of())));
+    }
 
     // language=json
     private static final JsonSchema CREATE_TASK_SCHEMA = JsonSchema.of("""

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/features/tools/ToolMethodHandlers.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/features/tools/ToolMethodHandlers.java
@@ -4,7 +4,6 @@ package dev.tachyonmcp.core.server.features.tools;
 import static dev.tachyonmcp.core.server.domain.ServerErrors.fromUnhandledException;
 import static dev.tachyonmcp.core.server.domain.ServerErrors.internalError;
 import static dev.tachyonmcp.core.server.domain.ServerErrors.invalidParams;
-import static dev.tachyonmcp.core.server.domain.ServerErrors.missingRequiredClientCapability;
 
 import dev.tachyonmcp.api.json.JsonDocument;
 import dev.tachyonmcp.api.json.JsonSchema;
@@ -132,17 +131,13 @@ public final class ToolMethodHandlers {
             if (taskSupport == TaskSupport.REQUIRED && !mapped.taskAugmented()) {
                 return CompletableFuture.completedFuture(invalidParams("Task augmentation required for this tool"));
             }
-            // 2026-07-28 (no session) requires the client to declare the tasks extension per request
-            // (SEP-2663) before the server may return a CreateTaskResult; 2025-11-25's legacy,
-            // session-negotiated task augmentation predates that extension and isn't gated by it.
-            if (mapped.taskAugmented()
-                    && !context.protocol().supportsSessions()
-                    && !context.isExtensionEnabled(TasksExtension.ID)) {
-                return CompletableFuture.completedFuture(missingRequiredClientCapability(
-                        "Requires the '" + TasksExtension.ID + "' extension",
-                        Map.of("extensions", Map.of(TasksExtension.ID, Map.of()))));
-            }
             if (mapped.taskAugmented()) {
+                // 2026-07-28 (no session) requires the client to declare the tasks extension per
+                // request (SEP-2663) before the server may return a CreateTaskResult; 2025-11-25's
+                // legacy, session-negotiated task augmentation predates the extension and isn't
+                // gated by it.
+                var missingCapability = TasksExtension.requireDeclared(context);
+                if (missingCapability != null) return CompletableFuture.completedFuture(missingCapability);
                 return CompletableFuture.completedFuture(
                         dispatchTaskAugmented(context, handler, request, mapped.taskTtl()));
             }

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/features/tools/ToolMethodHandlers.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/features/tools/ToolMethodHandlers.java
@@ -5,6 +5,7 @@ import static dev.tachyonmcp.core.server.domain.ServerErrors.fromUnhandledExcept
 import static dev.tachyonmcp.core.server.domain.ServerErrors.internalError;
 import static dev.tachyonmcp.core.server.domain.ServerErrors.invalidParams;
 
+import dev.tachyonmcp.api.annotations.InternalApi;
 import dev.tachyonmcp.api.json.JsonDocument;
 import dev.tachyonmcp.api.json.JsonSchema;
 import dev.tachyonmcp.api.json.JsonSchemaValidator;
@@ -40,6 +41,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /** JSON-RPC adapters for tool operations. */
+@InternalApi
 public final class ToolMethodHandlers {
 
     private ToolMethodHandlers() {}
@@ -124,23 +126,9 @@ public final class ToolMethodHandlers {
 
             var taskSupport = handler.descriptor().taskSupport();
             if (taskSupport == null) taskSupport = TaskSupport.FORBIDDEN;
-            if (taskSupport == TaskSupport.FORBIDDEN && mapped.taskAugmented()) {
-                return CompletableFuture.completedFuture(
-                        invalidParams("Task augmentation not supported for this tool"));
-            }
-            if (taskSupport == TaskSupport.REQUIRED && !mapped.taskAugmented()) {
-                return CompletableFuture.completedFuture(invalidParams("Task augmentation required for this tool"));
-            }
-            if (mapped.taskAugmented()) {
-                // 2026-07-28 (no session) requires the client to declare the tasks extension per
-                // request (SEP-2663) before the server may return a CreateTaskResult; 2025-11-25's
-                // legacy, session-negotiated task augmentation predates the extension and isn't
-                // gated by it.
-                var missingCapability = TasksExtension.requireDeclared(context);
-                if (missingCapability != null) return CompletableFuture.completedFuture(missingCapability);
-                return CompletableFuture.completedFuture(
-                        dispatchTaskAugmented(context, handler, request, mapped.taskTtl()));
-            }
+
+            var taskDispatch = dispatchIfTaskAugmented(context, handler, request, mapped, taskSupport);
+            if (taskDispatch != null) return CompletableFuture.completedFuture(taskDispatch);
 
             sendLogging(context, request.name(), "started");
             return HandlerFutures.invokeAndMap(
@@ -154,6 +142,42 @@ public final class ToolMethodHandlers {
                                 .callToolResult(
                                         prepareResult(handler.descriptor().outputSchema(), toolResult));
                     });
+        }
+
+        /**
+         * Decides whether this call runs as a task instead of synchronously, dispatching it if so.
+         * Returns {@code null} to signal "run synchronously" -- the only case that falls through to
+         * {@link #handleAsync}'s normal dispatch below.
+         */
+        private @Nullable Object dispatchIfTaskAugmented(
+                DispatchContext context,
+                ToolHandler handler,
+                ToolRequest request,
+                dev.tachyonmcp.core.protocol.ProtocolRequestMapper.ToolCallRequest mapped,
+                TaskSupport taskSupport) {
+            if (context.requestMapper().supportsLegacyTaskAugmentation()) {
+                if (taskSupport == TaskSupport.FORBIDDEN && mapped.taskAugmented()) {
+                    return invalidParams("Task augmentation not supported for this tool");
+                }
+                if (taskSupport == TaskSupport.REQUIRED && !mapped.taskAugmented()) {
+                    return invalidParams("Task augmentation required for this tool");
+                }
+                return mapped.taskAugmented()
+                        ? dispatchTaskAugmented(context, handler, request, mapped.taskTtl())
+                        : null;
+            }
+            if (taskSupport != TaskSupport.REQUIRED) {
+                return null;
+            }
+            // MCP 2026-07-28 (SEP-2663): task creation is server-directed, not client-requested --
+            // the legacy "task" field is ignored entirely (see McpRequestMapper). A REQUIRED tool
+            // can't run synchronously, so the server always creates a task for it, gated on the
+            // client having declared the tasks extension per request (the server can't return a
+            // CreateTaskResult otherwise).
+            var missingCapability = TasksExtension.requireDeclared(context);
+            return missingCapability != null
+                    ? missingCapability
+                    : dispatchTaskAugmented(context, handler, request, null);
         }
 
         private @Nullable Object dispatchTaskAugmented(

--- a/tachyon-core/src/test/java/dev/tachyonmcp/core/protocol/mcp/v2026_07_28/codecs/McpRequestMapperTest.java
+++ b/tachyon-core/src/test/java/dev/tachyonmcp/core/protocol/mcp/v2026_07_28/codecs/McpRequestMapperTest.java
@@ -3,51 +3,29 @@ package dev.tachyonmcp.core.protocol.mcp.v2026_07_28.codecs;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import dev.tachyonmcp.api.server.features.tasks.TaskState;
+import dev.tachyonmcp.api.json.PayloadDeserializer;
+import java.lang.reflect.Type;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 
-/**
- * 2026-07-28 inbound task-status parsing (SEP-1686). The two extra states — {@code "submitted"} and
- * {@code "unknown"} — must parse to their own {@link TaskState}; on 2025-11-25 both fall through to
- * {@code WORKING}.
- */
 class McpRequestMapperTest {
 
-    private final McpRequestMapper mapper = new McpRequestMapper();
-
-    private TaskState parse(String wireStatus) {
-        var request = mapper.taskStatus(Map.of("taskId", "t1", "status", wireStatus));
-        assertThat(request).isNotNull();
-        assertThat(request.taskId()).isEqualTo("t1");
-        return request.state();
-    }
+    private static final PayloadDeserializer NOOP_DESERIALIZER = new PayloadDeserializer() {
+        @Override
+        public <T> T deserialize(String json, Type targetType) {
+            throw new UnsupportedOperationException("not used by these tests");
+        }
+    };
 
     @Test
-    void parsesSubmittedAndUnknown() {
-        assertThat(parse("submitted")).isEqualTo(TaskState.SUBMITTED);
-        assertThat(parse("unknown")).isEqualTo(TaskState.UNKNOWN);
-    }
+    void ignoresLegacyTaskAugmentation() {
+        var mapper = new McpRequestMapper();
 
-    @Test
-    void parsesTheFiveClassicStates() {
-        assertThat(parse("input_required")).isEqualTo(TaskState.INPUT_REQUIRED);
-        assertThat(parse("completed")).isEqualTo(TaskState.COMPLETED);
-        assertThat(parse("failed")).isEqualTo(TaskState.FAILED);
-        assertThat(parse("cancelled")).isEqualTo(TaskState.CANCELLED);
-        assertThat(parse("working")).isEqualTo(TaskState.WORKING);
-    }
+        var result = mapper.callTool(Map.of("name", "greet", "task", "ignored"), NOOP_DESERIALIZER);
 
-    @Test
-    void unrecognisedStatusFallsBackToWorking() {
-        assertThat(parse("nonsense")).isEqualTo(TaskState.WORKING);
-    }
-
-    @Test
-    void carriesStatusMessageAndReturnsNullWithoutTaskId() {
-        var request = mapper.taskStatus(Map.of("taskId", "t1", "status", "unknown", "statusMessage", "boom"));
-        assertThat(request).isNotNull();
-        assertThat(request.message()).isEqualTo("boom");
-        assertThat(mapper.taskStatus(Map.of("status", "submitted"))).isNull();
+        assertThat(mapper.supportsLegacyTaskAugmentation()).isFalse();
+        assertThat(result.request().name()).isEqualTo("greet");
+        assertThat(result.taskAugmented()).isFalse();
+        assertThat(result.taskTtl()).isNull();
     }
 }

--- a/tachyon-core/src/test/java/dev/tachyonmcp/core/protocol/mcp/v2026_07_28/codecs/McpTaskMapperTest.java
+++ b/tachyon-core/src/test/java/dev/tachyonmcp/core/protocol/mcp/v2026_07_28/codecs/McpTaskMapperTest.java
@@ -3,17 +3,21 @@ package dev.tachyonmcp.core.protocol.mcp.v2026_07_28.codecs;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import dev.tachyonmcp.api.server.domain.ServerError;
+import dev.tachyonmcp.api.server.domain.TaskResult;
 import dev.tachyonmcp.api.server.features.tasks.TaskDescriptor;
 import dev.tachyonmcp.api.server.features.tasks.TaskState;
 import dev.tachyonmcp.core.server.features.tasks.TaskEntry;
 import java.time.Duration;
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
+import tools.jackson.databind.node.JsonNodeFactory;
 
 /**
- * 2026-07-28 task status mapping (SEP-1686). Confirms the two states 2025-11-25 cannot express on
- * the wire: {@code SUBMITTED → "submitted"} (2025 folds to {@code "working"}) and
- * {@code UNKNOWN → "unknown"} (2025 throws).
+ * MCP 2026-07-28 task wire mapping (SEP-2663): {@code ttlMs}/{@code pollIntervalMs} field names,
+ * the {@code resultType} discriminator, a flat {@code CreateTaskResult}, and an empty-ack
+ * {@code CancelTaskResult} — none of which match 2025-11-25's experimental tasks shape.
  */
 class McpTaskMapperTest {
 
@@ -30,16 +34,17 @@ class McpTaskMapperTest {
 
     @Test
     void submittedMapsToSubmittedWireString() {
-        var node = McpTaskMapper.toGetTaskResult(entry(TaskState.SUBMITTED));
+        var node = McpTaskMapper.toGetTaskResult(entry(TaskState.SUBMITTED), null, null);
         assertThat(node.get("status").asString()).isEqualTo("submitted");
         assertThat(node.get("taskId").asString()).isEqualTo("task-1");
         assertThat(node.get("createdAt").asString()).isNotEmpty();
         assertThat(node.get("lastUpdatedAt").asString()).isNotEmpty();
+        assertThat(node.get("resultType").asString()).isEqualTo("complete");
     }
 
     @Test
     void unknownMapsToUnknownWireStringInsteadOfThrowing() {
-        var node = McpTaskMapper.toGetTaskResult(entry(TaskState.UNKNOWN));
+        var node = McpTaskMapper.toGetTaskResult(entry(TaskState.UNKNOWN), null, null);
         assertThat(node.get("status").asString()).isEqualTo("unknown");
     }
 
@@ -55,29 +60,88 @@ class McpTaskMapperTest {
     }
 
     @Test
-    void wireShapeOmitsNullFieldsButAlwaysWritesTtlAndMeta() {
-        var node = McpTaskMapper.toGetTaskResult(entry(TaskState.SUBMITTED));
-        assertThat(node.has("ttl")).isTrue();
-        assertThat(node.get("ttl").asLong()).isEqualTo(Duration.ofMinutes(1).toMillis());
+    void wireShapeOmitsNullFieldsButAlwaysWritesTtlMsAndMeta() {
+        var node = McpTaskMapper.toGetTaskResult(entry(TaskState.SUBMITTED), null, null);
+        assertThat(node.has("ttlMs")).isTrue();
+        assertThat(node.get("ttlMs").asLong()).isEqualTo(Duration.ofMinutes(1).toMillis());
         assertThat(node.has("statusMessage")).isFalse();
-        assertThat(node.has("pollInterval")).isFalse();
+        assertThat(node.has("pollIntervalMs")).isFalse();
         assertThat(node.get("_meta").get("trace").asString()).isEqualTo("abc");
     }
 
     @Test
-    void createTaskResultNestsTaskUnderTaskKey() {
+    void ttlMsIsWrittenAsNullRatherThanOmittedWhenUnlimited() {
+        // SEP-2663 types Task.ttlMs as `number | null` (required) unlike the optional
+        // pollIntervalMs -- an unlimited task must still report the key, just with a null value.
+        var unlimited = new TaskEntry(
+                TaskDescriptor.builder().id("task-2").build(), "task-2", TaskState.SUBMITTED, null, null, null, null);
+
+        var node = McpTaskMapper.toGetTaskResult(unlimited, null, null);
+
+        assertThat(node.has("ttlMs")).isTrue();
+        assertThat(node.get("ttlMs").isNull()).isTrue();
+    }
+
+    @Test
+    void getTaskResultInlinesTheGivenResultNode() {
+        var resultNode = JsonNodeFactory.instance.objectNode().put("text", "done");
+
+        var node = McpTaskMapper.toGetTaskResult(entry(TaskState.COMPLETED), resultNode, null);
+
+        assertThat(node.get("result").get("text").asString()).isEqualTo("done");
+        assertThat(node.has("error")).isFalse();
+    }
+
+    @Test
+    void getTaskResultInlinesTheGivenErrorNode() {
+        var errorNode = JsonNodeFactory.instance.objectNode().put("code", -32603);
+
+        var node = McpTaskMapper.toGetTaskResult(entry(TaskState.FAILED), null, errorNode);
+
+        assertThat(node.get("error").get("code").asInt()).isEqualTo(-32603);
+        assertThat(node.has("result")).isFalse();
+    }
+
+    @Test
+    void toolLevelErrorReportsCompletedStatusNotFailed() {
+        var task = entry(TaskState.WORKING);
+        task.fail(new TaskResult.Failed(List.of(), null, null));
+
+        var node = McpTaskMapper.toGetTaskResult(task, null, null);
+
+        assertThat(node.get("status").asString()).isEqualTo("completed");
+    }
+
+    @Test
+    void protocolErrorReportsFailedStatus() {
+        var task = entry(TaskState.WORKING);
+        task.fail(TaskResult.failed(new ServerError(ServerError.Kind.INTERNAL_ERROR, "boom")));
+
+        var node = McpTaskMapper.toGetTaskResult(task, null, null);
+
+        assertThat(node.get("status").asString()).isEqualTo("failed");
+    }
+
+    @Test
+    void createTaskResultIsFlatWithTaskDiscriminator() {
         var node = McpTaskMapper.toCreateTaskResult(entry(TaskState.SUBMITTED));
-        assertThat(node.get("task").get("status").asString()).isEqualTo("submitted");
-        assertThat(node.get("task").get("taskId").asString()).isEqualTo("task-1");
+        assertThat(node.get("status").asString()).isEqualTo("submitted");
+        assertThat(node.get("taskId").asString()).isEqualTo("task-1");
+        assertThat(node.get("resultType").asString()).isEqualTo("task");
         assertThat(node.get("_meta").get("trace").asString()).isEqualTo("abc");
+        assertThat(node.has("task")).isFalse();
     }
 
     @Test
-    void cancelAndNotificationCarryTheSameStatus() {
-        assertThat(McpTaskMapper.toCancelTaskResult(entry(TaskState.CANCELLED))
-                        .get("status")
-                        .asString())
-                .isEqualTo("cancelled");
+    void cancelTaskResultIsAnEmptyAcknowledgement() {
+        var node = McpTaskMapper.toCancelTaskResult();
+        assertThat(node.get("resultType").asString()).isEqualTo("complete");
+        assertThat(node.has("taskId")).isFalse();
+        assertThat(node.has("status")).isFalse();
+    }
+
+    @Test
+    void statusNotificationCarriesTheCurrentStatus() {
         assertThat(McpTaskMapper.toStatusNotification(entry(TaskState.INPUT_REQUIRED))
                         .get("status")
                         .asString())


### PR DESCRIPTION
## Summary

The change updates MCP 2026-07-28 task handling to use server-directed creation and per-request extension declarations. Legacy `tools/call.task` handling remains available for MCP 2025-11-25 but is ignored in 2026-07-28. Task wire results now use `ttlMs`, `pollIntervalMs`, result discriminators, inline outcomes, and empty cancel acknowledgements. `tasks/list` and `tasks/result` are removed. `tasks/get` and `tasks/cancel` require the declared extension. Tests and documentation cover the new behavior.

### New Features

  - Added support for MCP 2026-07-28 task semantics, including server-directed task creation and per-request capability declarations.
  - Task results now distinguish successful, tool-level error, and protocol-failure outcomes.
  - Task responses support updated fields such as `ttlMs`, `pollIntervalMs`, and `resultType`.

### Bug Fixes

  - Legacy task augmentation is ignored where unsupported.
  - Undeclared task operations are rejected with clear capability errors.
  - Removed task methods now return method-not-found responses.

### Documentation

  - Updated task behavior and protocol method availability documentation.

### Tests
  - Expanded coverage for task lifecycle, capability gating, and result handling.

