### PR TITLE
feat(kotlin): add ToolScope wrappers for raw/empty/fail-blocks/inputRequired

### DIFF
--- a/e2e/src/test/kotlin/dev/tachyonmcp/e2e/KotlinE2eTest.kt
+++ b/e2e/src/test/kotlin/dev/tachyonmcp/e2e/KotlinE2eTest.kt
@@ -1,11 +1,13 @@
 // Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors.
 package dev.tachyonmcp.e2e
 
-import dev.tachyonmcp.api.server.features.tools.ToolResult
+import dev.tachyonmcp.api.json.JsonSchema
+import dev.tachyonmcp.api.server.features.tools.ToolResult.structured
 import dev.tachyonmcp.kotlin.server.TachyonServer
 import dev.tachyonmcp.kotlin.server.domain.decode
 import dev.tachyonmcp.kotlin.server.json.KxSerializationSerde
 import io.kotest.assertions.json.shouldEqualJson
+import io.kotest.matchers.equals.shouldEqual
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import org.junit.jupiter.api.Test
@@ -40,7 +42,8 @@ internal class KotlinE2eTest : AbstractStatelessMcpE2eTest() {
                     """{"type":"object"}""",
                 ) {
                     val input = request.arguments().decode<GreetArgs>()
-                    ToolResult.structured(
+
+                    structured(
                         GreetReply("${input.greeting}, ${input.name}!"),
                         "greeting response",
                     )
@@ -83,7 +86,8 @@ internal class KotlinE2eTest : AbstractStatelessMcpE2eTest() {
                     """{"type":"object"}""",
                 ) {
                     val input = request.arguments().decode<GreetArgs>()
-                    ToolResult.structured(GreetReply("${input.greeting}, ${input.name}!"))
+
+                    structured(GreetReply("${input.greeting}, ${input.name}!"))
                 }
             }
         port = sv.port()
@@ -120,13 +124,14 @@ internal class KotlinE2eTest : AbstractStatelessMcpE2eTest() {
                     serde = KxSerializationSerde(Json { ignoreUnknownKeys = false })
                 }
                 tool(
-                    "strict-greet",
-                    "Strict typed greet tool",
-                    """{"type":"object"}""",
-                    """{"type":"object"}""",
+                    name = "strict-greet",
+                    description = "Strict typed greet tool",
+                    inputSchema = JsonSchema.objectSchema(),
+                    outputSchema = JsonSchema.objectSchema(),
                 ) {
                     val input = request.arguments().decode<GreetArgs>()
-                    ToolResult.structured(
+
+                    structured(
                         GreetReply("${input.greeting}, ${input.name}!"),
                         "greeting response",
                     )
@@ -144,7 +149,7 @@ internal class KotlinE2eTest : AbstractStatelessMcpE2eTest() {
                 """.trimIndent(),
             )
 
-        assert(response.statusCode() == 200) { "Expected 200, got ${response.statusCode()}" }
+        response.statusCode() shouldEqual 200
         response.body() shouldEqualJson
             """
             {

--- a/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/config/ToolScope.kt
+++ b/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/config/ToolScope.kt
@@ -3,12 +3,15 @@
 
 package dev.tachyonmcp.kotlin.server.config
 
+import dev.tachyonmcp.api.annotations.ExperimentalApi
 import dev.tachyonmcp.api.runtime.InteractionContext
 import dev.tachyonmcp.api.server.domain.Args
+import dev.tachyonmcp.api.server.domain.InputRequest
 import dev.tachyonmcp.api.server.domain.Task
 import dev.tachyonmcp.api.server.features.tools.ToolRequest
 import dev.tachyonmcp.api.server.features.tools.ToolResult
 import dev.tachyonmcp.kotlin.server.TachyonDsl
+import org.intellij.lang.annotations.Language
 
 @TachyonDsl
 public class ToolScope
@@ -52,12 +55,78 @@ public class ToolScope
         public fun text(text: String): ToolResult = ToolResult.text(text)
 
         /**
+         * Creates a success result with a pre-serialized JSON payload. The bytes skip the
+         * Jackson value-to-tree conversion of ordinary structured values and are parsed once at
+         * envelope encoding.
+         *
+         * @param json a pre-serialized JSON object string
+         * @param text the text content for the content block
+         */
+        @ExperimentalApi
+        public fun raw(
+            @Language("json") json: String,
+            text: String,
+        ): ToolResult = ToolResult.raw(json, text)
+
+        /** Returns a [ToolResult] with no structured value and no content blocks. */
+        @ExperimentalApi
+        public fun empty(): ToolResult = ToolResult.empty()
+
+        /**
          * Returns a failed [ToolResult] carrying a single plain-text error message.
          *
          * Named `fail` rather than `error` because a member `error(String)` here would shadow
          * Kotlin's stdlib [kotlin.error], which throws instead of returning a value.
          */
+        @ExperimentalApi
         public fun fail(message: String): ToolResult = ToolResult.error(message)
+
+        /**
+         * Returns a failed [ToolResult] built from the content blocks collected in [block], for
+         * structured or multi-block error output. Mirrors [content].
+         *
+         * ```kotlin
+         * fail {
+         *     text("Validation failed")
+         *     text("field 'email' is required")
+         * }
+         * ```
+         */
+        @ExperimentalApi
+        public fun fail(block: ContentScope.() -> Unit): ToolResult {
+            val scope = ContentScope().apply(block)
+            return ToolResult.error(*scope.blocks.toTypedArray())
+        }
+
+        /**
+         * Returns a [ToolResult] signaling that completing the tool call requires additional
+         * input from the caller. Build [InputRequest] values with the top-level factories in
+         * [dev.tachyonmcp.kotlin.server.domain] ([dev.tachyonmcp.kotlin.server.domain.FormInputRequest],
+         * [dev.tachyonmcp.kotlin.server.domain.UrlInputRequest],
+         * [dev.tachyonmcp.kotlin.server.domain.RpcMethodRequest]).
+         *
+         * @param requests the requested inputs, keyed by request id
+         * @param state    an opaque state token to echo back with the caller's response
+         */
+        @ExperimentalApi
+        public fun inputRequired(
+            requests: Map<String, InputRequest>,
+            state: String? = null,
+        ): ToolResult = ToolResult.inputRequired(requests, state)
+
+        /**
+         * Convenience overload of [inputRequired] taking the requested inputs as `id to request`
+         * pairs.
+         *
+         * ```kotlin
+         * inputRequired("email" to FormInputRequest("Enter email", schema))
+         * ```
+         */
+        @ExperimentalApi
+        public fun inputRequired(
+            vararg requests: Pair<String, InputRequest>,
+            state: String? = null,
+        ): ToolResult = inputRequired(requests.toMap(), state)
 
         /**
          * Returns a [ToolResult] built from the content blocks collected in [block]:

--- a/tachyon-kotlin/src/test/kotlin/dev/tachyonmcp/kotlin/server/KotlinApiTest.kt
+++ b/tachyon-kotlin/src/test/kotlin/dev/tachyonmcp/kotlin/server/KotlinApiTest.kt
@@ -13,6 +13,7 @@ import dev.tachyonmcp.api.server.features.tools.ToolRequest
 import dev.tachyonmcp.api.server.features.tools.ToolResult
 import dev.tachyonmcp.kotlin.server.config.PromptScope
 import dev.tachyonmcp.kotlin.server.config.ToolScope
+import dev.tachyonmcp.kotlin.server.domain.RpcMethodRequest
 import dev.tachyonmcp.kotlin.server.domain.arrayOrNull
 import dev.tachyonmcp.kotlin.server.domain.boolean
 import dev.tachyonmcp.kotlin.server.domain.booleanOrNull
@@ -474,6 +475,105 @@ internal class KotlinApiTest {
             val result = scope.fail("boom")
             result.shouldBeInstanceOf<ToolResult.Error>()
             (result.content().single() as TextContent).text() shouldBe "boom"
+        }
+    }
+
+    @Test
+    fun `ToolScope fail with content DSL builds a multi-block error ToolResult`() {
+        withStatelessContext { ctx ->
+            val request =
+                ToolRequest
+                    .builder()
+                    .name("t")
+                    .arguments(Args.of(null, null))
+                    .build()
+            val scope = ToolScope(ctx, request = request)
+            val result =
+                scope.fail {
+                    text("Validation failed")
+                    text("field 'email' is required")
+                }
+            result.shouldBeInstanceOf<ToolResult.Error>()
+            assertSoftly {
+                result.content() shouldHaveSize 2
+                (result.content()[0] as TextContent).text() shouldBe "Validation failed"
+                (result.content()[1] as TextContent).text() shouldBe "field 'email' is required"
+            }
+        }
+    }
+
+    @Test
+    fun `ToolScope raw returns a structured ToolResult with the pre-serialized JSON and text`() {
+        withStatelessContext { ctx ->
+            val request =
+                ToolRequest
+                    .builder()
+                    .name("t")
+                    .arguments(Args.of(null, null))
+                    .build()
+            val scope = ToolScope(ctx, request = request)
+            val result = scope.raw("""{"k":"v"}""", "raw text")
+            result.shouldBeInstanceOf<ToolResult.Success>()
+            (result.content().single() as TextContent).text() shouldBe "raw text"
+        }
+    }
+
+    @Test
+    fun `ToolScope empty returns a ToolResult with no structured value and no content`() {
+        withStatelessContext { ctx ->
+            val request =
+                ToolRequest
+                    .builder()
+                    .name("t")
+                    .arguments(Args.of(null, null))
+                    .build()
+            val scope = ToolScope(ctx, request = request)
+            val result = scope.empty()
+            result.shouldBeInstanceOf<ToolResult.Success>()
+            assertSoftly {
+                result.structured().isPresent shouldBe false
+                result.content() shouldHaveSize 0
+            }
+        }
+    }
+
+    @Test
+    fun `ToolScope inputRequired with a map returns an InputRequired ToolResult`() {
+        withStatelessContext { ctx ->
+            val request =
+                ToolRequest
+                    .builder()
+                    .name("t")
+                    .arguments(Args.of(null, null))
+                    .build()
+            val scope = ToolScope(ctx, request = request)
+            val ask = RpcMethodRequest("elicitation/create")
+            val result = scope.inputRequired(mapOf("confirm" to ask), state = "opaque")
+            result.shouldBeInstanceOf<ToolResult.InputRequired>()
+            assertSoftly {
+                result.inputRequests() shouldBe mapOf("confirm" to ask)
+                result.requestState() shouldBe "opaque"
+            }
+        }
+    }
+
+    @Test
+    fun `ToolScope inputRequired with vararg pairs returns an InputRequired ToolResult`() {
+        withStatelessContext { ctx ->
+            val request =
+                ToolRequest
+                    .builder()
+                    .name("t")
+                    .arguments(Args.of(null, null))
+                    .build()
+            val scope = ToolScope(ctx, request = request)
+            val ask = RpcMethodRequest("elicitation/create")
+            val result = scope.inputRequired("confirm" to ask)
+            result.shouldBeInstanceOf<ToolResult.InputRequired>()
+            assertSoftly {
+                result.inputRequests() shouldBe mapOf("confirm" to ask)
+                result.requestState() shouldBe null
+            }
         }
     }
 


### PR DESCRIPTION

ToolScope only covered ToolResult.structured/text/error(String) — callers had to reach past the DSL into the Java statics for raw JSON payloads, empty results, multi-block errors, and input-required results. Adds matching Kotlin-idiomatic wrappers (raw, empty, fail { }, inputRequired with Map and vararg-pairs overloads) marked @ExperimentalApi, plus an e2e test exercising the JsonSchema overload of tool() end to end. #144 

### New Features

- Added experimental helpers for creating raw JSON, empty, plain-text, multi-block error, and input-required tool results.
- Added support for specifying caller input requests with optional request state.

### Tests

- Expanded coverage for new tool result formats and input-request handling.
- Updated end-to-end assertions for structured responses and strict serialization errors.