### PR TITLE
fix(core)!: bind pending requests to owners

### DIFF
--- a/tachyon-core/revapi.json
+++ b/tachyon-core/revapi.json
@@ -643,6 +643,36 @@
           "attachments": {
             "since": "1.0.0-beta.19"
           }
+        },
+        {
+          "ignore": true,
+          "code": "java.method.numberOfParametersChanged",
+          "old": "method boolean dev.tachyonmcp.core.server.internal.ServerEngine::completePendingRequest(dev.tachyonmcp.api.server.domain.RequestId, java.lang.String)",
+          "new": "method boolean dev.tachyonmcp.core.server.internal.ServerEngine::completePendingRequest(dev.tachyonmcp.api.server.domain.RequestId, java.lang.String, java.lang.String, java.lang.String)",
+          "justification": "Session or channel ownership prevents one client from completing another client's pending request",
+          "attachments": {
+            "since": "1.0.0-beta.19"
+          }
+        },
+        {
+          "ignore": true,
+          "code": "java.method.numberOfParametersChanged",
+          "old": "method boolean dev.tachyonmcp.core.server.internal.ServerEngine::failPendingRequest(dev.tachyonmcp.api.server.domain.RequestId, java.lang.String)",
+          "new": "method boolean dev.tachyonmcp.core.server.internal.ServerEngine::failPendingRequest(dev.tachyonmcp.api.server.domain.RequestId, java.lang.String, java.lang.String, java.lang.String)",
+          "justification": "Session or channel ownership prevents one client from failing another client's pending request",
+          "attachments": {
+            "since": "1.0.0-beta.19"
+          }
+        },
+        {
+          "ignore": true,
+          "code": "java.method.numberOfParametersChanged",
+          "old": "method void dev.tachyonmcp.core.server.internal.ServerEngine::registerPendingRequest(dev.tachyonmcp.api.server.domain.RequestId, java.util.concurrent.CompletableFuture<java.lang.String>)",
+          "new": "method void dev.tachyonmcp.core.server.internal.ServerEngine::registerPendingRequest(dev.tachyonmcp.api.server.domain.RequestId, java.lang.String, dev.tachyonmcp.core.server.OutboundSseStream, java.util.concurrent.CompletableFuture<java.lang.String>)",
+          "justification": "Pending requests retain their session and transport ownership for completion checks",
+          "attachments": {
+            "since": "1.0.0-beta.19"
+          }
         }
       ]
     }

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/DefaultTachyonServer.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/DefaultTachyonServer.java
@@ -87,6 +87,9 @@ final class DefaultTachyonServer implements ServerEngine, ExtensionContext {
 
     private static final Logger logger = LoggerFactory.getLogger(DefaultTachyonServer.class);
 
+    private record PendingRequestEntry(
+            @Nullable String sessionId, @Nullable String channelId, CompletableFuture<String> future) {}
+
     private final ServerConfig config;
     private final SessionEventStore sessionEventStore;
     private final SessionManager sessionManager;
@@ -103,7 +106,7 @@ final class DefaultTachyonServer implements ServerEngine, ExtensionContext {
     private final PayloadDeserializer payloadDeserializer;
     private final Map<String, RpcMethodHandler> methodHandlers = new ConcurrentHashMap<>();
     final Map<String, LoggingLevel> loggingLevels = new ConcurrentHashMap<>();
-    final ConcurrentHashMap<RequestId, CompletableFuture<String>> pendingRequests = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<RequestId, PendingRequestEntry> pendingRequests = new ConcurrentHashMap<>();
     private final ExecutorService executor;
     private final List<ServerExtension> extensions;
     private final @Nullable Consumer<ChannelPipeline> pipelineCustomizer;
@@ -665,10 +668,10 @@ final class DefaultTachyonServer implements ServerEngine, ExtensionContext {
         final var paramsStr = JsonRpcCodec.toJsonParams(params);
         final var requestId = RequestId.of(UUID.randomUUID().toString());
         final var future = new CompletableFuture<String>();
-        registerPendingRequest(requestId, future);
 
         final var requestJson = JsonRpcCodec.serializeRequestAsString(requestId, method, paramsStr);
         final var target = stream != null ? stream : outboundStreamResolver.resolve(session);
+        registerPendingRequest(requestId, session.id(), target, future);
         final var streamKey = target != null ? target.streamKey() : null;
         final var sseEventId = nextEventId();
 
@@ -693,43 +696,57 @@ final class DefaultTachyonServer implements ServerEngine, ExtensionContext {
     }
 
     @Override
-    public boolean completePendingRequest(@Nullable RequestId requestId, String resultJson) {
-        // ConcurrentHashMap#remove throws NPE on a null key; a null id (malformed client
-        // response, no JSON-RPC id) can never match a pending request, since registered ids are
-        // always server-generated and non-null.
-        if (requestId == null) {
-            return false;
-        }
-        var future = pendingRequests.remove(requestId);
-        if (future != null) {
-            future.complete(resultJson);
-            return true;
-        }
-        return false;
+    public boolean completePendingRequest(
+            @Nullable RequestId requestId, @Nullable String sessionId, @Nullable String channelId, String resultJson) {
+        var entry = removePendingRequest(requestId, sessionId, channelId);
+        return entry != null && entry.future().complete(resultJson);
     }
 
     @Override
-    public boolean failPendingRequest(@Nullable RequestId requestId, String message) {
+    public boolean failPendingRequest(
+            @Nullable RequestId requestId, @Nullable String sessionId, @Nullable String channelId, String message) {
+        var entry = removePendingRequest(requestId, sessionId, channelId);
+        return entry != null && entry.future().completeExceptionally(new RuntimeException(message));
+    }
+
+    private DefaultTachyonServer.@Nullable PendingRequestEntry removePendingRequest(
+            @Nullable RequestId requestId, @Nullable String sessionId, @Nullable String channelId) {
         if (requestId == null) {
-            return false;
+            return null;
         }
-        var future = pendingRequests.remove(requestId);
-        if (future != null) {
-            future.completeExceptionally(new RuntimeException(message));
-            return true;
+        var entry = pendingRequests.get(requestId);
+        if (entry == null) {
+            return null;
         }
-        return false;
+        var expectedOwner = isStateless() ? entry.channelId() : entry.sessionId();
+        var actualOwner = isStateless() ? channelId : sessionId;
+        var matches = expectedOwner != null && actualOwner != null && expectedOwner.equals(actualOwner);
+        if (!matches) {
+            logger.warn(
+                    "Pending request ownership mismatch: id={}, expectedSession={}, actualSession={}, expectedChannel={}, actualChannel={}",
+                    requestId,
+                    entry.sessionId(),
+                    sessionId,
+                    entry.channelId(),
+                    channelId);
+            return null;
+        }
+        return pendingRequests.remove(requestId, entry) ? entry : null;
     }
 
     @Override
-    public void registerPendingRequest(RequestId requestId, CompletableFuture<String> future) {
-        pendingRequests.put(requestId, future);
+    public void registerPendingRequest(
+            RequestId requestId,
+            @Nullable String sessionId,
+            @Nullable OutboundSseStream stream,
+            CompletableFuture<String> future) {
+        var entry = new PendingRequestEntry(sessionId, stream != null ? stream.channelId() : null, future);
+        pendingRequests.put(requestId, entry);
         var timeout = config.runtime().requestTimeout();
         future.orTimeout(timeout.toMillis(), TimeUnit.MILLISECONDS);
         future.whenComplete((res, ex) -> {
             if (ex instanceof TimeoutException) {
-                var removed = pendingRequests.remove(requestId);
-                if (removed != null) {
+                if (pendingRequests.remove(requestId, entry)) {
                     logger.debug(
                             "Pending request timed out after {}s: id={}, pendingCount={}",
                             timeout.toSeconds(),

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/McpDispatcher.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/McpDispatcher.java
@@ -376,20 +376,14 @@ public class McpDispatcher {
                 .ifPresentOrElse(
                         session -> {
                             var reasonMsg = cancellation.reason() != null ? ": " + cancellation.reason() : "";
-                            var cancelled =
-                                    server.failPendingRequest(cancellation.requestId(), "Cancelled" + reasonMsg);
-                            if (cancelled) {
-                                logger.debug(
-                                        "Cancelled pending request: requestId={}, sessionId={}, reason={}",
-                                        cancellation.requestId(),
-                                        sessionId,
-                                        cancellation.reason());
-                            } else {
-                                logger.debug(
-                                        "No pending request found for cancellation: requestId={}, sessionId={}",
-                                        cancellation.requestId(),
-                                        sessionId);
-                            }
+                            var cancelled = server.failPendingRequest(
+                                    cancellation.requestId(), sessionId, null, "Cancelled" + reasonMsg);
+                            logger.debug(
+                                    "Cancellation received: requestId={}, sessionId={}, reason={}, pending={}",
+                                    cancellation.requestId(),
+                                    sessionId,
+                                    cancellation.reason(),
+                                    cancelled);
                             server.appendEvent(new SessionEvent.CancelEvent(
                                     sessionId, cancellation.requestId(), System.currentTimeMillis()));
                         },

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/OutboundSseStream.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/OutboundSseStream.java
@@ -22,6 +22,14 @@ import org.jspecify.annotations.Nullable;
 public interface OutboundSseStream {
 
     /**
+     * Returns the transport-channel identity backing this stream, or {@code null} when the
+     * transport has no channel identity.
+     */
+    default @Nullable String channelId() {
+        return null;
+    }
+
+    /**
      * A stable key identifying this stream within its session, used to tag event-log entries and
      * to suffix SSE event ids ({@code <n>#<key>}) so a {@code Last-Event-ID} can be correlated
      * back to the originating stream for per-stream replay. {@code null} identifies the session's

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/internal/ServerEngine.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/internal/ServerEngine.java
@@ -106,14 +106,30 @@ public interface ServerEngine extends TachyonServer {
     CompletableFuture<String> sendRequest(
             Session session, String method, Object params, @Nullable OutboundSseStream stream);
 
-    /** Completes a pending client request with the given result JSON. {@code null} requestId is a no-op. */
-    boolean completePendingRequest(@Nullable RequestId requestId, String resultJson);
+    /**
+     * Completes a pending server-to-client request when {@code sessionId} owns it in stateful mode
+     * or {@code channelId} owns it in stateless mode. Missing or mismatched ownership is ignored.
+     *
+     * @return {@code true} when the matching pending request was completed
+     */
+    boolean completePendingRequest(
+            @Nullable RequestId requestId, @Nullable String sessionId, @Nullable String channelId, String resultJson);
 
-    /** Fails a pending client request with the given error message. {@code null} requestId is a no-op. */
-    boolean failPendingRequest(@Nullable RequestId requestId, String message);
+    /**
+     * Fails a pending server-to-client request when {@code sessionId} owns it in stateful mode or
+     * {@code channelId} owns it in stateless mode. Missing or mismatched ownership is ignored.
+     *
+     * @return {@code true} when the matching pending request was failed
+     */
+    boolean failPendingRequest(
+            @Nullable RequestId requestId, @Nullable String sessionId, @Nullable String channelId, String message);
 
-    /** Registers a pending request with a timeout. */
-    void registerPendingRequest(RequestId requestId, CompletableFuture<String> future);
+    /** Registers a pending request with its stateful session or stateless transport owner. */
+    void registerPendingRequest(
+            RequestId requestId,
+            @Nullable String sessionId,
+            @Nullable OutboundSseStream stream,
+            CompletableFuture<String> future);
 
     /** Appends an event to the session log. */
     void appendEvent(SessionEvent event);

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/transport/netty/McpOperationHandler.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/transport/netty/McpOperationHandler.java
@@ -168,8 +168,10 @@ public class McpOperationHandler extends ChannelInboundHandlerAdapter {
         }
         switch (message) {
             case JsonRpcMessage.Request<?> reqMsg -> handlePostRequest(ctx, sessionId, reqMsg, origin);
-            case JsonRpcMessage.Response resp -> handlePostResponse(ctx, resp, origin);
-            case JsonRpcMessage.Error err -> handlePostError(ctx, err, origin);
+            case JsonRpcMessage.Response resp ->
+                handlePostResponse(ctx, sessionId, ctx.channel().id().asLongText(), resp, origin);
+            case JsonRpcMessage.Error err ->
+                handlePostError(ctx, sessionId, ctx.channel().id().asLongText(), err, origin);
             case JsonRpcMessage.Notification<?> not -> {
                 var channelContext = ChannelHandlerUtils.getInteractionContext(ctx);
                 if (McpDispatcher.NOTIFICATIONS_INITIALIZED.equals(not.method())) {
@@ -203,20 +205,30 @@ public class McpOperationHandler extends ChannelInboundHandlerAdapter {
         }
     }
 
-    private void handlePostResponse(ChannelHandlerContext ctx, JsonRpcMessage.Response resp, @Nullable String origin) {
+    private void handlePostResponse(
+            ChannelHandlerContext ctx,
+            @Nullable String sessionId,
+            String channelId,
+            JsonRpcMessage.Response resp,
+            @Nullable String origin) {
         ctx.executor().execute(() -> sendAccepted(ctx, origin));
         executor.execute(() -> {
-            if (!server.completePendingRequest(resp.id(), resp.resultJson())) {
-                logger.warn("No pending request for response id: {}", resp.id());
+            if (!server.completePendingRequest(resp.id(), sessionId, channelId, resp.resultJson())) {
+                logger.debug("No matching pending request for response id: {}", resp.id());
             }
         });
     }
 
-    private void handlePostError(ChannelHandlerContext ctx, JsonRpcMessage.Error err, @Nullable String origin) {
+    private void handlePostError(
+            ChannelHandlerContext ctx,
+            @Nullable String sessionId,
+            String channelId,
+            JsonRpcMessage.Error err,
+            @Nullable String origin) {
         ctx.executor().execute(() -> sendAccepted(ctx, origin));
         executor.execute(() -> {
-            if (!server.failPendingRequest(err.id(), err.code() + ": " + err.message())) {
-                logger.warn("No pending request for error id: {}", err.id());
+            if (!server.failPendingRequest(err.id(), sessionId, channelId, err.code() + ": " + err.message())) {
+                logger.debug("No matching pending request for error id: {}", err.id());
             }
         });
     }

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/transport/netty/sse/PostSseStream.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/transport/netty/sse/PostSseStream.java
@@ -72,6 +72,11 @@ public final class PostSseStream implements OutboundSseStream {
     }
 
     @Override
+    public String channelId() {
+        return channel.id().asLongText();
+    }
+
+    @Override
     public String streamKey() {
         return streamKey;
     }

--- a/tachyon-core/src/test/java/dev/tachyonmcp/core/server/McpDispatcherTest.java
+++ b/tachyon-core/src/test/java/dev/tachyonmcp/core/server/McpDispatcherTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import dev.tachyonmcp.api.server.domain.RequestId;
 import dev.tachyonmcp.core.server.internal.ServerEngine;
+import dev.tachyonmcp.core.server.session.SessionEvent;
 import java.util.Map;
 import java.util.function.Consumer;
 import org.junit.jupiter.api.Test;
@@ -106,22 +107,29 @@ class McpDispatcherTest {
     }
 
     @Test
-    void cancelsPendingRequestWithMatchingId() {
+    void cancellationFromAnotherSessionDoesNotFailPendingRequest() {
         try (ServerEngine server = (ServerEngine)
                 TachyonServer.builder().session(s -> s.enabled(true)).build()) {
-            var session = server.createSession("sess_cancel-pending");
-            session.activate();
+            var owner = server.createSession("sess_cancel-owner");
+            owner.activate();
+            var other = server.createSession("sess_cancel-other");
+            other.activate();
             var dispatcher = new McpDispatcher(server, server.executor());
 
-            var requestId = "test-req-1";
-            var pending = new java.util.concurrent.CompletableFuture<String>();
-            server.registerPendingRequest(RequestId.of(requestId), pending);
+            var pending = server.sendRequest(owner, "sampling/createMessage", Map.of());
+            var requestId = server.replay(owner.id(), -1).stream()
+                    .filter(SessionEvent.OutboundRequestEvent.class::isInstance)
+                    .map(SessionEvent.OutboundRequestEvent.class::cast)
+                    .map(SessionEvent.OutboundRequestEvent::requestId)
+                    .findFirst()
+                    .orElseThrow();
 
-            var params = Map.of("requestId", requestId, "reason", "User cancelled");
-            var result = dispatcher.dispatchNotification("notifications/cancelled", params, "sess_cancel-pending");
+            var params = Map.of("requestId", requestId.toString(), "reason", "User cancelled");
+            var result = dispatcher.dispatchNotification("notifications/cancelled", params, other.id());
             assertThat(result).isInstanceOf(McpDispatcher.DispatchResult.Accepted.class);
-            assertThat(pending).isCompletedExceptionally();
-            assertThat(pending.exceptionNow().getMessage()).contains("Cancelled: User cancelled");
+            assertThat(pending).isNotDone();
+            assertThat(server.completePendingRequest(requestId, owner.id(), null, "{}"))
+                    .isTrue();
         }
     }
 

--- a/tachyon-core/src/test/java/dev/tachyonmcp/core/server/ServerTest.java
+++ b/tachyon-core/src/test/java/dev/tachyonmcp/core/server/ServerTest.java
@@ -15,14 +15,20 @@ import dev.tachyonmcp.core.runtime.SseConnection;
 import dev.tachyonmcp.core.runtime.SseEvent;
 import dev.tachyonmcp.core.server.internal.ServerEngine;
 import dev.tachyonmcp.core.server.session.SessionEvent;
+import dev.tachyonmcp.core.transport.netty.sse.PostSseStream;
+import io.netty.channel.embedded.EmbeddedChannel;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class ServerTest {
 
@@ -138,6 +144,51 @@ class ServerTest {
             assertThat(outbound).hasSize(1);
             assertThat(outbound.getFirst().method()).isEqualTo("sampling/createMessage");
             assertThat(outbound.getFirst().sseEventId()).isGreaterThan(0L);
+        }
+    }
+
+    @Test
+    void statelessPendingRequestIsBoundToOutboundChannel() {
+        try (DefaultTachyonServer server =
+                (DefaultTachyonServer) TachyonServer.builder().build()) {
+            var channel = new EmbeddedChannel();
+            try {
+                var session = server.createSession("stateless-request");
+                session.activate();
+                var stream = new PostSseStream(channel, null, server::nextEventId, Duration.ofSeconds(30));
+                var pending = server.sendRequest(session, "sampling/createMessage", Map.of(), stream);
+                var requestId = server.replay(session.id(), -1).stream()
+                        .filter(SessionEvent.OutboundRequestEvent.class::isInstance)
+                        .map(SessionEvent.OutboundRequestEvent.class::cast)
+                        .map(SessionEvent.OutboundRequestEvent::requestId)
+                        .findFirst()
+                        .orElseThrow();
+
+                assertThat(server.failPendingRequest(requestId, null, "other-channel", "Rejected"))
+                        .isFalse();
+                assertThat(pending).isNotDone();
+                assertThat(server.completePendingRequest(requestId, null, stream.channelId(), "{}"))
+                        .isTrue();
+                assertThat(pending).isCompletedWithValue("{}");
+            } finally {
+                channel.finishAndReleaseAll();
+            }
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    void pendingRequestRejectsMissingOwner(boolean sessionsEnabled) {
+        try (DefaultTachyonServer server = (DefaultTachyonServer) TachyonServer.builder()
+                .session(session -> session.enabled(sessionsEnabled))
+                .build()) {
+            var requestId = RequestId.of("missing-owner");
+            var pending = new CompletableFuture<String>();
+            server.registerPendingRequest(requestId, null, null, pending);
+
+            assertThat(server.completePendingRequest(requestId, null, null, "{}"))
+                    .isFalse();
+            assertThat(pending).isNotDone();
         }
     }
 

--- a/tachyon-core/src/test/java/dev/tachyonmcp/core/transport/netty/McpOperationHandlerTest.java
+++ b/tachyon-core/src/test/java/dev/tachyonmcp/core/transport/netty/McpOperationHandlerTest.java
@@ -3,9 +3,11 @@ package dev.tachyonmcp.core.transport.netty;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import dev.tachyonmcp.api.server.domain.RequestId;
 import dev.tachyonmcp.core.server.McpDispatcher;
 import dev.tachyonmcp.core.server.TachyonServer;
 import dev.tachyonmcp.core.server.internal.ServerEngine;
+import dev.tachyonmcp.core.server.session.SessionEvent;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.http.DefaultFullHttpRequest;
@@ -19,6 +21,7 @@ import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.timeout.IdleStateEvent;
 import io.netty.util.ReferenceCountUtil;
 import java.nio.charset.StandardCharsets;
+import java.util.Map;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -75,6 +78,43 @@ class McpOperationHandlerTest {
         var response = readResponse();
         assertThat(response.status()).isEqualTo(HttpResponseStatus.ACCEPTED);
         response.release();
+    }
+
+    @Test
+    void responseCannotCompleteRequestOwnedByAnotherSession() {
+        // MCP 2025-11-25 Streamable HTTP session ownership.
+        var owner = server.createSession("sess-response-owner");
+        owner.activate();
+        server.createSession("sess-response-other").activate();
+        var pending = server.sendRequest(owner, "sampling/createMessage", Map.of());
+        var requestId = outboundRequestId(owner.id());
+        var body = """
+                {"jsonrpc":"2.0","id":"%s","result":{"answer":42}}""".formatted(requestId);
+
+        assertAccepted(postJsonRpc("sess-response-other", body));
+        assertThat(pending).isNotDone();
+
+        assertAccepted(postJsonRpc(owner.id(), body));
+        assertThat(pending).isCompletedWithValue("{\"answer\":42}");
+    }
+
+    @Test
+    void errorCannotFailRequestOwnedByAnotherSession() {
+        // MCP 2025-11-25 Streamable HTTP session ownership.
+        var owner = server.createSession("sess-error-owner");
+        owner.activate();
+        server.createSession("sess-error-other").activate();
+        var pending = server.sendRequest(owner, "elicitation/create", Map.of());
+        var requestId = outboundRequestId(owner.id());
+        var body = """
+                {"jsonrpc":"2.0","id":"%s","error":{"code":-32000,"message":"Rejected"}}""".formatted(requestId);
+
+        assertAccepted(postJsonRpc("sess-error-other", body));
+        assertThat(pending).isNotDone();
+
+        assertAccepted(postJsonRpc(owner.id(), body));
+        assertThat(pending).isCompletedExceptionally();
+        assertThat(pending.exceptionNow()).hasMessage("-32000: Rejected");
     }
 
     @Test
@@ -233,6 +273,34 @@ class McpOperationHandlerTest {
             request.headers().set(HttpHeaderNames.ORIGIN, origin);
         }
         channel.writeInbound(request);
+    }
+
+    private FullHttpResponse postJsonRpc(String sessionId, String body) {
+        var request = new DefaultFullHttpRequest(
+                HttpVersion.HTTP_1_1, HttpMethod.POST, "/mcp", Unpooled.copiedBuffer(body, StandardCharsets.UTF_8));
+        request.headers()
+                .set(HttpHeaderNames.ORIGIN, "http://localhost:3000")
+                .set("MCP-Session-Id", sessionId)
+                .set(HttpHeaderNames.ACCEPT, "application/json, text/event-stream");
+        channel.writeInbound(request);
+        return readResponse();
+    }
+
+    private RequestId outboundRequestId(String sessionId) {
+        return server.replay(sessionId, -1).stream()
+                .filter(SessionEvent.OutboundRequestEvent.class::isInstance)
+                .map(SessionEvent.OutboundRequestEvent.class::cast)
+                .map(SessionEvent.OutboundRequestEvent::requestId)
+                .findFirst()
+                .orElseThrow();
+    }
+
+    private static void assertAccepted(FullHttpResponse response) {
+        try {
+            assertThat(response.status()).isEqualTo(HttpResponseStatus.ACCEPTED);
+        } finally {
+            response.release();
+        }
     }
 
     private FullHttpResponse readResponse() {


### PR DESCRIPTION
Bind completions and failures to the originating session or transport channel so another client cannot resolve a pending request.

BREAKING CHANGE: ServerEngine pending-request methods now require ownership context.


### Bug Fixes

- Improved pending-request handling by ensuring responses, failures, and cancellations are accepted only from the owning session or connection.
- Prevented unrelated sessions or channels from completing another session’s request.
- Improved timeout cleanup and reduced log noise for expected pending-request lookup failures.

### Tests

- Added coverage for cross-session cancellation and channel ownership validation.