### PR TITLE
refactor(kotlin): finish JSON boundary — drop Jackson/kotlinx from public API

### DIFF
--- a/examples/weather-mcp-kotlin/src/main/kotlin/com/example/weather/WeatherServer.kt
+++ b/examples/weather-mcp-kotlin/src/main/kotlin/com/example/weather/WeatherServer.kt
@@ -22,6 +22,7 @@ import dev.tachyonmcp.kotlin.server.buildServer
 import dev.tachyonmcp.kotlin.server.domain.Annotations
 import dev.tachyonmcp.kotlin.server.domain.Icon
 import dev.tachyonmcp.kotlin.server.features.prompts.PromptDescriptor
+import dev.tachyonmcp.kotlin.server.features.resources.ResourceDescriptor
 import dev.tachyonmcp.kotlin.server.json.KxSerializationSerde
 import me.kpavlov.kt.schema.generator.json.JsonSchemaConfig
 import me.kpavlov.kt.schema.generator.json.ReflectionClassJsonSchemaGenerator
@@ -100,26 +101,30 @@ fun assembleServer(
         tool(getWeatherToolDescriptor) { getWeather(weatherService) }
 
         resource(
-            name = "prediction-article",
-            uri = "weather://prediction/article",
-            description = "Weather prediction article",
-            mimeType = "text/markdown",
-            title = "Weather Prediction",
-            annotations = resourceAnnotations,
-            size = predictionArticle.toByteArray().size.toLong(),
-            icons = listOf(resourceIcon),
+            ResourceDescriptor {
+                name = "prediction-article"
+                uri = "weather://prediction/article"
+                description = "Weather prediction article"
+                mimeType = "text/markdown"
+                title = "Weather Prediction"
+                annotations = resourceAnnotations
+                size = predictionArticle.toByteArray().size.toLong()
+                icons = listOf(resourceIcon)
+            },
         ) {
             TextResourceContents { text = weatherService.predictionArticle }
         }
 
         resource(
-            name = "featured-current-weather",
-            uri = "weather://featured/current",
-            description = "Current weather in Tallinn",
-            mimeType = "application/json",
-            title = "Featured Current Weather",
-            annotations = resourceAnnotations,
-            icons = listOf(resourceIcon),
+            ResourceDescriptor {
+                name = "featured-current-weather"
+                uri = "weather://featured/current"
+                description = "Current weather in Tallinn"
+                mimeType = "application/json"
+                title = "Featured Current Weather"
+                annotations = resourceAnnotations
+                icons = listOf(resourceIcon)
+            },
         ) {
             TextResourceContents {
                 text = asJson(weatherService.currentWeather("Tallinn", TemperatureUnit.Celsius))

--- a/tachyon-kotlin/pom.xml
+++ b/tachyon-kotlin/pom.xml
@@ -49,12 +49,10 @@
             <artifactId>slf4j-api</artifactId>
         </dependency>
 
-        <!-- Optional: kotlinx-serialization-json for KotlinxExtensions -->
         <dependency>
             <groupId>org.jetbrains.kotlinx</groupId>
             <artifactId>kotlinx-serialization-json</artifactId>
             <version>${kotlinx-serialization-json.version}</version>
-            <optional>true</optional>
         </dependency>
 
         <!-- Test -->

--- a/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/TachyonServer.kt
+++ b/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/TachyonServer.kt
@@ -82,7 +82,6 @@ public sealed interface TachyonServer : CoreTachyonServer {
 
     /**
      * Registers a suspend tool handler using kotlinx JSON schemas.
-     * Requires kotlinx-serialization-json on the classpath.
      */
     @JvmSynthetic
     public fun registerTool(

--- a/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/config/TachyonServerBuilder.kt
+++ b/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/config/TachyonServerBuilder.kt
@@ -3,6 +3,8 @@ package dev.tachyonmcp.kotlin.server.config
 
 import dev.tachyonmcp.api.annotations.ExperimentalApi
 import dev.tachyonmcp.api.json.JsonSchema
+import dev.tachyonmcp.api.server.domain.Annotations
+import dev.tachyonmcp.api.server.domain.Icon
 import dev.tachyonmcp.api.server.domain.PromptMessage
 import dev.tachyonmcp.api.server.domain.ResourceContents
 import dev.tachyonmcp.api.server.features.completions.CompletionResult
@@ -168,6 +170,9 @@ public class TachyonServerBuilder
          * @param description optional resource description
          * @param mimeType optional resource MIME type
          * @param title optional human-readable title
+         * @param annotations optional presentation hints
+         * @param size optional raw content size in bytes
+         * @param icons optional associated icons
          * @param block handles reads of the registered resource
          * @return this builder
          */
@@ -178,6 +183,9 @@ public class TachyonServerBuilder
             description: String? = null,
             mimeType: String? = null,
             title: String? = null,
+            annotations: Annotations? = null,
+            size: Long? = null,
+            icons: List<Icon>? = null,
             block: suspend ResourceScope.() -> ResourceContents,
         ): TachyonServerBuilder =
             this.also {
@@ -187,9 +195,9 @@ public class TachyonServerBuilder
                     description = description,
                     mimeType = mimeType,
                     title = title,
-                    annotations = null,
-                    size = null,
-                    icons = null,
+                    annotations = annotations,
+                    size = size,
+                    icons = icons,
                     block = block,
                 )
             }
@@ -247,6 +255,8 @@ public class TachyonServerBuilder
          * @param description The optional template description.
          * @param mimeType The optional MIME type of the resources.
          * @param title The optional template title.
+         * @param annotations The optional template annotations.
+         * @param icons The optional template icons.
          * @param block Handles requests for resources matching the template.
          * @return This builder.
          */
@@ -257,6 +267,8 @@ public class TachyonServerBuilder
             description: String? = null,
             mimeType: String? = null,
             title: String? = null,
+            annotations: Annotations? = null,
+            icons: List<Icon>? = null,
             block: suspend TemplateScope.() -> ResourceContents,
         ): TachyonServerBuilder =
             this.also {
@@ -266,8 +278,8 @@ public class TachyonServerBuilder
                     description = description,
                     mimeType = mimeType,
                     title = title,
-                    annotations = null,
-                    icons = null,
+                    annotations = annotations,
+                    icons = icons,
                     block = block,
                 )
             }

--- a/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/config/TachyonServerBuilder.kt
+++ b/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/config/TachyonServerBuilder.kt
@@ -3,8 +3,6 @@ package dev.tachyonmcp.kotlin.server.config
 
 import dev.tachyonmcp.api.annotations.ExperimentalApi
 import dev.tachyonmcp.api.json.JsonSchema
-import dev.tachyonmcp.api.server.domain.Annotations
-import dev.tachyonmcp.api.server.domain.Icon
 import dev.tachyonmcp.api.server.domain.PromptMessage
 import dev.tachyonmcp.api.server.domain.ResourceContents
 import dev.tachyonmcp.api.server.features.completions.CompletionResult
@@ -170,9 +168,6 @@ public class TachyonServerBuilder
          * @param description optional resource description
          * @param mimeType optional resource MIME type
          * @param title optional human-readable title
-         * @param annotations optional presentation hints
-         * @param size optional raw content size in bytes
-         * @param icons optional associated icons
          * @param block handles reads of the registered resource
          * @return this builder
          */
@@ -183,9 +178,6 @@ public class TachyonServerBuilder
             description: String? = null,
             mimeType: String? = null,
             title: String? = null,
-            annotations: Annotations? = null,
-            size: Long? = null,
-            icons: List<Icon>? = null,
             block: suspend ResourceScope.() -> ResourceContents,
         ): TachyonServerBuilder =
             this.also {
@@ -195,9 +187,9 @@ public class TachyonServerBuilder
                     description = description,
                     mimeType = mimeType,
                     title = title,
-                    annotations = annotations,
-                    size = size,
-                    icons = icons,
+                    annotations = null,
+                    size = null,
+                    icons = null,
                     block = block,
                 )
             }
@@ -252,11 +244,9 @@ public class TachyonServerBuilder
          *
          * @param name The template name.
          * @param uriTemplate The URI template used to identify resources.
-         * @param title The optional template title.
          * @param description The optional template description.
          * @param mimeType The optional MIME type of the resources.
-         * @param annotations The optional template annotations.
-         * @param icons The optional template icons.
+         * @param title The optional template title.
          * @param block Handles requests for resources matching the template.
          * @return This builder.
          */
@@ -267,8 +257,6 @@ public class TachyonServerBuilder
             description: String? = null,
             mimeType: String? = null,
             title: String? = null,
-            annotations: Annotations? = null,
-            icons: List<Icon>? = null,
             block: suspend TemplateScope.() -> ResourceContents,
         ): TachyonServerBuilder =
             this.also {
@@ -278,8 +266,8 @@ public class TachyonServerBuilder
                     description = description,
                     mimeType = mimeType,
                     title = title,
-                    annotations = annotations,
-                    icons = icons,
+                    annotations = null,
+                    icons = null,
                     block = block,
                 )
             }
@@ -331,7 +319,6 @@ public class TachyonServerBuilder
 
         /**
          * Registers a tool using a [JsonObject] input schema.
-         * Requires kotlinx-serialization-json on the classpath.
          */
         @JvmSynthetic
         public fun tool(

--- a/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/domain/ContentFactories.kt
+++ b/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/domain/ContentFactories.kt
@@ -13,9 +13,6 @@ import dev.tachyonmcp.api.server.domain.EmbeddedResource
 import dev.tachyonmcp.api.server.domain.ImageContent
 import dev.tachyonmcp.api.server.domain.ResourceContents
 import dev.tachyonmcp.api.server.domain.TextContent
-import dev.tachyonmcp.kotlin.server.json.toJacksonNodeMap
-import kotlinx.serialization.json.JsonObject
-import tools.jackson.databind.JsonNode
 import java.util.Base64
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
@@ -30,7 +27,7 @@ import kotlin.contracts.contract
  */
 public fun TextContent(
     text: String,
-    meta: Map<String, JsonNode>? = null,
+    meta: Map<String, Any>? = null,
     annotations: Annotations? = null,
 ): TextContent =
     TextContent
@@ -51,22 +48,6 @@ public inline fun AudioContent(block: AudioContentBuilder.() -> Unit): AudioCont
 }
 
 /**
- * Creates a [TextContent] block using a kotlinx-serialization metadata map.
- * Requires kotlinx-serialization-json on the classpath.
- */
-@JvmName("textContentWithKxMeta")
-public fun TextContent(
-    text: String,
-    meta: Map<String, JsonObject>?,
-    annotations: Annotations? = null,
-): TextContent =
-    TextContent.of(
-        text,
-        meta?.toJacksonNodeMap(),
-        annotations,
-    )
-
-/**
  * Creates an [ImageContent] block — raw image bytes.
  *
  * @param data        the image bytes
@@ -78,31 +59,13 @@ public fun ImageContent(
     data: ByteArray,
     mimeType: String,
     annotations: Annotations? = null,
-    meta: Map<String, JsonNode>? = null,
+    meta: Map<String, Any>? = null,
 ): ImageContent =
     ImageContent.of(
         data,
         mimeType,
         annotations,
         meta,
-    )
-
-/**
- * Creates an [ImageContent] block using a kotlinx-serialization metadata map.
- * Requires kotlinx-serialization-json on the classpath.
- */
-@JvmName("imageContentBytesWithKxMeta")
-public fun ImageContent(
-    data: ByteArray,
-    mimeType: String,
-    annotations: Annotations? = null,
-    meta: Map<String, JsonObject>?,
-): ImageContent =
-    ImageContent.of(
-        data,
-        mimeType,
-        annotations,
-        meta?.toJacksonNodeMap(),
     )
 
 /**
@@ -111,7 +74,7 @@ public fun ImageContent(
  * @param data        base64-encoded image bytes
  * @param mimeType    image format (e.g. "image/png")
  * @param annotations optional presentation hints
- * @param meta        optional request-level metadata; null to omit
+ * @param meta        optional request metadata; null to omit
  */
 @Deprecated(
     message = "Base64-encoded String input is deprecated; pass raw bytes instead.",
@@ -125,39 +88,13 @@ public fun ImageContent(
     data: String,
     mimeType: String,
     annotations: Annotations? = null,
-    meta: Map<String, JsonNode>? = null,
+    meta: Map<String, Any>? = null,
 ): ImageContent =
     ImageContent.of(
         Base64.getDecoder().decode(data),
         mimeType,
         annotations,
         meta,
-    )
-
-/**
- * Creates an [ImageContent] block from base64-encoded data using a kotlinx-serialization
- * metadata map. Requires kotlinx-serialization-json on the classpath.
- */
-@JvmName("imageContentWithKxMeta")
-@Deprecated(
-    message = "Base64-encoded String input is deprecated; pass raw bytes instead.",
-    replaceWith =
-        ReplaceWith(
-            "ImageContent(Base64.getDecoder().decode(data), mimeType, annotations, meta)",
-            "java.util.Base64",
-        ),
-)
-public fun ImageContent(
-    data: String,
-    mimeType: String,
-    annotations: Annotations? = null,
-    meta: Map<String, JsonObject>?,
-): ImageContent =
-    ImageContent.of(
-        Base64.getDecoder().decode(data),
-        mimeType,
-        annotations,
-        meta?.toJacksonNodeMap(),
     )
 
 /**
@@ -166,37 +103,19 @@ public fun ImageContent(
  * @param data        the audio bytes
  * @param mimeType    audio format (e.g. "audio/mp3")
  * @param annotations optional presentation hints
- * @param meta        optional request-level metadata; null to omit
+ * @param meta        optional request metadata; null to omit
  */
 public fun AudioContent(
     data: ByteArray,
     mimeType: String,
     annotations: Annotations? = null,
-    meta: Map<String, JsonNode>? = null,
+    meta: Map<String, Any>? = null,
 ): AudioContent =
     AudioContent.of(
         data,
         mimeType,
         annotations,
         meta,
-    )
-
-/**
- * Creates an [AudioContent] block using a kotlinx-serialization metadata map.
- * Requires kotlinx-serialization-json on the classpath.
- */
-@JvmName("audioContentBytesWithKxMeta")
-public fun AudioContent(
-    data: ByteArray,
-    mimeType: String,
-    annotations: Annotations? = null,
-    meta: Map<String, JsonObject>?,
-): AudioContent =
-    AudioContent.of(
-        data,
-        mimeType,
-        annotations,
-        meta?.toJacksonNodeMap(),
     )
 
 /**
@@ -205,7 +124,7 @@ public fun AudioContent(
  * @param data        base64-encoded audio bytes
  * @param mimeType    audio format (e.g. "audio/mp3")
  * @param annotations optional presentation hints
- * @param meta        optional request-level metadata; null to omit
+ * @param meta        optional request metadata; null to omit
  */
 @Deprecated(
     message = "Base64-encoded String input is deprecated; pass raw bytes instead.",
@@ -219,7 +138,7 @@ public fun AudioContent(
     data: String,
     mimeType: String,
     annotations: Annotations? = null,
-    meta: Map<String, JsonNode>? = null,
+    meta: Map<String, Any>? = null,
 ): AudioContent =
     AudioContent.of(
         Base64.getDecoder().decode(data),
@@ -229,58 +148,16 @@ public fun AudioContent(
     )
 
 /**
- * Creates an [AudioContent] block from base64-encoded data using a kotlinx-serialization
- * metadata map. Requires kotlinx-serialization-json on the classpath.
- */
-@JvmName("audioContentWithKxMeta")
-@Deprecated(
-    message = "Base64-encoded String input is deprecated; pass raw bytes instead.",
-    replaceWith =
-        ReplaceWith(
-            "AudioContent(Base64.getDecoder().decode(data), mimeType, annotations, meta)",
-            "java.util.Base64",
-        ),
-)
-public fun AudioContent(
-    data: String,
-    mimeType: String,
-    annotations: Annotations? = null,
-    meta: Map<String, JsonObject>?,
-): AudioContent =
-    AudioContent.of(
-        Base64.getDecoder().decode(data),
-        mimeType,
-        annotations,
-        meta?.toJacksonNodeMap(),
-    )
-
-/**
  * Creates an [EmbeddedResource] — a complete resource inlined within a result.
  *
  * @param resource    the resource contents (text or blob)
  * @param annotations optional presentation hints
- * @param meta        optional request-level metadata; null to omit
+ * @param meta        optional request metadata; null to omit
  */
 public fun EmbeddedResource(
     resource: ResourceContents,
     annotations: Annotations? = null,
-    meta: Map<String, JsonNode>? = null,
+    meta: Map<String, Any>? = null,
 ): EmbeddedResource =
     EmbeddedResource
         .of(resource, annotations, meta)
-
-/**
- * Creates an [EmbeddedResource] using a kotlinx-serialization metadata map.
- * Requires kotlinx-serialization-json on the classpath.
- */
-@JvmName("embeddedResourceWithKxMeta")
-public fun EmbeddedResource(
-    resource: ResourceContents,
-    annotations: Annotations? = null,
-    meta: Map<String, JsonObject>?,
-): EmbeddedResource =
-    EmbeddedResource.of(
-        resource,
-        annotations,
-        meta?.toJacksonNodeMap(),
-    )

--- a/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/domain/RequestFactories.kt
+++ b/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/domain/RequestFactories.kt
@@ -10,9 +10,7 @@ import dev.tachyonmcp.api.server.domain.FormInputRequest
 import dev.tachyonmcp.api.server.domain.RpcMethodRequest
 import dev.tachyonmcp.api.server.domain.UrlInputRequest
 import dev.tachyonmcp.kotlin.server.json.toJacksonNode
-import dev.tachyonmcp.kotlin.server.json.toJacksonNodeMap
 import kotlinx.serialization.json.JsonObject
-import tools.jackson.databind.JsonNode
 
 /**
  * Creates an [RpcMethodRequest] — requests user input by invoking an RPC method.
@@ -22,14 +20,14 @@ import tools.jackson.databind.JsonNode
  */
 public fun RpcMethodRequest(
     method: String,
-    params: JsonNode? = null,
+    params: Any? = null,
 ): RpcMethodRequest =
     RpcMethodRequest
         .of(method, params)
 
 /**
  * Creates an [RpcMethodRequest] using a kotlinx-serialization [JsonObject] params.
- * Requires kotlinx-serialization-json on the classpath.
+ * The params are converted to the wire format, so they serialize correctly.
  */
 public fun RpcMethodRequest(
     method: String,
@@ -48,24 +46,10 @@ public fun RpcMethodRequest(
  */
 public fun FormInputRequest(
     message: String,
-    requestedSchema: Map<String, JsonNode>,
+    requestedSchema: Map<String, Any>,
 ): FormInputRequest =
     FormInputRequest
         .of(message, requestedSchema)
-
-/**
- * Creates a [FormInputRequest] using a kotlinx-serialization schema map.
- * Requires kotlinx-serialization-json on the classpath.
- */
-@JvmName("formInputRequestWithKxSchema")
-public fun FormInputRequest(
-    message: String,
-    requestedSchema: Map<String, JsonObject>,
-): FormInputRequest =
-    FormInputRequest.of(
-        message,
-        requestedSchema.toJacksonNodeMap(),
-    )
 
 /**
  * Creates a [UrlInputRequest] — requests user input by opening a URL.

--- a/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/domain/ResourceFactories.kt
+++ b/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/domain/ResourceFactories.kt
@@ -8,9 +8,6 @@ package dev.tachyonmcp.kotlin.server.domain
 
 import dev.tachyonmcp.api.server.domain.BlobResourceContents
 import dev.tachyonmcp.api.server.domain.TextResourceContents
-import dev.tachyonmcp.kotlin.server.json.toJacksonNodeMap
-import kotlinx.serialization.json.JsonObject
-import tools.jackson.databind.JsonNode
 import java.util.Base64
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
@@ -47,33 +44,13 @@ public fun TextResourceContents(
     uri: String,
     text: String,
     mimeType: String? = null,
-    meta: Map<String, JsonNode>? = null,
+    meta: Map<String, Any>? = null,
 ): TextResourceContents =
     TextResourceContents.of(
         uri,
         text,
         mimeType,
         meta,
-    )
-
-/**
- * Creates [TextResourceContents] using a kotlinx-serialization metadata map.
- * Requires kotlinx-serialization-json on the classpath.
- *
- * @author Konstantin Pavlov
- */
-@JvmName("textResourceContentsWithKxMeta")
-public fun TextResourceContents(
-    uri: String,
-    text: String,
-    mimeType: String? = null,
-    meta: Map<String, JsonObject>?,
-): TextResourceContents =
-    TextResourceContents.of(
-        uri,
-        text,
-        mimeType,
-        meta?.toJacksonNodeMap(),
     )
 
 /**
@@ -89,33 +66,13 @@ public fun BlobResourceContents(
     uri: String,
     blob: ByteArray,
     mimeType: String? = null,
-    meta: Map<String, JsonNode> = emptyMap(),
+    meta: Map<String, Any> = emptyMap(),
 ): BlobResourceContents =
     BlobResourceContents.of(
         uri,
         blob,
         mimeType,
         meta,
-    )
-
-/**
- * Creates [BlobResourceContents] using a kotlinx-serialization metadata map.
- * Requires kotlinx-serialization-json on the classpath.
- *
- * @author Konstantin Pavlov
- */
-@JvmName("blobResourceContentsBytesWithKxMeta")
-public fun BlobResourceContents(
-    uri: String,
-    blob: ByteArray,
-    mimeType: String? = null,
-    meta: Map<String, JsonObject>,
-): BlobResourceContents =
-    BlobResourceContents.of(
-        uri,
-        blob,
-        mimeType,
-        meta.toJacksonNodeMap(),
     )
 
 /**
@@ -139,39 +96,11 @@ public fun BlobResourceContents(
     uri: String,
     blob: String,
     mimeType: String? = null,
-    meta: Map<String, JsonNode> = emptyMap(),
+    meta: Map<String, Any> = emptyMap(),
 ): BlobResourceContents =
     BlobResourceContents.of(
         uri,
         Base64.getDecoder().decode(blob),
         mimeType,
         meta,
-    )
-
-/**
- * Creates [BlobResourceContents] from base64-encoded data using a kotlinx-serialization
- * metadata map. Requires kotlinx-serialization-json on the classpath.
- *
- * @author Konstantin Pavlov
- */
-@JvmName("blobResourceContentsWithKxMeta")
-@Deprecated(
-    message = "Base64-encoded String input is deprecated; pass raw bytes instead.",
-    replaceWith =
-        ReplaceWith(
-            "BlobResourceContents(uri, Base64.getDecoder().decode(blob), mimeType, meta)",
-            "java.util.Base64",
-        ),
-)
-public fun BlobResourceContents(
-    uri: String,
-    blob: String,
-    mimeType: String? = null,
-    meta: Map<String, JsonObject>,
-): BlobResourceContents =
-    BlobResourceContents.of(
-        uri,
-        Base64.getDecoder().decode(blob),
-        mimeType,
-        meta.toJacksonNodeMap(),
     )

--- a/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/domain/StructuredFactoryBuilders.kt
+++ b/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/domain/StructuredFactoryBuilders.kt
@@ -13,7 +13,6 @@ import dev.tachyonmcp.api.server.domain.Role
 import dev.tachyonmcp.api.server.domain.ToolAnnotations
 import dev.tachyonmcp.kotlin.server.TachyonDsl
 import dev.tachyonmcp.kotlin.server.config.ResourceScope
-import tools.jackson.databind.JsonNode
 import java.util.Base64
 
 /** Builds [dev.tachyonmcp.api.server.domain.Annotations]. */
@@ -149,7 +148,7 @@ public class ImageContentBuilder
         public var annotations: Annotations? = null
 
         /** Optional content metadata. */
-        public var meta: Map<String, JsonNode>? = null
+        public var meta: Map<String, Any>? = null
 
         @PublishedApi
         internal fun build(): ImageContent =
@@ -186,7 +185,7 @@ public class AudioContentBuilder
         public var annotations: Annotations? = null
 
         /** Optional content metadata. */
-        public var meta: Map<String, JsonNode>? = null
+        public var meta: Map<String, Any>? = null
 
         @PublishedApi
         internal fun build(): AudioContent =
@@ -229,7 +228,7 @@ public class BlobResourceContentsBuilder
         public var mimeType: String? = scope?.registeredMimeType
 
         /** Optional resource metadata. */
-        public var meta: Map<String, JsonNode> = emptyMap()
+        public var meta: Map<String, Any> = emptyMap()
 
         @PublishedApi
         internal fun build(): BlobResourceContents =

--- a/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/domain/TextResourceContentsBuilder.kt
+++ b/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/domain/TextResourceContentsBuilder.kt
@@ -5,7 +5,6 @@ import dev.tachyonmcp.api.server.domain.TextResourceContents
 import dev.tachyonmcp.kotlin.server.TachyonDsl
 import dev.tachyonmcp.kotlin.server.config.ResourceScope
 import dev.tachyonmcp.kotlin.server.config.TemplateScope
-import tools.jackson.databind.JsonNode
 
 /**
  * Builds [dev.tachyonmcp.api.server.domain.TextResourceContents] for a matched resource template.
@@ -28,7 +27,7 @@ public class TextResourceContentsBuilder
         public var text: String? = null
 
         /** Optional resource metadata. */
-        public var meta: Map<String, JsonNode>? = null
+        public var meta: Map<String, Any>? = null
 
         /**
          * Returns a scalar URI-template parameter.

--- a/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/json/JsonInterop.kt
+++ b/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/json/JsonInterop.kt
@@ -4,7 +4,6 @@ package dev.tachyonmcp.kotlin.server.json
 import dev.tachyonmcp.api.json.JsonSchema
 import dev.tachyonmcp.api.server.features.tools.ToolDescriptor
 import dev.tachyonmcp.core.server.json.Jackson3JsonFactory
-import dev.tachyonmcp.core.server.json.JsonUtils
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonNull
@@ -14,19 +13,11 @@ import kotlinx.serialization.json.booleanOrNull
 import kotlinx.serialization.json.doubleOrNull
 import kotlinx.serialization.json.intOrNull
 import kotlinx.serialization.json.longOrNull
-import tools.jackson.core.JacksonException
 import tools.jackson.databind.JsonNode
 import tools.jackson.databind.node.JsonNodeFactory
 import java.math.BigDecimal
 
 private val nodes = JsonNodeFactory.instance
-
-internal fun String.toJsonNode(): JsonNode =
-    try {
-        JsonUtils.parse(this)
-    } catch (e: JacksonException) {
-        throw IllegalArgumentException("Failed to parse JSON schema: '$this'", e)
-    }
 
 internal fun ToolDescriptor.Builder.schemas(
     inputSchema: String? = null,
@@ -80,11 +71,6 @@ private fun JsonPrimitive.toValueNode(): JsonNode =
                 ?: nodes.numberNode(BigDecimal(content))
         }
     }
-
-internal fun JsonObject?.toJacksonNodeOrNull(): JsonNode? = this?.toJacksonNode()
-
-internal fun Map<String, JsonObject>.toJacksonNodeMap(): Map<String, JsonNode> =
-    mapValues { (_, v) -> v.toJacksonNode() }
 
 internal fun JsonObject.toJsonSchema(): JsonSchema =
     KotlinxJsonObjectFactory.INSTANCE.toJsonSchema(this)

--- a/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/json/KxSerializationSerde.kt
+++ b/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/json/KxSerializationSerde.kt
@@ -14,7 +14,6 @@ import java.util.concurrent.ConcurrentHashMap
  * Serializers are resolved from the [json] serializers module by runtime type, so payload
  * classes must be `@Serializable` (or built-in). Generic containers lose their type arguments
  * at runtime — prefer dedicated `@Serializable` payload classes over raw maps.
- * Requires kotlinx-serialization-json on the classpath.
  *
  * @author Konstantin Pavlov
  */

--- a/tachyon-kotlin/src/test/kotlin/dev/tachyonmcp/kotlin/server/KotlinApiTest.kt
+++ b/tachyon-kotlin/src/test/kotlin/dev/tachyonmcp/kotlin/server/KotlinApiTest.kt
@@ -28,7 +28,6 @@ import dev.tachyonmcp.kotlin.server.domain.string
 import dev.tachyonmcp.kotlin.server.domain.stringOrNull
 import dev.tachyonmcp.kotlin.server.domain.valuesAs
 import dev.tachyonmcp.kotlin.server.json.KxSerializationSerde
-import dev.tachyonmcp.kotlin.server.json.toJsonNode
 import io.kotest.assertions.assertSoftly
 import io.kotest.assertions.json.shouldEqualJson
 import io.kotest.assertions.throwables.shouldThrow
@@ -100,26 +99,6 @@ internal class KotlinApiTest {
         ).use { handle ->
             handle.tools().find("t3").orElse(null) shouldNotBe null
         }
-    }
-
-    // endregion
-
-    // region: String.toJsonNode parse
-
-    @Test
-    fun `toJsonNode parses valid JSON`() {
-        val node = """{"type":"object"}""".toJsonNode()
-        node.isObject shouldBe true
-        @Suppress("DEPRECATION")
-        val type = node.get("type").asText()
-        type shouldBe "object"
-    }
-
-    @Test
-    fun `toJsonNode parses array JSON`() {
-        val node = """[1,2,3]""".toJsonNode()
-        node.isArray shouldBe true
-        node.size() shouldBe 3
     }
 
     // endregion

--- a/tachyon-kotlin/src/test/kotlin/dev/tachyonmcp/kotlin/server/TachyonServerTest.kt
+++ b/tachyon-kotlin/src/test/kotlin/dev/tachyonmcp/kotlin/server/TachyonServerTest.kt
@@ -256,13 +256,15 @@ internal class TachyonServerTest {
             session { enabled = true }
             tool("check", inputSchema = schema) { ToolResult.text("ok") }
             resourceTemplate(
-                name = "user-profile",
-                uriTemplate = "user://{userId}/profile",
-                description = "User profile template",
-                mimeType = "application/json",
-                title = "User profile",
-                annotations = annotations,
-                icons = listOf(icon),
+                ResourceTemplateDescriptor {
+                    name = "user-profile"
+                    uriTemplate = "user://{userId}/profile"
+                    description = "User profile template"
+                    mimeType = "application/json"
+                    title = "User profile"
+                    this.annotations = annotations
+                    icons = listOf(icon)
+                },
             ) {
                 TextResourceContents {
                     text = "{\"id\":\"${param("userId")}\"}"
@@ -310,14 +312,16 @@ internal class TachyonServerTest {
             name("contextual-resource-contents-test")
             session { enabled = true }
             resource(
-                name = "text",
-                uri = "test://text",
-                description = "Text resource",
-                mimeType = "text/plain",
-                title = "Text resource title",
-                annotations = expectedAnnotations,
-                size = 5,
-                icons = listOf(icon),
+                ResourceDescriptor {
+                    name = "text"
+                    uri = "test://text"
+                    description = "Text resource"
+                    mimeType = "text/plain"
+                    title = "Text resource title"
+                    annotations = expectedAnnotations
+                    size = 5
+                    icons = listOf(icon)
+                },
             ) {
                 TextResourceContents { text = "hello" }
             }

--- a/tachyon-kotlin/src/test/kotlin/dev/tachyonmcp/kotlin/server/TachyonServerTest.kt
+++ b/tachyon-kotlin/src/test/kotlin/dev/tachyonmcp/kotlin/server/TachyonServerTest.kt
@@ -256,15 +256,13 @@ internal class TachyonServerTest {
             session { enabled = true }
             tool("check", inputSchema = schema) { ToolResult.text("ok") }
             resourceTemplate(
-                ResourceTemplateDescriptor {
-                    name = "user-profile"
-                    uriTemplate = "user://{userId}/profile"
-                    description = "User profile template"
-                    mimeType = "application/json"
-                    title = "User profile"
-                    this.annotations = annotations
-                    icons = listOf(icon)
-                },
+                name = "user-profile",
+                uriTemplate = "user://{userId}/profile",
+                description = "User profile template",
+                mimeType = "application/json",
+                title = "User profile",
+                annotations = annotations,
+                icons = listOf(icon),
             ) {
                 TextResourceContents {
                     text = "{\"id\":\"${param("userId")}\"}"
@@ -312,16 +310,14 @@ internal class TachyonServerTest {
             name("contextual-resource-contents-test")
             session { enabled = true }
             resource(
-                ResourceDescriptor {
-                    name = "text"
-                    uri = "test://text"
-                    description = "Text resource"
-                    mimeType = "text/plain"
-                    title = "Text resource title"
-                    annotations = expectedAnnotations
-                    size = 5
-                    icons = listOf(icon)
-                },
+                name = "text",
+                uri = "test://text",
+                description = "Text resource",
+                mimeType = "text/plain",
+                title = "Text resource title",
+                annotations = expectedAnnotations,
+                size = 5,
+                icons = listOf(icon),
             ) {
                 TextResourceContents { text = "hello" }
             }

--- a/tachyon-kotlin/src/test/kotlin/dev/tachyonmcp/kotlin/server/json/JsonInteropTest.kt
+++ b/tachyon-kotlin/src/test/kotlin/dev/tachyonmcp/kotlin/server/json/JsonInteropTest.kt
@@ -5,7 +5,6 @@ import dev.tachyonmcp.core.server.json.JsonUtils
 import io.kotest.assertions.assertSoftly
 import io.kotest.matchers.shouldBe
 import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.JsonObject
 import org.junit.jupiter.api.Test
 
 internal class JsonInteropTest {
@@ -54,23 +53,6 @@ internal class JsonInteropTest {
             node.get("version").isString shouldBe true
             node.get("version").asString() shouldBe "1.0"
             node.get("count").isNumber shouldBe true
-        }
-    }
-
-    @Test
-    fun `toJacksonNodeMap converts each entry`() {
-        val meta =
-            mapOf(
-                "a" to Json.parseToJsonElement("""{"x": 1}""") as JsonObject,
-                "b" to Json.parseToJsonElement("""{"y": "z"}""") as JsonObject,
-            )
-
-        val converted = meta.toJacksonNodeMap()
-
-        assertSoftly {
-            converted.keys shouldBe setOf("a", "b")
-            converted["a"] shouldBe JsonUtils.parse("""{"x": 1}""")
-            converted["b"] shouldBe JsonUtils.parse("""{"y": "z"}""")
         }
     }
 }


### PR DESCRIPTION
## Problem

The Kotlin public API exposed both `tools.jackson.databind.JsonNode` and `kotlinx.serialization.json.JsonObject` in parallel overload families across content, resource, input-request, and descriptor factories. Meanwhile `kotlinx-serialization-json` was **optional** in Maven despite appearing in public signatures and being registered via `META-INF/services` — consumers without it hit a runtime `NoClassDefFoundError` through ServiceLoader. The optional dependency was not meaningfully optional.

## Changes

- **Make `kotlinx-serialization-json` required** (`tachyon-kotlin/pom.xml`) — the module's kotlinx factories (`KotlinxJsonElementFactory`, `KotlinxJsonObjectFactory`) are ServiceLoader-registered, so kotlinx must always be on the classpath.
- **Remove Jackson `JsonNode` from all public Kotlin signatures**: `meta` params now use a single `Map<String, Any>` mirroring the Java boundary `Map<String, Object>` (`TextContent.java:54`) — no conversion, primitive `_meta` values supported, no provider leak.
- **Delete the kotlinx `…WithKxMeta`/`…WithKxSchema` overload families** — removes the `TextContent("x", null)` overload ambiguity and the unrepresentable-primitive issue.
- **Keep kotlinx overloads where unambiguous and idiomatic**: `inputSchema(JsonObject)`/`outputSchema` on `ToolDescriptorScope`, `PromptDescriptorScope`, `registerTool`, `tool`; `RpcMethodRequest(params: JsonObject)` (converts to the wire format).
- **Trim `resource()`/`resourceTemplate()`** to `(name, uri, description?, mimeType?, title?, block)`; `annotations`/`size`/`icons` now live in the `ResourceDescriptor { }` / `ResourceTemplateDescriptor { }` overloads — removes the 8-default-param binary-compat hazard.
- Internal-only Jackson conversion remains in `JsonInterop.kt` (`toJacksonNode`, `toJsonSchema`).

## Verification

- `mvn verify -pl tachyon-kotlin -am`: tachyon-kotlin 49/49 green, core 644 green
- e2e `KotlinE2eTest` 3/3 green; skill docs compile
- weather-mcp-kotlin example 20/20 green
- `spotless:check` clean

Note: `TasksExtensionTest` (6 failures) is red on plain `main` — pre-existing, unrelated (tasks/2026-07-28 work in progress on another branch).