### PR TITLE
ci: add revapi maven plugin

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,6 +95,7 @@ jobs:
             **/target/*-reports/**
             reports/target/site/jacoco-aggregate/
             **/spotbugsXml.xml
+            **/target/revapi-report.txt
 
   examples-snapshot:
     strategy:

--- a/Makefile
+++ b/Makefile
@@ -15,9 +15,9 @@ MAVEN_TEST_ARGS := -Dsurefire.forkCount=$(SUREFIRE_FORK_COUNT) $(NETTY_ARGS)
 help: ## List available targets
 	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  %-22s %s\n", $$1, $$2}'
 
-all: clean install-server examples-snapshot examples ## Full build: clean, live examples, build+install, SNAPSHOT examples
+all: clean install-server revapi examples-snapshot examples ## Full build: clean, live examples, build+install, SNAPSHOT examples
 
-ci: clean build ## CI pipeline: clean + build
+ci: clean build revapi ## CI pipeline: clean + build
 
 build: ## Compile, test, verify (mvn verify)
 	@echo " 🏗️ Building..."
@@ -27,6 +27,12 @@ build: ## Compile, test, verify (mvn verify)
 test: ## Run unit + e2e tests
 	@echo " 🧪 Running tests..."
 	@./mvnw test $(MAVEN_TEST_ARGS) --no-transfer-progress
+
+revapi: ## Check API compatibility against baseline (oldVersion) + write report
+	@echo " 🔄  Checking API compatibility..."
+	@./mvnw revapi:check -pl tachyon-api,tachyon-core,tachyon-extensions,tachyon-testkit -DskipTests --no-transfer-progress
+	@./mvnw revapi:report -pl tachyon-api,tachyon-core,tachyon-extensions,tachyon-testkit -DskipTests --no-transfer-progress
+	@echo " ✅  Done!"
 
 install-server: ## Build with tests and install to local Maven repo
 	@echo "🔄  Building and installing with tests..."

--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,7 @@
         <java.version>21</java.version>
         <kotlin.version>2.2.21</kotlin.version>
         <kotlin-language.version>2.2</kotlin-language.version>
+        <api.oldVersion>1.0.0-beta.18</api.oldVersion>
 
         <!-- Dependencies -->
         <assertj.version>3.27.7</assertj.version>
@@ -84,6 +85,8 @@
 
         <!-- Plugins -->
         <jacoco-maven-plugin.version>0.8.15</jacoco-maven-plugin.version>
+        <revapi.version>0.15.1</revapi.version>
+        <revapi-java.version>0.28.4</revapi-java.version>
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
         <maven-javadoc-plugin.version>3.12.0</maven-javadoc-plugin.version>
         <maven-source-plugin.version>3.4.0</maven-source-plugin.version>
@@ -442,6 +445,68 @@
                             <phase>verify</phase>
                         </execution>
                     </executions>
+                </plugin>
+                <plugin>
+                    <groupId>org.revapi</groupId>
+                    <artifactId>revapi-maven-plugin</artifactId>
+                    <version>${revapi.version}</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.revapi</groupId>
+                            <artifactId>revapi-java</artifactId>
+                            <version>${revapi-java.version}</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>org.revapi</groupId>
+                            <artifactId>revapi-reporter-text</artifactId>
+                            <version>${revapi.version}</version>
+                        </dependency>
+                    </dependencies>
+                    <configuration>
+                        <oldVersion>${api.oldVersion}</oldVersion>
+                        <failCriticality>error</failCriticality>
+                        <pipelineConfiguration>
+                            <severityMapping>
+                                <equivalent>allowed</equivalent>
+                                <nonBreaking>documented</nonBreaking>
+                                <potentiallyBreaking>highlight</potentiallyBreaking>
+                                <breaking>error</breaking>
+                            </severityMapping>
+                        </pipelineConfiguration>
+                        <analysisConfigurationFiles>
+                            <configurationFile>
+                                <path>${project.basedir}/revapi.json</path>
+                            </configurationFile>
+                        </analysisConfigurationFiles>
+                        <failOnMissingConfigurationFiles>false</failOnMissingConfigurationFiles>
+                        <analysisConfiguration>
+                            <revapi.filter>
+                                <archives>
+                                    <include>
+                                        <item>dev\.tachyonmcp:.*</item>
+                                    </include>
+                                </archives>
+                            </revapi.filter>
+                            <revapi.differences>
+                                <ignore>true</ignore>
+                                <differences>
+                                    <item>
+                                        <regex>true</regex>
+                                        <code>java\.annotation\.(added|removed)</code>
+                                        <annotation>@org\.immutables\..*</annotation>
+                                        <justification>Same annotation; revapi renders nested name $ vs .
+                                            inconsistently.
+                                        </justification>
+                                    </item>
+                                </differences>
+                            </revapi.differences>
+                            <revapi.reporter.text>
+                                <output>${project.build.directory}/revapi-report.txt</output>
+                                <minCriticality>documented</minCriticality>
+                                <keepEmptyFile>true</keepEmptyFile>
+                            </revapi.reporter.text>
+                        </analysisConfiguration>
+                    </configuration>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -464,6 +464,7 @@
                     </dependencies>
                     <configuration>
                         <oldVersion>${api.oldVersion}</oldVersion>
+                        <checkDependencies>false</checkDependencies>
                         <failCriticality>error</failCriticality>
                         <pipelineConfiguration>
                             <severityMapping>
@@ -483,7 +484,7 @@
                             <revapi.filter>
                                 <archives>
                                     <include>
-                                        <item>dev\.tachyonmcp:.*</item>
+                                        <item>dev\.tachyonmcp:${project.artifactId}:.*</item>
                                     </include>
                                 </archives>
                             </revapi.filter>

--- a/tachyon-api/pom.xml
+++ b/tachyon-api/pom.xml
@@ -88,6 +88,10 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>org.revapi</groupId>
+                <artifactId>revapi-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
                 <executions>

--- a/tachyon-api/revapi.json
+++ b/tachyon-api/revapi.json
@@ -3,7 +3,17 @@
     "extension": "revapi.differences",
     "configuration": {
       "ignore": true,
-      "differences": []
+      "differences": [
+        {
+          "ignore": true,
+          "code": "java.method.removed",
+          "old": "method java.lang.String dev.tachyonmcp.api.server.domain.Args::rawJson()",
+          "justification": "Args.rawJson() replaced with Args.json()",
+          "attachments": {
+            "since": "1.0.0-beta.19"
+          }
+        }
+      ]
     }
   }
 ]

--- a/tachyon-api/revapi.json
+++ b/tachyon-api/revapi.json
@@ -1,0 +1,9 @@
+[
+  {
+    "extension": "revapi.differences",
+    "configuration": {
+      "ignore": true,
+      "differences": []
+    }
+  }
+]

--- a/tachyon-core/pom.xml
+++ b/tachyon-core/pom.xml
@@ -194,6 +194,10 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>org.revapi</groupId>
+                <artifactId>revapi-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
                 <executions>

--- a/tachyon-core/revapi.json
+++ b/tachyon-core/revapi.json
@@ -1,0 +1,19 @@
+[
+  {
+    "extension": "revapi.java",
+    "configuration": {
+      "checks": {
+        "nonPublicPartOfAPI": {
+          "reportUnchanged": false
+        }
+      }
+    }
+  },
+  {
+    "extension": "revapi.differences",
+    "configuration": {
+      "ignore": true,
+      "differences": []
+    }
+  }
+]

--- a/tachyon-extensions/pom.xml
+++ b/tachyon-extensions/pom.xml
@@ -119,6 +119,11 @@
                 </executions>
             </plugin>
 
+        <plugin>
+                <groupId>org.revapi</groupId>
+                <artifactId>revapi-maven-plugin</artifactId>
+            </plugin>
+
         </plugins>
     </build>
 </project>

--- a/tachyon-extensions/revapi.json
+++ b/tachyon-extensions/revapi.json
@@ -1,0 +1,9 @@
+[
+  {
+    "extension": "revapi.differences",
+    "configuration": {
+      "ignore": true,
+      "differences": []
+    }
+  }
+]

--- a/tachyon-testkit/pom.xml
+++ b/tachyon-testkit/pom.xml
@@ -122,6 +122,10 @@
                     </execution>
                 </executions>
             </plugin>
+        <plugin>
+                <groupId>org.revapi</groupId>
+                <artifactId>revapi-maven-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/tachyon-testkit/revapi.json
+++ b/tachyon-testkit/revapi.json
@@ -1,0 +1,9 @@
+[
+  {
+    "extension": "revapi.differences",
+    "configuration": {
+      "ignore": true,
+      "differences": []
+    }
+  }
+]


### PR DESCRIPTION
## Summary

The build now configures Revapi with API baseline 1.0.0-beta.18. Four modules declare Revapi configuration. Make targets run compatibility checks and generate reports. CI uploads the reports as build artifacts.

### New Features

- Added automated API compatibility checks against a configured baseline.
- API compatibility reports are generated and included in build artifacts.

### Bug Fixes

- Standard and continuous integration builds now automatically run API compatibility validation.
- API checks cover the project’s primary modules and flag unintended public API changes.
