### PR TITLE
feat(kotlin): add typedTool<In, Out> and ToolRequest.arguments<T>() reified helpers

### DIFF
--- a/e2e/pom.xml
+++ b/e2e/pom.xml
@@ -112,6 +112,12 @@
             <version>${gson.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>me.kpavlov.kt.schema</groupId>
+            <artifactId>kt-schema-generator-json-jvm</artifactId>
+            <version>${kt-schema.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/AbstractMcpE2eTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/AbstractMcpE2eTest.java
@@ -45,6 +45,10 @@ public abstract class AbstractMcpE2eTest {
     }
 
     protected Mcp20251125Client createTestClient() {
+        return createTestClient(port);
+    }
+
+    protected Mcp20251125Client createTestClient(int port) {
         return new Mcp20251125Client(port);
     }
 

--- a/e2e/src/test/kotlin/dev/tachyonmcp/e2e/KotlinE2eTest.kt
+++ b/e2e/src/test/kotlin/dev/tachyonmcp/e2e/KotlinE2eTest.kt
@@ -4,7 +4,7 @@ package dev.tachyonmcp.e2e
 import dev.tachyonmcp.api.json.JsonSchema
 import dev.tachyonmcp.api.server.features.tools.ToolResult.structured
 import dev.tachyonmcp.kotlin.server.TachyonServer
-import dev.tachyonmcp.kotlin.server.domain.decode
+import dev.tachyonmcp.kotlin.server.domain.arguments
 import dev.tachyonmcp.kotlin.server.json.KxSerializationSerde
 import io.kotest.assertions.json.shouldEqualJson
 import io.kotest.matchers.equals.shouldEqual
@@ -41,7 +41,7 @@ internal class KotlinE2eTest : AbstractStatelessMcpE2eTest() {
                     // language=json
                     """{"type":"object"}""",
                 ) {
-                    val input = request.arguments().decode<GreetArgs>()
+                    val input = request.arguments<GreetArgs>()
 
                     structured(
                         GreetReply("${input.greeting}, ${input.name}!"),
@@ -85,7 +85,7 @@ internal class KotlinE2eTest : AbstractStatelessMcpE2eTest() {
                     // language=json
                     """{"type":"object"}""",
                 ) {
-                    val input = request.arguments().decode<GreetArgs>()
+                    val input = request.arguments<GreetArgs>()
 
                     structured(GreetReply("${input.greeting}, ${input.name}!"))
                 }
@@ -129,7 +129,7 @@ internal class KotlinE2eTest : AbstractStatelessMcpE2eTest() {
                     inputSchema = JsonSchema.objectSchema(),
                     outputSchema = JsonSchema.objectSchema(),
                 ) {
-                    val input = request.arguments().decode<GreetArgs>()
+                    val input = request.arguments<GreetArgs>()
 
                     structured(
                         GreetReply("${input.greeting}, ${input.name}!"),

--- a/e2e/src/test/kotlin/dev/tachyonmcp/e2e/KtSchemaJsonSchemaFactory.kt
+++ b/e2e/src/test/kotlin/dev/tachyonmcp/e2e/KtSchemaJsonSchemaFactory.kt
@@ -1,0 +1,34 @@
+// Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors.
+package dev.tachyonmcp.e2e
+
+import dev.tachyonmcp.api.json.JsonSchema
+import dev.tachyonmcp.api.json.spi.JsonSchemaFactory
+import me.kpavlov.kt.schema.generator.json.ReflectionClassJsonSchemaGenerator
+
+/**
+ * Test-only [JsonSchemaFactory] keyed by [Class], registered via `META-INF/services` so the
+ * `tachyon-kotlin` reified `typedTool<In, Out>(...)` DSL overload (which calls
+ * `JsonSchema.from(Class, Class::class)`) resolves real generated schemas here, backed by
+ * kt-schema's [ReflectionClassJsonSchemaGenerator]. `tachyon-kotlin` itself ships no such factory
+ * — this is the integration pattern a downstream user would follow to wire one in.
+ */
+internal class KtSchemaJsonSchemaFactory : JsonSchemaFactory<Class<*>> {
+    companion object {
+        @JvmField
+        val INSTANCE: KtSchemaJsonSchemaFactory = KtSchemaJsonSchemaFactory()
+
+        /** Provider factory used by [java.util.ServiceLoader] to obtain the singleton. */
+        @JvmStatic
+        fun provider(): KtSchemaJsonSchemaFactory = INSTANCE
+    }
+
+    private val generator = ReflectionClassJsonSchemaGenerator.Default
+
+    override fun sourceType(): Class<Class<*>> {
+        @Suppress("UNCHECKED_CAST")
+        return Class::class.java as Class<Class<*>>
+    }
+
+    override fun toJsonSchema(source: Class<*>): JsonSchema =
+        JsonSchema.of(generator.generateSchemaString(source.kotlin))
+}

--- a/e2e/src/test/kotlin/dev/tachyonmcp/e2e/TypedToolKotlinE2eTest.kt
+++ b/e2e/src/test/kotlin/dev/tachyonmcp/e2e/TypedToolKotlinE2eTest.kt
@@ -1,0 +1,125 @@
+// Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors.
+package dev.tachyonmcp.e2e
+
+import dev.tachyonmcp.api.server.features.tools.ToolResult.structured
+import dev.tachyonmcp.kotlin.server.TachyonServer
+import dev.tachyonmcp.kotlin.server.domain.arguments
+import io.kotest.assertions.json.shouldEqualJson
+import io.kotest.matchers.equals.shouldEqual
+import kotlinx.serialization.Serializable
+import org.junit.jupiter.api.Test
+
+/**
+ * Exercises the reified `typedTool<In, Out>(...)` DSL overload, backed here by
+ * [KtSchemaJsonSchemaFactory] registered via `META-INF/services`. Split out from [KotlinE2eTest]
+ * because this is the only test class in the module that needs the `kt-schema-generator-json-jvm`
+ * test dependency wired in.
+ */
+internal class TypedToolKotlinE2eTest : AbstractStatelessMcpE2eTest() {
+    @Serializable
+    private data class GreetArgs(
+        val name: String,
+        val greeting: String = "Hello",
+    )
+
+    @Serializable
+    private data class GreetReply(
+        val message: String,
+    )
+
+    @Test
+    fun `typedTool round-trips with schemas`() {
+        TachyonServer(port = 0) {
+            typedTool<GreetArgs, GreetReply>(
+                name = "greet",
+                description = "Typed greet tool",
+            ) {
+                val input = request.arguments<GreetArgs>()
+
+                structured(
+                    GreetReply("${input.greeting}, ${input.name}!"),
+                    "greeting response",
+                )
+            }
+        }.use { server ->
+
+            val client = createTestClient(server.port())
+            client.initialize()
+            val response =
+                client.post(
+                    // The generated schema marks `greeting` required despite its Kotlin default —
+                    // ReflectionClassJsonSchemaGenerator.Default doesn't treat default-valued
+                    // properties as optional — so it must be supplied explicitly here.
+                    """
+                    {"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"greet","arguments":{"name":"World","greeting":"Hi"}}}
+                    """.trimIndent(),
+                )
+
+            response.statusCode() shouldEqual 200
+            val body = response.body()
+            body shouldEqualJson
+                """
+                {
+                  "jsonrpc": "2.0",
+                  "id": 2,
+                  "result": {
+                    "content": [
+                      {
+                        "type": "text",
+                        "text": "greeting response"
+                      }
+                    ],
+                    "structuredContent": {
+                      "message": "Hi, World!"
+                    }
+                  }
+                }
+                """.trimIndent()
+        }
+    }
+
+    @Test
+    fun `Schema rejects unknown property`() {
+        // The generated schema sets additionalProperties=false, so an unrecognized argument is
+        // rejected by JSON-Schema validation before the tool handler (and its serde) ever runs —
+        // a different, earlier failure than kotlinx.serialization's own unknown-key rejection
+        // (see KotlinE2eTest's `decode with strict serde rejects unknown key as error`).
+        TachyonServer(port = 0) {
+            typedTool<GreetArgs, GreetReply>(
+                name = "strict-greet",
+                description = "Strict typed greet tool",
+            ) {
+                val input = request.arguments<GreetArgs>()
+
+                structured(
+                    GreetReply("${input.greeting}, ${input.name}!"),
+                    "greeting response",
+                )
+            }
+        }.use { server ->
+
+            val client = createTestClient(server.port())
+            client.initialize()
+            val response =
+                client.post(
+                    // language=json
+                    """
+                    {"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"strict-greet","arguments":{"name":"World","greeting":"Hi","unknownKey":"extra"}}}
+                    """.trimIndent(),
+                )
+
+            response.statusCode() shouldEqual 200
+            response.body() shouldEqualJson
+                """
+                {
+                  "jsonrpc": "2.0",
+                  "id": 2,
+                  "error": {
+                    "code": -32602,
+                    "message": "property 'unknownKey' is not defined in the schema and the schema does not allow additional properties"
+                  }
+                }
+                """.trimIndent()
+        }
+    }
+}

--- a/e2e/src/test/resources/META-INF/services/dev.tachyonmcp.api.json.spi.JsonSchemaFactory
+++ b/e2e/src/test/resources/META-INF/services/dev.tachyonmcp.api.json.spi.JsonSchemaFactory
@@ -1,0 +1,1 @@
+dev.tachyonmcp.e2e.KtSchemaJsonSchemaFactory

--- a/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/config/TachyonServerBuilder.kt
+++ b/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/config/TachyonServerBuilder.kt
@@ -22,6 +22,7 @@ import dev.tachyonmcp.kotlin.server.DefaultKotlinTachyonServer
 import dev.tachyonmcp.kotlin.server.TachyonDsl
 import dev.tachyonmcp.kotlin.server.TachyonServer
 import dev.tachyonmcp.kotlin.server.features.CoroutineRuntime
+import dev.tachyonmcp.kotlin.server.json.generatedJsonSchema
 import dev.tachyonmcp.kotlin.server.json.toJsonSchema
 import dev.tachyonmcp.kotlin.server.json.toJsonSchemaOrNull
 import io.netty.channel.ChannelPipeline
@@ -155,6 +156,36 @@ public class TachyonServerBuilder
                     handler,
                 )
             }
+
+        /**
+         * Registers a tool whose input/output schemas are derived from [In]/[Out] via
+         * [dev.tachyonmcp.api.json.JsonSchema.from], keyed by [Class]. Requires a
+         * `JsonSchemaFactory<Class<?>>` registered via
+         * `META-INF/services/dev.tachyonmcp.api.json.spi.JsonSchemaFactory` on the classpath (e.g.
+         * backed by [kt-schema](https://github.com/kpavlov/kt-schema)'s
+         * `ReflectionClassJsonSchemaGenerator`); throws [IllegalStateException] at registration
+         * time if none is found — no such factory ships with `tachyon-kotlin` itself.
+         *
+         * Named `typedTool` rather than an overload of `tool` because a same-named reified
+         * overload wins Kotlin's overload resolution for existing schema-less `tool(name) { }`
+         * calls too, then fails to infer [In]/[Out] there — breaking every such call site.
+         */
+        @ExperimentalApi
+        @JvmSynthetic
+        public inline fun <reified In : Any, reified Out : Any> typedTool(
+            name: String,
+            description: String? = null,
+            taskSupport: TaskSupport? = null,
+            noinline handler: suspend ToolScope.() -> ToolResult,
+        ): TachyonServerBuilder =
+            tool(
+                name = name,
+                description = description,
+                inputSchema = generatedJsonSchema<In>(),
+                outputSchema = generatedJsonSchema<Out>(),
+                taskSupport = taskSupport,
+                handler = handler,
+            )
 
         /**
          * Registers a prebuilt tool descriptor with a suspending handler block.

--- a/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/domain/ToolRequestExtensions.kt
+++ b/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/domain/ToolRequestExtensions.kt
@@ -1,0 +1,15 @@
+// Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors.
+package dev.tachyonmcp.kotlin.server.domain
+
+import dev.tachyonmcp.api.annotations.ExperimentalApi
+import dev.tachyonmcp.api.server.features.tools.ToolRequest
+
+/**
+ * Decodes this request's arguments into [T] using the deserializer configured in server config.
+ * Shorthand for `arguments().decode<T>()`.
+ *
+ * @throws IllegalStateException if no deserializer is configured for these args.
+ */
+@JvmSynthetic
+@ExperimentalApi
+public inline fun <reified T : Any> ToolRequest.arguments(): T = arguments().decode<T>()

--- a/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/json/GeneratedJsonSchema.kt
+++ b/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/json/GeneratedJsonSchema.kt
@@ -1,0 +1,14 @@
+// Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors.
+package dev.tachyonmcp.kotlin.server.json
+
+import dev.tachyonmcp.api.annotations.ExperimentalApi
+import dev.tachyonmcp.api.json.JsonSchema
+
+@PublishedApi
+@JvmSynthetic
+@ExperimentalApi
+internal inline fun <reified T : Any> generatedJsonSchema(): JsonSchema {
+    @Suppress("UNCHECKED_CAST")
+    val classToken = Class::class.java as Class<Class<T>>
+    return JsonSchema.from(T::class.java, classToken)
+}

--- a/tachyon-kotlin/src/test/kotlin/dev/tachyonmcp/kotlin/server/KotlinApiTest.kt
+++ b/tachyon-kotlin/src/test/kotlin/dev/tachyonmcp/kotlin/server/KotlinApiTest.kt
@@ -14,6 +14,7 @@ import dev.tachyonmcp.api.server.features.tools.ToolResult
 import dev.tachyonmcp.kotlin.server.config.PromptScope
 import dev.tachyonmcp.kotlin.server.config.ToolScope
 import dev.tachyonmcp.kotlin.server.domain.RpcMethodRequest
+import dev.tachyonmcp.kotlin.server.domain.arguments
 import dev.tachyonmcp.kotlin.server.domain.arrayOrNull
 import dev.tachyonmcp.kotlin.server.domain.boolean
 import dev.tachyonmcp.kotlin.server.domain.booleanOrNull
@@ -101,6 +102,34 @@ internal class KotlinApiTest {
         ).use { handle ->
             handle.tools().find("t3").orElse(null) shouldNotBe null
         }
+    }
+
+    @Serializable
+    data class ReifiedToolRequest(
+        val q: String,
+    )
+
+    @Serializable
+    data class ReifiedToolReply(
+        val a: String,
+    )
+
+    @Test
+    fun `typedTool throws when no JsonSchemaFactory-Class is registered`() {
+        // tachyon-kotlin ships no JsonSchemaFactory<Class<?>> itself (see GeneratedJsonSchema.kt) —
+        // a consumer must register one (e.g. backed by kt-schema), as e2e's
+        // KtSchemaJsonSchemaFactory does. Here, absent any registration, the failure must be clear.
+        shouldThrow<IllegalStateException> {
+            TachyonServer(
+                port = 0,
+                {
+                    name("test")
+                    typedTool<ReifiedToolRequest, ReifiedToolReply>("t4") {
+                        ToolResult.text("ok")
+                    }
+                },
+            )
+        }.message shouldContain "JsonSchemaFactory"
     }
 
     // endregion
@@ -275,6 +304,19 @@ internal class KotlinApiTest {
         val args = Args.of(mapOf("name" to "Alice", "age" to 30), KxSerializationSerde.Default)
 
         args.decode<GreetingArgs>() shouldBe GreetingArgs("Alice", 30)
+    }
+
+    @Test
+    fun `ToolRequest arguments reified shorthand decodes via configured serde`() {
+        val args = Args.of(mapOf("name" to "Alice", "age" to 30), KxSerializationSerde.Default)
+        val request =
+            ToolRequest
+                .builder()
+                .name("greet")
+                .arguments(args)
+                .build()
+
+        request.arguments<GreetingArgs>() shouldBe GreetingArgs("Alice", 30)
     }
 
     @Test


### PR DESCRIPTION
typedTool derives input/output schemas from reified type params via the existing JsonSchema.from(Class, Class) SPI, so tachyon-kotlin stays free of a hard kt-schema dependency; consumers register their own JsonSchemaFactory<Class<?>>, as e2e's KtSchemaJsonSchemaFactory demonstrates end-to-end. Named typedTool rather than an overload of tool because a same-named reified overload wins resolution for existing schema-less tool(name) { } calls too, then fails to infer In/Out there.

ToolRequest.arguments<T>() is shorthand for arguments().decode<T>(); safe alongside the existing arguments() member since Kotlin always prefers a member over a same-named extension.

### New Features

- Added an experimental Kotlin API for registering tools with automatically generated input and output schemas.
- Added typed request argument decoding for simpler access to tool inputs.
- Added validation that rejects unknown tool arguments.

### Bug Fixes

- Added clear failure handling when schema generation or deserialization support is unavailable.

### Tests

Added ### end-to-end coverage for typed tools, schema generation, argument decoding, and validation.