### PR TITLE
fix(kotlin): extend ToolScope and tool(taskSupport=...)

### DIFF
--- a/docs/kotlin.md
+++ b/docs/kotlin.md
@@ -107,10 +107,10 @@ Tool lambdas are `suspend` functions with access to `ToolScope`:
 ```kotlin
 tool(name = "reverse", description = "Reverse a string") {
     // this: ToolScope
-    // ctx: InteractionContext
-    // request: ToolRequest
-    val msg = request.arguments().stringValue("message")
-    ToolResult.text(msg.reversed())
+    // ctx: InteractionContext, request: ToolRequest
+    // arguments: Args, task: Task? — convenience access to request.arguments()/request.task()
+    val msg = arguments.stringValue("message")
+    text(msg.reversed())
 }
 ```
 
@@ -239,7 +239,7 @@ clients may truncate them.
 ## kotlinx.serialization integration
 
 `kotlinx-serialization-json` is an **optional** dependency of `tachyon-kotlin`.
-Add it to use `JsonObject` schemas, `request.arguments().decode<T>()`, and `success(value)`:
+Add it to use `JsonObject` schemas, `arguments.decode<T>()`, and `success(value)`:
 
 ```xml
 <dependency>
@@ -258,7 +258,7 @@ tool(
     inputSchema = """{"type":"object","properties":{"message":{"type":"string"}}}""",
     outputSchema = """{"type":"object","properties":{"echo":{"type":"string"}}}""",
 ) {
-    val input = request.arguments().decode<EchoArgs>() // typed decode via configured serde
+    val input = arguments.decode<EchoArgs>() // typed decode via configured serde
     success(EchoReply(input.message)) // structuredContent via configured serde
 }
 ```
@@ -289,19 +289,21 @@ through the deserializer set in `json { serde = ... }`.
 @Serializable data class GreetReply(val message: String)
 
 tool(name = "greet", inputSchema = ..., outputSchema = ...) {
-    val input = request.arguments().decode<GreetArgs>() // honors configured serde
+    val input = arguments.decode<GreetArgs>() // honors configured serde
     success(GreetReply("${input.greeting}, ${input.name}!"), "greeting response")  // symmetric typed result
 }
 ```
 
 ## Args accessors
 
+Available via `ToolScope.arguments` (or `PromptScope.arguments`):
+
 | Call | Behaviour |
 |---|---|
-| `request.arguments().stringValue("k")` / `intValue` / `boolValue` / `doubleValue` | Required — throws when missing |
-| `request.arguments().stringOrNull("k")` / `intOrNull` / `booleanOrNull` / `doubleOrNull` | Returns `null` when missing |
-| `request.arguments().stringOr("k", "d")` / `int("k", 0)` / `boolean("k", true)` / `double("k", 0.0)` | Falls back to default |
-| `request.arguments().decode<T>()` | typed decode via configured serde (Jackson by default) |
+| `arguments.stringValue("k")` / `intValue` / `boolValue` / `doubleValue` | Required — throws when missing |
+| `arguments.stringOrNull("k")` / `intOrNull` / `booleanOrNull` / `doubleOrNull` | Returns `null` when missing |
+| `arguments.stringOr("k", "d")` / `int("k", 0)` / `boolean("k", true)` / `double("k", 0.0)` | Falls back to default |
+| `arguments.decode<T>()` | typed decode via configured serde (Jackson by default) |
 
 ## Scope reference
 
@@ -312,7 +314,7 @@ tool(name = "greet", inputSchema = ..., outputSchema = ...) {
 | `NetworkScope` | `network { }` | `host`, `port`, `endpointPath`, `allowedOrigins`, `allowedHeaders`, `allowedHosts`, `maxContentLength` |
 | `SessionScope` | `session { }` | `enabled`, `sessionTtl`, `sessionIdGenerator` |
 | `RuntimeScope` | `runtime { }` | `shutdownGracePeriod` |
-| `ToolScope` | tool lambda | `ctx`, `request` |
+| `ToolScope` | tool lambda | `ctx`, `request`, `arguments`, `task`; `success(v)`, `text(t)`, `fail(msg)`, `content { }` |
 | `ResourceScope` | resource lambda | `ctx`, `uri`, `params`, `uriTemplate` |
 | `TemplateScope` | resource-template lambda | `ctx`, `uri`, `params`, `uriTemplate`; contextual `TextResourceContents { }` |
 | `PromptScope` | prompt lambda | `ctx`, `request`, `arguments` |
@@ -329,7 +331,7 @@ server.registerTool(
         description = "Echo a message"
     },
 ) {
-    ToolResult.text(request.arguments().stringValue("msg"))
+    text(arguments.stringValue("msg"))
 }
 ```
 
@@ -353,6 +355,10 @@ TachyonServer(port = 8080) {
 | `ToolResult.structured(payload)` | POJO → `structuredContent` via Jackson |
 | `ToolResult.structured(payload, text)` | Structured + human-readable text |
 | `ToolResult.empty()` | No content |
+
+Inside a tool lambda, prefer the `ToolScope` shortcuts: `text(t)`, `success(v)`, `fail(msg)`.
+`fail`, not `error` — a member `error(String)` would shadow Kotlin's stdlib `error()`, silently
+turning a thrown `IllegalStateException` into a returned value.
 
 `structuredContent` requires a JSON object shape. Tachyon rejects primitives and arrays at runtime.
 

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -85,6 +85,14 @@ var descriptor = ToolDescriptor.builder()
         .build();
 ```
 
+Kotlin DSL — the name-based `tool(...)` registration takes `taskSupport` directly, no descriptor needed:
+
+```kotlin
+tool("import-data", description = "Long-running import", taskSupport = TaskSupport.OPTIONAL) {
+    success(runImport())
+}
+```
+
 ```json
 {"method": "tools/call", "params": {"name": "import-data", "arguments": {}, "task": {"ttl": 60000}}}
 ```

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -138,8 +138,8 @@ Tachyon uses **Jackson 3** (`tools.jackson.*`), not Jackson 2. Import `tools.jac
 
 ```kotlin
 tool(name = "reverse", description = "Reverse a string") {
-    val msg = request.arguments().stringValue("message")
-    ToolResult.text(msg.reversed())
+    val msg = arguments.stringValue("message")
+    text(msg.reversed())
 }
 ```
 
@@ -150,12 +150,12 @@ tool(name = "reverse", description = "Reverse a string") {
 @Serializable data class Reply(val echo: String)
 
 tool("echo", inputSchema = ..., outputSchema = ...) {
-    val input = request.arguments().decode<Args>() // via configured serde
+    val input = arguments.decode<Args>() // via configured serde
     success(Reply(input.message))       // symmetric typed result
 }
 ```
 
-- `request.arguments().decode<T>()` — honors the configured serde (Jackson by default)
+- `arguments.decode<T>()` — honors the configured serde (Jackson by default)
 - `scope.success(value)` / `scope.success(value, text)` — symmetric typed result via configured serializer
 
 See [kotlin.md](kotlin.md) for the full Kotlin DSL reference.

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/features/tools/ToolMethodHandlers.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/features/tools/ToolMethodHandlers.java
@@ -191,7 +191,8 @@ public final class ToolMethodHandlers {
                     OutboundSseStreamMessageRouter.currentSessionId(),
                     request.progressToken());
             task.transitionTo(TaskState.WORKING);
-            var taskRequest = ToolRequest.builder()
+            final var taskResult = context.responseMapper().createTaskResult(task);
+            final var taskRequest = ToolRequest.builder()
                     .name(request.name())
                     .arguments(request.arguments())
                     .meta(request.meta())
@@ -246,7 +247,7 @@ public final class ToolMethodHandlers {
                 handleFutureFailure(taskRegistry, task, throwable);
                 return null;
             });
-            return context.responseMapper().createTaskResult(task);
+            return taskResult;
         }
 
         private void completeTask(

--- a/tachyon-kotlin/README.md
+++ b/tachyon-kotlin/README.md
@@ -8,14 +8,13 @@ Kotlin coroutine-first DSL for [Tachyon MCP](../README.md). Wraps the Java `Serv
 <dependency>
     <groupId>dev.tachyonmcp</groupId>
     <artifactId>tachyon-kotlin</artifactId>
-    <version>1.0.0-beta.15</version>
+    <version>[LATEST]</version>
 </dependency>
 ```
 
 Requires `tachyon-core` on the classpath (included transitively).
 
-Optionally add `org.jetbrains.kotlinx:kotlinx-serialization-json` to unlock `JsonObject`
-schemas, `request.arguments().decode<T>()`, and `success(value)` tool results.
+Uses `tachyon-core` and `org.jetbrains.kotlinx:kotlinx-serialization-json`, and provides `JsonObject` schemas, `request.arguments().decode<T>()`, and `success(value)` tool results.
 
 ## Documentation
 

--- a/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/config/KotlinFeatureRegistrar.kt
+++ b/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/config/KotlinFeatureRegistrar.kt
@@ -10,6 +10,7 @@ import dev.tachyonmcp.api.server.features.completions.CompletionResult
 import dev.tachyonmcp.api.server.features.prompts.PromptDescriptor
 import dev.tachyonmcp.api.server.features.resources.ResourceDescriptor
 import dev.tachyonmcp.api.server.features.resources.ResourceTemplateDescriptor
+import dev.tachyonmcp.api.server.features.tasks.TaskSupport
 import dev.tachyonmcp.api.server.features.tools.ToolDescriptor
 import dev.tachyonmcp.api.server.features.tools.ToolResult
 import dev.tachyonmcp.core.server.ServerBuilder
@@ -107,6 +108,7 @@ internal class KotlinFeatureRegistrar(
         description: String?,
         inputSchema: JsonSchema?,
         outputSchema: JsonSchema?,
+        taskSupport: TaskSupport?,
         handler: suspend ToolScope.() -> ToolResult,
     ) {
         delegate.withTools { tools ->
@@ -117,6 +119,7 @@ internal class KotlinFeatureRegistrar(
                         .description(description)
                         .inputSchema(inputSchema)
                         .outputSchema(outputSchema)
+                        .taskSupport(taskSupport)
                 },
                 toolFn(name, runtime, handler),
             )
@@ -128,6 +131,7 @@ internal class KotlinFeatureRegistrar(
         description: String?,
         inputSchema: String,
         outputSchema: String?,
+        taskSupport: TaskSupport?,
         handler: suspend ToolScope.() -> ToolResult,
     ) {
         delegate.withTools { tools ->
@@ -138,6 +142,7 @@ internal class KotlinFeatureRegistrar(
                         .description(description)
                         .inputSchema(inputSchema)
                         .outputSchema(outputSchema)
+                        .taskSupport(taskSupport)
                 },
                 toolFn(name, runtime, handler),
             )

--- a/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/config/TachyonServerBuilder.kt
+++ b/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/config/TachyonServerBuilder.kt
@@ -11,6 +11,7 @@ import dev.tachyonmcp.api.server.features.completions.CompletionResult
 import dev.tachyonmcp.api.server.features.prompts.PromptDescriptor
 import dev.tachyonmcp.api.server.features.resources.ResourceDescriptor
 import dev.tachyonmcp.api.server.features.resources.ResourceTemplateDescriptor
+import dev.tachyonmcp.api.server.features.tasks.TaskSupport
 import dev.tachyonmcp.api.server.features.tools.ToolDescriptor
 import dev.tachyonmcp.api.server.features.tools.ToolResult
 import dev.tachyonmcp.core.server.ServerBuilder
@@ -119,6 +120,7 @@ public class TachyonServerBuilder
             description: String? = null,
             inputSchema: JsonSchema? = null,
             outputSchema: JsonSchema? = null,
+            taskSupport: TaskSupport? = null,
             handler: suspend ToolScope.() -> ToolResult,
         ): TachyonServerBuilder =
             this.also {
@@ -127,6 +129,7 @@ public class TachyonServerBuilder
                     description,
                     inputSchema,
                     outputSchema,
+                    taskSupport,
                     handler,
                 )
             }
@@ -137,6 +140,7 @@ public class TachyonServerBuilder
             description: String? = null,
             inputSchema: String,
             outputSchema: String? = null,
+            taskSupport: TaskSupport? = null,
             handler: suspend ToolScope.() -> ToolResult,
         ): TachyonServerBuilder =
             this.also {
@@ -145,6 +149,7 @@ public class TachyonServerBuilder
                     description,
                     inputSchema,
                     outputSchema,
+                    taskSupport,
                     handler,
                 )
             }
@@ -338,6 +343,7 @@ public class TachyonServerBuilder
             description: String? = null,
             inputSchema: JsonObject,
             outputSchema: JsonObject? = null,
+            taskSupport: TaskSupport? = null,
             handler: suspend ToolScope.() -> ToolResult,
         ): TachyonServerBuilder =
             this.tool(
@@ -345,6 +351,7 @@ public class TachyonServerBuilder
                 description = description,
                 inputSchema = inputSchema.toJsonSchema(),
                 outputSchema = outputSchema.toJsonSchemaOrNull(),
+                taskSupport = taskSupport,
                 handler = handler,
             )
 

--- a/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/config/ToolScope.kt
+++ b/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/config/ToolScope.kt
@@ -4,6 +4,8 @@
 package dev.tachyonmcp.kotlin.server.config
 
 import dev.tachyonmcp.api.runtime.InteractionContext
+import dev.tachyonmcp.api.server.domain.Args
+import dev.tachyonmcp.api.server.domain.Task
 import dev.tachyonmcp.api.server.features.tools.ToolRequest
 import dev.tachyonmcp.api.server.features.tools.ToolResult
 import dev.tachyonmcp.kotlin.server.TachyonDsl
@@ -14,6 +16,14 @@ public class ToolScope
         public val ctx: InteractionContext,
         public val request: ToolRequest,
     ) {
+        /** Convenience access to the tool call arguments. */
+        public val arguments: Args
+            get() = request.arguments()
+
+        /** Convenience access to the task handle for task-augmented calls, or `null`. */
+        public val task: Task?
+            get() = request.task()
+
         /**
          * Returns a [ToolResult] whose structured value is [value], serialized to
          * `structuredContent` by the serde configured in server config at encode time
@@ -40,6 +50,14 @@ public class ToolScope
 
         /** Returns a [ToolResult] carrying a single plain-text content block. */
         public fun text(text: String): ToolResult = ToolResult.text(text)
+
+        /**
+         * Returns a failed [ToolResult] carrying a single plain-text error message.
+         *
+         * Named `fail` rather than `error` because a member `error(String)` here would shadow
+         * Kotlin's stdlib [kotlin.error], which throws instead of returning a value.
+         */
+        public fun fail(message: String): ToolResult = ToolResult.error(message)
 
         /**
          * Returns a [ToolResult] built from the content blocks collected in [block]:

--- a/tachyon-kotlin/src/test/kotlin/dev/tachyonmcp/kotlin/server/KotlinApiTest.kt
+++ b/tachyon-kotlin/src/test/kotlin/dev/tachyonmcp/kotlin/server/KotlinApiTest.kt
@@ -8,6 +8,7 @@ import dev.tachyonmcp.api.server.domain.InvalidArgumentException
 import dev.tachyonmcp.api.server.domain.Role
 import dev.tachyonmcp.api.server.domain.TextContent
 import dev.tachyonmcp.api.server.features.prompts.PromptRequest
+import dev.tachyonmcp.api.server.features.tasks.TaskSupport
 import dev.tachyonmcp.api.server.features.tools.ToolRequest
 import dev.tachyonmcp.api.server.features.tools.ToolResult
 import dev.tachyonmcp.kotlin.server.config.PromptScope
@@ -426,6 +427,73 @@ internal class KotlinApiTest {
             (result.content().single() as TextContent).text() shouldBe "hi"
         }
     }
+
+    // endregion
+
+    // region: ToolScope convenience accessors
+
+    @Test
+    fun `ToolScope arguments delegates to request arguments`() {
+        withStatelessContext { ctx ->
+            val args = Args.of(mapOf("k" to "v"), null)
+            val request =
+                ToolRequest
+                    .builder()
+                    .name("t")
+                    .arguments(args)
+                    .build()
+            val scope = ToolScope(ctx, request = request)
+            scope.arguments shouldBe args
+        }
+    }
+
+    @Test
+    fun `ToolScope task delegates to request task`() {
+        withStatelessContext { ctx ->
+            val request =
+                ToolRequest
+                    .builder()
+                    .name("t")
+                    .arguments(Args.of(null, null))
+                    .build()
+            val scope = ToolScope(ctx, request = request)
+            scope.task shouldBe null
+        }
+    }
+
+    @Test
+    fun `ToolScope fail returns a failed ToolResult with the message`() {
+        withStatelessContext { ctx ->
+            val request =
+                ToolRequest
+                    .builder()
+                    .name("t")
+                    .arguments(Args.of(null, null))
+                    .build()
+            val scope = ToolScope(ctx, request = request)
+            val result = scope.fail("boom")
+            result.shouldBeInstanceOf<ToolResult.Error>()
+            (result.content().single() as TextContent).text() shouldBe "boom"
+        }
+    }
+
+    @Test
+    fun `tool builder sets taskSupport on the registered descriptor`() {
+        TachyonServer(port = 0) {
+            name("task-support-test")
+            tool("t-task", taskSupport = TaskSupport.OPTIONAL) {
+                ToolResult.text("ok")
+            }
+        }.use { handle ->
+            handle
+                .tools()
+                .find("t-task")
+                .orElse(null)
+                ?.taskSupport() shouldBe TaskSupport.OPTIONAL
+        }
+    }
+
+    // endregion
 
     @Test
     @Suppress("DEPRECATION")


### PR DESCRIPTION
### Fixed
- ToolScope (ToolScope.kt): added arguments, task, fail(msg) — mirrors PromptScope.arguments.
- tool(name, ...) overloads (TachyonServerBuilder.kt + KotlinFeatureRegistrar.kt): added taskSupport: TaskSupport? = null param, threaded to the descriptor builder. No new scope type.
- Tests added in KotlinApiTest.kt (25→ passing, incl. 4 new).
- Docs (kotlin.md, tools.md, tasks.md) updated to the new idiom.