### PR TITLE
feat: kt-schema support, builder ergonomics

### DIFF
--- a/e2e/pom.xml
+++ b/e2e/pom.xml
@@ -117,6 +117,24 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>me.kpavlov.kt.schema</groupId>
+                            <artifactId>kt-schema-apt</artifactId>
+                            <version>${kt-schema.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                    <compilerArgs>
+                        <arg>-Xlint:unchecked</arg>
+                        <arg>-Ame.kpavlov.kt.schema.rootPackage=dev.tachyonmcp.e2e</arg>
+                        <arg>-Ame.kpavlov.kt.schema.include=dev.tachyonmcp.e2e.Farewell*</arg>
+                    </compilerArgs>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
                 <executions>

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/FarewellRequest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/FarewellRequest.java
@@ -1,0 +1,5 @@
+/* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
+package dev.tachyonmcp.e2e;
+
+/** Schema generated at compile time by kt-schema-apt (see e2e's {@code pom.xml}). */
+record FarewellRequest(String name) {}

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/FarewellResponse.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/FarewellResponse.java
@@ -1,0 +1,5 @@
+/* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
+package dev.tachyonmcp.e2e;
+
+/** Schema generated at compile time by kt-schema-apt (see e2e's {@code pom.xml}). */
+record FarewellResponse(String farewell) {}

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/TypedToolRegistrationTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/TypedToolRegistrationTest.java
@@ -1,0 +1,253 @@
+/* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
+package dev.tachyonmcp.e2e;
+
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import dev.tachyonmcp.api.json.JsonSchema;
+import dev.tachyonmcp.api.server.features.tools.ToolDescriptor;
+import dev.tachyonmcp.testkit.McpTestClients;
+import dev.tachyonmcp.testkit.McpTestServers;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/** Verifies {@code Tools.register(Class, Class, ...)} / {@code registerAsync(Class, Class, ...)} end to end. */
+class TypedToolRegistrationTest {
+
+    private static final JsonSchema GREET_REQUEST_SCHEMA = JsonSchema.of("""
+            {"type": "object", "properties": {"name": {"type": "string"}}, "required": ["name"]}
+            """);
+    private static final JsonSchema GREET_RESPONSE_SCHEMA = JsonSchema.of("""
+            {"type": "object", "properties": {"greeting": {"type": "string"}}, "required": ["greeting"]}
+            """);
+    private static final JsonSchema FAREWELL_REQUEST_SCHEMA = JsonSchema.of("""
+            {"type": "object", "properties": {"name": {"type": "string"}}, "required": ["name"]}
+            """);
+    private static final JsonSchema FAREWELL_RESPONSE_SCHEMA = JsonSchema.of("""
+            {"type": "object", "properties": {"farewell": {"type": "string"}}, "required": ["farewell"]}
+            """);
+
+    record GreetRequest(String name) {}
+
+    record GreetResponse(String greeting) {}
+
+    // GreetRequest/GreetResponse intentionally have no generated schema resource on the classpath.
+
+    @Test
+    void syncRegisterDecodesArgumentsAndWrapsTypedResult() throws Exception {
+        try (var server = McpTestServers.start(
+                        b -> {},
+                        s -> s.tools()
+                                .register(
+                                        GreetRequest.class,
+                                        GreetResponse.class,
+                                        d -> d.name("greet")
+                                                .description("Greets by name")
+                                                .inputSchema(GREET_REQUEST_SCHEMA)
+                                                .outputSchema(GREET_RESPONSE_SCHEMA),
+                                        (ctx, input) -> new GreetResponse("Hello, " + input.name() + "!")));
+                var client = McpTestClients.latest(server.port())) {
+            var response = client.post("""
+                    {"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"greet","arguments":{"name":"Ada"}}}
+                    """);
+
+            // language=JSON
+            var expected = """
+                    {"jsonrpc":"2.0","id":1,"result":{
+                        "content":[{"type":"text","text":"{\\"greeting\\":\\"Hello, Ada!\\"}"}],
+                        "structuredContent":{"greeting":"Hello, Ada!"},
+                        "resultType":"complete"
+                    }}
+                    """;
+            assertThatJson(response.body()).isEqualTo(expected);
+        }
+    }
+
+    @Test
+    void syncRegisterAdvertisesTheExplicitSchemas() throws Exception {
+        try (var server = McpTestServers.start(
+                        b -> {},
+                        s -> s.tools()
+                                .register(
+                                        GreetRequest.class,
+                                        GreetResponse.class,
+                                        d -> d.name("greet")
+                                                .description("Greets by name")
+                                                .inputSchema(GREET_REQUEST_SCHEMA)
+                                                .outputSchema(GREET_RESPONSE_SCHEMA),
+                                        (ctx, input) -> new GreetResponse("Hello, " + input.name() + "!")));
+                var client = McpTestClients.latest(server.port())) {
+            var response = client.post("""
+                    {"jsonrpc":"2.0","id":2,"method":"tools/list"}
+                    """);
+
+            // language=JSON
+            var expected = """
+                    {"jsonrpc":"2.0","id":2,"result":{
+                        "cacheScope":"public",
+                        "resultType":"complete",
+                        "ttlMs":0,
+                        "tools":[{
+                            "name":"greet",
+                            "description":"Greets by name",
+                            "inputSchema":{"type":"object","properties":{"name":{"type":"string"}},"required":["name"]},
+                            "outputSchema":{"type":"object","properties":{"greeting":{"type":"string"}},"required":["greeting"]}
+                        }]
+                    }}
+                    """;
+            assertThatJson(response.body()).isEqualTo(expected);
+        }
+    }
+
+    @Test
+    void asyncRegisterWithConfigurerDecodesArgumentsAndWrapsTypedResult() throws Exception {
+        try (var server = McpTestServers.start(
+                        b -> {},
+                        s -> s.tools()
+                                .registerAsync(
+                                        GreetRequest.class,
+                                        GreetResponse.class,
+                                        d -> d.name("greet-async")
+                                                .inputSchema(GREET_REQUEST_SCHEMA)
+                                                .outputSchema(GREET_RESPONSE_SCHEMA),
+                                        (ctx, input) -> CompletableFuture.completedFuture(
+                                                new GreetResponse("Hi, " + input.name() + "!"))));
+                var client = McpTestClients.latest(server.port())) {
+            var response = client.post("""
+                    {"jsonrpc":"2.0","id":1,"method":"tools/call",
+                     "params":{"name":"greet-async","arguments":{"name":"Ada"}}}
+                    """);
+
+            // language=JSON
+            var expected = """
+                    {"jsonrpc":"2.0","id":1,"result":{
+                        "content":[{"type":"text","text":"{\\"greeting\\":\\"Hi, Ada!\\"}"}],
+                        "structuredContent":{"greeting":"Hi, Ada!"},
+                        "resultType":"complete"
+                    }}
+                    """;
+            assertThatJson(response.body()).isEqualTo(expected);
+        }
+    }
+
+    @ParameterizedTest(name = "[{index}] {0}")
+    @MethodSource
+    void generatesTheOmittedSchemaWhileKeepingTheExplicitOne(
+            String toolName, Consumer<ToolDescriptor.Builder> configurer, String expectedJson) throws Exception {
+        try (var server = McpTestServers.start(
+                        b -> {},
+                        s -> s.tools()
+                                .register(
+                                        FarewellRequest.class,
+                                        FarewellResponse.class,
+                                        configurer,
+                                        (ctx, input) -> new FarewellResponse("Bye, " + input.name() + "!")));
+                var client = McpTestClients.latest(server.port())) {
+            var response = client.post("""
+                    {"jsonrpc":"2.0","id":2,"method":"tools/list"}
+                    """);
+
+            assertThatJson(response.body()).isEqualTo(expectedJson);
+        }
+    }
+
+    static Stream<Arguments> generatesTheOmittedSchemaWhileKeepingTheExplicitOne() {
+        return Stream.of(
+                Arguments.of(
+                        "farewell-output-generated",
+                        (Consumer<ToolDescriptor.Builder>)
+                                d -> d.name("farewell-output-generated").inputSchema(FAREWELL_REQUEST_SCHEMA),
+                        // language=JSON
+                        """
+                        {"jsonrpc":"2.0","id":2,"result":{
+                            "cacheScope":"public",
+                            "resultType":"complete",
+                            "ttlMs":0,
+                            "tools":[{
+                                "name":"farewell-output-generated",
+                                "inputSchema":{"type":"object","properties":{"name":{"type":"string"}},"required":["name"]},
+                                "outputSchema":{
+                                    "$schema":"https://json-schema.org/draft/2020-12/schema",
+                                    "$id":"dev.tachyonmcp.e2e.FarewellResponse",
+                                    "type":"object",
+                                    "properties":{"farewell":{"type":"string"}},
+                                    "additionalProperties":false,
+                                    "required":["farewell"]
+                                }
+                            }]
+                        }}
+                        """),
+                Arguments.of(
+                        "farewell-input-generated",
+                        (Consumer<ToolDescriptor.Builder>)
+                                d -> d.name("farewell-input-generated").outputSchema(FAREWELL_RESPONSE_SCHEMA),
+                        // language=JSON
+                        """
+                        {"jsonrpc":"2.0","id":2,"result":{
+                            "cacheScope":"public",
+                            "resultType":"complete",
+                            "ttlMs":0,
+                            "tools":[{
+                                "name":"farewell-input-generated",
+                                "inputSchema":{
+                                    "$schema":"https://json-schema.org/draft/2020-12/schema",
+                                    "$id":"dev.tachyonmcp.e2e.FarewellRequest",
+                                    "type":"object",
+                                    "properties":{"name":{"type":"string"}},
+                                    "additionalProperties":false,
+                                    "required":["name"]
+                                },
+                                "outputSchema":{"type":"object","properties":{"farewell":{"type":"string"}},"required":["farewell"]}
+                            }]
+                        }}
+                        """));
+    }
+
+    @Test
+    void asyncRegisterWithConfigurerGeneratesBothSchemasWhenDescriptorOmitsThem() throws Exception {
+        try (var server = McpTestServers.start(
+                        b -> {},
+                        s -> s.tools()
+                                .registerAsync(
+                                        FarewellRequest.class,
+                                        FarewellResponse.class,
+                                        d -> d.name("farewell-async-generated"),
+                                        (ctx, input) -> CompletableFuture.completedFuture(
+                                                new FarewellResponse("Bye, " + input.name() + "!"))));
+                var client = McpTestClients.latest(server.port())) {
+            var response = client.post("""
+                    {"jsonrpc":"2.0","id":1,"method":"tools/call",
+                     "params":{"name":"farewell-async-generated","arguments":{"name":"Ada"}}}
+                    """);
+
+            // language=JSON
+            var expected = """
+                    {"jsonrpc":"2.0","id":1,"result":{
+                        "content":[{"type":"text","text":"{\\"farewell\\":\\"Bye, Ada!\\"}"}],
+                        "structuredContent":{"farewell":"Bye, Ada!"},
+                        "resultType":"complete"
+                    }}
+                    """;
+            assertThatJson(response.body()).isEqualTo(expected);
+        }
+    }
+
+    @Test
+    void registrationThrowsWhenDescriptorOmitsSchemasAndNoneAreGenerated() {
+        assertThatThrownBy(() -> McpTestServers.start(
+                        b -> {},
+                        s -> s.tools()
+                                .register(
+                                        GreetRequest.class,
+                                        GreetResponse.class,
+                                        d -> d.name("greet-no-schema"),
+                                        (ctx, input) -> new GreetResponse("hi"))))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("META-INF/kt-schema/schemas/");
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,7 @@
         <junit.platform.version>1.12.2</junit.platform.version>
         <junit.version>6.1.2</junit.version>
         <kotest.version>6.2.3</kotest.version>
+        <kt-schema.version>0.8.3</kt-schema.version>
         <mockito.version>5.23.0</mockito.version>
         <netty.version>4.2.17.Final</netty.version>
         <slf4j.version>2.0.18</slf4j.version>

--- a/tachyon-api/src/main/java/dev/tachyonmcp/api/json/JsonSchema.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/api/json/JsonSchema.java
@@ -4,7 +4,6 @@ package dev.tachyonmcp.api.json;
 import dev.tachyonmcp.api.annotations.ExperimentalApi;
 import dev.tachyonmcp.api.json.spi.JsonSchemaFactory;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 

--- a/tachyon-api/src/main/java/dev/tachyonmcp/api/json/JsonSchema.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/api/json/JsonSchema.java
@@ -1,7 +1,12 @@
 /* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
 package dev.tachyonmcp.api.json;
 
+import dev.tachyonmcp.api.annotations.ExperimentalApi;
 import dev.tachyonmcp.api.json.spi.JsonSchemaFactory;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
 
 /**
  * An immutable, encoded JSON Schema.
@@ -18,7 +23,11 @@ public interface JsonSchema extends JsonDocument {
         return DefaultJsonSchema.OBJECT;
     }
 
-    /** Creates a schema from encoded JSON. */
+    /**
+     * Creates a schema from encoded JSON without parsing and verifying if the schema is correct.
+     *
+     * @throws IllegalArgumentException when json is null or blank string
+     */
     static JsonSchema of(String json) {
         return new DefaultJsonSchema(JsonDocuments.requireContent(json));
     }
@@ -47,7 +56,30 @@ public interface JsonSchema extends JsonDocument {
      * @return the parsed schema
      * @throws IllegalStateException if no {@code JsonSchemaFactory<T>} is registered for {@code type}
      */
+    @ExperimentalApi
     static <T> JsonSchema from(T source, Class<T> type) {
         return JsonSchemas.from(source, type);
+    }
+
+    /**
+     * Loads a schema generated at build time for {@code type}, e.g. by the
+     * <a href="https://github.com/kpavlov/kt-schema">kt-schema</a> annotation processor, from
+     * {@code META-INF/kt-schema/schemas/<binary-class-name>.json} on {@code type}'s classloader.
+     *
+     * @param type the annotated Java or Kotlin type whose schema was generated at build time
+     * @return the loaded schema
+     * @throws IllegalStateException if no generated schema resource is found for {@code type}
+     */
+    @ExperimentalApi
+    static JsonSchema generated(Class<?> type) {
+        var path = "META-INF/kt-schema/schemas/%s.json".formatted(type.getName().replace('.', '/'));
+        try (var in = Thread.currentThread().getContextClassLoader().getResourceAsStream(path)) {
+            if (in == null) {
+                throw new IllegalStateException("Missing generated schema resource: " + path);
+            }
+            return of(new String(in.readAllBytes(), StandardCharsets.UTF_8));
+        } catch (IOException e) {
+            throw new UncheckedIOException("Could not read schema resource: " + path, e);
+        }
     }
 }

--- a/tachyon-api/src/main/java/dev/tachyonmcp/api/server/config/MonitoringConfig.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/api/server/config/MonitoringConfig.java
@@ -39,6 +39,9 @@ public interface MonitoringConfig {
     /** Builder for {@link MonitoringConfig}. */
     interface Builder {
 
+        /** Fills this builder with the attribute values from {@code instance}. */
+        Builder from(MonitoringConfig instance);
+
         /** Sets whether slow request logging is enabled. */
         Builder slowRequestLogging(boolean slowRequestLogging);
 

--- a/tachyon-api/src/main/java/dev/tachyonmcp/api/server/config/ServerIdentity.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/api/server/config/ServerIdentity.java
@@ -50,6 +50,9 @@ public interface ServerIdentity {
     /** Builder for {@link ServerIdentity}. */
     interface Builder {
 
+        /** Fills this builder with the attribute values from {@code instance}. */
+        Builder from(ServerIdentity instance);
+
         Builder name(String name);
 
         Builder version(String version);

--- a/tachyon-api/src/main/java/dev/tachyonmcp/api/server/domain/Annotations.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/api/server/domain/Annotations.java
@@ -82,6 +82,9 @@ public interface Annotations {
     /** Builder for {@link Annotations}. */
     interface Builder {
 
+        /** Fills this builder with the attribute values from {@code instance}. */
+        Builder from(Annotations instance);
+
         /**
          * Sets the intended audience.
          *

--- a/tachyon-api/src/main/java/dev/tachyonmcp/api/server/domain/AudioContent.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/api/server/domain/AudioContent.java
@@ -126,6 +126,9 @@ public non-sealed interface AudioContent extends ContentBlock, HasMeta {
      * Builder for {@link AudioContent}.
      */
     interface Builder {
+        /** Fills this builder with the attribute values from {@code instance}. */
+        Builder from(AudioContent instance);
+
         /**
          * Sets the audio data.
          *

--- a/tachyon-api/src/main/java/dev/tachyonmcp/api/server/domain/BlobResourceContents.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/api/server/domain/BlobResourceContents.java
@@ -105,6 +105,9 @@ public non-sealed interface BlobResourceContents extends ResourceContents {
      * Builder for {@link BlobResourceContents}.
      */
     interface Builder {
+        /** Fills this builder with the attribute values from {@code instance}. */
+        Builder from(BlobResourceContents instance);
+
         /**
          * Sets the resource URI.
          *

--- a/tachyon-api/src/main/java/dev/tachyonmcp/api/server/domain/EmbeddedResource.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/api/server/domain/EmbeddedResource.java
@@ -53,6 +53,9 @@ public non-sealed interface EmbeddedResource extends ContentBlock, HasMeta {
     }
 
     interface Builder {
+        /** Fills this builder with the attribute values from {@code instance}. */
+        Builder from(EmbeddedResource instance);
+
         Builder resource(ResourceContents resource);
 
         Builder annotations(@Nullable Annotations annotations);

--- a/tachyon-api/src/main/java/dev/tachyonmcp/api/server/domain/FormInputRequest.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/api/server/domain/FormInputRequest.java
@@ -32,6 +32,9 @@ public non-sealed interface FormInputRequest extends InputRequest {
     }
 
     interface Builder {
+        /** Fills this builder with the attribute values from {@code instance}. */
+        Builder from(FormInputRequest instance);
+
         Builder message(String message);
 
         Builder requestedSchema(Map<String, ?> entries);

--- a/tachyon-api/src/main/java/dev/tachyonmcp/api/server/domain/Icon.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/api/server/domain/Icon.java
@@ -86,6 +86,9 @@ public interface Icon {
     /** Builder for {@link Icon}. */
     interface Builder {
 
+        /** Fills this builder with the attribute values from {@code instance}. */
+        Builder from(Icon instance);
+
         /**
          * Sets the image URL or data URI.
          *

--- a/tachyon-api/src/main/java/dev/tachyonmcp/api/server/domain/ImageContent.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/api/server/domain/ImageContent.java
@@ -116,6 +116,9 @@ public non-sealed interface ImageContent extends ContentBlock {
      * Builder for {@link ImageContent}.
      */
     interface Builder {
+        /** Fills this builder with the attribute values from {@code instance}. */
+        Builder from(ImageContent instance);
+
         /**
          * Sets the image data.
          *

--- a/tachyon-api/src/main/java/dev/tachyonmcp/api/server/domain/PromptArgument.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/api/server/domain/PromptArgument.java
@@ -45,6 +45,9 @@ public interface PromptArgument {
 
     interface Builder {
 
+        /** Fills this builder with the attribute values from {@code instance}. */
+        Builder from(PromptArgument instance);
+
         Builder name(String name);
 
         Builder title(@Nullable String title);

--- a/tachyon-api/src/main/java/dev/tachyonmcp/api/server/domain/PromptMessage.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/api/server/domain/PromptMessage.java
@@ -39,6 +39,9 @@ public interface PromptMessage {
     }
 
     interface Builder {
+        /** Fills this builder with the attribute values from {@code instance}. */
+        Builder from(PromptMessage instance);
+
         Builder role(Role role);
 
         Builder content(ContentBlock content);

--- a/tachyon-api/src/main/java/dev/tachyonmcp/api/server/domain/ResourceLink.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/api/server/domain/ResourceLink.java
@@ -84,6 +84,9 @@ public non-sealed interface ResourceLink extends ContentBlock {
 
     interface Builder {
 
+        /** Fills this builder with the attribute values from {@code instance}. */
+        Builder from(ResourceLink instance);
+
         Builder name(String name);
 
         Builder title(@Nullable String title);

--- a/tachyon-api/src/main/java/dev/tachyonmcp/api/server/domain/RpcMethodRequest.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/api/server/domain/RpcMethodRequest.java
@@ -33,6 +33,9 @@ public non-sealed interface RpcMethodRequest extends InputRequest {
     }
 
     interface Builder {
+        /** Fills this builder with the attribute values from {@code instance}. */
+        Builder from(RpcMethodRequest instance);
+
         Builder method(String method);
 
         Builder params(@Nullable Object params);

--- a/tachyon-api/src/main/java/dev/tachyonmcp/api/server/domain/ServerCapabilities.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/api/server/domain/ServerCapabilities.java
@@ -49,6 +49,9 @@ public interface ServerCapabilities {
      * Builder for {@link ServerCapabilities}.
      */
     interface Builder {
+        /** Fills this builder with the attribute values from {@code instance}. */
+        Builder from(ServerCapabilities instance);
+
         /** Prompt capabilities ({@code null} = not supported). */
         Builder prompts(@Nullable Prompts prompts);
 

--- a/tachyon-api/src/main/java/dev/tachyonmcp/api/server/domain/TextContent.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/api/server/domain/TextContent.java
@@ -56,6 +56,9 @@ public non-sealed interface TextContent extends ContentBlock {
     }
 
     interface Builder {
+        /** Fills this builder with the attribute values from {@code instance}. */
+        Builder from(TextContent instance);
+
         Builder text(String text);
 
         Builder meta(@Nullable Map<String, ?> entries);

--- a/tachyon-api/src/main/java/dev/tachyonmcp/api/server/domain/TextResourceContents.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/api/server/domain/TextResourceContents.java
@@ -68,6 +68,9 @@ public non-sealed interface TextResourceContents extends ResourceContents {
     }
 
     interface Builder {
+        /** Fills this builder with the attribute values from {@code instance}. */
+        Builder from(TextResourceContents instance);
+
         Builder uri(String uri);
 
         Builder text(String text);

--- a/tachyon-api/src/main/java/dev/tachyonmcp/api/server/domain/ToolAnnotations.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/api/server/domain/ToolAnnotations.java
@@ -49,6 +49,9 @@ public interface ToolAnnotations {
     }
 
     interface Builder {
+        /** Fills this builder with the attribute values from {@code instance}. */
+        Builder from(ToolAnnotations instance);
+
         Builder title(@Nullable String title);
 
         Builder readOnlyHint(@Nullable Boolean readOnlyHint);

--- a/tachyon-api/src/main/java/dev/tachyonmcp/api/server/domain/UrlInputRequest.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/api/server/domain/UrlInputRequest.java
@@ -36,6 +36,9 @@ public non-sealed interface UrlInputRequest extends InputRequest {
     }
 
     interface Builder {
+        /** Fills this builder with the attribute values from {@code instance}. */
+        Builder from(UrlInputRequest instance);
+
         Builder message(String message);
 
         Builder elicitationId(String elicitationId);

--- a/tachyon-api/src/main/java/dev/tachyonmcp/api/server/features/PaginatedResult.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/api/server/features/PaginatedResult.java
@@ -53,6 +53,9 @@ public interface PaginatedResult<R> {
     }
 
     interface Builder<R> {
+        /** Fills this builder with the attribute values from {@code instance}. */
+        Builder<R> from(PaginatedResult<R> instance);
+
         Builder<R> items(Iterable<? extends R> elements);
 
         Builder<R> nextCursor(@Nullable String nextCursor);

--- a/tachyon-api/src/main/java/dev/tachyonmcp/api/server/features/completions/CompletionRequest.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/api/server/features/completions/CompletionRequest.java
@@ -59,6 +59,9 @@ public interface CompletionRequest extends ServerFeature.Request {
     }
 
     interface Builder {
+        /** Fills this builder with the attribute values from {@code instance}. */
+        Builder from(CompletionRequest instance);
+
         Builder argumentName(String argumentName);
 
         Builder argumentValue(String argumentValue);

--- a/tachyon-api/src/main/java/dev/tachyonmcp/api/server/features/completions/CompletionResult.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/api/server/features/completions/CompletionResult.java
@@ -77,6 +77,9 @@ public interface CompletionResult extends HasMeta {
     /** Builder for {@link CompletionResult}. */
     interface Builder {
 
+        /** Fills this builder with the attribute values from {@code instance}. */
+        Builder from(CompletionResult instance);
+
         /**
          * Sets the candidate values ranked by relevance.
          *

--- a/tachyon-api/src/main/java/dev/tachyonmcp/api/server/features/prompts/PromptDescriptor.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/api/server/features/prompts/PromptDescriptor.java
@@ -97,6 +97,9 @@ public interface PromptDescriptor extends ServerFeature.Descriptor, HasMeta {
     /** Builder for {@link PromptDescriptor}. */
     interface Builder {
 
+        /** Fills this builder with the attribute values from {@code instance}. */
+        Builder from(PromptDescriptor instance);
+
         /** Sets the prompt name, unique within the server. */
         Builder name(String name);
 

--- a/tachyon-api/src/main/java/dev/tachyonmcp/api/server/features/resources/ResourceDescriptor.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/api/server/features/resources/ResourceDescriptor.java
@@ -110,6 +110,9 @@ public interface ResourceDescriptor extends ServerFeature.Descriptor, HasMeta {
     /** Builder for {@link ResourceDescriptor}. */
     interface Builder {
 
+        /** Fills this builder with the attribute values from {@code instance}. */
+        Builder from(ResourceDescriptor instance);
+
         Builder name(String name);
 
         Builder title(@Nullable String title);

--- a/tachyon-api/src/main/java/dev/tachyonmcp/api/server/features/resources/ResourceRequest.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/api/server/features/resources/ResourceRequest.java
@@ -72,6 +72,9 @@ public interface ResourceRequest extends ServerFeature.Request {
     /** Builder for {@link ResourceRequest}. */
     interface Builder {
 
+        /** Fills this builder with the attribute values from {@code instance}. */
+        Builder from(ResourceRequest instance);
+
         /** Sets the resource URI being requested. */
         Builder uri(String uri);
 

--- a/tachyon-api/src/main/java/dev/tachyonmcp/api/server/features/resources/ResourceTemplateDescriptor.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/api/server/features/resources/ResourceTemplateDescriptor.java
@@ -87,6 +87,9 @@ public interface ResourceTemplateDescriptor extends ServerFeature.Descriptor, Ha
     /** Builder for {@link ResourceTemplateDescriptor}. */
     interface Builder {
 
+        /** Fills this builder with the attribute values from {@code instance}. */
+        Builder from(ResourceTemplateDescriptor instance);
+
         /** Sets the template name, unique within the server. */
         Builder name(String name);
 

--- a/tachyon-api/src/main/java/dev/tachyonmcp/api/server/features/tasks/TaskDescriptor.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/api/server/features/tasks/TaskDescriptor.java
@@ -28,6 +28,9 @@ public interface TaskDescriptor extends ServerFeature.Descriptor {
     }
 
     interface Builder {
+        /** Fills this builder with the attribute values from {@code instance}. */
+        Builder from(TaskDescriptor instance);
+
         Builder id(String id);
 
         TaskDescriptor build();

--- a/tachyon-api/src/main/java/dev/tachyonmcp/api/server/features/tasks/TaskOptions.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/api/server/features/tasks/TaskOptions.java
@@ -46,6 +46,9 @@ public interface TaskOptions extends HasMeta {
     }
 
     interface Builder {
+        /** Fills this builder with the attribute values from {@code instance}. */
+        Builder from(TaskOptions instance);
+
         Builder id(@Nullable String id);
 
         Builder ttl(@Nullable Duration ttl);

--- a/tachyon-api/src/main/java/dev/tachyonmcp/api/server/features/tools/AsyncTypedToolFn.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/api/server/features/tools/AsyncTypedToolFn.java
@@ -1,0 +1,26 @@
+/* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
+package dev.tachyonmcp.api.server.features.tools;
+
+import dev.tachyonmcp.api.annotations.ExperimentalApi;
+import dev.tachyonmcp.api.runtime.InteractionContext;
+import java.util.concurrent.CompletionStage;
+
+/**
+ * Asynchronous, typed tool function. Unlike {@link TypedToolFn}, {@link #apply} does not throw
+ * checked exceptions — failures propagate through the returned {@link CompletionStage}, matching
+ * {@link AsyncToolFn}.
+ *
+ * <p>Use this with {@link Tools#registerAsync(Class, Class, ToolDescriptor, AsyncTypedToolFn)}
+ * when a handler only needs the decoded input, not {@link ToolRequest#progressToken()} or {@link
+ * ToolRequest#task()} — register with the plain {@link AsyncToolFn} for that.
+ *
+ * @param <I> the decoded input type
+ * @param <O> the result type, wrapped as structured content
+ * @author Konstantin Pavlov
+ */
+@FunctionalInterface
+@ExperimentalApi
+public interface AsyncTypedToolFn<I, O> {
+
+    CompletionStage<? extends O> apply(InteractionContext ctx, I input);
+}

--- a/tachyon-api/src/main/java/dev/tachyonmcp/api/server/features/tools/AsyncTypedToolFn.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/api/server/features/tools/AsyncTypedToolFn.java
@@ -22,5 +22,13 @@ import java.util.concurrent.CompletionStage;
 @ExperimentalApi
 public interface AsyncTypedToolFn<I, O> {
 
+    /**
+     * Invokes the handler with the decoded input.
+     *
+     * @param ctx the interaction context
+     * @param input the tool arguments decoded into {@code I}
+     * @return a future that completes with the result, wrapped as structured content; failures
+     *     propagate through the returned stage
+     */
     CompletionStage<? extends O> apply(InteractionContext ctx, I input);
 }

--- a/tachyon-api/src/main/java/dev/tachyonmcp/api/server/features/tools/ToolDescriptor.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/api/server/features/tools/ToolDescriptor.java
@@ -90,6 +90,9 @@ public interface ToolDescriptor extends ServerFeature.Descriptor, HasMeta {
     /** Builder for {@link ToolDescriptor}. */
     interface Builder {
 
+        /** Fills this builder with the attribute values from {@code instance}. */
+        Builder from(ToolDescriptor instance);
+
         /** Sets the tool name, unique within the server. */
         Builder name(String name);
 

--- a/tachyon-api/src/main/java/dev/tachyonmcp/api/server/features/tools/ToolRequest.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/api/server/features/tools/ToolRequest.java
@@ -110,6 +110,9 @@ public interface ToolRequest extends ServerFeature.Request {
     }
 
     interface Builder {
+        /** Fills this builder with the attribute values from {@code instance}. */
+        Builder from(ToolRequest instance);
+
         /**
          * Sets the tool name.
          *

--- a/tachyon-api/src/main/java/dev/tachyonmcp/api/server/features/tools/Tools.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/api/server/features/tools/Tools.java
@@ -41,6 +41,8 @@ public interface Tools {
      * ToolDescriptor#outputSchema()}, they are filled in via {@link JsonSchema#generated(Class)}
      * for {@code inputType}/{@code outputType} respectively.
      *
+     * @param <I> the type arguments are decoded into
+     * @param <O> the result type
      * @param inputType  the type arguments are decoded into
      * @param outputType the result type
      * @param descriptor the tool descriptor
@@ -60,6 +62,8 @@ public interface Tools {
      * Builds and registers a tool with a synchronous function operating on decoded, typed
      * arguments. See {@link #register(Class, Class, ToolDescriptor, TypedToolFn)}.
      *
+     * @param <I> the type arguments are decoded into
+     * @param <O> the result type
      * @param inputType  the type arguments are decoded into
      * @param outputType the result type
      * @param configurer the descriptor builder configurer
@@ -103,6 +107,8 @@ public interface Tools {
      * Registers a tool with an asynchronous function operating on decoded, typed arguments. See
      * {@link #register(Class, Class, ToolDescriptor, TypedToolFn)}.
      *
+     * @param <I> the type arguments are decoded into
+     * @param <O> the result type
      * @param inputType  the type arguments are decoded into
      * @param outputType the result type
      * @param descriptor the tool descriptor
@@ -122,6 +128,8 @@ public interface Tools {
      * Builds and registers a tool with an asynchronous function operating on decoded, typed
      * arguments. See {@link #register(Class, Class, ToolDescriptor, TypedToolFn)}.
      *
+     * @param <I> the type arguments are decoded into
+     * @param <O> the result type
      * @param inputType  the type arguments are decoded into
      * @param outputType the result type
      * @param configurer the descriptor builder configurer

--- a/tachyon-api/src/main/java/dev/tachyonmcp/api/server/features/tools/Tools.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/api/server/features/tools/Tools.java
@@ -1,6 +1,8 @@
 /* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
 package dev.tachyonmcp.api.server.features.tools;
 
+import dev.tachyonmcp.api.annotations.ExperimentalApi;
+import dev.tachyonmcp.api.json.JsonSchema;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Consumer;
@@ -31,6 +33,51 @@ public interface Tools {
     }
 
     /**
+     * Registers a tool with a synchronous function operating on decoded, typed arguments.
+     *
+     * <p>{@code request.arguments()} is decoded into {@code inputType} before {@code fn} runs, and
+     * {@code fn}'s return value is wrapped via {@code ToolResult.structured(Object)}. If {@code
+     * descriptor} is missing {@link ToolDescriptor#inputSchema()} and/or {@link
+     * ToolDescriptor#outputSchema()}, they are filled in via {@link JsonSchema#generated(Class)}
+     * for {@code inputType}/{@code outputType} respectively.
+     *
+     * @param inputType  the type arguments are decoded into
+     * @param outputType the result type
+     * @param descriptor the tool descriptor
+     * @param fn the typed tool function
+     * @return this registry
+     */
+    @ExperimentalApi
+    default <I, O> Tools register(
+            Class<I> inputType, Class<O> outputType, ToolDescriptor descriptor, TypedToolFn<I, O> fn) {
+        return register(
+                withGeneratedSchemas(descriptor, inputType, outputType),
+                (ctx, request) ->
+                        ToolResult.structured(fn.apply(ctx, request.arguments().decode(inputType))));
+    }
+
+    /**
+     * Builds and registers a tool with a synchronous function operating on decoded, typed
+     * arguments. See {@link #register(Class, Class, ToolDescriptor, TypedToolFn)}.
+     *
+     * @param inputType  the type arguments are decoded into
+     * @param outputType the result type
+     * @param configurer the descriptor builder configurer
+     * @param fn the typed tool function
+     * @return this registry
+     */
+    @ExperimentalApi
+    default <I, O> Tools register(
+            Class<I> inputType,
+            Class<O> outputType,
+            Consumer<ToolDescriptor.Builder> configurer,
+            TypedToolFn<I, O> fn) {
+        var builder = ToolDescriptor.builder();
+        configurer.accept(builder);
+        return register(inputType, outputType, builder.build(), fn);
+    }
+
+    /**
      * Registers a tool descriptor with an asynchronous function.
      *
      * @param descriptor the tool descriptor
@@ -50,6 +97,58 @@ public interface Tools {
         var builder = ToolDescriptor.builder();
         configurer.accept(builder);
         return registerAsync(builder.build(), fn);
+    }
+
+    /**
+     * Registers a tool with an asynchronous function operating on decoded, typed arguments. See
+     * {@link #register(Class, Class, ToolDescriptor, TypedToolFn)}.
+     *
+     * @param inputType  the type arguments are decoded into
+     * @param outputType the result type
+     * @param descriptor the tool descriptor
+     * @param fn the typed asynchronous tool function
+     * @return this registry
+     */
+    @ExperimentalApi
+    default <I, O> Tools registerAsync(
+            Class<I> inputType, Class<O> outputType, ToolDescriptor descriptor, AsyncTypedToolFn<I, O> fn) {
+        return registerAsync(
+                withGeneratedSchemas(descriptor, inputType, outputType),
+                (ctx, request) ->
+                        fn.apply(ctx, request.arguments().decode(inputType)).thenApply(ToolResult::structured));
+    }
+
+    /**
+     * Builds and registers a tool with an asynchronous function operating on decoded, typed
+     * arguments. See {@link #register(Class, Class, ToolDescriptor, TypedToolFn)}.
+     *
+     * @param inputType  the type arguments are decoded into
+     * @param outputType the result type
+     * @param configurer the descriptor builder configurer
+     * @param fn the typed asynchronous tool function
+     * @return this registry
+     */
+    @ExperimentalApi
+    default <I, O> Tools registerAsync(
+            Class<I> inputType,
+            Class<O> outputType,
+            Consumer<ToolDescriptor.Builder> configurer,
+            AsyncTypedToolFn<I, O> fn) {
+        var builder = ToolDescriptor.builder();
+        configurer.accept(builder);
+        return registerAsync(inputType, outputType, builder.build(), fn);
+    }
+
+    /** Fills in {@code descriptor}'s schemas from {@code inputType}/{@code outputType} if absent. */
+    private static ToolDescriptor withGeneratedSchemas(
+            ToolDescriptor descriptor, Class<?> inputType, Class<?> outputType) {
+        if (descriptor.inputSchema() != null && descriptor.outputSchema() != null) {
+            return descriptor;
+        }
+        var builder = ToolDescriptor.builder().from(descriptor);
+        if (descriptor.inputSchema() == null) builder.inputSchema(JsonSchema.generated(inputType));
+        if (descriptor.outputSchema() == null) builder.outputSchema(JsonSchema.generated(outputType));
+        return builder.build();
     }
 
     /**

--- a/tachyon-api/src/main/java/dev/tachyonmcp/api/server/features/tools/TypedToolFn.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/api/server/features/tools/TypedToolFn.java
@@ -1,0 +1,25 @@
+/* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
+package dev.tachyonmcp.api.server.features.tools;
+
+import dev.tachyonmcp.api.annotations.ExperimentalApi;
+import dev.tachyonmcp.api.runtime.InteractionContext;
+
+/**
+ * Synchronous, typed tool function. Receives arguments already decoded into {@code I} instead of
+ * the raw {@link ToolRequest}; the returned {@code O} is wrapped as structured content, matching
+ * {@code ToolResult.structured(Object)}.
+ *
+ * <p>Use this with {@link Tools#register(Class, Class, ToolDescriptor, TypedToolFn)} when a
+ * handler only needs the decoded input, not {@link ToolRequest#progressToken()} or {@link
+ * ToolRequest#task()} — register with the plain {@link ToolFn} for that.
+ *
+ * @param <I> the decoded input type
+ * @param <O> the result type, wrapped as structured content
+ * @author Konstantin Pavlov
+ */
+@FunctionalInterface
+@ExperimentalApi
+public interface TypedToolFn<I, O> {
+
+    O apply(InteractionContext ctx, I input) throws Exception;
+}

--- a/tachyon-api/src/main/java/dev/tachyonmcp/api/server/features/tools/TypedToolFn.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/api/server/features/tools/TypedToolFn.java
@@ -21,5 +21,14 @@ import dev.tachyonmcp.api.runtime.InteractionContext;
 @ExperimentalApi
 public interface TypedToolFn<I, O> {
 
+    /**
+     * Invokes the handler with the decoded input.
+     *
+     * @param ctx the interaction context
+     * @param input the tool arguments decoded into {@code I}
+     * @return the result, wrapped as structured content
+     * @throws Exception if the handler fails; the dispatcher logs it and maps it to a JSON-RPC
+     *     error
+     */
     O apply(InteractionContext ctx, I input) throws Exception;
 }

--- a/tachyon-api/src/test/java/dev/tachyonmcp/api/json/GeneratedSchemaFixture.java
+++ b/tachyon-api/src/test/java/dev/tachyonmcp/api/json/GeneratedSchemaFixture.java
@@ -1,0 +1,5 @@
+/* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
+package dev.tachyonmcp.api.json;
+
+/** Matches the generated schema resource at {@code META-INF/kt-schema/schemas/.../GeneratedSchemaFixture.json}. */
+record GeneratedSchemaFixture(String name) {}

--- a/tachyon-api/src/test/java/dev/tachyonmcp/api/json/JsonSchemaTest.java
+++ b/tachyon-api/src/test/java/dev/tachyonmcp/api/json/JsonSchemaTest.java
@@ -1,0 +1,24 @@
+/* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
+package dev.tachyonmcp.api.json;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+class JsonSchemaTest {
+
+    @Test
+    void generatedLoadsSchemaResourceByClassName() {
+        var schema = JsonSchema.generated(GeneratedSchemaFixture.class);
+
+        assertThat(schema.json()).contains("\"required\"", "\"name\"");
+    }
+
+    @Test
+    void generatedThrowsWhenNoSchemaResourceExists() {
+        assertThatThrownBy(() -> JsonSchema.generated(JsonSchemaTest.class))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("META-INF/kt-schema/schemas");
+    }
+}

--- a/tachyon-api/src/test/resources/META-INF/kt-schema/schemas/dev/tachyonmcp/api/json/GeneratedSchemaFixture.json
+++ b/tachyon-api/src/test/resources/META-INF/kt-schema/schemas/dev/tachyonmcp/api/json/GeneratedSchemaFixture.json
@@ -1,0 +1,7 @@
+{
+  "type": "object",
+  "properties": {
+    "name": { "type": "string" }
+  },
+  "required": ["name"]
+}

--- a/tachyon-kotlin/pom.xml
+++ b/tachyon-kotlin/pom.xml
@@ -62,6 +62,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.immutables</groupId>
+            <artifactId>value-annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-test-junit5</artifactId>
             <scope>test</scope>

--- a/tachyon-testkit/pom.xml
+++ b/tachyon-testkit/pom.xml
@@ -62,6 +62,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.immutables</groupId>
+            <artifactId>value-annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
## Summary

Added experimental typed synchronous and asynchronous tool registration APIs. The APIs decode typed inputs, wrap typed results, and generate missing JSON schemas. Added `JsonSchema.generated` for build-time schema resources. Added `Builder.from` methods across configuration and domain models. Added Maven schema-processing configuration and end-to-end tests.

### New Features

- Added experimental synchronous and asynchronous typed tool registration.
- Typed tools decode inputs, wrap results, and generate missing schemas automatically.
- Added runtime loading of generated JSON schemas.
- Added typed tool handler interfaces for synchronous and asynchronous operations.
- Added builder methods to copy values from existing objects across API models and configurations.

### Tests

- Added end-to-end coverage for typed tools, schema generation, schema advertisement, and error handling.
- Added validation for successful and missing generated schema loading.


