### PR TITLE
fix(netty): require exact MCP endpoint path

### DIFF
--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/transport/netty/http/EndpointValidatorHandler.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/transport/netty/http/EndpointValidatorHandler.java
@@ -8,6 +8,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.util.ReferenceCountUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -23,7 +24,7 @@ public class EndpointValidatorHandler extends ChannelInboundHandlerAdapter {
     private final String mcpEndpoint;
 
     public EndpointValidatorHandler(String mcpEndpoint) {
-        this.mcpEndpoint = mcpEndpoint;
+        this.mcpEndpoint = normalizedPath(mcpEndpoint);
     }
 
     @Override
@@ -31,12 +32,19 @@ public class EndpointValidatorHandler extends ChannelInboundHandlerAdapter {
         if (msg instanceof HttpRequest req) {
             var uri = req.uri();
 
-            if (!uri.startsWith(mcpEndpoint)) {
+            if (!normalizedPath(uri).equals(mcpEndpoint)) {
                 LOGGER.warn("Unknown endpoint: {}", uri);
+                ReferenceCountUtil.release(msg);
                 sendPlainTextAndClose(ctx, HttpResponseStatus.NOT_FOUND, "Not Found");
                 return;
             }
         }
         ctx.fireChannelRead(msg);
+    }
+
+    private static String normalizedPath(String uri) {
+        var queryStart = uri.indexOf('?');
+        var path = queryStart < 0 ? uri : uri.substring(0, queryStart);
+        return path.length() > 1 && path.endsWith("/") ? path.substring(0, path.length() - 1) : path;
     }
 }

--- a/tachyon-core/src/test/java/dev/tachyonmcp/core/transport/netty/http/EndpointValidatorHandlerTest.java
+++ b/tachyon-core/src/test/java/dev/tachyonmcp/core/transport/netty/http/EndpointValidatorHandlerTest.java
@@ -1,0 +1,60 @@
+/* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
+package dev.tachyonmcp.core.transport.netty.http;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.http.DefaultFullHttpRequest;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpVersion;
+import io.netty.util.ReferenceCountUtil;
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class EndpointValidatorHandlerTest {
+
+    private @Nullable EmbeddedChannel channel;
+
+    @AfterEach
+    void releaseChannel() {
+        if (channel != null) {
+            channel.finishAndReleaseAll();
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"/mcp", "/mcp/", "/mcp?client=test", "/mcp/?client=test"})
+    void allowsNormalizedEndpoint(String uri) {
+        channel = new EmbeddedChannel(new EndpointValidatorHandler("/mcp/"));
+
+        assertThat(channel.writeInbound(request(uri))).isTrue();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"/mcp-evil", "/mcp/x/y"})
+    void rejectsEndpointPrefixes(String uri) {
+        channel = new EmbeddedChannel(new EndpointValidatorHandler("/mcp"));
+        var request = request(uri);
+
+        assertThat(channel.writeInbound(request)).isFalse();
+        assertThat(request.refCnt()).isZero();
+        assertThat(rejectionStatus(channel)).isEqualTo(HttpResponseStatus.NOT_FOUND);
+    }
+
+    private static DefaultFullHttpRequest request(String uri) {
+        return new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, uri);
+    }
+
+    private static @Nullable HttpResponseStatus rejectionStatus(EmbeddedChannel channel) {
+        Object out = channel.readOutbound();
+        try {
+            return out instanceof HttpResponse response ? response.status() : null;
+        } finally {
+            ReferenceCountUtil.release(out);
+        }
+    }
+}


### PR DESCRIPTION
Prefix matching routed sibling and descendant paths through MCP handlers. Normalize the query and trailing slash before exact comparison.