### PR TITLE
fix!: internal API lists never null; Task.ttl as Duration 

### DIFF
--- a/.agents/skills/tachyon-development/SKILL.md
+++ b/.agents/skills/tachyon-development/SKILL.md
@@ -14,11 +14,15 @@ description: Apply Tachyon MCP project rules when designing, implementing, revie
   MCP features, metadata, behavior, and coverage functionally identical when changing either one.
 - Keep Kotlin source files focused. At more than 300 lines, consider splitting by owned
   responsibility before adding code.
+- A public API change (new/changed method, param, wire field, or behavior contract like TTL/null
+  semantics) is not done until its docs are done: update the relevant file under `docs/`, this
+  skill, and/or `docs/architecture/guidance.md` in the same change. Don't defer it to a follow-up.
 
 # Test Rules 🧪
 
 - AssertJ fluent. Short spec ref comment in method. JUnit6+JUnit Pioneer annotations. Prefer parametrized tests.
 - Handlers that throw: test with a real checked exception thrown directly from the lambda (no try/catch) — exercises the `throws Exception` SAM contract, not just unchecked paths.
+- "Omitted/null on wire" claims: serialize through the real codec (`CodecRegistry.codecFor(X.class).encodeToBytes(value)`, or `JsonRpcCodec.writeValueAsString`) and assert on the resulting JSON. Asserting a domain/model field is `null` only proves the mapper produced `null` — it trusts, but doesn't verify, that the codec omits it.
 
 ## E2E
 

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -102,7 +102,8 @@ background — sync, async, and Kotlin suspend handlers all work. The client the
 `tasks/get` and fetches the outcome via `tasks/result`.
 
 - `taskSupport = REQUIRED` rejects plain calls; `FORBIDDEN` (default) rejects task-augmented calls.
-- `task.ttl` (milliseconds) bounds retention; expired tasks transition to `FAILED`.
+- `task.ttl` (milliseconds) bounds retention; expired tasks transition to `FAILED`. Zero or negative
+  `ttl` means "never expires" — same convention as `keepAlive` below.
 - `tasks/cancel` interrupts synchronous handlers running on virtual threads and cancels the
   `CompletionStage` returned by asynchronous handlers. Kotlin suspend handlers receive coroutine
   cancellation.

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/PromptCapabilitiesTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/PromptCapabilitiesTest.java
@@ -32,7 +32,7 @@ class PromptCapabilitiesTest extends AbstractStatelessMcpE2eTest {
         if (hasTitle) {
             server.prompts()
                     .register(
-                            PromptDescriptor.of(promptName, "A " + promptName + " prompt", title, null, null),
+                            PromptDescriptor.of(promptName, "A " + promptName + " prompt", title, List.of(), null),
                             List.of(of(Role.USER, TextContent.of("Hello"))));
         } else {
             server.prompts().register(PromptDescriptor.of(promptName, "A " + promptName + " prompt"), List.of());

--- a/tachyon-api/revapi.json
+++ b/tachyon-api/revapi.json
@@ -67,6 +67,13 @@
           "attachments": {
             "since": "1.0.0-beta.18"
           }
+        },
+        {
+          "ignore": true,
+          "code": "java.method.returnTypeChanged",
+          "old": "method java.lang.Long dev.tachyonmcp.api.server.domain.Task::ttl()",
+          "new": "method java.time.Duration dev.tachyonmcp.api.server.domain.Task::ttl()",
+          "justification": "Use idiomatic domain types"
         }
       ]
     }

--- a/tachyon-api/src/main/java/dev/tachyonmcp/api/server/config/ServerIdentity.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/api/server/config/ServerIdentity.java
@@ -38,7 +38,6 @@ public interface ServerIdentity {
     @Nullable
     String instructions();
 
-    @Nullable
     List<Icon> icons();
 
     ServerIdentity DEFAULT = DefaultServerIdentity.builder().build();
@@ -65,7 +64,7 @@ public interface ServerIdentity {
 
         Builder instructions(@Nullable String instructions);
 
-        Builder icons(@Nullable Iterable<? extends Icon> icons);
+        Builder icons(Iterable<? extends Icon> icons);
 
         default Builder icons(Icon... icons) {
             return icons(List.of(icons));

--- a/tachyon-api/src/main/java/dev/tachyonmcp/api/server/domain/Annotations.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/api/server/domain/Annotations.java
@@ -10,19 +10,19 @@ import org.jspecify.annotations.Nullable;
  *
  * <p>{@code audience} hints at the intended role (user/assistant), {@code priority} controls
  * ordering, and {@code lastModified} carries an RFC-3339 timestamp of the last modification.
- * All fields are {@code null} when absent — omit the annotation block entirely rather than
- * sending empty values.
+ * {@code audience} is an empty list when unrestricted; {@code priority} and {@code lastModified}
+ * are {@code null} when absent — omit the annotation block entirely rather than sending empty
+ * values.
  */
 @Value.Immutable
 @Value.Style(visibility = Value.Style.ImplementationVisibility.PACKAGE, typeImmutable = "Default*")
 public interface Annotations {
 
     /**
-     * Intended audience roles, or {@code null} when unrestricted.
+     * Intended audience roles, or an empty list when unrestricted.
      *
-     * @return the audience list, or {@code null}
+     * @return the audience list, or an empty list
      */
-    @Nullable
     List<Role> audience();
 
     /**
@@ -66,12 +66,12 @@ public interface Annotations {
     /**
      * Creates annotations with the given values.
      *
-     * @param audience     intended audience roles, or {@code null}
+     * @param audience     intended audience roles, or an empty list
      * @param priority     ordering hint, or {@code null}
      * @param lastModified RFC-3339 timestamp, or {@code null}
      * @return the new annotations
      */
-    static Annotations of(@Nullable List<Role> audience, @Nullable Double priority, @Nullable String lastModified) {
+    static Annotations of(List<Role> audience, @Nullable Double priority, @Nullable String lastModified) {
         return DefaultAnnotations.builder()
                 .audience(audience)
                 .priority(priority)
@@ -88,10 +88,10 @@ public interface Annotations {
         /**
          * Sets the intended audience.
          *
-         * @param elements the audience roles, or {@code null}
+         * @param elements the audience roles
          * @return this builder
          */
-        Builder audience(@Nullable Iterable<? extends Role> elements);
+        Builder audience(Iterable<? extends Role> elements);
 
         /**
          * Sets the intended audience.

--- a/tachyon-api/src/main/java/dev/tachyonmcp/api/server/domain/BlobResourceContents.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/api/server/domain/BlobResourceContents.java
@@ -44,12 +44,11 @@ public non-sealed interface BlobResourceContents extends ResourceContents {
     /**
      * Validates that required fields are not blank.
      *
-     * @throws IllegalArgumentException if {@code uri} is blank or {@code blob} is empty
+     * @throws IllegalArgumentException if {@code uri} is blank
      */
     @Value.Check
     default void check() {
         if (uri().isBlank()) throw new IllegalArgumentException("uri must not be blank");
-        if (blob().length == 0) throw new IllegalArgumentException("blob must not be empty");
     }
 
     /**

--- a/tachyon-api/src/main/java/dev/tachyonmcp/api/server/domain/Icon.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/api/server/domain/Icon.java
@@ -38,9 +38,8 @@ public interface Icon {
     /**
      * Conventional size labels (e.g. {@code ["16x16", "32x32"]}).
      *
-     * @return the size labels, or {@code null} when unspecified
+     * @return the size labels, or an empty list when unspecified
      */
-    @Nullable
     List<String> sizes();
 
     /**
@@ -75,11 +74,11 @@ public interface Icon {
      *
      * @param src      image URL or data URI
      * @param mimeType image MIME type, or {@code null}
-     * @param sizes    conventional size labels, or {@code null}
+     * @param sizes    conventional size labels, or an empty list
      * @param theme    theme variant, or {@code null}
      * @return the new icon
      */
-    static Icon of(String src, @Nullable String mimeType, @Nullable List<String> sizes, @Nullable String theme) {
+    static Icon of(String src, @Nullable String mimeType, List<String> sizes, @Nullable String theme) {
         return DefaultIcon.of(src, mimeType, sizes, theme);
     }
 
@@ -108,10 +107,10 @@ public interface Icon {
         /**
          * Sets the conventional size labels.
          *
-         * @param elements size labels (e.g. "16x16"), or {@code null}
+         * @param elements size labels (e.g. "16x16")
          * @return this builder
          */
-        Builder sizes(@Nullable Iterable<String> elements);
+        Builder sizes(Iterable<String> elements);
 
         /**
          * Sets the conventional size labels.

--- a/tachyon-api/src/main/java/dev/tachyonmcp/api/server/domain/ResourceLink.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/api/server/domain/ResourceLink.java
@@ -24,7 +24,6 @@ public non-sealed interface ResourceLink extends ContentBlock {
     @Nullable
     String title();
 
-    @Nullable
     List<Icon> icons();
 
     String uri();
@@ -91,7 +90,7 @@ public non-sealed interface ResourceLink extends ContentBlock {
 
         Builder title(@Nullable String title);
 
-        Builder icons(@Nullable Iterable<? extends Icon> elements);
+        Builder icons(Iterable<? extends Icon> elements);
 
         default Builder icons(Icon... elements) {
             return icons(List.of(elements));

--- a/tachyon-api/src/main/java/dev/tachyonmcp/api/server/domain/Task.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/api/server/domain/Task.java
@@ -33,7 +33,7 @@ public interface Task extends HasMeta {
 
     /** Time-to-live duration after which the task is eligible for eviction, or {@code null}. */
     @Nullable
-    Long ttl();
+    Duration ttl();
 
     /** Suggested polling interval for {@code tasks/get}, or {@code null} to not suggest one. */
     @Nullable

--- a/tachyon-api/src/main/java/dev/tachyonmcp/api/server/features/prompts/PromptDescriptor.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/api/server/features/prompts/PromptDescriptor.java
@@ -32,16 +32,14 @@ public interface PromptDescriptor extends ServerFeature.Descriptor, HasMeta {
     @Nullable
     String description();
 
-    /** Optional arguments accepted by this prompt. */
-    @Nullable
+    /** Arguments accepted by this prompt, or an empty list. */
     List<PromptArgument> arguments();
 
     /** Optional JSON schema describing the prompt's arguments. */
     @Nullable
     JsonSchema inputSchema();
 
-    /** Optional icons for this prompt. */
-    @Nullable
+    /** Icons for this prompt, or an empty list. */
     List<Icon> icons();
 
     /** Optional identifier of the extension that owns this prompt. */
@@ -73,9 +71,9 @@ public interface PromptDescriptor extends ServerFeature.Descriptor, HasMeta {
             String name,
             @Nullable String description,
             @Nullable String title,
-            @Nullable List<PromptArgument> arguments,
+            List<PromptArgument> arguments,
             @Nullable JsonSchema inputSchema) {
-        return DefaultPromptDescriptor.of(name, title, description, arguments, inputSchema, null, null, null);
+        return DefaultPromptDescriptor.of(name, title, description, arguments, inputSchema, List.of(), null, null);
     }
 
     /** Creates a prompt descriptor with the given fields, including icons. */
@@ -83,15 +81,15 @@ public interface PromptDescriptor extends ServerFeature.Descriptor, HasMeta {
             String name,
             @Nullable String description,
             @Nullable String title,
-            @Nullable List<PromptArgument> arguments,
+            List<PromptArgument> arguments,
             @Nullable JsonSchema inputSchema,
-            @Nullable List<Icon> icons) {
+            List<Icon> icons) {
         return DefaultPromptDescriptor.of(name, title, description, arguments, inputSchema, icons, null, null);
     }
 
     /** Creates a prompt descriptor with just a name and description. */
     static PromptDescriptor of(String name, String description) {
-        return DefaultPromptDescriptor.of(name, null, description, null, null, null, null, null);
+        return DefaultPromptDescriptor.of(name, null, description, List.of(), null, List.of(), null, null);
     }
 
     /** Builder for {@link PromptDescriptor}. */
@@ -113,7 +111,7 @@ public interface PromptDescriptor extends ServerFeature.Descriptor, HasMeta {
         Builder addArguments(PromptArgument... elements);
 
         /** Sets the arguments accepted by this prompt. */
-        Builder arguments(@Nullable Iterable<? extends PromptArgument> elements);
+        Builder arguments(Iterable<? extends PromptArgument> elements);
 
         /** Sets the optional JSON schema describing the prompt's arguments. */
         Builder inputSchema(@Nullable JsonSchema inputSchema);
@@ -123,8 +121,8 @@ public interface PromptDescriptor extends ServerFeature.Descriptor, HasMeta {
             return inputSchema(inputSchema != null ? JsonSchema.unchecked(inputSchema) : null);
         }
 
-        /** Sets the optional icons for this prompt. */
-        Builder icons(@Nullable Iterable<? extends Icon> elements);
+        /** Sets the icons for this prompt. */
+        Builder icons(Iterable<? extends Icon> elements);
 
         /** Sets the optional identifier of the extension that owns this prompt. */
         Builder extensionId(@Nullable String extensionId);

--- a/tachyon-api/src/main/java/dev/tachyonmcp/api/server/features/prompts/PromptResult.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/api/server/features/prompts/PromptResult.java
@@ -53,11 +53,10 @@ public sealed interface PromptResult extends HasMeta permits PromptResult.Messag
     non-sealed interface Messages extends PromptResult {
 
         /**
-         * Returns the prompt messages, or {@code null} for an empty response.
+         * Returns the prompt messages.
          *
-         * @return the prompt messages, or {@code null}
+         * @return the prompt messages, or an empty list
          */
-        @Nullable
         List<PromptMessage> messages();
 
         @Override
@@ -82,10 +81,10 @@ public sealed interface PromptResult extends HasMeta permits PromptResult.Messag
         /**
          * Creates a message result with no {@code _meta}.
          *
-         * @param messages the prompt messages, or {@code null}
+         * @param messages the prompt messages
          * @return a new message result
          */
-        static Messages of(@Nullable List<PromptMessage> messages) {
+        static Messages of(List<PromptMessage> messages) {
             return builder().messages(messages).build();
         }
 
@@ -96,10 +95,10 @@ public sealed interface PromptResult extends HasMeta permits PromptResult.Messag
             /**
              * Sets the prompt messages.
              *
-             * @param messages the prompt messages, or {@code null}
+             * @param messages the prompt messages
              * @return this builder
              */
-            Builder messages(@Nullable Iterable<? extends PromptMessage> messages);
+            Builder messages(Iterable<? extends PromptMessage> messages);
 
             /**
              * Sets the prompt messages.
@@ -200,10 +199,10 @@ public sealed interface PromptResult extends HasMeta permits PromptResult.Messag
     /**
      * Creates a prompt result with the given messages.
      *
-     * @param messages the prompt messages, or {@code null}
+     * @param messages the prompt messages
      * @return the prompt result
      */
-    static PromptResult messages(@Nullable List<PromptMessage> messages) {
+    static PromptResult messages(List<PromptMessage> messages) {
         return Messages.of(messages);
     }
 

--- a/tachyon-api/src/main/java/dev/tachyonmcp/api/server/features/resources/ResourceDescriptor.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/api/server/features/resources/ResourceDescriptor.java
@@ -49,8 +49,7 @@ public interface ResourceDescriptor extends ServerFeature.Descriptor, HasMeta {
     @Nullable
     Long size();
 
-    /** Optional icons for this resource. */
-    @Nullable
+    /** Icons for this resource, or an empty list. */
     List<Icon> icons();
 
     /** Optional identifier of the extension that owns this resource. */
@@ -94,7 +93,7 @@ public interface ResourceDescriptor extends ServerFeature.Descriptor, HasMeta {
             @Nullable String title,
             @Nullable Annotations annotations,
             @Nullable Long size,
-            @Nullable List<Icon> icons) {
+            List<Icon> icons) {
         return ResourceDescriptor.builder()
                 .name(name)
                 .uri(uri)
@@ -131,7 +130,7 @@ public interface ResourceDescriptor extends ServerFeature.Descriptor, HasMeta {
             return size((long) size);
         }
 
-        Builder icons(@Nullable Iterable<? extends Icon> elements);
+        Builder icons(Iterable<? extends Icon> elements);
 
         default Builder icons(Icon... elements) {
             return icons(List.of(elements));

--- a/tachyon-api/src/main/java/dev/tachyonmcp/api/server/features/resources/ResourceTemplateDescriptor.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/api/server/features/resources/ResourceTemplateDescriptor.java
@@ -110,7 +110,7 @@ public interface ResourceTemplateDescriptor extends ServerFeature.Descriptor, Ha
         /** Sets the icons for resources matching this template. */
         Builder icons(Iterable<? extends Icon> elements);
 
-        /** Sets the optional icons for resources matching this template. */
+        /** Sets the icons for resources matching this template; an empty array means no icons. */
         default Builder icons(Icon... elements) {
             return icons(List.of(elements));
         }

--- a/tachyon-api/src/main/java/dev/tachyonmcp/api/server/features/resources/ResourceTemplateDescriptor.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/api/server/features/resources/ResourceTemplateDescriptor.java
@@ -52,8 +52,7 @@ public interface ResourceTemplateDescriptor extends ServerFeature.Descriptor, Ha
     @Nullable
     String extensionId();
 
-    /** Optional icons for resources matching this template. */
-    @Nullable
+    /** Icons for resources matching this template, or an empty list. */
     List<Icon> icons();
 
     /** Optional protocol extension metadata. */
@@ -108,8 +107,8 @@ public interface ResourceTemplateDescriptor extends ServerFeature.Descriptor, Ha
         /** Sets the optional annotations shared by resources matching this template. */
         Builder annotations(@Nullable Annotations annotations);
 
-        /** Sets the optional icons for resources matching this template. */
-        Builder icons(@Nullable Iterable<? extends Icon> elements);
+        /** Sets the icons for resources matching this template. */
+        Builder icons(Iterable<? extends Icon> elements);
 
         /** Sets the optional icons for resources matching this template. */
         default Builder icons(Icon... elements) {

--- a/tachyon-api/src/main/java/dev/tachyonmcp/api/server/features/tools/ToolDescriptor.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/api/server/features/tools/ToolDescriptor.java
@@ -49,8 +49,7 @@ public interface ToolDescriptor extends ServerFeature.Descriptor, HasMeta {
     @Nullable
     ToolAnnotations annotations();
 
-    /** Optional icons for this tool. */
-    @Nullable
+    /** Icons for this tool, or an empty list. */
     List<Icon> icons();
 
     /** Optional identifier of the extension that owns this tool. */
@@ -79,12 +78,12 @@ public interface ToolDescriptor extends ServerFeature.Descriptor, HasMeta {
 
     /** Creates a tool descriptor with just a name. */
     static ToolDescriptor of(String name) {
-        return DefaultToolDescriptor.of(name, null, null, null, null, null, null, null, null, null);
+        return DefaultToolDescriptor.of(name, null, null, null, null, null, null, List.of(), null, null);
     }
 
     /** Creates a tool descriptor with a name and description. */
     static ToolDescriptor of(String name, @Nullable String description) {
-        return DefaultToolDescriptor.of(name, null, description, null, null, null, null, null, null, null);
+        return DefaultToolDescriptor.of(name, null, description, null, null, null, null, List.of(), null, null);
     }
 
     /** Builder for {@link ToolDescriptor}. */
@@ -124,8 +123,8 @@ public interface ToolDescriptor extends ServerFeature.Descriptor, HasMeta {
         /** Sets the optional behavioral annotations (e.g. read-only, destructive) for this tool. */
         Builder annotations(@Nullable ToolAnnotations annotations);
 
-        /** Sets the optional icons for this tool. */
-        Builder icons(@Nullable Iterable<? extends Icon> icons);
+        /** Sets the icons for this tool. */
+        Builder icons(Iterable<? extends Icon> icons);
 
         /** Sets the optional icons for this tool. */
         default Builder icons(Icon... icons) {

--- a/tachyon-api/src/main/java/dev/tachyonmcp/api/server/features/tools/ToolDescriptor.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/api/server/features/tools/ToolDescriptor.java
@@ -126,7 +126,7 @@ public interface ToolDescriptor extends ServerFeature.Descriptor, HasMeta {
         /** Sets the icons for this tool. */
         Builder icons(Iterable<? extends Icon> icons);
 
-        /** Sets the optional icons for this tool. */
+        /** Sets the icons for this tool; an empty array means no icons. */
         default Builder icons(Icon... icons) {
             return icons(List.of(icons));
         }

--- a/tachyon-api/src/test/java/dev/tachyonmcp/api/server/domain/AnnotationsTest.java
+++ b/tachyon-api/src/test/java/dev/tachyonmcp/api/server/domain/AnnotationsTest.java
@@ -4,42 +4,43 @@ package dev.tachyonmcp.api.server.domain;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
 class AnnotationsTest {
 
     @Test
     void shouldAcceptPriorityAtLowerBound() {
-        assertThatNoException().isThrownBy(() -> Annotations.of(null, 0.0, null));
+        assertThatNoException().isThrownBy(() -> Annotations.of(List.of(), 0.0, null));
     }
 
     @Test
     void shouldAcceptPriorityAtUpperBound() {
-        assertThatNoException().isThrownBy(() -> Annotations.of(null, 1.0, null));
+        assertThatNoException().isThrownBy(() -> Annotations.of(List.of(), 1.0, null));
     }
 
     @Test
     void shouldAcceptNullPriority() {
-        assertThatNoException().isThrownBy(() -> Annotations.of(null, null, null));
+        assertThatNoException().isThrownBy(() -> Annotations.of(List.of(), null, null));
     }
 
     @Test
     void shouldRejectPriorityBelowZero() {
-        assertThatThrownBy(() -> Annotations.of(null, -0.1, null))
+        assertThatThrownBy(() -> Annotations.of(List.of(), -0.1, null))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("priority");
     }
 
     @Test
     void shouldRejectPriorityAboveOne() {
-        assertThatThrownBy(() -> Annotations.of(null, 1.1, null))
+        assertThatThrownBy(() -> Annotations.of(List.of(), 1.1, null))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("priority");
     }
 
     @Test
     void shouldRejectNaNPriority() {
-        assertThatThrownBy(() -> Annotations.of(null, Double.NaN, null))
+        assertThatThrownBy(() -> Annotations.of(List.of(), Double.NaN, null))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("priority");
     }

--- a/tachyon-api/src/test/java/dev/tachyonmcp/api/server/domain/BlobResourceContentsTest.java
+++ b/tachyon-api/src/test/java/dev/tachyonmcp/api/server/domain/BlobResourceContentsTest.java
@@ -1,0 +1,24 @@
+/* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
+package dev.tachyonmcp.api.server.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+class BlobResourceContentsTest {
+
+    @Test
+    void shouldAcceptEmptyBlob() {
+        var contents = BlobResourceContents.of("resource://x", new byte[0], "application/octet-stream");
+
+        assertThat(contents.blob()).isEmpty();
+    }
+
+    @Test
+    void shouldRejectBlankUri() {
+        assertThatThrownBy(() -> BlobResourceContents.of("  ", new byte[0], null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("uri");
+    }
+}

--- a/tachyon-api/src/test/java/dev/tachyonmcp/api/server/features/resources/ResourceDescriptorTest.java
+++ b/tachyon-api/src/test/java/dev/tachyonmcp/api/server/features/resources/ResourceDescriptorTest.java
@@ -3,6 +3,7 @@ package dev.tachyonmcp.api.server.features.resources;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
 class ResourceDescriptorTest {
@@ -23,7 +24,7 @@ class ResourceDescriptorTest {
 
     @Test
     void shouldRejectNegativeSize() {
-        assertThatThrownBy(() -> ResourceDescriptor.of("res", "resource://x", null, null, null, null, -1L, null))
+        assertThatThrownBy(() -> ResourceDescriptor.of("res", "resource://x", null, null, null, null, -1L, List.of()))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("size");
     }

--- a/tachyon-api/src/test/java/dev/tachyonmcp/api/server/features/resources/ResourceTemplateDescriptorTest.java
+++ b/tachyon-api/src/test/java/dev/tachyonmcp/api/server/features/resources/ResourceTemplateDescriptorTest.java
@@ -13,7 +13,7 @@ class ResourceTemplateDescriptorTest {
     @Test
     void shouldBuildWithAllParameters() {
         var annotations = Annotations.of(List.of(), 0.5, "2026-01-01T00:00:00Z");
-        var icons = List.of(Icon.of("https://example.com/icon.png", "image/png", null, null));
+        var icons = List.of(Icon.of("https://example.com/icon.png", "image/png", List.of(), null));
         var descriptor = ResourceTemplateDescriptor.builder()
                 .name("tmpl")
                 .uriTemplate("resource://{id}")

--- a/tachyon-core/revapi.json
+++ b/tachyon-core/revapi.json
@@ -34,6 +34,13 @@
           "old": "method dev.tachyonmcp.api.json.JsonSchema dev.tachyonmcp.core.server.json.JacksonObjectJsonFactory::toJsonSchema(tools.jackson.databind.node.ObjectNode)",
           "new": "method java.util.Optional<dev.tachyonmcp.api.json.JsonSchema> dev.tachyonmcp.core.server.json.JacksonObjectJsonFactory::toJsonSchema(tools.jackson.databind.node.ObjectNode)",
           "justification": "JsonSchemaFactory returns Optional to continue the resolution chain"
+        },
+        {
+          "ignore": true,
+          "code": "java.method.returnTypeChanged",
+          "old": "method java.lang.Long dev.tachyonmcp.core.server.features.tasks.TaskEntry::ttl()",
+          "new": "method java.time.Duration dev.tachyonmcp.core.server.features.tasks.TaskEntry::ttl()",
+          "justification": "Use idiomatic domain types"
         }
       ]
     }

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/mcp/v2025_11_25/codecs/ContentBlockMappers.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/mcp/v2025_11_25/codecs/ContentBlockMappers.java
@@ -20,13 +20,13 @@ public final class ContentBlockMappers {
     public static dev.tachyonmcp.core.protocol.mcp.v2025_11_25.models.Annotations toProtocolAnnotations(
             Annotations domain) {
         if (domain == null) return null;
-        var audience = domain.audience() != null
-                ? domain.audience().stream()
+        var audience = domain.audience().isEmpty()
+                ? null
+                : domain.audience().stream()
                         .map(r -> r == Role.USER
                                 ? dev.tachyonmcp.core.protocol.mcp.v2025_11_25.models.Role.USER
                                 : dev.tachyonmcp.core.protocol.mcp.v2025_11_25.models.Role.ASSISTANT)
-                        .toList()
-                : null;
+                        .toList();
         return new dev.tachyonmcp.core.protocol.mcp.v2025_11_25.models.Annotations(
                 audience, domain.priority(), domain.lastModified());
     }
@@ -34,16 +34,16 @@ public final class ContentBlockMappers {
     /**
      * Maps domain icons to the protocol shape.
      *
-     * @param domain the domain icons, or {@code null}
-     * @return the protocol icons, or {@code null} if {@code domain} is {@code null}
+     * @param domain the domain icons, never {@code null} but possibly empty
+     * @return the protocol icons, or {@code null} if {@code domain} is empty
      */
     @Nullable
     public static List<dev.tachyonmcp.core.protocol.mcp.v2025_11_25.models.Icon> toProtocolIcons(
-            @Nullable List<? extends Icon> domain) {
-        if (domain == null) return null;
+            List<? extends Icon> domain) {
+        if (domain.isEmpty()) return null;
         return domain.stream()
                 .map(i -> new dev.tachyonmcp.core.protocol.mcp.v2025_11_25.models.Icon(
-                        i.src(), i.mimeType(), i.sizes(), i.theme()))
+                        i.src(), i.mimeType(), i.sizes().isEmpty() ? null : i.sizes(), i.theme()))
                 .toList();
     }
 

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/mcp/v2025_11_25/codecs/McpPromptMapper.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/mcp/v2025_11_25/codecs/McpPromptMapper.java
@@ -25,7 +25,7 @@ final class McpPromptMapper {
 
     static List<dev.tachyonmcp.core.protocol.mcp.v2025_11_25.models.PromptArgument> toProtocolPromptArguments(
             List<PromptArgument> domain) {
-        if (domain == null) return null;
+        if (domain.isEmpty()) return null;
         return domain.stream()
                 .map(a -> new dev.tachyonmcp.core.protocol.mcp.v2025_11_25.models.PromptArgument(
                         a.description(), a.required(), a.name(), a.title()))

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/mcp/v2025_11_25/codecs/McpPromptMapper.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/mcp/v2025_11_25/codecs/McpPromptMapper.java
@@ -8,6 +8,7 @@ import dev.tachyonmcp.api.server.features.prompts.PromptDescriptor;
 import dev.tachyonmcp.core.protocol.mcp.v2025_11_25.models.Prompt;
 import dev.tachyonmcp.core.server.json.JsonUtils;
 import java.util.List;
+import org.jspecify.annotations.Nullable;
 
 final class McpPromptMapper {
 
@@ -23,6 +24,7 @@ final class McpPromptMapper {
                 ContentBlockMappers.toProtocolIcons(d.icons()));
     }
 
+    @Nullable
     static List<dev.tachyonmcp.core.protocol.mcp.v2025_11_25.models.PromptArgument> toProtocolPromptArguments(
             List<PromptArgument> domain) {
         if (domain.isEmpty()) return null;

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/mcp/v2025_11_25/codecs/McpTaskMapper.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/mcp/v2025_11_25/codecs/McpTaskMapper.java
@@ -32,6 +32,10 @@ final class McpTaskMapper {
         return pollInterval != null ? pollInterval.toMillis() : null;
     }
 
+    private static @Nullable Long ttlToMillis(@Nullable Duration ttl) {
+        return ttl != null ? ttl.toMillis() : null;
+    }
+
     static Task toTaskProto(TaskEntry entry) {
         return new Task(
                 entry.id(),
@@ -39,7 +43,7 @@ final class McpTaskMapper {
                 entry.statusMessage(),
                 entry.createdAtIso(),
                 entry.lastUpdatedAtIso(),
-                entry.ttl(),
+                ttlToMillis(entry.ttl()),
                 pollIntervalToMillis(entry.pollInterval()));
     }
 
@@ -51,7 +55,7 @@ final class McpTaskMapper {
                 entry.statusMessage(),
                 entry.createdAtIso(),
                 entry.lastUpdatedAtIso(),
-                entry.ttl(),
+                ttlToMillis(entry.ttl()),
                 pollIntervalToMillis(entry.pollInterval()));
     }
 
@@ -63,7 +67,7 @@ final class McpTaskMapper {
                 entry.statusMessage(),
                 entry.createdAtIso(),
                 entry.lastUpdatedAtIso(),
-                entry.ttl(),
+                ttlToMillis(entry.ttl()),
                 pollIntervalToMillis(entry.pollInterval()));
     }
 
@@ -79,7 +83,7 @@ final class McpTaskMapper {
                 entry.statusMessage(),
                 entry.createdAtIso(),
                 entry.lastUpdatedAtIso(),
-                entry.ttl(),
+                ttlToMillis(entry.ttl()),
                 pollIntervalToMillis(entry.pollInterval()));
     }
 }

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/mcp/v2025_11_25/codecs/McpTaskMapper.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/mcp/v2025_11_25/codecs/McpTaskMapper.java
@@ -32,10 +32,6 @@ final class McpTaskMapper {
         return pollInterval != null ? pollInterval.toMillis() : null;
     }
 
-    private static @Nullable Long ttlToMillis(@Nullable Duration ttl) {
-        return ttl != null ? ttl.toMillis() : null;
-    }
-
     static Task toTaskProto(TaskEntry entry) {
         return new Task(
                 entry.id(),
@@ -43,7 +39,7 @@ final class McpTaskMapper {
                 entry.statusMessage(),
                 entry.createdAtIso(),
                 entry.lastUpdatedAtIso(),
-                ttlToMillis(entry.ttl()),
+                entry.ttlMillis(),
                 pollIntervalToMillis(entry.pollInterval()));
     }
 
@@ -55,7 +51,7 @@ final class McpTaskMapper {
                 entry.statusMessage(),
                 entry.createdAtIso(),
                 entry.lastUpdatedAtIso(),
-                ttlToMillis(entry.ttl()),
+                entry.ttlMillis(),
                 pollIntervalToMillis(entry.pollInterval()));
     }
 
@@ -67,7 +63,7 @@ final class McpTaskMapper {
                 entry.statusMessage(),
                 entry.createdAtIso(),
                 entry.lastUpdatedAtIso(),
-                ttlToMillis(entry.ttl()),
+                entry.ttlMillis(),
                 pollIntervalToMillis(entry.pollInterval()));
     }
 
@@ -83,7 +79,7 @@ final class McpTaskMapper {
                 entry.statusMessage(),
                 entry.createdAtIso(),
                 entry.lastUpdatedAtIso(),
-                ttlToMillis(entry.ttl()),
+                entry.ttlMillis(),
                 pollIntervalToMillis(entry.pollInterval()));
     }
 }

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/mcp/v2025_11_25/codecs/McpToolMapper.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/mcp/v2025_11_25/codecs/McpToolMapper.java
@@ -64,16 +64,15 @@ final class McpToolMapper {
 
     @Nullable
     public static List<dev.tachyonmcp.core.protocol.mcp.v2025_11_25.models.Icon> toProtocolIcons(
-            @Nullable List<? extends dev.tachyonmcp.api.server.domain.Icon> domain) {
+            List<? extends dev.tachyonmcp.api.server.domain.Icon> domain) {
         return ContentBlockMappers.toProtocolIcons(domain);
     }
 
-    @Nullable
     public static List<Icon> toDomainIcons(
             @Nullable List<dev.tachyonmcp.core.protocol.mcp.v2025_11_25.models.Icon> protocol) {
-        if (protocol == null) return null;
+        if (protocol == null) return List.of();
         return protocol.stream()
-                .map(i -> Icon.of(i.src(), i.mimeType(), i.sizes(), i.theme()))
+                .map(i -> Icon.of(i.src(), i.mimeType(), i.sizes() == null ? List.of() : i.sizes(), i.theme()))
                 .toList();
     }
 
@@ -121,7 +120,7 @@ final class McpToolMapper {
                                 ? Role.USER
                                 : Role.ASSISTANT)
                         .toList()
-                : null;
+                : List.<Role>of();
         return Annotations.of(audience, protocol.priority(), protocol.lastModified());
     }
 

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/mcp/v2025_11_25/codecs/ServerInfoMapper.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/mcp/v2025_11_25/codecs/ServerInfoMapper.java
@@ -22,7 +22,7 @@ class ServerInfoMapper {
                 .description(serverIdentity.description())
                 .title(serverIdentity.title())
                 .websiteUrl(serverIdentity.websiteUrl());
-        if (serverIdentity.icons() != null && !serverIdentity.icons().isEmpty()) {
+        if (!serverIdentity.icons().isEmpty()) {
             builder.icons(serverIdentity.icons().stream()
                     .map(ServerInfoMapper::toIcon)
                     .toList());
@@ -34,7 +34,7 @@ class ServerInfoMapper {
         return Icon.builder()
                 .src(icon.src())
                 .mimeType(icon.mimeType())
-                .sizes(icon.sizes())
+                .sizes(icon.sizes().isEmpty() ? null : icon.sizes())
                 .theme(icon.theme())
                 .build();
     }

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/mcp/v2026_07_28/codecs/McpResponseMapper.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/mcp/v2026_07_28/codecs/McpResponseMapper.java
@@ -306,7 +306,7 @@ public final class McpResponseMapper extends dev.tachyonmcp.core.protocol.mcp.v2
     }
 
     private static Prompt toPrompt(PromptDescriptor d) {
-        var arguments = d.arguments() == null
+        var arguments = d.arguments().isEmpty()
                 ? null
                 : d.arguments().stream()
                         .map(a -> new PromptArgument(a.description(), a.required(), a.name(), a.title()))
@@ -403,7 +403,7 @@ public final class McpResponseMapper extends dev.tachyonmcp.core.protocol.mcp.v2
     private static dev.tachyonmcp.core.protocol.mcp.v2026_07_28.models.Annotations toAnnotations(
             @Nullable Annotations domain) {
         if (domain == null) return null;
-        var audience = domain.audience() == null
+        var audience = domain.audience().isEmpty()
                 ? null
                 : domain.audience().stream()
                         .map(role -> switch (role) {
@@ -416,12 +416,15 @@ public final class McpResponseMapper extends dev.tachyonmcp.core.protocol.mcp.v2
     }
 
     private static @Nullable List<dev.tachyonmcp.core.protocol.mcp.v2026_07_28.models.Icon> toIcons(
-            @Nullable List<dev.tachyonmcp.api.server.domain.Icon> icons) {
-        return icons == null
+            List<dev.tachyonmcp.api.server.domain.Icon> icons) {
+        return icons.isEmpty()
                 ? null
                 : icons.stream()
                         .map(icon -> new dev.tachyonmcp.core.protocol.mcp.v2026_07_28.models.Icon(
-                                icon.src(), icon.mimeType(), icon.sizes(), icon.theme()))
+                                icon.src(),
+                                icon.mimeType(),
+                                icon.sizes().isEmpty() ? null : icon.sizes(),
+                                icon.theme()))
                         .toList();
     }
 

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/mcp/v2026_07_28/codecs/McpTaskMapper.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/mcp/v2026_07_28/codecs/McpTaskMapper.java
@@ -90,7 +90,7 @@ final class McpTaskMapper {
         // SEP-2663 types Task.ttlMs as `number | null` (required, nullable) but
         // Task.pollIntervalMs as `number?` (optional) -- ttlMs is always written, even when null;
         // pollIntervalMs is omitted rather than written as null.
-        fields.put("ttlMs", ttlMillis(entry.ttl()));
+        fields.put("ttlMs", entry.ttlMillis());
         putIfPresent(fields, "pollIntervalMs", pollIntervalMillis(entry.pollInterval()));
         return fields;
     }
@@ -110,9 +110,5 @@ final class McpTaskMapper {
 
     private static @Nullable Long pollIntervalMillis(@Nullable Duration pollInterval) {
         return pollInterval != null ? pollInterval.toMillis() : null;
-    }
-
-    private static @Nullable Long ttlMillis(@Nullable Duration ttl) {
-        return ttl != null ? ttl.toMillis() : null;
     }
 }

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/mcp/v2026_07_28/codecs/McpTaskMapper.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/mcp/v2026_07_28/codecs/McpTaskMapper.java
@@ -90,7 +90,7 @@ final class McpTaskMapper {
         // SEP-2663 types Task.ttlMs as `number | null` (required, nullable) but
         // Task.pollIntervalMs as `number?` (optional) -- ttlMs is always written, even when null;
         // pollIntervalMs is omitted rather than written as null.
-        fields.put("ttlMs", entry.ttl());
+        fields.put("ttlMs", ttlMillis(entry.ttl()));
         putIfPresent(fields, "pollIntervalMs", pollIntervalMillis(entry.pollInterval()));
         return fields;
     }
@@ -110,5 +110,9 @@ final class McpTaskMapper {
 
     private static @Nullable Long pollIntervalMillis(@Nullable Duration pollInterval) {
         return pollInterval != null ? pollInterval.toMillis() : null;
+    }
+
+    private static @Nullable Long ttlMillis(@Nullable Duration ttl) {
+        return ttl != null ? ttl.toMillis() : null;
     }
 }

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/mcp/v2026_07_28/codecs/ServerInfoMapper.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/mcp/v2026_07_28/codecs/ServerInfoMapper.java
@@ -22,7 +22,7 @@ class ServerInfoMapper {
                 .description(serverIdentity.description())
                 .title(serverIdentity.title())
                 .websiteUrl(serverIdentity.websiteUrl());
-        if (serverIdentity.icons() != null && !serverIdentity.icons().isEmpty()) {
+        if (!serverIdentity.icons().isEmpty()) {
             builder.icons(serverIdentity.icons().stream()
                     .map(ServerInfoMapper::toIcon)
                     .toList());
@@ -34,7 +34,7 @@ class ServerInfoMapper {
         return Icon.builder()
                 .src(icon.src())
                 .mimeType(icon.mimeType())
-                .sizes(icon.sizes())
+                .sizes(icon.sizes().isEmpty() ? null : icon.sizes())
                 .theme(icon.theme())
                 .build();
     }

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/features/prompts/PromptMethodHandlers.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/features/prompts/PromptMethodHandlers.java
@@ -4,7 +4,6 @@ package dev.tachyonmcp.core.server.features.prompts;
 import dev.tachyonmcp.api.json.JsonDocument;
 import dev.tachyonmcp.api.json.JsonSchemaValidator;
 import dev.tachyonmcp.api.json.SchemaValidationError;
-import dev.tachyonmcp.api.server.domain.PromptMessage;
 import dev.tachyonmcp.api.server.domain.ServerError;
 import dev.tachyonmcp.api.server.features.HandlerFutures;
 import dev.tachyonmcp.api.server.features.prompts.PromptResult;
@@ -12,7 +11,6 @@ import dev.tachyonmcp.core.protocol.RequestMappingException;
 import dev.tachyonmcp.core.server.RpcMethodHandler;
 import dev.tachyonmcp.core.server.domain.ServerErrors;
 import dev.tachyonmcp.core.server.session.DispatchContext;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -110,12 +108,7 @@ public final class PromptMethodHandlers {
                         return switch (result) {
                             case PromptResult.Messages messages ->
                                 context.responseMapper()
-                                        .getPromptResult(
-                                                entry.descriptor().description(),
-                                                messages.messages() != null
-                                                        ? messages.messages()
-                                                        : List.<PromptMessage>of(),
-                                                meta);
+                                        .getPromptResult(entry.descriptor().description(), messages.messages(), meta);
                             case PromptResult.InputRequired inputRequired ->
                                 context.responseMapper()
                                         .inputRequiredResult(

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/features/tasks/TaskEntry.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/features/tasks/TaskEntry.java
@@ -148,7 +148,7 @@ public class TaskEntry implements ServerFeature<TaskDescriptor>, Task {
         this.status = new AtomicReference<>(status);
         this.createdAt = System.currentTimeMillis();
         this.lastUpdatedAt = this.createdAt;
-        this.ttl = ttl;
+        this.ttl = normalizeTtl(ttl);
         this.keepAlive = Objects.requireNonNull(keepAlive, "keepAlive");
         this.pollInterval = pollInterval;
         this.progressToken = progressToken;
@@ -199,6 +199,26 @@ public class TaskEntry implements ServerFeature<TaskDescriptor>, Task {
     @Override
     public @Nullable Duration ttl() {
         return ttl;
+    }
+
+    /**
+     * The normalized TTL in milliseconds, or {@code null} if this task never expires. Clamped to
+     * {@link Long#MAX_VALUE} rather than throwing if {@code ttl} overflows {@link Duration#toMillis()}.
+     */
+    public @Nullable Long ttlMillis() {
+        if (ttl == null) {
+            return null;
+        }
+        try {
+            return ttl.toMillis();
+        } catch (ArithmeticException e) {
+            return Long.MAX_VALUE;
+        }
+    }
+
+    /** Zero and negative durations mean "never expires", same as {@code null}. */
+    private static @Nullable Duration normalizeTtl(@Nullable Duration ttl) {
+        return ttl == null || ttl.isZero() || ttl.isNegative() ? null : ttl;
     }
 
     /**
@@ -376,10 +396,8 @@ public class TaskEntry implements ServerFeature<TaskDescriptor>, Task {
     }
 
     public boolean isExpired() {
-        if (ttl == null || ttl.isZero() || ttl.isNegative()) {
-            return false;
-        }
-        return System.currentTimeMillis() - lastUpdatedAt > ttl.toMillis();
+        var millis = ttlMillis();
+        return millis != null && System.currentTimeMillis() - lastUpdatedAt > millis;
     }
 
     /**

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/features/tasks/TaskEntry.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/features/tasks/TaskEntry.java
@@ -32,7 +32,7 @@ public class TaskEntry implements ServerFeature<TaskDescriptor>, Task {
     private final @Nullable Map<String, Object> meta;
     private final AtomicReference<TaskState> status;
     private final long createdAt;
-    private final @Nullable Long ttl;
+    private final @Nullable Duration ttl;
     private final Duration keepAlive;
     private final @Nullable Duration pollInterval;
     private volatile long lastUpdatedAt;
@@ -148,7 +148,7 @@ public class TaskEntry implements ServerFeature<TaskDescriptor>, Task {
         this.status = new AtomicReference<>(status);
         this.createdAt = System.currentTimeMillis();
         this.lastUpdatedAt = this.createdAt;
-        this.ttl = ttl != null ? ttl.toMillis() : null;
+        this.ttl = ttl;
         this.keepAlive = Objects.requireNonNull(keepAlive, "keepAlive");
         this.pollInterval = pollInterval;
         this.progressToken = progressToken;
@@ -197,7 +197,7 @@ public class TaskEntry implements ServerFeature<TaskDescriptor>, Task {
     }
 
     @Override
-    public @Nullable Long ttl() {
+    public @Nullable Duration ttl() {
         return ttl;
     }
 
@@ -376,10 +376,10 @@ public class TaskEntry implements ServerFeature<TaskDescriptor>, Task {
     }
 
     public boolean isExpired() {
-        if (ttl == null || ttl <= 0) {
+        if (ttl == null || ttl.isZero() || ttl.isNegative()) {
             return false;
         }
-        return System.currentTimeMillis() - lastUpdatedAt > ttl;
+        return System.currentTimeMillis() - lastUpdatedAt > ttl.toMillis();
     }
 
     /**

--- a/tachyon-core/src/test/java/dev/tachyonmcp/core/protocol/mcp/v2025_11_25/codecs/McpTaskMapperTest.java
+++ b/tachyon-core/src/test/java/dev/tachyonmcp/core/protocol/mcp/v2025_11_25/codecs/McpTaskMapperTest.java
@@ -48,4 +48,32 @@ class McpTaskMapperTest {
         assertThatThrownBy(() -> McpTaskMapper.toGetTaskResult(entry(TaskState.UNKNOWN)))
                 .isInstanceOf(UnsupportedOperationException.class);
     }
+
+    @Test
+    void ttlIsConvertedToMillisAcrossAllResponseShapes() {
+        var withTtl = new TaskEntry(
+                TaskDescriptor.builder().id("task-1").build(),
+                "task-1",
+                TaskState.WORKING,
+                Duration.ofSeconds(90),
+                null,
+                null,
+                null);
+
+        assertThat(McpTaskMapper.toTaskProto(withTtl).ttl()).isEqualTo(90_000L);
+        assertThat(McpTaskMapper.toGetTaskResult(withTtl).ttl()).isEqualTo(90_000L);
+        assertThat(McpTaskMapper.toCancelTaskResult(withTtl).ttl()).isEqualTo(90_000L);
+        assertThat(McpTaskMapper.toStatusNotification(withTtl).ttl()).isEqualTo(90_000L);
+    }
+
+    @Test
+    void nullTtlIsPreservedAcrossAllResponseShapes() {
+        var withoutTtl = new TaskEntry(
+                TaskDescriptor.builder().id("task-1").build(), "task-1", TaskState.WORKING, null, null, null, null);
+
+        assertThat(McpTaskMapper.toTaskProto(withoutTtl).ttl()).isNull();
+        assertThat(McpTaskMapper.toGetTaskResult(withoutTtl).ttl()).isNull();
+        assertThat(McpTaskMapper.toCancelTaskResult(withoutTtl).ttl()).isNull();
+        assertThat(McpTaskMapper.toStatusNotification(withoutTtl).ttl()).isNull();
+    }
 }

--- a/tachyon-core/src/test/java/dev/tachyonmcp/core/protocol/mcp/v2025_11_25/codecs/McpToolMapperTest.java
+++ b/tachyon-core/src/test/java/dev/tachyonmcp/core/protocol/mcp/v2025_11_25/codecs/McpToolMapperTest.java
@@ -244,6 +244,14 @@ class McpToolMapperTest {
     }
 
     @Test
+    void toDomainAnnotationsConvertsAbsentAudienceToEmptyList() {
+        var protocol = new dev.tachyonmcp.core.protocol.mcp.v2025_11_25.models.Annotations(null, 0.5, null);
+        var domain = McpToolMapper.toDomainAnnotations(protocol);
+        assertThat(domain.audience()).isEmpty();
+        assertThat(domain.priority()).isEqualTo(0.5);
+    }
+
+    @Test
     void toDomainContentBlockConvertsTextContent() {
         var protocol = new dev.tachyonmcp.core.protocol.mcp.v2025_11_25.models.TextContent("text", "hello", null, null);
         var domain = McpToolMapper.toDomainContentBlock(protocol);

--- a/tachyon-core/src/test/java/dev/tachyonmcp/core/protocol/mcp/v2025_11_25/codecs/McpToolMapperTest.java
+++ b/tachyon-core/src/test/java/dev/tachyonmcp/core/protocol/mcp/v2025_11_25/codecs/McpToolMapperTest.java
@@ -227,13 +227,20 @@ class McpToolMapperTest {
     }
 
     @Test
-    void toDomainIconsReturnsNullForNullInput() {
-        assertThat(McpToolMapper.toDomainIcons(null)).isNull();
+    void toDomainIconsReturnsEmptyForNullInput() {
+        assertThat(McpToolMapper.toDomainIcons(null)).isEmpty();
     }
 
     @Test
-    void toProtocolIconsReturnsNullForNullInput() {
-        assertThat(McpToolMapper.toProtocolIcons(null)).isNull();
+    void toProtocolIconsReturnsNullForEmptyInput() {
+        assertThat(McpToolMapper.toProtocolIcons(List.of())).isNull();
+    }
+
+    @Test
+    void toProtocolIconsOmitsSizesWhenEmpty() {
+        var domainIcon = Icon.of("https://example.com/icon.png", "image/png", List.of(), null);
+        var protocolIcons = McpToolMapper.toProtocolIcons(List.of(domainIcon));
+        assertThat(protocolIcons.getFirst().sizes()).isNull();
     }
 
     @Test

--- a/tachyon-core/src/test/java/dev/tachyonmcp/core/protocol/mcp/v2025_11_25/codecs/ServerInfoMapperTest.java
+++ b/tachyon-core/src/test/java/dev/tachyonmcp/core/protocol/mcp/v2025_11_25/codecs/ServerInfoMapperTest.java
@@ -1,0 +1,31 @@
+/* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
+package dev.tachyonmcp.core.protocol.mcp.v2025_11_25.codecs;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.tachyonmcp.api.server.config.ServerIdentity;
+import dev.tachyonmcp.api.server.domain.Icon;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class ServerInfoMapperTest {
+
+    @Test
+    void omitsIconsWhenServerIdentityHasNone() {
+        var implementation = ServerInfoMapper.toImplementation(ServerIdentity.DEFAULT);
+
+        assertThat(implementation.icons()).isNull();
+    }
+
+    @Test
+    void carriesIconsAndOmitsEmptySizes() {
+        var icon = Icon.of("https://example.test/icon.png", "image/png", List.of(), "light");
+        var serverIdentity = ServerIdentity.builder().icons(icon).build();
+
+        var implementation = ServerInfoMapper.toImplementation(serverIdentity);
+
+        assertThat(implementation.icons()).hasSize(1);
+        assertThat(implementation.icons().getFirst().src()).isEqualTo("https://example.test/icon.png");
+        assertThat(implementation.icons().getFirst().sizes()).isNull();
+    }
+}

--- a/tachyon-core/src/test/java/dev/tachyonmcp/core/protocol/mcp/v2026_07_28/codecs/McpResponseMapperTest.java
+++ b/tachyon-core/src/test/java/dev/tachyonmcp/core/protocol/mcp/v2026_07_28/codecs/McpResponseMapperTest.java
@@ -25,6 +25,7 @@ import dev.tachyonmcp.core.protocol.mcp.v2026_07_28.models.ListPromptsResult;
 import dev.tachyonmcp.core.protocol.mcp.v2026_07_28.models.ListResourceTemplatesResult;
 import dev.tachyonmcp.core.protocol.mcp.v2026_07_28.models.ListResourcesResult;
 import dev.tachyonmcp.core.protocol.mcp.v2026_07_28.models.ListToolsResult;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -164,11 +165,19 @@ class McpResponseMapperTest {
         var resourceResult = (ListResourcesResult) mapper.listResourcesResult(List.of(resource), null);
         var promptResult = (ListPromptsResult) mapper.listPromptsResult(List.of(prompt), null);
 
-        assertThat(toolResult.tools().getFirst().icons()).isNull();
-        assertThat(resourceResult.resources().getFirst().annotations().audience())
-                .isNull();
-        assertThat(resourceResult.resources().getFirst().icons().getFirst().sizes())
-                .isNull();
-        assertThat(promptResult.prompts().getFirst().arguments()).isNull();
+        var toolJson = new String(
+                CodecRegistry.codecFor(ListToolsResult.class).encodeToBytes(toolResult), StandardCharsets.UTF_8);
+        var resourceJson = new String(
+                CodecRegistry.codecFor(ListResourcesResult.class).encodeToBytes(resourceResult),
+                StandardCharsets.UTF_8);
+        var promptJson = new String(
+                CodecRegistry.codecFor(ListPromptsResult.class).encodeToBytes(promptResult), StandardCharsets.UTF_8);
+
+        assertThat(toolJson).doesNotContain("\"icons\"");
+        assertThat(resourceJson)
+                .contains("\"icons\"")
+                .doesNotContain("\"audience\"")
+                .doesNotContain("\"sizes\"");
+        assertThat(promptJson).doesNotContain("\"arguments\"");
     }
 }

--- a/tachyon-core/src/test/java/dev/tachyonmcp/core/protocol/mcp/v2026_07_28/codecs/McpResponseMapperTest.java
+++ b/tachyon-core/src/test/java/dev/tachyonmcp/core/protocol/mcp/v2026_07_28/codecs/McpResponseMapperTest.java
@@ -146,4 +146,29 @@ class McpResponseMapperTest {
         assertThat(promptResult.prompts().getFirst()._meta())
                 .containsEntry("kind", JsonNodeFactory.instance.textNode("prompt"));
     }
+
+    @Test
+    void emptyDescriptorFieldsOmitIconsAudienceArgumentsAndSizesOnWire() {
+        var iconWithNoSizes = Icon.of("https://example.test/icon.png", "image/png", List.of(), null);
+        var annotations = Annotations.of(List.of(), 0.5, null);
+        var tool = ToolDescriptor.builder().name("bare-tool").build();
+        var resource = ResourceDescriptor.builder()
+                .name("bare-resource")
+                .uri("memory://bare")
+                .annotations(annotations)
+                .icons(iconWithNoSizes)
+                .build();
+        var prompt = PromptDescriptor.builder().name("bare-prompt").build();
+
+        var toolResult = (ListToolsResult) mapper.listToolsResult(List.of(tool), null);
+        var resourceResult = (ListResourcesResult) mapper.listResourcesResult(List.of(resource), null);
+        var promptResult = (ListPromptsResult) mapper.listPromptsResult(List.of(prompt), null);
+
+        assertThat(toolResult.tools().getFirst().icons()).isNull();
+        assertThat(resourceResult.resources().getFirst().annotations().audience())
+                .isNull();
+        assertThat(resourceResult.resources().getFirst().icons().getFirst().sizes())
+                .isNull();
+        assertThat(promptResult.prompts().getFirst().arguments()).isNull();
+    }
 }

--- a/tachyon-core/src/test/java/dev/tachyonmcp/core/protocol/mcp/v2026_07_28/codecs/ServerInfoMapperTest.java
+++ b/tachyon-core/src/test/java/dev/tachyonmcp/core/protocol/mcp/v2026_07_28/codecs/ServerInfoMapperTest.java
@@ -1,0 +1,31 @@
+/* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
+package dev.tachyonmcp.core.protocol.mcp.v2026_07_28.codecs;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.tachyonmcp.api.server.config.ServerIdentity;
+import dev.tachyonmcp.api.server.domain.Icon;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class ServerInfoMapperTest {
+
+    @Test
+    void omitsIconsWhenServerIdentityHasNone() {
+        var implementation = ServerInfoMapper.toImplementation(ServerIdentity.DEFAULT);
+
+        assertThat(implementation.icons()).isNull();
+    }
+
+    @Test
+    void carriesIconsAndOmitsEmptySizes() {
+        var icon = Icon.of("https://example.test/icon.png", "image/png", List.of(), "light");
+        var serverIdentity = ServerIdentity.builder().icons(icon).build();
+
+        var implementation = ServerInfoMapper.toImplementation(serverIdentity);
+
+        assertThat(implementation.icons()).hasSize(1);
+        assertThat(implementation.icons().getFirst().src()).isEqualTo("https://example.test/icon.png");
+        assertThat(implementation.icons().getFirst().sizes()).isNull();
+    }
+}

--- a/tachyon-core/src/test/java/dev/tachyonmcp/core/server/domain/BinaryContentToStringTest.java
+++ b/tachyon-core/src/test/java/dev/tachyonmcp/core/server/domain/BinaryContentToStringTest.java
@@ -8,6 +8,7 @@ import dev.tachyonmcp.api.server.domain.BlobResourceContents;
 import dev.tachyonmcp.api.server.domain.Icon;
 import dev.tachyonmcp.api.server.domain.ImageContent;
 import java.util.Base64;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
 class BinaryContentToStringTest {
@@ -17,7 +18,7 @@ class BinaryContentToStringTest {
 
     @Test
     void binaryResourceContainersDoNotExposePayloads() {
-        var icon = Icon.of("data:image/png;base64," + BINARY_PAYLOAD, "image/png", null, null);
+        var icon = Icon.of("data:image/png;base64," + BINARY_PAYLOAD, "image/png", List.of(), null);
         var image = ImageContent.of(BINARY_BYTES, "image/png");
         var audio = AudioContent.of(BINARY_BYTES, "audio/wav");
         var blob = BlobResourceContents.of("test://blob", BINARY_BYTES, "application/octet-stream");

--- a/tachyon-core/src/test/java/dev/tachyonmcp/core/server/features/prompts/DefaultPromptRegistryTest.java
+++ b/tachyon-core/src/test/java/dev/tachyonmcp/core/server/features/prompts/DefaultPromptRegistryTest.java
@@ -220,7 +220,7 @@ class DefaultPromptRegistryTest {
 
     @Test
     void shouldMapAllDescriptorFieldsToProtocolModel() throws Exception {
-        var icon = Icon.of("https://example.com/prompt-icon.svg", "image/svg+xml", null, null);
+        var icon = Icon.of("https://example.com/prompt-icon.svg", "image/svg+xml", List.of(), null);
         var arg = PromptArgument.of("topic", null, "The topic", true);
         var descriptor =
                 PromptDescriptor.of("full-prompt", "Full description", "Full Title", List.of(arg), null, List.of(icon));

--- a/tachyon-core/src/test/java/dev/tachyonmcp/core/server/features/resources/DefaultResourceRegistryTest.java
+++ b/tachyon-core/src/test/java/dev/tachyonmcp/core/server/features/resources/DefaultResourceRegistryTest.java
@@ -677,7 +677,7 @@ class DefaultResourceRegistryTest {
     @Test
     void shouldMapAllResourceDescriptorFieldsToProtocolModel() throws Exception {
         var annotations = Annotations.of(List.of(Role.USER), 0.9, "2026-01-01T00:00:00Z");
-        var icon = Icon.of("https://example.com/icon.png", "image/png", null, null);
+        var icon = Icon.of("https://example.com/icon.png", "image/png", List.of(), null);
         var descriptor = ResourceDescriptor.of(
                 "full-resource",
                 "test://full",
@@ -825,8 +825,8 @@ class DefaultResourceRegistryTest {
 
     @Test
     void shouldMapAllResourceTemplateFieldsToProtocolModel() throws Exception {
-        var annotations = Annotations.of(null, 0.5, null);
-        var icon = Icon.of("https://example.com/tmpl.png", null, null, null);
+        var annotations = Annotations.of(List.of(), 0.5, null);
+        var icon = Icon.of("https://example.com/tmpl.png", null, List.of(), null);
         registry.registerTemplate(
                 ResourceTemplateDescriptor.builder()
                         .name("tmpl")
@@ -860,7 +860,14 @@ class DefaultResourceRegistryTest {
     void shouldReportResourceSizeWithoutLoadingContent() throws Exception {
         // size is declared upfront; content is loaded lazily via handler only on resources/read
         var descriptor = ResourceDescriptor.of(
-                "sized-resource", "test://sized", "A resource", "application/octet-stream", null, null, 4096L, null);
+                "sized-resource",
+                "test://sized",
+                "A resource",
+                "application/octet-stream",
+                null,
+                null,
+                4096L,
+                List.of());
         var contentLoaded = new java.util.concurrent.atomic.AtomicBoolean(false);
         registry.register(descriptor, (ctx, request) -> {
             contentLoaded.set(true);

--- a/tachyon-core/src/test/java/dev/tachyonmcp/core/server/features/tasks/TaskEntryTest.java
+++ b/tachyon-core/src/test/java/dev/tachyonmcp/core/server/features/tasks/TaskEntryTest.java
@@ -1,0 +1,43 @@
+/* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
+package dev.tachyonmcp.core.server.features.tasks;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.tachyonmcp.api.server.features.tasks.TaskDescriptor;
+import dev.tachyonmcp.api.server.features.tasks.TaskState;
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+
+class TaskEntryTest {
+
+    private static TaskEntry entry(Duration ttl) {
+        return new TaskEntry(
+                TaskDescriptor.builder().id("task-1").build(), "task-1", TaskState.WORKING, ttl, null, null);
+    }
+
+    @Test
+    void zeroAndNegativeTtlMeanNeverExpires() {
+        assertThat(entry(Duration.ZERO).ttl()).isNull();
+        assertThat(entry(Duration.ZERO).ttlMillis()).isNull();
+        assertThat(entry(Duration.ZERO).isExpired()).isFalse();
+
+        assertThat(entry(Duration.ofSeconds(-1)).ttl()).isNull();
+        assertThat(entry(Duration.ofSeconds(-1)).isExpired()).isFalse();
+    }
+
+    @Test
+    void ttlMillisClampsInsteadOfOverflowing() {
+        var entry = entry(Duration.ofSeconds(Long.MAX_VALUE));
+
+        assertThat(entry.ttlMillis()).isEqualTo(Long.MAX_VALUE);
+        assertThat(entry.isExpired()).isFalse();
+    }
+
+    @Test
+    void positiveTtlIsPreserved() {
+        var entry = entry(Duration.ofMinutes(5));
+
+        assertThat(entry.ttl()).isEqualTo(Duration.ofMinutes(5));
+        assertThat(entry.ttlMillis()).isEqualTo(Duration.ofMinutes(5).toMillis());
+    }
+}

--- a/tachyon-core/src/test/java/dev/tachyonmcp/core/server/features/tools/DefaultToolRegistryTest.java
+++ b/tachyon-core/src/test/java/dev/tachyonmcp/core/server/features/tools/DefaultToolRegistryTest.java
@@ -332,7 +332,7 @@ class DefaultToolRegistryTest {
     void shouldMapIconsFromDescriptorToProtocolModel() throws Exception {
         var handlers = new HashMap<String, RpcMethodHandler>();
         registerHandlers(registry, handlers);
-        var icon = Icon.of("https://example.com/tool-icon.png", "image/png", null, null);
+        var icon = Icon.of("https://example.com/tool-icon.png", "image/png", List.of(), null);
         registry.register(
                 ToolDescriptor.builder()
                         .name("icon-tool")

--- a/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/config/KotlinFeatureRegistrar.kt
+++ b/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/config/KotlinFeatureRegistrar.kt
@@ -34,7 +34,7 @@ internal class KotlinFeatureRegistrar(
         title: String?,
         annotations: Annotations?,
         size: Long?,
-        icons: List<Icon>?,
+        icons: List<Icon>,
         block: suspend ResourceScope.() -> ResourceContents,
     ) {
         delegate.withResources { resources ->
@@ -71,7 +71,7 @@ internal class KotlinFeatureRegistrar(
         mimeType: String?,
         title: String?,
         annotations: Annotations?,
-        icons: List<Icon>?,
+        icons: List<Icon>,
         block: suspend TemplateScope.() -> ResourceContents,
     ) {
         delegate.withResources { resources ->

--- a/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/config/TachyonServerBuilder.kt
+++ b/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/config/TachyonServerBuilder.kt
@@ -244,7 +244,7 @@ public class TachyonServerBuilder
          * @param title optional human-readable title
          * @param annotations optional presentation hints
          * @param size optional raw content size in bytes
-         * @param icons optional associated icons
+         * @param icons associated icons, or an empty list
          * @param block handles reads of the registered resource
          * @return this builder
          */
@@ -257,7 +257,7 @@ public class TachyonServerBuilder
             title: String? = null,
             annotations: Annotations? = null,
             size: Long? = null,
-            icons: List<Icon>? = null,
+            icons: List<Icon> = emptyList(),
             block: suspend ResourceScope.() -> ResourceContents,
         ): TachyonServerBuilder =
             this.also {
@@ -302,7 +302,7 @@ public class TachyonServerBuilder
             handler: suspend PromptScope.() -> List<PromptMessage>,
         ): TachyonServerBuilder =
             this.also {
-                val descriptor = PromptDescriptor.of(name, description, null, null, null)
+                val descriptor = PromptDescriptor.of(name, description, null, emptyList(), null)
                 featureRegistrar.prompt(descriptor, handler)
             }
 
@@ -328,7 +328,7 @@ public class TachyonServerBuilder
          * @param mimeType The optional MIME type of the resources.
          * @param title The optional template title.
          * @param annotations The optional template annotations.
-         * @param icons The optional template icons.
+         * @param icons The template icons, or an empty list.
          * @param block Handles requests for resources matching the template.
          * @return This builder.
          */
@@ -340,7 +340,7 @@ public class TachyonServerBuilder
             mimeType: String? = null,
             title: String? = null,
             annotations: Annotations? = null,
-            icons: List<Icon>? = null,
+            icons: List<Icon> = emptyList(),
             block: suspend TemplateScope.() -> ResourceContents,
         ): TachyonServerBuilder =
             this.also {

--- a/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/domain/AnnotationsFactories.kt
+++ b/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/domain/AnnotationsFactories.kt
@@ -22,12 +22,12 @@ public inline fun Annotations(block: AnnotationsBuilder.() -> Unit): Annotations
 /**
  * Creates [Annotations] — optional metadata for tailoring content presentation.
  *
- * @param audience     intended roles (user, assistant); null when unrestricted
+ * @param audience     intended roles (user, assistant); empty when unrestricted
  * @param priority     ordering hint in [0.0, 1.0]; null for default
  * @param lastModified RFC-3339 timestamp of last modification; null when unknown
  */
 public fun Annotations(
-    audience: List<Role>? = null,
+    audience: List<Role> = emptyList(),
     priority: Double? = null,
     lastModified: String? = null,
 ): Annotations = Annotations.of(audience, priority, lastModified)

--- a/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/domain/IconFactories.kt
+++ b/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/domain/IconFactories.kt
@@ -24,13 +24,13 @@ public inline fun Icon(block: IconBuilder.() -> Unit): Icon {
  *
  * @param src     image URL or data URI
  * @param mimeType image MIME type (e.g. "image/png"); defaults to a guess from `src`'s extension
- * @param sizes   conventional size labels (e.g. ["16x16", "32x32"]); null when unspecified
+ * @param sizes   conventional size labels (e.g. ["16x16", "32x32"]); empty when unspecified
  * @param theme   theme variant ("light", "dark"); null when universal
  */
 public fun Icon(
     src: String,
     mimeType: String? = MimeTypes.guess(src),
-    sizes: List<String>? = null,
+    sizes: List<String> = emptyList(),
     theme: String? = null,
 ): Icon =
     Icon

--- a/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/domain/StructuredFactoryBuilders.kt
+++ b/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/domain/StructuredFactoryBuilders.kt
@@ -33,7 +33,7 @@ public class AnnotationsBuilder
         @PublishedApi
         internal fun build(): Annotations =
             Annotations.of(
-                audience,
+                audience.orEmpty(),
                 priority,
                 lastModified,
             )
@@ -61,7 +61,7 @@ public class IconBuilder
             Icon.of(
                 requireNotNull(src) { "Icon.src is required" },
                 mimeType,
-                sizes,
+                sizes.orEmpty(),
                 theme,
             )
     }

--- a/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/features/prompts/PromptDescriptorScope.kt
+++ b/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/features/prompts/PromptDescriptorScope.kt
@@ -51,9 +51,9 @@ public class PromptDescriptorScope
                 .name(n)
                 .description(description)
                 .title(title)
-                .arguments(arguments)
+                .arguments(arguments.orEmpty())
                 .inputSchema(inputSchema)
-                .icons(icons)
+                .icons(icons.orEmpty())
                 .meta(meta)
                 .build()
         }

--- a/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/features/resources/Factories.kt
+++ b/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/features/resources/Factories.kt
@@ -21,7 +21,7 @@ import dev.tachyonmcp.core.server.features.resources.MimeTypes
  * @param title       human-readable title; null to omit
  * @param annotations optional presentation hints
  * @param size        estimated size hint in bytes; null = unknown
- * @param icons       list of associated icons; null to omit
+ * @param icons       list of associated icons, or empty
  * @param meta        protocol extension metadata; null to omit
  */
 public fun ResourceDescriptor(
@@ -32,7 +32,7 @@ public fun ResourceDescriptor(
     title: String? = null,
     annotations: Annotations? = null,
     size: Long? = null,
-    icons: List<Icon>? = null,
+    icons: List<Icon> = emptyList(),
     meta: Map<String, Any>? = null,
 ): ResourceDescriptor =
     ResourceDescriptor

--- a/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/features/resources/ResourceDescriptorScope.kt
+++ b/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/features/resources/ResourceDescriptorScope.kt
@@ -23,7 +23,7 @@ public class ResourceDescriptorScope
         public var title: String? = null
         public var annotations: Annotations? = null
         public var size: Long? = null
-        public var icons: List<Icon>? = null
+        public var icons: List<Icon> = emptyList()
         public var meta: Map<String, Any>? = null
 
         @PublishedApi

--- a/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/features/resources/ResourceTemplateDescriptorBuilder.kt
+++ b/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/features/resources/ResourceTemplateDescriptorBuilder.kt
@@ -40,7 +40,7 @@ public class ResourceTemplateDescriptorBuilder
         public var annotations: Annotations? = null
 
         /** Associated icons. */
-        public var icons: List<Icon>? = null
+        public var icons: List<Icon> = emptyList()
 
         /** Protocol extension metadata. */
         public var meta: Map<String, Any>? = null

--- a/tachyon-kotlin/src/test/kotlin/dev/tachyonmcp/kotlin/server/domain/StructuredFactoryBuildersTest.kt
+++ b/tachyon-kotlin/src/test/kotlin/dev/tachyonmcp/kotlin/server/domain/StructuredFactoryBuildersTest.kt
@@ -1,0 +1,21 @@
+// Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors.
+package dev.tachyonmcp.kotlin.server.domain
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+internal class StructuredFactoryBuildersTest {
+    @Test
+    fun `Annotations block omits audience defaults to empty list`() {
+        val annotations = Annotations { priority = 0.5 }
+
+        annotations.audience() shouldBe emptyList()
+    }
+
+    @Test
+    fun `Icon block omits sizes defaults to empty list`() {
+        val icon = Icon { src = "https://example.test/icon.png" }
+
+        icon.sizes() shouldBe emptyList()
+    }
+}

--- a/tachyon-kotlin/src/test/kotlin/dev/tachyonmcp/kotlin/server/features/prompts/PromptDescriptorScopeTest.kt
+++ b/tachyon-kotlin/src/test/kotlin/dev/tachyonmcp/kotlin/server/features/prompts/PromptDescriptorScopeTest.kt
@@ -1,0 +1,15 @@
+// Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors.
+package dev.tachyonmcp.kotlin.server.features.prompts
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+internal class PromptDescriptorScopeTest {
+    @Test
+    fun `PromptDescriptor block omits arguments and icons defaults to empty lists`() {
+        val descriptor = PromptDescriptor { name = "bare-prompt" }
+
+        descriptor.arguments() shouldBe emptyList()
+        descriptor.icons() shouldBe emptyList()
+    }
+}


### PR DESCRIPTION
## Summary

The API now models optional collections as non-null empty lists across descriptors, annotations, icons, prompts, and resources. Task TTL values now use Duration internally and serialize as milliseconds. Protocol mappers convert empty collections and icon sizes to omitted wire fields. Kotlin builders and test fixtures use empty-list defaults. Empty binary blobs are now valid.

### Improvements

- Standardized optional collections across prompts, resources, tools, icons, and annotations: absent values now appear as empty lists.
- Updated task time-to-live handling to use duration-based values while preserving protocol compatibility.
- Empty icon metadata is omitted from serialized responses for cleaner payloads.
- Empty binary resources are now accepted when their URI is valid.

### Bug Fixes

- Improved prompt, resource, and icon mapping for empty or unspecified optional fields.
- Refined registration APIs with clearer non-null collection requirements and empty-list defaults.
