### PR TITLE
fix: add JsonSchema.unchecked, JsonSchema.generated->JsonSchema.generate

### DIFF
--- a/.agents/skills/tachyon-mcp/resources/java/ToolHandlerExample.java
+++ b/.agents/skills/tachyon-mcp/resources/java/ToolHandlerExample.java
@@ -16,7 +16,7 @@ import org.jspecify.annotations.NonNull;
  */
 final class ToolHandlerExample {
 
-    private static final JsonSchema GREET_SCHEMA = JsonSchema.of("""
+    private static final JsonSchema GREET_SCHEMA = JsonSchema.unchecked("""
         {
           "type": "object",
           "properties": {

--- a/.agents/skills/tachyon-mcp/resources/kotlin/ToolHandlerExample.kt
+++ b/.agents/skills/tachyon-mcp/resources/kotlin/ToolHandlerExample.kt
@@ -19,7 +19,7 @@ import java.util.concurrent.CompletionStage
 import kotlin.time.Duration.Companion.seconds
 
 private val GREET_SCHEMA =
-    JsonSchema.of(
+    JsonSchema.unchecked(
         """
     {"type":"object","properties":{"name":{"type":"string","description":"Name to greet"}},"required":["name"]}
 """,

--- a/conformance/src/test/java/dev/tachyonmcp/conformance/AbstractConformanceServer.java
+++ b/conformance/src/test/java/dev/tachyonmcp/conformance/AbstractConformanceServer.java
@@ -70,7 +70,7 @@ abstract class AbstractConformanceServer {
     private static final String HMAC_SECRET = "conformance-test-hmac-secret";
 
     protected static JsonSchema parseJson(String json) {
-        return JsonSchema.of(json);
+        return JsonSchema.from(json, String.class);
     }
 
     protected static FormInputRequest buildFormElicitation(String message, String propName, String propType) {

--- a/conformance/src/test/java/dev/tachyonmcp/conformance/DefaultConformanceServer.java
+++ b/conformance/src/test/java/dev/tachyonmcp/conformance/DefaultConformanceServer.java
@@ -87,7 +87,7 @@ class DefaultConformanceServer extends AbstractConformanceServer {
                             if (messageOpt.isPresent()) {
                                 var message = messageOpt.get();
                                 try {
-                                    var schema = JsonSchema.of(JsonRpcCodec.writeValueAsString(Map.of(
+                                    var schema = JsonSchema.unchecked(JsonRpcCodec.writeValueAsString(Map.of(
                                             "type",
                                             "object",
                                             "properties",
@@ -119,7 +119,7 @@ class DefaultConformanceServer extends AbstractConformanceServer {
                                 .inputSchema(INPUT_SCHEMA_NO_ARGS),
                         (ctx, request) -> {
                             try {
-                                var schema = JsonSchema.of(JsonRpcCodec.writeValueAsString(Map.of(
+                                var schema = JsonSchema.unchecked(JsonRpcCodec.writeValueAsString(Map.of(
                                         "type",
                                         "object",
                                         "properties",
@@ -203,7 +203,7 @@ class DefaultConformanceServer extends AbstractConformanceServer {
                                                         List.of(
                                                                 Map.of("const", "item1", "title", "Item One"),
                                                                 Map.of("const", "item2", "title", "Item Two")))));
-                                var schema = JsonSchema.of(
+                                var schema = JsonSchema.unchecked(
                                         JsonRpcCodec.writeValueAsString(Map.of("type", "object", "properties", props)));
                                 var result = ctx.client()
                                         .elicitation()

--- a/docs/json.md
+++ b/docs/json.md
@@ -13,10 +13,10 @@ your application to a specific JSON library. Most applications need four types f
 
 ## Define a schema
 
-Use `JsonSchema.of` for schema literals you control:
+Use `JsonSchema.unchecked` for schema literals you control:
 
 ```java
-var inputSchema = JsonSchema.of("""
+var inputSchema = JsonSchema.unchecked("""
     {
       "type": "object",
       "properties": {

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/EchoToolHandler.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/EchoToolHandler.java
@@ -9,7 +9,7 @@ import java.util.concurrent.CompletableFuture;
 
 class EchoToolHandler {
 
-    static final JsonSchema ECHO_INPUT_SCHEMA = JsonSchema.of("""
+    static final JsonSchema ECHO_INPUT_SCHEMA = JsonSchema.unchecked("""
         {
           "type": "object",
           "properties": {

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/PayloadSerdeTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/PayloadSerdeTest.java
@@ -16,6 +16,7 @@ import java.lang.reflect.Type;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import tools.jackson.databind.node.JsonNodeFactory;
+import tools.jackson.databind.node.ObjectNode;
 
 class PayloadSerdeTest extends AbstractStatelessMcpE2eTest {
 
@@ -108,7 +109,7 @@ class PayloadSerdeTest extends AbstractStatelessMcpE2eTest {
                                 ToolDescriptor.builder()
                                         .name("validated-output")
                                         .description("Validated output")
-                                        .outputSchema(JsonSchema.of(outputSchema.toString()))
+                                        .outputSchema(JsonSchema.from(outputSchema, ObjectNode.class))
                                         .build(),
                                 (ctx, request) ->
                                         ToolResult.structured(Map.of("message", "valid", "extra", 42), "ok")));

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/SchemaValidationTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/SchemaValidationTest.java
@@ -23,10 +23,8 @@ class SchemaValidationTest extends AbstractStatelessMcpE2eTest {
 
     private static final JsonSchemaValidator VALIDATOR = new NetworkntJsonSchemaValidator();
 
-    private static final JsonSchema TOOL_SCHEMA =
-            JsonSchema.of(buildToolSchema().toString());
-    private static final JsonSchema PROMPT_SCHEMA =
-            JsonSchema.of(buildPromptSchema().toString());
+    private static final JsonSchema TOOL_SCHEMA = JsonSchema.from(buildToolSchema(), JsonNode.class);
+    private static final JsonSchema PROMPT_SCHEMA = JsonSchema.from(buildPromptSchema(), JsonNode.class);
 
     // region: Tool input schema validation
 
@@ -214,7 +212,7 @@ class SchemaValidationTest extends AbstractStatelessMcpE2eTest {
         return ToolDescriptor.builder()
                 .name("validated2")
                 .description("Another tool with a distinct input schema")
-                .inputSchema(JsonSchema.of(buildToolSchema2().toString()))
+                .inputSchema(JsonSchema.from(buildToolSchema2(), JsonNode.class))
                 .build();
     }
 

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/TaskAugmentedToolTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/TaskAugmentedToolTest.java
@@ -149,7 +149,7 @@ class TaskAugmentedToolTest extends AbstractStatelessMcpE2eTest {
     @Test
     void taskResultValidatesStructuredOutput() throws Exception {
         // language=json
-        var outputSchema = JsonSchema.of("""
+        var outputSchema = JsonSchema.unchecked("""
             {"type":"object","properties":{"result":{"type":"string"}},"required":["result"]}
             """);
         var validationCalls = new AtomicInteger();

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/ToolCapabilitiesTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/ToolCapabilitiesTest.java
@@ -279,8 +279,7 @@ class ToolCapabilitiesTest extends AbstractStatelessMcpE2eTest {
 
     // ---- JSON schemas ----
 
-    private static final JsonSchema OUTPUT_SCHEMA =
-            JsonSchema.of(buildOutputSchema().toString());
+    private static final JsonSchema OUTPUT_SCHEMA = JsonSchema.from(buildOutputSchema(), JsonNode.class);
 
     private static JsonNode buildOutputSchema() {
         var schema = JsonNodeFactory.instance.objectNode();
@@ -292,8 +291,7 @@ class ToolCapabilitiesTest extends AbstractStatelessMcpE2eTest {
         return schema;
     }
 
-    private static final JsonSchema INPUT_SCHEMA =
-            JsonSchema.of(buildInputSchema().toString());
+    private static final JsonSchema INPUT_SCHEMA = JsonSchema.from(buildInputSchema(), JsonNode.class);
 
     private static final ToolFn OK = (ctx, request) -> ToolResult.text("ok");
 

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/TypedToolRegistrationTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/TypedToolRegistrationTest.java
@@ -18,16 +18,16 @@ import org.junit.jupiter.params.provider.MethodSource;
 /** Verifies {@code Tools.register(Class, Class, ...)} / {@code registerAsync(Class, Class, ...)} end to end. */
 class TypedToolRegistrationTest {
 
-    private static final JsonSchema GREET_REQUEST_SCHEMA = JsonSchema.of("""
+    private static final JsonSchema GREET_REQUEST_SCHEMA = JsonSchema.unchecked("""
             {"type": "object", "properties": {"name": {"type": "string"}}, "required": ["name"]}
             """);
-    private static final JsonSchema GREET_RESPONSE_SCHEMA = JsonSchema.of("""
+    private static final JsonSchema GREET_RESPONSE_SCHEMA = JsonSchema.unchecked("""
             {"type": "object", "properties": {"greeting": {"type": "string"}}, "required": ["greeting"]}
             """);
-    private static final JsonSchema FAREWELL_REQUEST_SCHEMA = JsonSchema.of("""
+    private static final JsonSchema FAREWELL_REQUEST_SCHEMA = JsonSchema.unchecked("""
             {"type": "object", "properties": {"name": {"type": "string"}}, "required": ["name"]}
             """);
-    private static final JsonSchema FAREWELL_RESPONSE_SCHEMA = JsonSchema.of("""
+    private static final JsonSchema FAREWELL_RESPONSE_SCHEMA = JsonSchema.unchecked("""
             {"type": "object", "properties": {"farewell": {"type": "string"}}, "required": ["farewell"]}
             """);
 

--- a/tachyon-api/revapi.json
+++ b/tachyon-api/revapi.json
@@ -57,6 +57,16 @@
           "attachments": {
             "since": "1.0.0-beta.18"
           }
+        },
+        {
+          "ignore": true,
+          "code": "java.method.returnTypeChanged",
+          "old": "method dev.tachyonmcp.api.json.JsonSchema dev.tachyonmcp.api.json.JsonSchema::parse(java.lang.String)",
+          "new": "method dev.tachyonmcp.api.json.JsonDocument dev.tachyonmcp.api.json.JsonDocument::parse(java.lang.String) @ dev.tachyonmcp.api.json.JsonSchema",
+          "justification": "JsonSchemas refactored",
+          "attachments": {
+            "since": "1.0.0-beta.18"
+          }
         }
       ]
     }

--- a/tachyon-api/src/main/java/dev/tachyonmcp/api/json/JsonSchema.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/api/json/JsonSchema.java
@@ -24,21 +24,20 @@ public interface JsonSchema extends JsonDocument {
      *
      * @throws IllegalArgumentException when json is null or blank string
      */
-    static JsonSchema of(String json) {
+    static JsonSchema unchecked(String json) {
         return new DefaultJsonSchema(JsonDocuments.requireContent(json));
     }
 
     /**
-     * Creates a schema from encoded JSON, validating it via the {@link JsonSchemaFactory}
-     * chain discovered through {@link java.util.ServiceLoader}.
+     * Same as {@link #unchecked(String)}
      *
-     * @param json the JSON string
-     * @return the parsed schema
-     * @throws IllegalArgumentException if {@code json} is not valid JSON
-     * @throws IllegalStateException if no {@code JsonSchemaFactory} handles {@code String} sources
+     * @param json Json string
+     * @throws IllegalArgumentException when json is null or blank string
+     * @deprecated Use {@link #unchecked(String)}
      */
-    static JsonSchema parse(String json) {
-        return from(json, String.class);
+    @Deprecated
+    static JsonSchema of(String json) {
+        return unchecked(json);
     }
 
     /**
@@ -80,7 +79,35 @@ public interface JsonSchema extends JsonDocument {
      *     for {@code type}
      */
     @ExperimentalApi
-    static JsonSchema generated(Class<?> type) {
+    static JsonSchema generate(Class<?> type) {
         return JsonSchemas.generated(type);
+    }
+
+    /**
+     * Use {@link #generate(Class)} instead.
+     */
+    @ExperimentalApi
+    @Deprecated
+    static JsonSchema generated(Class<?> type) {
+        return JsonSchema.generate(type);
+    }
+
+    /**
+     * Resolves and validates a schema from encoded JSON, via the {@link JsonSchemaFactory} chain
+     * discovered through {@link java.util.ServiceLoader}: the registered factory whose {@link
+     * JsonSchemaFactory#sourceType()} is {@code String.class} validates {@code json} and produces
+     * the schema. Delegates to {@link #from(Object, Class)} ({@code from(json, String.class)}).
+     *
+     * <p>This API is {@link ExperimentalApi} and may change in a future release.
+     *
+     * @param json the encoded JSON schema
+     * @return the parsed schema
+     * @throws IllegalArgumentException when {@code json} is not valid JSON
+     * @throws IllegalStateException    if no {@code JsonSchemaFactory<String>} is registered for
+     *                                  {@code String} sources
+     */
+    @ExperimentalApi
+    static JsonSchema parse(String json) {
+        return JsonSchema.from(json, String.class);
     }
 }

--- a/tachyon-api/src/main/java/dev/tachyonmcp/api/json/spi/package-info.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/api/json/spi/package-info.java
@@ -12,7 +12,7 @@
  *
  * <p>Implement {@link JsonSchemaFactory} to plug a schema factory for both parsed JSON sources
  * ({@link JsonSchema#from(Object, Class)}) and generated class types
- * ({@link JsonSchema#generated(Class)}), and register it in
+ * ({@link JsonSchema#generate(Class)}), and register it in
  * {@code META-INF/services/dev.tachyonmcp.api.json.spi.JsonSchemaFactory}.
  */
 @NullMarked

--- a/tachyon-api/src/main/java/dev/tachyonmcp/api/server/features/prompts/PromptDescriptor.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/api/server/features/prompts/PromptDescriptor.java
@@ -120,7 +120,7 @@ public interface PromptDescriptor extends ServerFeature.Descriptor, HasMeta {
 
         /** Sets the optional JSON schema describing the prompt's arguments, parsed from a string. */
         default Builder inputSchema(@Nullable String inputSchema) {
-            return inputSchema(inputSchema != null ? JsonSchema.of(inputSchema) : null);
+            return inputSchema(inputSchema != null ? JsonSchema.unchecked(inputSchema) : null);
         }
 
         /** Sets the optional icons for this prompt. */

--- a/tachyon-api/src/main/java/dev/tachyonmcp/api/server/features/tools/ToolDescriptor.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/api/server/features/tools/ToolDescriptor.java
@@ -110,12 +110,12 @@ public interface ToolDescriptor extends ServerFeature.Descriptor, HasMeta {
 
         /** Sets the optional JSON schema describing the tool's input arguments, parsed from a string. */
         default Builder inputSchema(@Nullable String inputSchema) {
-            return inputSchema(inputSchema != null ? JsonSchema.of(inputSchema) : null);
+            return inputSchema(inputSchema != null ? JsonSchema.unchecked(inputSchema) : null);
         }
 
         /** Sets the optional JSON schema describing the tool's output, parsed from a string. */
         default Builder outputSchema(@Nullable String outputSchema) {
-            return outputSchema(outputSchema != null ? JsonSchema.of(outputSchema) : null);
+            return outputSchema(outputSchema != null ? JsonSchema.unchecked(outputSchema) : null);
         }
 
         /** Sets the optional declaration of this tool's support for long-running tasks. */

--- a/tachyon-api/src/main/java/dev/tachyonmcp/api/server/features/tools/Tools.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/api/server/features/tools/Tools.java
@@ -38,7 +38,7 @@ public interface Tools {
      * <p>{@code request.arguments()} is decoded into {@code inputType} before {@code fn} runs, and
      * {@code fn}'s return value is wrapped via {@code ToolResult.structured(Object)}. If {@code
      * descriptor} is missing {@link ToolDescriptor#inputSchema()} and/or {@link
-     * ToolDescriptor#outputSchema()}, they are filled in via {@link JsonSchema#generated(Class)}
+     * ToolDescriptor#outputSchema()}, they are filled in via {@link JsonSchema#generate(Class)}
      * for {@code inputType}/{@code outputType} respectively.
      *
      * @param <I> the type arguments are decoded into
@@ -154,8 +154,8 @@ public interface Tools {
             return descriptor;
         }
         var builder = ToolDescriptor.builder().from(descriptor);
-        if (descriptor.inputSchema() == null) builder.inputSchema(JsonSchema.generated(inputType));
-        if (descriptor.outputSchema() == null) builder.outputSchema(JsonSchema.generated(outputType));
+        if (descriptor.inputSchema() == null) builder.inputSchema(JsonSchema.generate(inputType));
+        if (descriptor.outputSchema() == null) builder.outputSchema(JsonSchema.generate(outputType));
         return builder.build();
     }
 

--- a/tachyon-api/src/test/java/dev/tachyonmcp/api/json/ChainPriorityHighFactory.java
+++ b/tachyon-api/src/test/java/dev/tachyonmcp/api/json/ChainPriorityHighFactory.java
@@ -28,7 +28,7 @@ public final class ChainPriorityHighFactory implements JsonSchemaFactory<Class<?
     @Override
     public Optional<JsonSchema> toJsonSchema(Class<?> type) {
         if (type == HighTarget.class) {
-            return Optional.of(JsonSchema.of("{\"title\":\"high\"}"));
+            return Optional.of(JsonSchema.unchecked("{\"title\":\"high\"}"));
         }
         return Optional.empty();
     }

--- a/tachyon-api/src/test/java/dev/tachyonmcp/api/json/ChainPriorityLowFactory.java
+++ b/tachyon-api/src/test/java/dev/tachyonmcp/api/json/ChainPriorityLowFactory.java
@@ -24,7 +24,7 @@ public final class ChainPriorityLowFactory implements JsonSchemaFactory<Class<?>
     @Override
     public Optional<JsonSchema> toJsonSchema(Class<?> type) {
         if (type == LowTarget.class) {
-            return Optional.of(JsonSchema.of("{\"title\":\"low\"}"));
+            return Optional.of(JsonSchema.unchecked("{\"title\":\"low\"}"));
         }
         return Optional.empty();
     }

--- a/tachyon-api/src/test/java/dev/tachyonmcp/api/json/JsonSchemaTest.java
+++ b/tachyon-api/src/test/java/dev/tachyonmcp/api/json/JsonSchemaTest.java
@@ -4,34 +4,58 @@ package dev.tachyonmcp.api.json;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import dev.tachyonmcp.api.json.spi.JsonSchemaFactory;
 import org.junit.jupiter.api.Test;
 
 /**
- * Exercises {@link JsonSchema#generated(Class)} against the {@link JsonSchemaFactory} chain
- * registered for this module via {@code META-INF/services}: {@link ChainPriorityLowFactory}
- * (priority {@code 0}) and {@link ChainPriorityHighFactory} (priority {@code 10}).
+ * Exercises {@link JsonSchema#generate(Class)} and {@link JsonSchema#parse(String)} against the
+ * {@link JsonSchemaFactory} chain registered for this module via {@code META-INF/services}: {@link
+ * ChainPriorityLowFactory} (priority {@code 0}), {@link ChainPriorityHighFactory} (priority {@code
+ * 10}) for {@code Class} sources, and {@link StringJsonSchemaFactory} for {@code String} sources.
  */
 class JsonSchemaTest {
 
     @Test
     void generatedPrefersTheLowestPriorityFactory() {
-        var schema = JsonSchema.generated(ChainPriorityLowFactory.LowTarget.class);
+        var schema = JsonSchema.generate(ChainPriorityLowFactory.LowTarget.class);
 
         assertThat(schema.json()).contains("\"low\"");
     }
 
     @Test
     void generatedContinuesToTheNextFactoryWhenTheLowestReturnsEmpty() {
-        var schema = JsonSchema.generated(ChainPriorityHighFactory.HighTarget.class);
+        var schema = JsonSchema.generate(ChainPriorityHighFactory.HighTarget.class);
 
         assertThat(schema.json()).contains("\"high\"");
     }
 
     @Test
     void generatedThrowsWhenEveryFactoryReturnsEmpty() {
-        assertThatThrownBy(() -> JsonSchema.generated(String.class))
+        assertThatThrownBy(() -> JsonSchema.generate(String.class))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("META-INF/services")
                 .hasMessageContaining("META-INF/kt-schema/schemas");
+    }
+
+    @Test
+    void parseResolvesValidJsonViaStringProvider() {
+        var schema = JsonSchema.parse("{\"type\":\"object\"}");
+
+        assertThat(schema.json()).isEqualTo("{\"type\":\"object\"}");
+    }
+
+    @Test
+    void parseRejectsMalformedJson() {
+        assertThatThrownBy(() -> JsonSchema.parse("not-json"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("not-json");
+    }
+
+    @Test
+    void parseThrowsWhenNoStringProviderCoversTheSource() {
+        assertThatThrownBy(() -> JsonSchema.parse("42"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("java.lang.String")
+                .hasMessageContaining("META-INF/services");
     }
 }

--- a/tachyon-api/src/test/java/dev/tachyonmcp/api/json/StringJsonSchemaFactory.java
+++ b/tachyon-api/src/test/java/dev/tachyonmcp/api/json/StringJsonSchemaFactory.java
@@ -1,0 +1,39 @@
+/* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
+package dev.tachyonmcp.api.json;
+
+import dev.tachyonmcp.api.json.spi.JsonSchemaFactory;
+import java.util.Map;
+import java.util.Optional;
+import net.minidev.json.parser.JSONParser;
+import net.minidev.json.parser.ParseException;
+
+/**
+ * Test-only {@link JsonSchemaFactory} for {@link String} sources, registered via {@code
+ * META-INF/services}. Validates the JSON strictly, returns a schema for object or boolean JSON,
+ * and returns {@link Optional#empty()} for other valid JSON so the resolution chain falls through.
+ */
+public final class StringJsonSchemaFactory implements JsonSchemaFactory<String> {
+
+    private final JSONParser parser = new JSONParser(JSONParser.MODE_STRICTEST);
+
+    public StringJsonSchemaFactory() {}
+
+    @Override
+    public Class<String> sourceType() {
+        return String.class;
+    }
+
+    @Override
+    public Optional<JsonSchema> toJsonSchema(String json) {
+        Object parsed;
+        try {
+            parsed = parser.parse(json);
+        } catch (ParseException e) {
+            throw new IllegalArgumentException("Not valid JSON: " + json, e);
+        }
+        if (parsed instanceof Boolean || parsed instanceof Map) {
+            return Optional.of(JsonSchema.unchecked(json));
+        }
+        return Optional.empty();
+    }
+}

--- a/tachyon-api/src/test/resources/META-INF/services/dev.tachyonmcp.api.json.spi.JsonSchemaFactory
+++ b/tachyon-api/src/test/resources/META-INF/services/dev.tachyonmcp.api.json.spi.JsonSchemaFactory
@@ -1,2 +1,3 @@
 dev.tachyonmcp.api.json.ChainPriorityLowFactory
 dev.tachyonmcp.api.json.ChainPriorityHighFactory
+dev.tachyonmcp.api.json.StringJsonSchemaFactory

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/features/tasks/TasksExtension.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/features/tasks/TasksExtension.java
@@ -44,7 +44,7 @@ public class TasksExtension implements ServerExtension {
     }
 
     // language=json
-    private static final JsonSchema CREATE_TASK_SCHEMA = JsonSchema.of("""
+    private static final JsonSchema CREATE_TASK_SCHEMA = JsonSchema.unchecked("""
         {
           "type": "object",
           "properties": {

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/json/Jackson3JsonFactory.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/json/Jackson3JsonFactory.java
@@ -42,7 +42,7 @@ public final class Jackson3JsonFactory implements JsonDocumentFactory<String>, J
     @Override
     public Optional<JsonSchema> toJsonSchema(String json) {
         validate(json);
-        return Optional.of(JsonSchema.of(json));
+        return Optional.of(JsonSchema.unchecked(json));
     }
 
     private static void validate(String json) {

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/json/KtSchemaResourceFactory.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/json/KtSchemaResourceFactory.java
@@ -44,7 +44,7 @@ public final class KtSchemaResourceFactory implements JsonSchemaFactory<Class<?>
             if (in == null) {
                 return Optional.empty();
             }
-            return Optional.of(JsonSchema.of(new String(in.readAllBytes(), StandardCharsets.UTF_8)));
+            return Optional.of(JsonSchema.unchecked(new String(in.readAllBytes(), StandardCharsets.UTF_8)));
         } catch (IOException e) {
             throw new UncheckedIOException("Could not read schema resource: " + path, e);
         }

--- a/tachyon-core/src/test/java/dev/tachyonmcp/core/server/json/JsonSpiDiscoveryTest.java
+++ b/tachyon-core/src/test/java/dev/tachyonmcp/core/server/json/JsonSpiDiscoveryTest.java
@@ -17,7 +17,8 @@ class JsonSpiDiscoveryTest {
 
     @Test
     void shouldParseValidJsonStringIntoSchemaViaDiscoveredFactory() {
-        assertThatJson(JsonSchema.parse("{\"type\":\"object\"}").json()).isEqualTo("{\"type\":\"object\"}");
+        assertThatJson(JsonSchema.from("{\"type\":\"object\"}", String.class).json())
+                .isEqualTo("{\"type\":\"object\"}");
     }
 
     @Test
@@ -27,7 +28,8 @@ class JsonSpiDiscoveryTest {
 
     @Test
     void shouldRejectMalformedJsonStringForSchema() {
-        assertThatThrownBy(() -> JsonSchema.parse("not-json")).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> JsonSchema.from("not-json", String.class))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test

--- a/tachyon-core/src/test/java/dev/tachyonmcp/core/server/json/KtSchemaResourceFactoryTest.java
+++ b/tachyon-core/src/test/java/dev/tachyonmcp/core/server/json/KtSchemaResourceFactoryTest.java
@@ -10,20 +10,20 @@ import org.junit.jupiter.api.Test;
 /**
  * Exercises {@link KtSchemaResourceFactory} as the {@code JsonSchemaFactory} chain registered for
  * this module: build-time resources resolve, types without a resource resolve to nothing, and
- * {@link JsonSchema#generated(Class)} fails once the chain is exhausted.
+ * {@link JsonSchema#generate(Class)} fails once the chain is exhausted.
  */
 class KtSchemaResourceFactoryTest {
 
     @Test
     void resolvesBuildTimeGeneratedSchemaResource() {
-        var schema = JsonSchema.generated(GeneratedSchemaFixture.class);
+        var schema = JsonSchema.generate(GeneratedSchemaFixture.class);
 
         assertThat(schema.json()).contains("\"title\": \"fixture\"", "\"name\"");
     }
 
     @Test
     void generatedFailsWhenChainExhausted() {
-        assertThatThrownBy(() -> JsonSchema.generated(String.class))
+        assertThatThrownBy(() -> JsonSchema.generate(String.class))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("META-INF/services")
                 .hasMessageContaining("META-INF/kt-schema/schemas");

--- a/tachyon-core/src/test/java/dev/tachyonmcp/core/server/json/NetworkntJsonSchemaValidatorTest.java
+++ b/tachyon-core/src/test/java/dev/tachyonmcp/core/server/json/NetworkntJsonSchemaValidatorTest.java
@@ -13,7 +13,7 @@ class NetworkntJsonSchemaValidatorTest {
 
     @Test
     void shouldReturnNoErrorsForValidArguments() {
-        var schema = JsonSchema.of("""
+        var schema = JsonSchema.unchecked("""
             {"type":"object","properties":{"name":{"type":"string"}},"required":["name"]}
             """);
         var arguments = JsonDocument.of("""
@@ -25,7 +25,7 @@ class NetworkntJsonSchemaValidatorTest {
 
     @Test
     void shouldReturnErrorWithPathAndKeywordForMissingRequiredProperty() {
-        var schema = JsonSchema.of("""
+        var schema = JsonSchema.unchecked("""
             {"type":"object","properties":{"name":{"type":"string"}},"required":["name"]}
             """);
         var arguments = JsonDocument.of("{}");
@@ -39,7 +39,7 @@ class NetworkntJsonSchemaValidatorTest {
 
     @Test
     void shouldReturnErrorForWrongType() {
-        var schema = JsonSchema.of("""
+        var schema = JsonSchema.unchecked("""
             {"type":"object","properties":{"age":{"type":"integer"}}}
             """);
         var arguments = JsonDocument.of("""
@@ -54,10 +54,10 @@ class NetworkntJsonSchemaValidatorTest {
 
     @Test
     void shouldValidateDistinctSchemasIndependently() {
-        var nameSchema = JsonSchema.of("""
+        var nameSchema = JsonSchema.unchecked("""
             {"type":"object","properties":{"name":{"type":"string"}},"required":["name"]}
             """);
-        var emailSchema = JsonSchema.of("""
+        var emailSchema = JsonSchema.unchecked("""
             {"type":"object","properties":{"email":{"type":"string"}},"required":["email"]}
             """);
 
@@ -78,10 +78,10 @@ class NetworkntJsonSchemaValidatorTest {
 
     @Test
     void shouldReuseCompiledSchemaForRepeatedCallsWithEquivalentSchemaContent() {
-        var schema1 = JsonSchema.of("""
+        var schema1 = JsonSchema.unchecked("""
             {"type":"object","properties":{"name":{"type":"string"}},"required":["name"]}
             """);
-        var schema2 = JsonSchema.of("""
+        var schema2 = JsonSchema.unchecked("""
             {"type":"object","properties":{"name":{"type":"string"}},"required":["name"]}
             """);
 
@@ -91,9 +91,9 @@ class NetworkntJsonSchemaValidatorTest {
 
     @Test
     void shouldSupportBooleanSchemas() {
-        assertThat(validator.validate(JsonSchema.of("true"), JsonDocument.of("{\"value\":1}")))
+        assertThat(validator.validate(JsonSchema.unchecked("true"), JsonDocument.of("{\"value\":1}")))
                 .isEmpty();
-        assertThat(validator.validate(JsonSchema.of("false"), JsonDocument.of("{\"value\":1}")))
+        assertThat(validator.validate(JsonSchema.unchecked("false"), JsonDocument.of("{\"value\":1}")))
                 .hasSize(1);
     }
 }

--- a/tachyon-extensions/src/main/java/dev/tachyonmcp/extensions/tools/echo/EchoToolHandler.java
+++ b/tachyon-extensions/src/main/java/dev/tachyonmcp/extensions/tools/echo/EchoToolHandler.java
@@ -10,7 +10,7 @@ import dev.tachyonmcp.api.server.features.tools.ToolResult;
 
 public class EchoToolHandler extends AbstractToolHandler {
 
-    static final JsonSchema ECHO_INPUT_SCHEMA = JsonSchema.of("""
+    static final JsonSchema ECHO_INPUT_SCHEMA = JsonSchema.unchecked("""
         {
           "type": "object",
           "properties": {

--- a/tachyon-kotlin-kt-schema/src/main/kotlin/dev/tachyonmcp/kotlin/server/json/ktschema/KtSchemaReflectionFactory.kt
+++ b/tachyon-kotlin-kt-schema/src/main/kotlin/dev/tachyonmcp/kotlin/server/json/ktschema/KtSchemaReflectionFactory.kt
@@ -26,5 +26,5 @@ internal class KtSchemaReflectionFactory : JsonSchemaFactory<Class<*>> {
     override fun priority(): Int = 10
 
     override fun toJsonSchema(type: Class<*>): Optional<JsonSchema> =
-        Optional.of(JsonSchema.of(generator.generateSchemaString(type.kotlin)))
+        Optional.of(JsonSchema.unchecked(generator.generateSchemaString(type.kotlin)))
 }

--- a/tachyon-kotlin-kt-schema/src/test/kotlin/dev/tachyonmcp/kotlin/server/json/ktschema/KtSchemaReflectionFactoryTest.kt
+++ b/tachyon-kotlin-kt-schema/src/test/kotlin/dev/tachyonmcp/kotlin/server/json/ktschema/KtSchemaReflectionFactoryTest.kt
@@ -43,7 +43,7 @@ internal class KtSchemaReflectionFactoryTest {
 
     @Test
     fun `JsonSchema generated from a class without a resource falls back to reflection`() {
-        val schema = JsonSchema.generated(Model::class.java)
+        val schema = JsonSchema.generate(Model::class.java)
 
         schema.json() shouldEqualJson
             $$"""

--- a/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/config/TachyonServerBuilder.kt
+++ b/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/config/TachyonServerBuilder.kt
@@ -168,7 +168,7 @@ public class TachyonServerBuilder
 
         /**
          * Registers a tool whose input/output schemas are resolved from [In]/[Out] via
-         * [dev.tachyonmcp.api.json.JsonSchema.generated], which tries the service-loaded
+         * [dev.tachyonmcp.api.json.JsonSchema.generate], which tries the service-loaded
          * [dev.tachyonmcp.api.json.spi.JsonSchemaFactory] chain in ascending priority order: a
          * build-time codegen resource (tachyon-core's `KtSchemaResourceFactory`) wins when
          * present, otherwise the runtime reflection generator in the `tachyon-kotlin-kt-schema`
@@ -214,8 +214,8 @@ public class TachyonServerBuilder
                 featureRegistrar.tool(
                     name,
                     description,
-                    JsonSchema.generated(inputType),
-                    JsonSchema.generated(outputType),
+                    JsonSchema.generate(inputType),
+                    JsonSchema.generate(outputType),
                     taskSupport,
                     handler,
                 )

--- a/tachyon-kotlin/src/test/kotlin/dev/tachyonmcp/kotlin/server/TachyonServerTest.kt
+++ b/tachyon-kotlin/src/test/kotlin/dev/tachyonmcp/kotlin/server/TachyonServerTest.kt
@@ -316,7 +316,7 @@ internal class TachyonServerTest {
         ) {
             name("template-test")
             session { enabled = true }
-            tool("check", inputSchema = JsonSchema.of(schema)) { ToolResult.text("ok") }
+            tool("check", inputSchema = JsonSchema.unchecked(schema)) { ToolResult.text("ok") }
             resourceTemplate(
                 name = "user-profile",
                 uriTemplate = "user://{userId}/profile",
@@ -548,8 +548,8 @@ internal class TachyonServerTest {
             tool(
                 "with-output",
                 "Has output schema",
-                inputSchema = JsonSchema.of(schema),
-                outputSchema = JsonSchema.of(outputSchema),
+                inputSchema = JsonSchema.unchecked(schema),
+                outputSchema = JsonSchema.unchecked(outputSchema),
             ) {
                 ToolResult.text("done")
             }
@@ -571,7 +571,7 @@ internal class TachyonServerTest {
         ) {
             name("string-schema-test")
             session { enabled = true }
-            tool("string-schema", inputSchema = JsonSchema.of(schema)) {
+            tool("string-schema", inputSchema = JsonSchema.unchecked(schema)) {
                 ToolResult.text("ok")
             }
         }.use { handle ->

--- a/tachyon-kotlin/src/test/kotlin/dev/tachyonmcp/kotlin/server/config/GeneratedTitleSchemaFactory.kt
+++ b/tachyon-kotlin/src/test/kotlin/dev/tachyonmcp/kotlin/server/config/GeneratedTitleSchemaFactory.kt
@@ -7,12 +7,16 @@ import java.util.Optional
 
 /**
  * Test-only [JsonSchemaFactory] registered via `META-INF/services` so this module's `typedTool`
- * tests resolve a schema through the real [dev.tachyonmcp.api.json.JsonSchema.generated] chain,
+ * tests resolve a schema through the real [dev.tachyonmcp.api.json.JsonSchema.generate] chain,
  * without depending on `tachyon-kotlin-kt-schema`'s reflection generator.
  */
 public class GeneratedTitleSchemaFactory : JsonSchemaFactory<Class<*>> {
     override fun sourceType(): Class<Class<*>> = Class::class.java
 
     override fun toJsonSchema(source: Class<*>): Optional<JsonSchema> =
-        Optional.of(JsonSchema.of("""{"type":"object","title":"${source.simpleName}"}"""))
+        Optional.of(
+            JsonSchema.unchecked(
+                """{"type":"object","title":"${source.simpleName}"}""",
+            ),
+        )
 }

--- a/tachyon-testkit/src/test/java/dev/tachyonmcp/testkit/McpTestKitSmokeTest.java
+++ b/tachyon-testkit/src/test/java/dev/tachyonmcp/testkit/McpTestKitSmokeTest.java
@@ -17,7 +17,7 @@ import tools.jackson.databind.ObjectMapper;
 /** Verifies the testkit client/helpers against a real port-0 server. */
 class McpTestKitSmokeTest {
 
-    private static final JsonSchema ECHO_SCHEMA = JsonSchema.of("""
+    private static final JsonSchema ECHO_SCHEMA = JsonSchema.unchecked("""
             {
               "type": "object",
               "properties": {


### PR DESCRIPTION
## Summary

- Add `JsonSchema.unchecked`, deprecate `JsonSchema.of`
- Add `JsonSchema.generate`, deprecate `JsonSchema.generated`

### New Features

- Added JsonSchema.generate(Class) for generating schemas from Java and Kotlin types.
- Added JsonSchema.unchecked(...) for constructing schemas without redundant validation.

### Deprecations

- Deprecated older schema factory aliases while retaining compatibility.

### Documentation

- Updated schema-generation examples and API references to use the current methods.

### Tests

- Updated schema parsing, generation, validation, and integration coverage for the revised APIs.