### PR TITLE
fix: refine nullability contracts

### DIFF
--- a/tachyon-api/src/main/java/dev/tachyonmcp/api/json/DefaultJsonArray.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/api/json/DefaultJsonArray.java
@@ -18,14 +18,14 @@ final class DefaultJsonArray implements JsonArray {
 
     static final JsonArray EMPTY = new DefaultJsonArray(List.of());
 
-    private final List<Object> values;
+    private final List<@Nullable Object> values;
     private final String json;
     private final Map<Integer, JsonObject> objects = new ConcurrentHashMap<>();
     private final Map<Integer, JsonArray> arrays = new ConcurrentHashMap<>();
 
-    DefaultJsonArray(List<?> values) {
+    DefaultJsonArray(List<? extends @Nullable Object> values) {
         Objects.requireNonNull(values, "values");
-        var copy = new ArrayList<>(values.size());
+        var copy = new ArrayList<@Nullable Object>(values.size());
         for (var item : values) {
             copy.add(JsonValues.copyValue(item, "[" + copy.size() + "]"));
         }
@@ -100,7 +100,7 @@ final class DefaultJsonArray implements JsonArray {
     }
 
     @Override
-    public List<Object> asList() {
+    public List<@Nullable Object> asList() {
         return values;
     }
 

--- a/tachyon-api/src/main/java/dev/tachyonmcp/api/json/DefaultJsonObject.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/api/json/DefaultJsonObject.java
@@ -17,14 +17,14 @@ final class DefaultJsonObject implements JsonObject {
 
     static final JsonObject EMPTY = new DefaultJsonObject(Map.of());
 
-    private final Map<String, Object> values;
+    private final Map<String, @Nullable Object> values;
     private volatile @Nullable String json;
     private final Map<String, JsonObject> objects = new ConcurrentHashMap<>();
     private final Map<String, JsonArray> arrays = new ConcurrentHashMap<>();
 
-    DefaultJsonObject(Map<String, ?> values) {
+    DefaultJsonObject(Map<String, ? extends @Nullable Object> values) {
         Objects.requireNonNull(values, "values");
-        var copy = new LinkedHashMap<String, Object>(values.size());
+        var copy = new LinkedHashMap<String, @Nullable Object>(values.size());
         values.forEach((name, value) -> {
             if (name == null) {
                 throw new IllegalArgumentException("JSON object property name must not be null");
@@ -34,12 +34,12 @@ final class DefaultJsonObject implements JsonObject {
         this.values = Collections.unmodifiableMap(copy);
     }
 
-    private DefaultJsonObject(Map<String, Object> values, @Nullable String json) {
+    private DefaultJsonObject(Map<String, @Nullable Object> values, @Nullable String json) {
         this.values = values;
         this.json = json;
     }
 
-    static DefaultJsonObject fromImmutableValues(Map<String, Object> values, @Nullable String json) {
+    static DefaultJsonObject fromImmutableValues(Map<String, @Nullable Object> values, @Nullable String json) {
         return new DefaultJsonObject(values, json);
     }
 
@@ -110,7 +110,7 @@ final class DefaultJsonObject implements JsonObject {
     }
 
     @Override
-    public Map<String, Object> asMap() {
+    public Map<String, @Nullable Object> asMap() {
         return values;
     }
 

--- a/tachyon-api/src/main/java/dev/tachyonmcp/api/json/JsonArray.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/api/json/JsonArray.java
@@ -8,6 +8,7 @@ import java.util.Optional;
 import java.util.OptionalDouble;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
+import org.jspecify.annotations.Nullable;
 
 /**
  * An immutable, provider-neutral view of a JSON array.
@@ -329,18 +330,18 @@ public interface JsonArray extends JsonDocument {
     /**
      * Returns an immutable list representation.
      *
-     * @return the list view
+     * @return the list view; elements may be {@code null} for JSON {@code null}
      */
     @ExperimentalApi
-    List<Object> asList();
+    List<@Nullable Object> asList();
 
     /**
      * Creates an immutable array by recursively snapshotting JSON-compatible values.
      *
-     * @param values the source list
+     * @param values the source list; elements may be {@code null} for JSON {@code null}
      * @return a new JSON array
      */
-    static JsonArray of(List<?> values) {
+    static JsonArray of(List<? extends @Nullable Object> values) {
         return new DefaultJsonArray(values);
     }
 

--- a/tachyon-api/src/main/java/dev/tachyonmcp/api/json/JsonObject.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/api/json/JsonObject.java
@@ -8,6 +8,7 @@ import java.util.Optional;
 import java.util.OptionalDouble;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
+import org.jspecify.annotations.Nullable;
 
 /**
  * An immutable, provider-neutral view of a JSON object.
@@ -281,18 +282,18 @@ public interface JsonObject extends JsonDocument {
     /**
      * Returns an immutable map representation.
      *
-     * @return the map view
+     * @return the map view; values may be {@code null} for JSON {@code null}
      */
     @ExperimentalApi
-    Map<String, Object> asMap();
+    Map<String, @Nullable Object> asMap();
 
     /**
      * Creates an immutable object by recursively snapshotting JSON-compatible values.
      *
-     * @param values the source map
+     * @param values the source map; values may be {@code null} for JSON {@code null}
      * @return a new JSON object
      */
-    static JsonObject of(Map<String, ?> values) {
+    static JsonObject of(Map<String, ? extends @Nullable Object> values) {
         return new DefaultJsonObject(values);
     }
 

--- a/tachyon-api/src/main/java/dev/tachyonmcp/api/json/JsonValues.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/api/json/JsonValues.java
@@ -82,7 +82,7 @@ final class JsonValues {
     static JsonObject object(Object value, String location) {
         if (value instanceof Map<?, ?> map) {
             @SuppressWarnings("unchecked")
-            var object = (Map<String, Object>) map;
+            var object = (Map<String, @Nullable Object>) map;
             return DefaultJsonObject.fromImmutableValues(object, null);
         }
         throw wrongType(location, "object", value);
@@ -137,7 +137,7 @@ final class JsonValues {
                 return number;
             }
             case Map<?, ?> map -> {
-                var copy = new LinkedHashMap<String, Object>(map.size());
+                var copy = new LinkedHashMap<String, @Nullable Object>(map.size());
                 map.forEach((key, nested) -> {
                     if (!(key instanceof String name)) {
                         throw invalidValue(path, "object property name is not a string");
@@ -147,7 +147,7 @@ final class JsonValues {
                 return Collections.unmodifiableMap(copy);
             }
             case List<?> list -> {
-                var copy = new ArrayList<>(list.size());
+                var copy = new ArrayList<@Nullable Object>(list.size());
                 for (var index = 0; index < list.size(); index++) {
                     copy.add(copyValue(list.get(index), path + "[" + index + "]"));
                 }

--- a/tachyon-api/src/main/java/dev/tachyonmcp/api/server/config/JsonConfig.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/api/server/config/JsonConfig.java
@@ -45,12 +45,12 @@ public record JsonConfig(
             return serializer(serde).deserializer(serde);
         }
 
-        public Builder serializer(PayloadSerializer serializer) {
+        public Builder serializer(@Nullable PayloadSerializer serializer) {
             this.serializer = serializer;
             return this;
         }
 
-        public Builder deserializer(PayloadDeserializer deserializer) {
+        public Builder deserializer(@Nullable PayloadDeserializer deserializer) {
             this.deserializer = deserializer;
             return this;
         }

--- a/tachyon-api/src/main/java/dev/tachyonmcp/api/server/domain/Args.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/api/server/domain/Args.java
@@ -31,10 +31,10 @@ public final class Args implements JsonObject {
     /**
      * Creates arguments from a map of values.
      *
-     * @param values the argument values, or {@code null} for empty
+     * @param values the argument values, whose values may be {@code null}, or {@code null} for empty
      * @return a new Args instance
      */
-    public static Args of(@Nullable Map<String, ?> values) {
+    public static Args of(@Nullable Map<String, ? extends @Nullable Object> values) {
         return new Args(values == null ? JsonObject.empty() : JsonObject.of(values), null);
     }
 
@@ -50,11 +50,12 @@ public final class Args implements JsonObject {
     /**
      * Creates arguments from a map of values with a deserializer.
      *
-     * @param values      the argument values, or {@code null} for empty
+     * @param values      the argument values, whose values may be {@code null}, or {@code null} for empty
      * @param deserializer the payload deserializer, or {@code null}
      * @return a new Args instance
      */
-    public static Args of(@Nullable Map<String, ?> values, @Nullable PayloadDeserializer deserializer) {
+    public static Args of(
+            @Nullable Map<String, ? extends @Nullable Object> values, @Nullable PayloadDeserializer deserializer) {
         return new Args(values == null ? JsonObject.empty() : JsonObject.of(values), deserializer);
     }
 
@@ -124,7 +125,7 @@ public final class Args implements JsonObject {
     }
 
     @Override
-    public Map<String, Object> asMap() {
+    public Map<String, @Nullable Object> asMap() {
         return values.asMap();
     }
 

--- a/tachyon-api/src/main/java/dev/tachyonmcp/api/server/session/package-info.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/api/server/session/package-info.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2026 Konstantin Pavlov and contributors.
+ */
+
+/**
+ * Session identity and lifecycle extension points.
+ */
+@NullMarked
+package dev.tachyonmcp.api.server.session;
+
+import org.jspecify.annotations.NullMarked;

--- a/tachyon-api/src/test/java/dev/tachyonmcp/api/json/JsonArrayTest.java
+++ b/tachyon-api/src/test/java/dev/tachyonmcp/api/json/JsonArrayTest.java
@@ -84,6 +84,7 @@ class JsonArrayTest {
         assertThatThrownBy(() -> array.valuesAs(String.class))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("[1]");
+        assertThat(array.asList()).containsExactly("a", null, "c");
     }
 
     @Test

--- a/tachyon-api/src/test/java/dev/tachyonmcp/api/json/JsonObjectTest.java
+++ b/tachyon-api/src/test/java/dev/tachyonmcp/api/json/JsonObjectTest.java
@@ -54,6 +54,7 @@ class JsonObjectTest {
         assertThat(object.stringOpt("missing")).isEmpty();
         assertThat(object.boolOpt("null")).isEmpty();
         assertThat(object.objectOpt("missing")).isEmpty();
+        assertThat(object.asMap()).containsEntry("null", null);
     }
 
     @Test

--- a/tachyon-api/src/test/java/dev/tachyonmcp/api/server/domain/ArgsTest.java
+++ b/tachyon-api/src/test/java/dev/tachyonmcp/api/server/domain/ArgsTest.java
@@ -15,6 +15,7 @@ import java.util.Optional;
 import java.util.OptionalDouble;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 
 class ArgsTest {
@@ -219,7 +220,7 @@ class ArgsTest {
         }
 
         @Override
-        public Map<String, Object> asMap() {
+        public Map<String, @Nullable Object> asMap() {
             return delegate.asMap();
         }
 

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/json/JacksonObjectJsonDocument.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/json/JacksonObjectJsonDocument.java
@@ -95,8 +95,8 @@ record JacksonObjectJsonDocument(ObjectNode node) implements JsonObject, Jackson
     }
 
     @Override
-    public Map<String, Object> asMap() {
-        var copy = new LinkedHashMap<String, Object>();
+    public Map<String, @Nullable Object> asMap() {
+        var copy = new LinkedHashMap<String, @Nullable Object>();
         for (var entry : node.properties()) {
             copy.put(entry.getKey(), JsonUtils.mapper().treeToValue(entry.getValue(), Object.class));
         }
@@ -109,8 +109,8 @@ record JacksonObjectJsonDocument(ObjectNode node) implements JsonObject, Jackson
     }
 
     @SuppressWarnings("unchecked")
-    private static List<Object> treeToList(JsonNode arrayNode) {
-        return (List<Object>) JsonUtils.mapper().treeToValue(arrayNode, List.class);
+    private static List<@Nullable Object> treeToList(JsonNode arrayNode) {
+        return (List<@Nullable Object>) JsonUtils.mapper().treeToValue(arrayNode, List.class);
     }
 
     private static IllegalArgumentException wrongType(String name, String expected, JsonNode actual) {

--- a/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/config/ResourceScope.kt
+++ b/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/config/ResourceScope.kt
@@ -1,4 +1,6 @@
 // Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors.
+@file:Suppress("FunctionName")
+
 package dev.tachyonmcp.kotlin.server.config
 
 import dev.tachyonmcp.api.runtime.InteractionContext

--- a/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/features/prompts/PromptDescriptorScope.kt
+++ b/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/features/prompts/PromptDescriptorScope.kt
@@ -1,4 +1,6 @@
 // Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors.
+@file:Suppress("FunctionName")
+
 package dev.tachyonmcp.kotlin.server.features.prompts
 
 import dev.tachyonmcp.api.json.JsonSchema

--- a/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/features/resources/ResourceDescriptorScope.kt
+++ b/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/features/resources/ResourceDescriptorScope.kt
@@ -1,4 +1,6 @@
 // Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors.
+@file:Suppress("FunctionName")
+
 package dev.tachyonmcp.kotlin.server.features.resources
 
 import dev.tachyonmcp.api.server.domain.Annotations

--- a/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/features/tools/ToolDescriptorScope.kt
+++ b/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/features/tools/ToolDescriptorScope.kt
@@ -1,4 +1,6 @@
 // Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors.
+@file:Suppress("FunctionName")
+
 package dev.tachyonmcp.kotlin.server.features.tools
 
 import dev.tachyonmcp.api.json.JsonSchema

--- a/tachyon-kotlin/src/test/kotlin/dev/tachyonmcp/kotlin/server/json/JsonInteropTest.kt
+++ b/tachyon-kotlin/src/test/kotlin/dev/tachyonmcp/kotlin/server/json/JsonInteropTest.kt
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors.
 package dev.tachyonmcp.kotlin.server.json
 
+import dev.tachyonmcp.api.json.JsonArray
+import dev.tachyonmcp.api.json.JsonObject
 import dev.tachyonmcp.core.server.json.JsonUtils
 import io.kotest.assertions.assertSoftly
 import io.kotest.matchers.shouldBe
@@ -8,6 +10,15 @@ import kotlinx.serialization.json.Json
 import org.junit.jupiter.api.Test
 
 internal class JsonInteropTest {
+    @Test
+    fun `JSON container views retain nullable entries`() {
+        val objectValues: Map<String, Any?> = JsonObject.of(mapOf("nothing" to null)).asMap()
+        val arrayValues: List<Any?> = JsonArray.of(listOf(null)).asList()
+
+        objectValues["nothing"] shouldBe null
+        arrayValues shouldBe listOf(null)
+    }
+
     @Test
     fun `toJacksonNode converts all JSON kinds without a parse round-trip`() {
         val source =


### PR DESCRIPTION
## 1. JSpecify nullability contract for JSON null values and package defaults

_meta/JSON payloads can legally contain null values; `Map<String,Object>`/
List<Object> across the JSON API surface silently lied about that under
`@NullMarked`. Widen to `@Nullable` element types end-to-end (`DefaultJsonArray`,
`DefaultJsonObject`, `JsonArray`/`JsonObject`, `Args`, `JsonValues`, and the Jackson
codec in tachyon-core), add the missing session package-info.java, and fix
`JsonConfig.Builder.serializer()`/`deserializer()` to match their own "or null"
Javadoc.

## 2.suppress FunctionName lint on uppercase DSL factory functions 

`ToolDescriptor(block)`/`ResourceDescriptor(block)`/`PromptDescriptor(block)` and
ResourceScope's TextResourceContents/BlobResourceContents shadow type names
by design but were missing `@file:Suppress("FunctionName")`, unlike every
other uppercase factory in tachyon-kotlin.