### PR TITLE
api cleanup

### DIFF
--- a/tachyon-api/src/main/java/dev/tachyonmcp/api/server/domain/Args.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/api/server/domain/Args.java
@@ -151,15 +151,6 @@ public final class Args implements JsonObject {
     }
 
     /**
-     * Returns the full arguments as a JSON string.
-     *
-     * @return the JSON string
-     */
-    public String rawJson() {
-        return json();
-    }
-
-    /**
      * Decodes the full arguments into the given type using the configured serde.
      *
      * @param <T>        the target type
@@ -174,7 +165,7 @@ public final class Args implements JsonObject {
             throw new IllegalStateException("PayloadDeserializer is not configured for these args");
         }
         try {
-            return deserializer.deserialize(rawJson(), targetType);
+            return deserializer.deserialize(json(), targetType);
         } catch (InvalidArgumentException e) {
             throw e;
         } catch (RuntimeException e) {

--- a/tachyon-api/src/test/java/dev/tachyonmcp/api/server/domain/ArgsTest.java
+++ b/tachyon-api/src/test/java/dev/tachyonmcp/api/server/domain/ArgsTest.java
@@ -166,7 +166,7 @@ class ArgsTest {
         var args = Args.from(values, new EchoingPayloadDeserializer());
 
         assertThat(args.stringValue("source")).isEqualTo("map");
-        assertThat(args.rawJson()).isEqualTo("{\"source\":\"provider\"}");
+        assertThat(args.json()).isEqualTo("{\"source\":\"provider\"}");
         assertThat(args.decode(String.class)).isEqualTo("{\"source\":\"provider\"}");
         assertThat(args.unwrap(Object.class)).containsSame(provider);
     }


### PR DESCRIPTION
## Summary

The public `Args.rawJson()` method was removed. `Args.decode(Type)` now passes `json()` to the configured deserializer. The retention test now verifies provider JSON through `args.json()`.

### Refactor

- Simplified argument JSON handling through the existing Args.json() interface.
- Removed the redundant raw JSON access method.

### Tests

- Updated coverage to verify argument JSON using the supported interface.

