### PR TITLE
feat(extensions): add withExtensions vararg, deprecate extension()

### DIFF
--- a/.agents/skills/tachyon-mcp/SKILL.md
+++ b/.agents/skills/tachyon-mcp/SKILL.md
@@ -46,7 +46,7 @@ server.start();
 | `.withResources(registrar)` | bootstrap resources/templates through their façade |
 | `.withPrompts(registrar)` | bootstrap through `Prompts.register/registerAsync` |
 | `.withCompletions(registrar)` | bootstrap completion functions |
-| `.extension(ext)` | `ServerExtension` plugin |
+| `.withExtensions(ext...)` | `ServerExtension` plugin(s), vararg — `.extension(ext)` still works but is deprecated |
 | `.json(cfg)` | serde + input/output schema validators |
 | ~~`.jsonSchemaValidator(v)`~~ | removed — use `.json(cfg -> cfg.inputSchemaValidator(v).outputSchemaValidator(v))` |
 | `.pipelineCustomizer(c)` | raw Netty pipeline escape hatch |
@@ -254,16 +254,17 @@ overloads have been removed, use `.name(...)` on the builder instead. `.tool(nam
 ## Extensions
 
 ```java
-public interface ServerExtension extends Extension<ChannelContext> {
-    default JsonNode serverSettings() { return JsonNodeFactory.instance.objectNode(); }
+public interface ServerExtension extends Extension<InteractionContext> {
+    String extensionId(); // reverse-DNS, e.g. "com.example/audit"
+    default ExtensionSettings serverSettings() { return ExtensionSettings.empty(); }
     default Set<String> methods() { return Set.of(); }
     default boolean requiresMetaEnvelope() { return true; }
-    default void bootstrap(ServerEngine server) {}
-    default void onConnectionInit(ChannelContext context, Map<String, JsonNode> clientSettings) {}
+    default void bootstrap(ExtensionContext context) {}
+    default void onConnectionInit(InteractionContext context, ExtensionSettings clientSettings) {}
 }
 ```
 
-Register with `.extension(myExtension)`.
+Register with `.withExtensions(myExtension)` (vararg — pass several in one call). `.extension(ext)` still works but is deprecated.
 
 ## Tests
 
@@ -299,6 +300,14 @@ val server = TachyonServer(8080) {
 ```
 
 `tool(inputSchema = ...)` accepts a `JsonSchema`, raw JSON `String`, or kotlinx `JsonObject`.
+
+Register `ServerExtension`s with `extensions(...)` (vararg — pass one or several):
+
+```kotlin
+val server = TachyonServer(8080) {
+    extensions(TasksExtension.instance(), MyAuditExtension())
+}
+```
 
 ### Typed decode/result (Kotlin)
 

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ See [docs/quickstart.md](docs/quickstart.md) for a full walkthrough with Java an
 
 ```java
 var server = TachyonServer.builder()
-    .extension(TasksExtension.instance())  // exposes create_task tool + task://{id} resource
+    .withExtensions(TasksExtension.instance())  // exposes create_task tool + task://{id} resource
     .port(8080)
     .build();
 server.start();

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -63,11 +63,14 @@ public void bootstrap(ExtensionContext context) {
 
 ```java
 var server = TachyonServer.builder()
-    .extension(new AuditExtension())
+    .withExtensions(new AuditExtension())
     .port(8080)
     .build();
 server.start();
 ```
+
+`withExtensions` is a vararg — pass several in one call: `.withExtensions(new AuditExtension(), TasksExtension.instance())`.
+The older `.extension(ServerExtension)` still works but is deprecated.
 
 ## How negotiation works
 

--- a/docs/extensions/mcp-skills.md
+++ b/docs/extensions/mcp-skills.md
@@ -13,7 +13,7 @@ import dev.tachyonmcp.extensions.skills.SkillsExtension;
 import java.nio.file.Path;
 
 var server = TachyonServer.builder()
-        .extension(SkillsExtension.builder()
+        .withExtensions(SkillsExtension.builder()
                 .registry(new FilesystemSkillsRegistry(Path.of("skills")))            // every subdirectory with a SKILL.md
                 .registry(new ClasspathSkillsRegistry("bundled-skills"))        // same, packaged inside the jar
                 .build())

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -141,7 +141,7 @@ server-to-client `notifications/tasks` push (needs `subscriptions/listen` over t
 `TasksExtension` (`io.modelcontextprotocol/tasks`) serves double duty. Under 2025-11-25 it's a
 negotiable extension example: it exposes a `create_task` tool and a `task://{id}` resource
 template only to clients that opt in during `initialize`. Under 2026-07-28, its ID is exactly the
-SEP-2663 capability gate described above — registering it (`.extension(TasksExtension.instance())`)
+SEP-2663 capability gate described above — registering it (`.withExtensions(TasksExtension.instance())`)
 is what makes `context.isExtensionEnabled(TasksExtension.ID)` satisfiable for a client that
 declares it per request.
 
@@ -149,7 +149,7 @@ declares it per request.
 import dev.tachyonmcp.core.server.features.tasks.TasksExtension;
 
 var server = TachyonServer.builder()
-    .extension(TasksExtension.instance())
+    .withExtensions(TasksExtension.instance())
     .port(8080)
     .build();
 server.start();

--- a/pom.xml
+++ b/pom.xml
@@ -499,6 +499,15 @@
                                             inconsistently.
                                         </justification>
                                     </item>
+                                    <item>
+                                        <regex>true</regex>
+                                        <code>java\.method\.addedToInterface</code>
+                                        <ignore>false</ignore>
+                                        <criticality>documented</criticality>
+                                        <justification>Adding a method to an interface is backwards
+                                            compatible; noted, not breaking.
+                                        </justification>
+                                    </item>
                                 </differences>
                             </revapi.differences>
                             <revapi.reporter.text>

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/DefaultServerBuilder.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/DefaultServerBuilder.java
@@ -227,12 +227,16 @@ final class DefaultServerBuilder implements ServerBuilder {
         return this;
     }
 
-    /**
-     * Registers a server extension.
-     */
     @Override
+    @Deprecated
     public ServerBuilder extension(ServerExtension extension) {
-        extensions.add(extension);
+        this.extensions.add(extension);
+        return this;
+    }
+
+    @Override
+    public ServerBuilder withExtensions(ServerExtension... extensions) {
+        this.extensions.addAll(List.of(extensions));
         return this;
     }
 

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/ServerBuilder.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/ServerBuilder.java
@@ -71,8 +71,18 @@ public interface ServerBuilder {
     /** Registers completions through the server's completion façade at the end of {@link #build()}. */
     ServerBuilder withCompletions(Consumer<Completions> registrar);
 
-    /** Registers a server extension. */
+    /**
+     * Registers a server extension.
+     *
+     * @deprecated Use {@link #withExtensions(ServerExtension...)}
+     */
+    @Deprecated
     ServerBuilder extension(ServerExtension extension);
+
+    /**
+     * Registers one or more {@link ServerExtension}.
+     */
+    ServerBuilder withExtensions(ServerExtension... extensions);
 
     /**
      * Sets a caller-owned thread-per-task executor. The caller must close the executor after the

--- a/tachyon-extensions/src/main/java/dev/tachyonmcp/extensions/skills/SkillsExtension.java
+++ b/tachyon-extensions/src/main/java/dev/tachyonmcp/extensions/skills/SkillsExtension.java
@@ -29,7 +29,7 @@ import org.jspecify.annotations.Nullable;
  *
  * <pre>{@code
  * TachyonServer.builder()
- *         .extension(SkillsExtension.builder()
+ *         .withExtensions(SkillsExtension.builder()
  *                 .registry(new PathSkillsRegistry(Path.of("skills")))
  *                 .registry(new ClasspathSkillsRegistry("bundled-skills"))
  *                 .build())

--- a/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/config/TachyonServerBuilder.kt
+++ b/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/config/TachyonServerBuilder.kt
@@ -7,6 +7,7 @@ import dev.tachyonmcp.api.server.domain.Annotations
 import dev.tachyonmcp.api.server.domain.Icon
 import dev.tachyonmcp.api.server.domain.PromptMessage
 import dev.tachyonmcp.api.server.domain.ResourceContents
+import dev.tachyonmcp.api.server.extensions.ServerExtension
 import dev.tachyonmcp.api.server.features.completions.CompletionResult
 import dev.tachyonmcp.api.server.features.prompts.PromptDescriptor
 import dev.tachyonmcp.api.server.features.resources.ResourceDescriptor
@@ -41,7 +42,7 @@ public class TachyonServerBuilder
         internal var networkPortExplicitlySet: Boolean = false
 
         private val coroutineRuntime: CoroutineRuntime =
-            CoroutineRuntime().also(delegate::extension)
+            CoroutineRuntime().also { delegate.withExtensions(it) }
 
         private val featureRegistrar: KotlinFeatureRegistrar =
             KotlinFeatureRegistrar(delegate, coroutineRuntime)
@@ -357,6 +358,10 @@ public class TachyonServerBuilder
             )
 
         public fun name(name: String): TachyonServerBuilder = this.also { delegate.name(name) }
+
+        /** Registers one or more [ServerExtension]s, e.g. from `tachyon-extensions`. */
+        public fun extensions(vararg extensions: ServerExtension): TachyonServerBuilder =
+            this.also { delegate.withExtensions(*extensions) }
 
         /** Configures the JSON payload boundary: serde and input/output schema validators. */
         @OptIn(ExperimentalContracts::class)

--- a/tachyon-kotlin/src/test/kotlin/dev/tachyonmcp/kotlin/server/TachyonServerTest.kt
+++ b/tachyon-kotlin/src/test/kotlin/dev/tachyonmcp/kotlin/server/TachyonServerTest.kt
@@ -3,6 +3,8 @@ package dev.tachyonmcp.kotlin.server
 
 import dev.tachyonmcp.api.server.config.Mode
 import dev.tachyonmcp.api.server.domain.Role
+import dev.tachyonmcp.api.server.extensions.ExtensionContext
+import dev.tachyonmcp.api.server.extensions.ServerExtension
 import dev.tachyonmcp.api.server.features.tools.ToolResult
 import dev.tachyonmcp.api.server.session.SessionIdGenerator
 import dev.tachyonmcp.core.server.session.InMemorySessionEventStore
@@ -210,6 +212,50 @@ internal class TachyonServerTest {
                 init.body() shouldContain appName
                 init.body() shouldContain "2.0.0"
             }
+        }
+    }
+
+    @Test
+    fun `extension is registered and bootstrapped`() {
+        var bootstrapped = false
+        val extension =
+            object : ServerExtension {
+                override fun extensionId(): String = "test.extension"
+
+                override fun bootstrap(context: ExtensionContext) {
+                    bootstrapped = true
+                }
+            }
+
+        buildServer {
+            name("extension-test")
+            extensions(extension)
+        }.use {
+            bootstrapped shouldBe true
+        }
+    }
+
+    @Test
+    fun `multiple extensions are all registered via a single vararg call`() {
+        val bootstrapped = mutableSetOf<String>()
+
+        fun extensionNamed(id: String) =
+            object : ServerExtension {
+                override fun extensionId(): String = id
+
+                override fun bootstrap(context: ExtensionContext) {
+                    bootstrapped += id
+                }
+            }
+
+        buildServer {
+            name("multi-extension-test")
+            extensions(
+                extensionNamed("one"),
+                extensionNamed("two"),
+            )
+        }.use {
+            bootstrapped shouldBe setOf("one", "two")
         }
     }
 

--- a/tachyon-kotlin/src/test/kotlin/dev/tachyonmcp/kotlin/server/ToolFnFactoryTest.kt
+++ b/tachyon-kotlin/src/test/kotlin/dev/tachyonmcp/kotlin/server/ToolFnFactoryTest.kt
@@ -92,7 +92,7 @@ internal class ToolFnFactoryTest {
         val delegate =
             TachyonServer
                 .builder()
-                .extension(runtime)
+                .withExtensions(runtime)
                 .build() as ServerEngine
         val started = CountDownLatch(1)
         val cancelled = AtomicBoolean()
@@ -137,7 +137,7 @@ internal class ToolFnFactoryTest {
                         .builder()
                         .executor(executor)
                         .runtime { it.shutdownGracePeriod(Duration.ofMillis(50)) }
-                        .extension(runtime)
+                        .withExtensions(runtime)
                         .build() as ServerEngine
                 val fn =
                     toolFn("bounded-shutdown", runtime) {
@@ -252,7 +252,7 @@ internal class ToolFnFactoryTest {
                     TachyonServer
                         .builder()
                         .executor(executor)
-                        .extension(runtime)
+                        .withExtensions(runtime)
                         .build() as ServerEngine
                 delegate.use {
                     block(runtime, DefaultDispatchContext.stateless(delegate))


### PR DESCRIPTION
Register multiple ServerExtensions in one call from both the Java builder and the Kotlin DSL; update internal callers, tests, and docs/skill examples to the new API. Whitelist the interface addition in the revapi API-diff config. #144

### New Features

- Added vararg extension registration, allowing multiple server extensions to be configured in a single call.
- Added Kotlin support for registering one or more extensions.

### Deprecations

- Marked the single-extension registration method as deprecated while keeping it supported.

### Documentation

- Updated setup examples and extension guidance to use the new registration approach.
- Clarified support for registering multiple extensions.
