### PR TITLE
refactor!: drop executor(), only threadFactory()

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -344,8 +344,7 @@ equivalents) — they mutate the same nested sub-config, so chaining still works
 
 | Option | Description |
 |---|---|
-| `executor(ExecutorService)` | Handler executor; default runs handlers on virtual threads |
-| `threadFactory(ThreadFactory)` | Thread factory for the default executor |
+| `threadFactory(ThreadFactory)` | Thread factory for the server-owned virtual-thread-per-task executor (default: `Thread.ofVirtual().name("tachyon-", 0)`) |
 | `pipelineCustomizer(Consumer<ChannelPipeline>)` | Hook to mutate the Netty pipeline after MCP handlers are installed |
 | `json(cfg -> cfg.inputSchemaValidator(...).outputSchemaValidator(...))` | Custom JSON Schema validators |
 

--- a/tachyon-core/revapi.json
+++ b/tachyon-core/revapi.json
@@ -634,6 +634,15 @@
           "attachments": {
             "since": "1.0.0-beta.19"
           }
+        },
+        {
+          "ignore": true,
+          "code": "java.method.removed",
+          "old": "method dev.tachyonmcp.core.server.ServerBuilder dev.tachyonmcp.core.server.ServerBuilder::executor(java.util.concurrent.ExecutorService)",
+          "justification": "Server always owns a virtual-thread-per-task executor; only threadFactory() remains configurable",
+          "attachments": {
+            "since": "1.0.0-beta.19"
+          }
         }
       ]
     }

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/DefaultServerBuilder.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/DefaultServerBuilder.java
@@ -4,7 +4,6 @@ package dev.tachyonmcp.core.server;
 import dev.tachyonmcp.api.json.JsonSchemaValidator;
 import dev.tachyonmcp.api.json.PayloadDeserializer;
 import dev.tachyonmcp.api.json.PayloadSerializer;
-import dev.tachyonmcp.api.json.spi.JsonSchemaFactory;
 import dev.tachyonmcp.api.server.config.JsonConfig;
 import dev.tachyonmcp.api.server.config.MonitoringConfig;
 import dev.tachyonmcp.api.server.config.RuntimeConfig;
@@ -25,11 +24,9 @@ import dev.tachyonmcp.core.server.session.InMemorySessionStore;
 import io.netty.channel.ChannelPipeline;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import org.jspecify.annotations.Nullable;
 
@@ -51,12 +48,10 @@ final class DefaultServerBuilder implements ServerBuilder {
     private JsonSchemaValidator outputSchemaValidator = new NetworkntJsonSchemaValidator();
     private PayloadSerializer payloadSerializer = new JacksonPayloadSerde();
     private PayloadDeserializer payloadDeserializer = new JacksonPayloadSerde();
-    private @Nullable JsonSchemaFactory<?> schemaFactory;
 
     @Nullable
     private Consumer<ChannelPipeline> pipelineCustomizer;
 
-    private @Nullable ExecutorService executor;
     private @Nullable ThreadFactory threadFactory;
 
     DefaultServerBuilder() {}
@@ -238,60 +233,13 @@ final class DefaultServerBuilder implements ServerBuilder {
     }
 
     /**
-     * Sets a caller-owned executor for handler dispatch. The server will not shut it down on close.
-     * Must be thread-per-task (each task starts on a new thread); bounded pools deadlock with
-     * the blocking-first dispatch contract. Mutually exclusive with {@link #threadFactory}.
-     */
-    @Override
-    public ServerBuilder executor(ExecutorService executor) {
-        if (threadFactory != null) {
-            throw new IllegalStateException("executor() and threadFactory() are mutually exclusive");
-        }
-        this.executor = executor;
-        return this;
-    }
-
-    /**
      * Sets a thread factory for virtual-thread-per-task executor creation. The server owns this
-     * executor and will shut it down on close. Mutually exclusive with {@link #executor}.
+     * executor and will shut it down on close.
      */
     @Override
     public ServerBuilder threadFactory(ThreadFactory threadFactory) {
-        if (executor != null) {
-            throw new IllegalStateException("executor() and threadFactory() are mutually exclusive");
-        }
         this.threadFactory = threadFactory;
         return this;
-    }
-
-    static void validateExecutor(ExecutorService executor) {
-        var thread1 = new Thread[1];
-        var thread2 = new Thread[1];
-        var latch = new CountDownLatch(1);
-        try {
-            var f1 = executor.submit(() -> {
-                thread1[0] = Thread.currentThread();
-                try {
-                    latch.await(10, TimeUnit.SECONDS);
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                }
-            });
-            var f2 = executor.submit(() -> thread2[0] = Thread.currentThread());
-            f2.get(2, TimeUnit.SECONDS);
-            latch.countDown();
-            f1.get(10, TimeUnit.SECONDS);
-        } catch (Exception e) {
-            throw new IllegalArgumentException(
-                    "executor must create a new (virtual) thread per task; bounded pools deadlock with blocking-first dispatch",
-                    e);
-        } finally {
-            latch.countDown();
-        }
-        if (thread1[0] == thread2[0]) {
-            throw new IllegalArgumentException(
-                    "executor must create a new (virtual) thread per task; bounded pools deadlock with blocking-first dispatch");
-        }
     }
 
     // === Transport escape hatch ===
@@ -325,22 +273,14 @@ final class DefaultServerBuilder implements ServerBuilder {
         var store = sessionConfig.sessionStore() != null ? sessionConfig.sessionStore() : new InMemorySessionStore();
         var allExtensions = List.copyOf(extensions);
         var serverConfig = buildConfig();
-        ExecutorService resolvedExecutor;
-        boolean ownsExecutor;
-        if (executor != null) {
-            validateExecutor(executor);
-            resolvedExecutor = executor;
-            ownsExecutor = false;
-        } else if (threadFactory != null) {
+        final ExecutorService resolvedExecutor;
+        if (threadFactory != null) {
             resolvedExecutor = Executors.newThreadPerTaskExecutor(threadFactory);
-            ownsExecutor = true;
         } else {
             resolvedExecutor = DefaultTachyonServer.defaultExecutorForBuilder();
-            ownsExecutor = true;
         }
         var server = new DefaultTachyonServer(
                 resolvedExecutor,
-                ownsExecutor,
                 sessionEventStore,
                 store,
                 serverConfig,
@@ -348,7 +288,7 @@ final class DefaultServerBuilder implements ServerBuilder {
                 outputSchemaValidator,
                 payloadSerializer,
                 payloadDeserializer,
-                schemaFactory,
+                null,
                 allExtensions,
                 pipelineCustomizer);
         bootstrapRegistrations.forEach(registrar -> registrar.accept(server));

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/DefaultTachyonServer.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/DefaultTachyonServer.java
@@ -105,7 +105,6 @@ final class DefaultTachyonServer implements ServerEngine, ExtensionContext {
     final Map<String, LoggingLevel> loggingLevels = new ConcurrentHashMap<>();
     final ConcurrentHashMap<RequestId, CompletableFuture<String>> pendingRequests = new ConcurrentHashMap<>();
     private final ExecutorService executor;
-    private final boolean ownsExecutor;
     private final List<ServerExtension> extensions;
     private final @Nullable Consumer<ChannelPipeline> pipelineCustomizer;
     private final Map<String, String> extensionMethodOwners = new ConcurrentHashMap<>();
@@ -242,7 +241,6 @@ final class DefaultTachyonServer implements ServerEngine, ExtensionContext {
 
     DefaultTachyonServer(
             ExecutorService executor,
-            boolean ownsExecutor,
             SessionEventStore sessionEventStore,
             SessionStore sessionStore,
             ServerConfig config,
@@ -254,7 +252,6 @@ final class DefaultTachyonServer implements ServerEngine, ExtensionContext {
             @Nullable List<ServerExtension> extensions,
             @Nullable Consumer<ChannelPipeline> pipelineCustomizer) {
         this.executor = executor;
-        this.ownsExecutor = ownsExecutor;
         this.config = Objects.requireNonNull(config, "config cannot be null");
         this.sessionEventStore = Objects.requireNonNull(sessionEventStore, "sessionEventStore cannot be null");
         this.port = config.network().port();
@@ -807,17 +804,15 @@ final class DefaultTachyonServer implements ServerEngine, ExtensionContext {
         try {
             logger.info("Shutting down TachyonMCP Server");
             shutdownExtensions();
-            if (ownsExecutor) {
-                executor.shutdown();
-                try {
-                    var grace = config.runtime().shutdownGracePeriod();
-                    if (!executor.awaitTermination(grace.toMillis(), TimeUnit.MILLISECONDS)) {
-                        executor.shutdownNow();
-                    }
-                } catch (InterruptedException e) {
+            executor.shutdown();
+            try {
+                var grace = config.runtime().shutdownGracePeriod();
+                if (!executor.awaitTermination(grace.toMillis(), TimeUnit.MILLISECONDS)) {
                     executor.shutdownNow();
-                    Thread.currentThread().interrupt();
                 }
+            } catch (InterruptedException e) {
+                executor.shutdownNow();
+                Thread.currentThread().interrupt();
             }
             taskRegistry.stopTtlJanitor();
             sessionManager.close();

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/ServerBuilder.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/ServerBuilder.java
@@ -16,7 +16,6 @@ import dev.tachyonmcp.core.server.config.NetworkConfig;
 import dev.tachyonmcp.core.server.config.ServerConfig;
 import dev.tachyonmcp.core.server.config.SessionConfig;
 import io.netty.channel.ChannelPipeline;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadFactory;
 import java.util.function.Consumer;
 import org.jspecify.annotations.Nullable;
@@ -84,14 +83,7 @@ public interface ServerBuilder {
      */
     ServerBuilder withExtensions(ServerExtension... extensions);
 
-    /**
-     * Sets a caller-owned thread-per-task executor. The caller must close the executor after the
-     * server is closed. {@link #build()} rejects bounded executors with an
-     * {@link IllegalArgumentException}.
-     */
-    ServerBuilder executor(ExecutorService executor);
-
-    /** Sets the thread factory used by the server-owned thread-per-task executor. */
+    /** Sets the thread factory used by the server-owned virtual-thread-per-task executor. */
     ServerBuilder threadFactory(ThreadFactory threadFactory);
 
     /** Customizes each Netty channel pipeline. */
@@ -101,8 +93,6 @@ public interface ServerBuilder {
     /**
      * Constructs the configured server without starting its transport, then executes the configured
      * feature-registration callbacks.
-     *
-     * @throws IllegalArgumentException if the configured executor is bounded
      */
     TachyonServer build();
 

--- a/tachyon-core/src/test/java/dev/tachyonmcp/core/server/ServerBuilderTest.java
+++ b/tachyon-core/src/test/java/dev/tachyonmcp/core/server/ServerBuilderTest.java
@@ -2,7 +2,6 @@
 package dev.tachyonmcp.core.server;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 
 import dev.tachyonmcp.api.server.domain.PromptMessage;
@@ -15,12 +14,10 @@ import dev.tachyonmcp.api.server.features.prompts.PromptResult;
 import dev.tachyonmcp.api.server.features.tools.ToolResult;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import org.junit.jupiter.api.Test;
 
 /**
- * Verifies {@link ServerBuilder} enforces the thread-per-task executor contract required by
+ * Verifies {@link ServerBuilder} configures a server-owned virtual-thread-per-task executor for
  * blocking-first dispatch.
  *
  * @author Konstantin Pavlov
@@ -33,18 +30,9 @@ class ServerBuilderTest {
     }
 
     @Test
-    void rejectsBoundedPool() {
-        try (ExecutorService executor = Executors.newFixedThreadPool(1)) {
-            assertThatIllegalArgumentException()
-                    .isThrownBy(() -> TachyonServer.builder().executor(executor).build())
-                    .withMessageContaining("thread per task");
-        }
-    }
-
-    @Test
     void acceptsVirtualThreadPerTaskExecutor() {
         try (var server = TachyonServer.builder()
-                .executor(Executors.newVirtualThreadPerTaskExecutor())
+                .threadFactory(Thread.ofVirtual().name("test-", 0).factory())
                 .build()) {
             assertThat(server).isNotNull();
         }

--- a/tachyon-core/src/test/java/dev/tachyonmcp/core/transport/netty/NettyServerThreadingTest.java
+++ b/tachyon-core/src/test/java/dev/tachyonmcp/core/transport/netty/NettyServerThreadingTest.java
@@ -10,9 +10,7 @@ import dev.tachyonmcp.core.server.McpDispatcher;
 import dev.tachyonmcp.core.server.internal.ServerEngine;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
@@ -83,20 +81,15 @@ class NettyServerThreadingTest {
     }
 
     @Test
-    void callerSuppliedExecutorIsNotShutDownByServerClose() throws Exception {
-        var executor = Executors.newVirtualThreadPerTaskExecutor();
-        var closed = new AtomicBoolean(false);
-
+    void serverOwnedExecutorIsShutDownByServerClose() {
         var server = newEngine(
-                b -> b.executor(executor),
+                b -> b.threadFactory(Thread.ofVirtual().name("tenant-", 0).factory()),
                 s -> s.tools().register(builder -> builder.name("exec_probe"), (ctx, request) -> ToolResult.empty()));
+        var executor = server.executor();
         server.close();
 
-        // The executor should still be usable (not shut down)
-        executor.submit(() -> closed.set(true)).get(5, TimeUnit.SECONDS);
-        assertThat(closed)
-                .as("caller-owned executor must remain active after server.close()")
+        assertThat(executor.isShutdown())
+                .as("server-owned executor must be shut down by server.close()")
                 .isTrue();
-        executor.shutdown();
     }
 }

--- a/tachyon-kotlin/src/test/kotlin/dev/tachyonmcp/kotlin/server/ToolFnFactoryTest.kt
+++ b/tachyon-kotlin/src/test/kotlin/dev/tachyonmcp/kotlin/server/ToolFnFactoryTest.kt
@@ -24,7 +24,6 @@ import tools.jackson.databind.ObjectMapper
 import java.time.Duration
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.ExecutionException
-import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
@@ -128,43 +127,38 @@ internal class ToolFnFactoryTest {
         val runtime = CoroutineRuntime()
         val release = CompletableDeferred<Unit>()
         val started = CountDownLatch(1)
-        Executors
-            .newThreadPerTaskExecutor(
-                Thread.ofVirtual().name("bounded-shutdown-", 0).factory(),
-            ).use { executor ->
-                val server =
-                    TachyonServer
-                        .builder()
-                        .executor(executor)
-                        .runtime { it.shutdownGracePeriod(Duration.ofMillis(50)) }
-                        .withExtensions(runtime)
-                        .build() as ServerEngine
-                val fn =
-                    toolFn("bounded-shutdown", runtime) {
-                        started.countDown()
-                        withContext(NonCancellable) {
-                            release.await()
-                        }
-                        ToolResult.text("done")
-                    }
-
-                fn.apply(
-                    DefaultDispatchContext.stateless(server),
-                    ToolRequest.builder().name("bounded-shutdown").build(),
-                )
-                try {
-                    started.await(5, TimeUnit.SECONDS) shouldBe true
-
-                    val before = System.nanoTime()
-                    server.close()
-                    val elapsed = Duration.ofNanos(System.nanoTime() - before)
-
-                    (elapsed < Duration.ofSeconds(2)) shouldBe true
-                } finally {
-                    release.complete(Unit)
-                    server.close()
+        val server =
+            TachyonServer
+                .builder()
+                .threadFactory(Thread.ofVirtual().name("bounded-shutdown-", 0).factory())
+                .runtime { it.shutdownGracePeriod(Duration.ofMillis(50)) }
+                .withExtensions(runtime)
+                .build() as ServerEngine
+        val fn =
+            toolFn("bounded-shutdown", runtime) {
+                started.countDown()
+                withContext(NonCancellable) {
+                    release.await()
                 }
+                ToolResult.text("done")
             }
+
+        fn.apply(
+            DefaultDispatchContext.stateless(server),
+            ToolRequest.builder().name("bounded-shutdown").build(),
+        )
+        try {
+            started.await(5, TimeUnit.SECONDS) shouldBe true
+
+            val before = System.nanoTime()
+            server.close()
+            val elapsed = Duration.ofNanos(System.nanoTime() - before)
+
+            (elapsed < Duration.ofSeconds(2)) shouldBe true
+        } finally {
+            release.complete(Unit)
+            server.close()
+        }
     }
 
     @Test
@@ -244,19 +238,14 @@ internal class ToolFnFactoryTest {
 
     private fun withCoroutineRuntime(block: (CoroutineRuntime, InteractionContext) -> Unit) {
         val runtime = CoroutineRuntime()
-        Executors
-            .newThreadPerTaskExecutor(
-                Thread.ofVirtual().name("kotlin-handler-", 0).factory(),
-            ).use { executor ->
-                val delegate =
-                    TachyonServer
-                        .builder()
-                        .executor(executor)
-                        .withExtensions(runtime)
-                        .build() as ServerEngine
-                delegate.use {
-                    block(runtime, DefaultDispatchContext.stateless(delegate))
-                }
-            }
+        val delegate =
+            TachyonServer
+                .builder()
+                .threadFactory(Thread.ofVirtual().name("kotlin-handler-", 0).factory())
+                .withExtensions(runtime)
+                .build() as ServerEngine
+        delegate.use {
+            block(runtime, DefaultDispatchContext.stateless(delegate))
+        }
     }
 }


### PR DESCRIPTION
Server always owns a virtual-thread-per-task executor; remove caller-owned ExecutorService injection and the ownsExecutor flag.