### PR TITLE
fix: advertise registered extensions

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -74,9 +74,9 @@ The older `.extension(ServerExtension)` still works but is deprecated.
 
 ## How negotiation works
 
-1. Client sends `initialize` with `"extensions": {"com.example/audit": {}}` in capabilities.
-2. Tachyon calls `onConnectionInit` for each negotiated extension.
-3. `serverSettings()` is returned to the client in `initialize` response under the extension key.
+1. Tachyon advertises every registered extension and its `serverSettings()` in the `initialize` response.
+2. The client sends `initialize` with the extensions it supports, such as `"extensions": {"com.example/audit": {}}`.
+3. Tachyon calls `onConnectionInit` for each extension declared by both client and server.
 4. Methods declared in `methods()` are only routed for sessions that negotiated the extension.
 
 ## Built-in: TasksExtension

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -10,6 +10,7 @@ internals.
 
 ```java
 import dev.tachyonmcp.api.runtime.InteractionContext;
+import dev.tachyonmcp.api.server.extensions.AdvertiseMode;
 import dev.tachyonmcp.api.server.extensions.ExtensionContext;
 import dev.tachyonmcp.api.server.extensions.ExtensionSettings;
 import dev.tachyonmcp.api.server.extensions.ServerExtension;
@@ -22,6 +23,11 @@ public class AuditExtension implements ServerExtension {
     @Override
     public String extensionId() {
         return "com.example/audit";  // reverse-DNS format
+    }
+
+    @Override
+    public AdvertiseMode advertiseMode() {
+        return AdvertiseMode.ALWAYS;
     }
 
     @Override
@@ -74,9 +80,13 @@ The older `.extension(ServerExtension)` still works but is deprecated.
 
 ## How negotiation works
 
-1. Tachyon advertises every registered extension and its `serverSettings()` in the `initialize` response.
+1. Tachyon advertises every registered extension whose `advertiseMode()` is `AdvertiseMode.ALWAYS`, along with its
+   `serverSettings()`, in the `initialize` response. Extensions with `AdvertiseMode.NEVER` are omitted from
+   `capabilities.extensions` — useful for internal-only extensions, e.g. `tachyon-kotlin`'s coroutine runtime
+   (`dev.tachyonmcp/kotlin-coroutines`), that clients aren't expected to know about or negotiate directly.
 2. The client sends `initialize` with the extensions it supports, such as `"extensions": {"com.example/audit": {}}`.
-3. Tachyon calls `onConnectionInit` for each extension declared by both client and server.
+3. Tachyon calls `onConnectionInit` for each extension declared by both client and server — this still works for
+   `NEVER`-mode extensions if a client already knows the ID, since hiding only affects advertisement, not negotiation.
 4. Methods declared in `methods()` are only routed for sessions that negotiated the extension.
 
 ## Built-in: TasksExtension

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/ExtensionsTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/ExtensionsTest.java
@@ -4,6 +4,7 @@ package dev.tachyonmcp.e2e;
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import dev.tachyonmcp.api.server.extensions.AdvertiseMode;
 import dev.tachyonmcp.api.server.extensions.ExtensionContext;
 import dev.tachyonmcp.api.server.extensions.ExtensionSettings;
 import dev.tachyonmcp.api.server.extensions.ServerExtension;
@@ -21,10 +22,11 @@ import tools.jackson.databind.node.JsonNodeFactory;
 class ExtensionsTest extends AbstractStatefulMcpE2eTest {
 
     private static final String TEST_EXT_ID = "com.example/test";
+    private static final String INTERNAL_EXT_ID = "com.example/internal";
 
     @Test
     void serverAdvertisesExtensionInCapabilities() throws Exception {
-        startServer(it -> it.extension(new TestExtension()));
+        startServer(it -> it.withExtensions(new TestExtension()));
 
         try (var client = createTestClient()) {
             // Send initialize with matching extension
@@ -41,7 +43,7 @@ class ExtensionsTest extends AbstractStatefulMcpE2eTest {
 
     @Test
     void extensionAdvertisedWhenClientDoesNotDeclare() throws Exception {
-        startServer(it -> it.extension(new TestExtension()));
+        startServer(it -> it.withExtensions(new TestExtension()));
 
         try (var client = createTestClient()) {
             var initBody = buildInitializeJson(Map.of());
@@ -62,8 +64,50 @@ class ExtensionsTest extends AbstractStatefulMcpE2eTest {
     }
 
     @Test
+    void extensionNotAdvertisedWhenAdvertiseModeIsNever() throws Exception {
+        startServer(it -> it.withExtensions(new TestExtension(), new NeverAdvertisedTestExtension()));
+
+        try (var client = createTestClient()) {
+            var initBody = buildInitializeJson(Map.of());
+            var response = client.post(null, initBody);
+            assertThatJson(response.body())
+                    .inPath("$.result.capabilities.extensions")
+                    // language=JSON
+                    .isEqualTo("""
+                    {"com.example/test": {"version": "1.0"}}
+                    """);
+        }
+    }
+
+    @Test
+    void neverAdvertisedExtensionMethodStillWorksWhenNegotiated() throws Exception {
+        startServer(it -> it.withExtensions(new NeverAdvertisedTestExtension()));
+
+        try (var client = createTestClient()) {
+            var initBody = buildInitializeJson(Map.of(INTERNAL_EXT_ID, JsonNodeFactory.instance.objectNode()));
+            var response = client.post(null, initBody);
+            var sessionId = response.headers().firstValue("MCP-Session-Id").orElseThrow();
+            client.sendInitialized(sessionId);
+
+            // language=JSON
+            var call = """
+                {"jsonrpc":"2.0","id":2,"method":"internal/hello","params":{"_meta":{"com.example/internal":{}}}}
+                """;
+            var callResp = client.post(sessionId, call);
+            // language=JSON
+            assertThatJson(callResp.body()).isEqualTo("""
+                {
+                  "jsonrpc": "2.0",
+                  "id": 2,
+                  "result": {"message": "Hi!"}
+                }
+                """);
+        }
+    }
+
+    @Test
     void extensionEnabledWhenClientDeclaresIt() throws Exception {
-        startServer(it -> it.extension(new TestExtension()));
+        startServer(it -> it.withExtensions(new TestExtension()));
 
         try (var client = createTestClient()) {
             var initBody = buildInitializeJson(Map.of(TEST_EXT_ID, JsonNodeFactory.instance.objectNode()));
@@ -79,7 +123,7 @@ class ExtensionsTest extends AbstractStatefulMcpE2eTest {
 
     @Test
     void extensionMethodRequiresMetaEnvelope() throws Exception {
-        startServer(it -> it.extension(new TestExtension()));
+        startServer(it -> it.withExtensions(new TestExtension()));
 
         try (var client = createTestClient()) {
             var initBody = buildInitializeJson(Map.of(TEST_EXT_ID, JsonNodeFactory.instance.objectNode()));
@@ -114,7 +158,7 @@ class ExtensionsTest extends AbstractStatefulMcpE2eTest {
 
     @Test
     void extensionToolInvisibleWhenNotNegotiated() throws Exception {
-        startServer(it -> it.extension(new TestExtensionWithTool()));
+        startServer(it -> it.withExtensions(new TestExtensionWithTool()));
 
         try (var client = createTestClient()) {
             var response = client.post(null, buildInitializeJson(Map.of()));
@@ -144,7 +188,7 @@ class ExtensionsTest extends AbstractStatefulMcpE2eTest {
 
     @Test
     void extensionToolVisibleAndCallableWhenNegotiated() throws Exception {
-        startServer(it -> it.extension(new TestExtensionWithTool()));
+        startServer(it -> it.withExtensions(new TestExtensionWithTool()));
 
         try (var client = createTestClient()) {
             var response =
@@ -207,6 +251,11 @@ class ExtensionsTest extends AbstractStatefulMcpE2eTest {
         }
 
         @Override
+        public AdvertiseMode advertiseMode() {
+            return AdvertiseMode.ALWAYS;
+        }
+
+        @Override
         public Set<String> methods() {
             return Set.of("test/ext-call");
         }
@@ -222,11 +271,39 @@ class ExtensionsTest extends AbstractStatefulMcpE2eTest {
         }
     }
 
+    private static class NeverAdvertisedTestExtension implements ServerExtension {
+
+        @Override
+        public String extensionId() {
+            return INTERNAL_EXT_ID;
+        }
+
+        @Override
+        public AdvertiseMode advertiseMode() {
+            return AdvertiseMode.NEVER;
+        }
+
+        @Override
+        public Set<String> methods() {
+            return Set.of("internal/hello");
+        }
+
+        @Override
+        public void bootstrap(ExtensionContext context) {
+            context.registerHandler("internal/hello", (interaction, params) -> Map.of("message", "Hi!"));
+        }
+    }
+
     private static class TestExtensionWithTool implements ServerExtension {
 
         @Override
         public String extensionId() {
             return TEST_EXT_ID;
+        }
+
+        @Override
+        public AdvertiseMode advertiseMode() {
+            return AdvertiseMode.ALWAYS;
         }
 
         @Override

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/ExtensionsTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/ExtensionsTest.java
@@ -40,15 +40,24 @@ class ExtensionsTest extends AbstractStatefulMcpE2eTest {
     }
 
     @Test
-    void extensionNotAdvertisedWhenClientDoesNotDeclare() throws Exception {
+    void extensionAdvertisedWhenClientDoesNotDeclare() throws Exception {
         startServer(it -> it.extension(new TestExtension()));
 
         try (var client = createTestClient()) {
             var initBody = buildInitializeJson(Map.of());
             var response = client.post(null, initBody);
             assertThatJson(response.body())
-                    .node("result.capabilities.extensions")
-                    .isAbsent();
+                    .when(Option.IGNORING_EXTRA_FIELDS)
+                    // language=JSON
+                    .isEqualTo("""
+                            {
+                              "result": {
+                                "capabilities": {
+                                  "extensions": {"com.example/test": {"version": "1.0"}}
+                                }
+                              }
+                            }
+                            """);
         }
     }
 

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp20260728/ExtensionNegotiationTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp20260728/ExtensionNegotiationTest.java
@@ -4,6 +4,7 @@ package dev.tachyonmcp.e2e.mcp20260728;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import dev.tachyonmcp.api.runtime.InteractionContext;
+import dev.tachyonmcp.api.server.extensions.AdvertiseMode;
 import dev.tachyonmcp.api.server.extensions.ExtensionSettings;
 import dev.tachyonmcp.api.server.extensions.ServerExtension;
 import dev.tachyonmcp.e2e.AbstractStatelessMcpE2eTest;
@@ -63,6 +64,11 @@ class ExtensionNegotiationTest extends AbstractStatelessMcpE2eTest {
         @Override
         public String extensionId() {
             return EXT_ID;
+        }
+
+        @Override
+        public AdvertiseMode advertiseMode() {
+            return AdvertiseMode.ALWAYS;
         }
 
         @Override

--- a/examples/echo-kotlin/src/test/kotlin/com/example/echo/EchoServerTest.kt
+++ b/examples/echo-kotlin/src/test/kotlin/com/example/echo/EchoServerTest.kt
@@ -15,7 +15,6 @@ import org.junit.jupiter.api.TestInstance
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class EchoServerTest {
-
     private lateinit var server: TachyonServer
 
     private lateinit var client: McpClient
@@ -46,16 +45,18 @@ class EchoServerTest {
         val sessionId = client.initialize()
 
         // language=json
-        val response = client.post(
-            sessionId,
-            """
-                    {"jsonrpc":"2.0","id":1,"method":"tools/list"}
-                    """.trimIndent(),
-        )
+        val response =
+            client.post(
+                sessionId,
+                """
+                {"jsonrpc":"2.0","id":1,"method":"tools/list"}
+                """.trimIndent(),
+            )
 
         val json = response.body()
-        json shouldEqualJson """
-                {"jsonrpc":"2.0","id":1,"result":{"tools":[
+        json shouldEqualJson
+            """
+            {"jsonrpc":"2.0","id":1,"result":{"tools":[
                 {
                   "name":"echo",
                   "description":"Echo message",
@@ -81,7 +82,7 @@ class EchoServerTest {
                   }
                 }
                           ]}}
-                """.trimIndent()
+            """.trimIndent()
     }
 
     @Test
@@ -89,17 +90,19 @@ class EchoServerTest {
         val sessionId = client.initialize()
 
         // language=json
-        val response = client.post(
-            sessionId,
-            """
-                    {"jsonrpc":"2.0","id":1,"method":"tools/call",
+        val response =
+            client.post(
+                sessionId,
+                """
+                {"jsonrpc":"2.0","id":1,"method":"tools/call",
                      "params":{"name":"echo","arguments":{"message":"Hello, MCP!"}}}
-                    """.trimIndent(),
-        )
+                """.trimIndent(),
+            )
 
         val json = response.body()
-        json shouldEqualJson """
-                {
+        json shouldEqualJson
+            """
+            {
                   "jsonrpc": "2.0",
                   "id": 1,
                   "result": {
@@ -122,14 +125,19 @@ class EchoServerTest {
         val response = client.post(
             sessionId,
             """
-                    {"jsonrpc":"2.0","id":1,"method":"tools/call",
-                     "params":{"name":"reverse-echo","arguments":{"message":"stressed"}}}
-                    """.trimIndent(),
+            {
+                "jsonrpc":"2.0",
+                "id":1,
+                "method":"tools/call",
+                "params":{"name":"reverse-echo","arguments":{"message":"stressed"}}
+            }
+            """.trimIndent(),
         )
 
         val json = response.body()
-        json shouldEqualJson """
-                {
+        json shouldEqualJson
+            """
+            {
                   "jsonrpc": "2.0",
                   "id": 1,
                   "result": {
@@ -157,8 +165,9 @@ class EchoServerTest {
                     """.trimIndent(),
         )
 
-        response.body() shouldEqualJson """
-                {
+        response.body() shouldEqualJson
+            """
+            {
                   "jsonrpc": "2.0",
                   "id": 1,
                   "error": {
@@ -166,29 +175,31 @@ class EchoServerTest {
                     "message": "required property 'message' not found"
                   }
                 }
-                """.trimIndent()
+            """.trimIndent()
     }
 
     @Test
     fun `should respond to initialize`() {
         // language=json
-        val response = client.post(
-            null,
-            """
-                    {"jsonrpc":"2.0",
+        val response =
+            client.post(
+                null,
+                """
+                {"jsonrpc":"2.0",
                       "id":1,
                       "method":"initialize",
                       "params":{"protocolVersion":"2025-11-25","capabilities":{},
                                "clientInfo":{"name":"test","version":"1.0"}}}
-                    """.trimIndent(),
-        )
+                """.trimIndent(),
+            )
 
-        response.body() shouldEqualJson """
+        response.body() shouldEqualJson
+            """
                 {
                   "jsonrpc": "2.0",
                   "id": 1,
                   "result": {
-                    "protocolVersion": "2025-11-25",
+            "protocolVersion": "2025-11-25",
                     "capabilities": {
                       "tools": {}
                     },
@@ -200,6 +211,6 @@ class EchoServerTest {
                     }
                   }
                 }
-                """.trimIndent()
+            """.trimIndent()
     }
 }

--- a/tachyon-api/src/main/java/dev/tachyonmcp/api/server/extensions/AdvertiseMode.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/api/server/extensions/AdvertiseMode.java
@@ -1,0 +1,19 @@
+/* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
+package dev.tachyonmcp.api.server.extensions;
+
+/**
+ * Controls whether a {@link ServerExtension} is listed in the {@code initialize} response's
+ * {@code capabilities.extensions}.
+ */
+public enum AdvertiseMode {
+    /** Always listed in {@code capabilities.extensions}. */
+    ALWAYS,
+
+    /**
+     * Never listed in {@code capabilities.extensions}. The extension is still registered and
+     * fully usable — a client that already knows its ID can still negotiate it and call its
+     * methods — this only hides it from capability discovery, e.g. for internal-only extensions
+     * clients aren't expected to know about.
+     */
+    NEVER
+}

--- a/tachyon-api/src/main/java/dev/tachyonmcp/api/server/extensions/ServerExtension.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/api/server/extensions/ServerExtension.java
@@ -14,6 +14,9 @@ public interface ServerExtension extends Extension<InteractionContext> {
         return ExtensionSettings.empty();
     }
 
+    /** Controls whether this extension is listed in the {@code initialize} response. See {@link AdvertiseMode}. */
+    AdvertiseMode advertiseMode();
+
     /** Returns the set of JSON-RPC methods this extension handles. */
     default Set<String> methods() {
         return Set.of();

--- a/tachyon-core/revapi.json
+++ b/tachyon-core/revapi.json
@@ -673,6 +673,24 @@
           "attachments": {
             "since": "1.0.0-beta.19"
           }
+        },
+        {
+          "ignore": true,
+          "code": "java.method.removed",
+          "old": "method java.util.Map<java.lang.String, dev.tachyonmcp.api.json.JsonObject> dev.tachyonmcp.core.server.domain.InitializeResponse::negotiatedExtensions()",
+          "justification": "Advertise all server extensions",
+          "attachments": {
+            "since": "1.0.0-beta.20"
+          }
+        },
+        {
+          "ignore": true,
+          "code": "java.method.removed",
+          "old": "method java.util.Map<java.lang.String, dev.tachyonmcp.api.json.JsonObject> dev.tachyonmcp.core.server.handlers.ExtensionNegotiator::negotiatedExtensions(dev.tachyonmcp.core.runtime.ChannelContext)",
+          "justification": "Advertise all server extensions",
+          "attachments": {
+            "since": "1.0.0-beta.20"
+          }
         }
       ]
     }

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/mcp/v2025_11_25/codecs/McpResponseMapper.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/mcp/v2025_11_25/codecs/McpResponseMapper.java
@@ -107,9 +107,9 @@ public class McpResponseMapper implements ProtocolResponseMapper {
     @Override
     public Object initializeResult(InitializeResponse response) {
         var capsBuilder = ServerInfoMapper.toServerCapabilities(response.capabilities());
-        if (response.negotiatedExtensions() != null
-                && !response.negotiatedExtensions().isEmpty()) {
-            capsBuilder.extensions(response.negotiatedExtensions().entrySet().stream()
+        if (response.registeredExtensions() != null
+                && !response.registeredExtensions().isEmpty()) {
+            capsBuilder.extensions(response.registeredExtensions().entrySet().stream()
                     .collect(java.util.stream.Collectors.toMap(
                             Map.Entry::getKey, entry -> JsonUtils.parse(entry.getValue()))));
         }

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/domain/InitializeResponse.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/domain/InitializeResponse.java
@@ -14,11 +14,11 @@ import org.jspecify.annotations.Nullable;
  * @param capabilities         the server's capabilities
  * @param serverIdentity       server identity metadata
  * @param instructions         optional server-level instructions for the client
- * @param negotiatedExtensions extension-specific negotiated data
+ * @param registeredExtensions every registered extension's server settings
  */
 public record InitializeResponse(
         String protocolVersion,
         ServerCapabilities capabilities,
         ServerIdentity serverIdentity,
         @Nullable String instructions,
-        @Nullable Map<String, JsonObject> negotiatedExtensions) {}
+        @Nullable Map<String, JsonObject> registeredExtensions) {}

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/features/tasks/TasksExtension.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/features/tasks/TasksExtension.java
@@ -5,6 +5,7 @@ import dev.tachyonmcp.api.json.JsonSchema;
 import dev.tachyonmcp.api.runtime.InteractionContext;
 import dev.tachyonmcp.api.server.domain.ServerError;
 import dev.tachyonmcp.api.server.domain.TextResourceContents;
+import dev.tachyonmcp.api.server.extensions.AdvertiseMode;
 import dev.tachyonmcp.api.server.extensions.ExtensionContext;
 import dev.tachyonmcp.api.server.extensions.ServerExtension;
 import dev.tachyonmcp.api.server.features.resources.ResourceTemplateDescriptor;
@@ -70,6 +71,11 @@ public class TasksExtension implements ServerExtension {
     @Override
     public String extensionId() {
         return ID;
+    }
+
+    @Override
+    public AdvertiseMode advertiseMode() {
+        return AdvertiseMode.ALWAYS;
     }
 
     /**

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/handlers/ExtensionNegotiator.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/handlers/ExtensionNegotiator.java
@@ -3,6 +3,7 @@ package dev.tachyonmcp.core.server.handlers;
 
 import dev.tachyonmcp.api.json.JsonObject;
 import dev.tachyonmcp.api.runtime.Extension;
+import dev.tachyonmcp.api.server.extensions.AdvertiseMode;
 import dev.tachyonmcp.api.server.extensions.ExtensionSettings;
 import dev.tachyonmcp.api.server.extensions.ServerExtension;
 import dev.tachyonmcp.core.runtime.ChannelContext;
@@ -42,9 +43,10 @@ public final class ExtensionNegotiator {
         }
     }
 
-    /** Returns every registered extension and its server settings for capability advertisement. */
+    /** Returns every {@code ALWAYS}-mode registered extension and its server settings for capability advertisement. */
     public Map<String, JsonObject> registeredExtensions() {
         return extensions.stream()
+                .filter(e -> e.advertiseMode() == AdvertiseMode.ALWAYS)
                 .collect(Collectors.toMap(
                         Extension::extensionId, e -> e.serverSettings().values()));
     }

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/handlers/ExtensionNegotiator.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/handlers/ExtensionNegotiator.java
@@ -21,8 +21,7 @@ import java.util.stream.Collectors;
  * <p>Shared by 2025-11-25's {@link InitializeHandler} (declared once via {@code initialize}, matches
  * {@link dev.tachyonmcp.core.protocol.ProtocolRequestMapper.InitializeRequest#extensions()}) and
  * 2026-07-28's {@code ExtensionNegotiationHandler} (declared per request, matches {@link
- * dev.tachyonmcp.core.protocol.ProtocolRequestMapper#declaredExtensions}) — both produce the same
- * {@code Map<String, JsonObject>} shape.
+ * dev.tachyonmcp.core.protocol.ProtocolRequestMapper#declaredExtensions}).
  */
 public final class ExtensionNegotiator {
 
@@ -43,10 +42,9 @@ public final class ExtensionNegotiator {
         }
     }
 
-    /** Returns the currently-enabled subset of registered extensions, for echoing back in a response. */
-    public Map<String, JsonObject> negotiatedExtensions(ChannelContext context) {
+    /** Returns every registered extension and its server settings for capability advertisement. */
+    public Map<String, JsonObject> registeredExtensions() {
         return extensions.stream()
-                .filter(e -> context.isExtensionEnabled(e.extensionId()))
                 .collect(Collectors.toMap(
                         Extension::extensionId, e -> e.serverSettings().values()));
     }

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/handlers/InitializeHandler.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/handlers/InitializeHandler.java
@@ -43,7 +43,7 @@ public final class InitializeHandler implements RpcMethodHandler {
         var capabilities = server.resolveCapabilities();
 
         negotiator.negotiate(context, initializeRequest.extensions());
-        var negotiatedExtensions = negotiator.negotiatedExtensions(context);
+        var registeredExtensions = negotiator.registeredExtensions();
 
         final var serverConfig = server.config();
         var domainResponse = new InitializeResponse(
@@ -51,7 +51,7 @@ public final class InitializeHandler implements RpcMethodHandler {
                 capabilities,
                 serverConfig.identity(),
                 serverConfig.identity().instructions(),
-                negotiatedExtensions.isEmpty() ? null : negotiatedExtensions);
+                registeredExtensions.isEmpty() ? null : registeredExtensions);
 
         return context.responseMapper().initializeResult(domainResponse);
     }

--- a/tachyon-core/src/test/java/dev/tachyonmcp/core/server/ServerBuilderTest.java
+++ b/tachyon-core/src/test/java/dev/tachyonmcp/core/server/ServerBuilderTest.java
@@ -8,6 +8,7 @@ import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 import dev.tachyonmcp.api.server.domain.PromptMessage;
 import dev.tachyonmcp.api.server.domain.TextResourceContents;
 import dev.tachyonmcp.api.server.domain.UriTemplateValue;
+import dev.tachyonmcp.api.server.extensions.AdvertiseMode;
 import dev.tachyonmcp.api.server.extensions.ServerExtension;
 import dev.tachyonmcp.api.server.features.completions.AsyncCompletionFn;
 import dev.tachyonmcp.api.server.features.completions.CompletionFn;
@@ -216,6 +217,11 @@ class ServerBuilderTest {
         @Override
         public String extensionId() {
             return id;
+        }
+
+        @Override
+        public AdvertiseMode advertiseMode() {
+            return AdvertiseMode.ALWAYS;
         }
     }
 }

--- a/tachyon-core/src/test/java/dev/tachyonmcp/core/server/handlers/ExtensionNegotiationTest.java
+++ b/tachyon-core/src/test/java/dev/tachyonmcp/core/server/handlers/ExtensionNegotiationTest.java
@@ -5,6 +5,7 @@ import static dev.tachyonmcp.core.test.TestUtils.newEngine;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import dev.tachyonmcp.api.runtime.InteractionContext;
+import dev.tachyonmcp.api.server.extensions.AdvertiseMode;
 import dev.tachyonmcp.api.server.extensions.ExtensionSettings;
 import dev.tachyonmcp.api.server.extensions.ServerExtension;
 import dev.tachyonmcp.core.protocol.Protocols;
@@ -108,6 +109,11 @@ class ExtensionNegotiationTest {
         @Override
         public String extensionId() {
             return "com.test/ext1";
+        }
+
+        @Override
+        public AdvertiseMode advertiseMode() {
+            return AdvertiseMode.ALWAYS;
         }
 
         @Override

--- a/tachyon-core/src/test/java/dev/tachyonmcp/core/transport/netty/ExtensionMethodRoutingTest.java
+++ b/tachyon-core/src/test/java/dev/tachyonmcp/core/transport/netty/ExtensionMethodRoutingTest.java
@@ -4,6 +4,7 @@ package dev.tachyonmcp.core.transport.netty;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import dev.tachyonmcp.api.server.domain.RequestId;
+import dev.tachyonmcp.api.server.extensions.AdvertiseMode;
 import dev.tachyonmcp.api.server.extensions.ExtensionContext;
 import dev.tachyonmcp.api.server.extensions.ServerExtension;
 import dev.tachyonmcp.core.protocol.Protocols;
@@ -89,6 +90,11 @@ class ExtensionMethodRoutingTest {
         @Override
         public String extensionId() {
             return "com.test/ext";
+        }
+
+        @Override
+        public AdvertiseMode advertiseMode() {
+            return AdvertiseMode.ALWAYS;
         }
 
         @Override

--- a/tachyon-extensions/src/main/java/dev/tachyonmcp/extensions/skills/SkillsExtension.java
+++ b/tachyon-extensions/src/main/java/dev/tachyonmcp/extensions/skills/SkillsExtension.java
@@ -6,6 +6,7 @@ import dev.tachyonmcp.api.runtime.InteractionContext;
 import dev.tachyonmcp.api.server.domain.BlobResourceContents;
 import dev.tachyonmcp.api.server.domain.ResourceContents;
 import dev.tachyonmcp.api.server.domain.TextResourceContents;
+import dev.tachyonmcp.api.server.extensions.AdvertiseMode;
 import dev.tachyonmcp.api.server.extensions.ExtensionContext;
 import dev.tachyonmcp.api.server.extensions.ExtensionSettings;
 import dev.tachyonmcp.api.server.extensions.ServerExtension;
@@ -73,6 +74,11 @@ public final class SkillsExtension implements ServerExtension {
     @Override
     public String extensionId() {
         return ID;
+    }
+
+    @Override
+    public AdvertiseMode advertiseMode() {
+        return AdvertiseMode.ALWAYS;
     }
 
     @Override

--- a/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/features/CoroutineRuntime.kt
+++ b/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/features/CoroutineRuntime.kt
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors.
 package dev.tachyonmcp.kotlin.server.features
 
+import dev.tachyonmcp.api.server.extensions.AdvertiseMode
 import dev.tachyonmcp.api.server.extensions.ExtensionContext
 import dev.tachyonmcp.api.server.extensions.ServerExtension
 import kotlinx.coroutines.CancellationException
@@ -24,6 +25,8 @@ internal class CoroutineRuntime : ServerExtension {
     private var shutdownGraceNanos: Long = 0
 
     override fun extensionId(): String = "dev.tachyonmcp/kotlin-coroutines"
+
+    override fun advertiseMode(): AdvertiseMode = AdvertiseMode.NEVER
 
     override fun bootstrap(server: ExtensionContext) {
         check(scope == null) { "Kotlin coroutine runtime already started" }

--- a/tachyon-kotlin/src/test/kotlin/dev/tachyonmcp/kotlin/server/TachyonServerTest.kt
+++ b/tachyon-kotlin/src/test/kotlin/dev/tachyonmcp/kotlin/server/TachyonServerTest.kt
@@ -4,6 +4,7 @@ package dev.tachyonmcp.kotlin.server
 import dev.tachyonmcp.api.json.JsonSchema
 import dev.tachyonmcp.api.server.config.Mode
 import dev.tachyonmcp.api.server.domain.Role
+import dev.tachyonmcp.api.server.extensions.AdvertiseMode
 import dev.tachyonmcp.api.server.extensions.ExtensionContext
 import dev.tachyonmcp.api.server.extensions.ServerExtension
 import dev.tachyonmcp.api.server.features.tools.ToolResult
@@ -242,6 +243,8 @@ internal class TachyonServerTest {
             object : ServerExtension {
                 override fun extensionId(): String = "test.extension"
 
+                override fun advertiseMode(): AdvertiseMode = AdvertiseMode.ALWAYS
+
                 override fun bootstrap(context: ExtensionContext) {
                     bootstrapped = true
                 }
@@ -262,6 +265,8 @@ internal class TachyonServerTest {
         fun extensionNamed(id: String) =
             object : ServerExtension {
                 override fun extensionId(): String = id
+
+                override fun advertiseMode(): AdvertiseMode = AdvertiseMode.ALWAYS
 
                 override fun bootstrap(context: ExtensionContext) {
                     bootstrapped += id
@@ -284,6 +289,8 @@ internal class TachyonServerTest {
         fun extensionNamed(id: String) =
             object : ServerExtension {
                 override fun extensionId(): String = id
+
+                override fun advertiseMode(): AdvertiseMode = AdvertiseMode.ALWAYS
             }
 
         shouldThrow<IllegalArgumentException> {


### PR DESCRIPTION
## Summary

- advertise every registered extension and its server settings in the initialize response when AdvertiseMode is set to ALWAYS
- keep activation and method routing limited to the client/server intersection
- document the advertisement and negotiation contract

## Testing

- `./mvnw test -pl e2e -am -Dtest=ExtensionsTest -Dsurefire.failIfNoSpecifiedTests=false`
- focused mapper, negotiation, and routing tests: 16 passed
- `./mvnw verify -Dsurefire.forkCount=1C --no-transfer-progress`

Closes #234

AI assistance: OpenAI Codex helped prepare the implementation and tests; the full project verification suite passed locally.