### PR TITLE
test(skills): verify resource MIME types

### DIFF
--- a/tachyon-extensions/src/test/java/dev/tachyonmcp/extensions/skills/SkillsExtensionTest.java
+++ b/tachyon-extensions/src/test/java/dev/tachyonmcp/extensions/skills/SkillsExtensionTest.java
@@ -50,6 +50,18 @@ class SkillsExtensionTest {
                 .get()
                 .extracting(ResourceDescriptor::description)
                 .isEqualTo("Extract, fill, and assemble PDF documents");
+        assertThat(server.resources().findByUri("skill://pdf-processing/SKILL.md"))
+                .get()
+                .extracting(ResourceDescriptor::mimeType)
+                .isEqualTo("text/markdown");
+        assertThat(server.resources().findByUri("skill://pdf-processing/scripts/extract.py"))
+                .get()
+                .extracting(ResourceDescriptor::mimeType)
+                .isEqualTo("text/plain");
+        assertThat(server.resources().findByUri("skill://pdf-processing/templates/invoice.md"))
+                .get()
+                .extracting(ResourceDescriptor::mimeType)
+                .isEqualTo("text/markdown");
     }
 
     @Test


### PR DESCRIPTION
Fixes #236

Add regression assertions for the MIME types exposed by skill resources:
- `SKILL.md` and Markdown templates use `text/markdown`
- Python scripts use `text/plain`

Verified with:
- `./mvnw -pl tachyon-extensions -am -Dtest=SkillsExtensionTest -Dsurefire.failIfNoSpecifiedTests=false test -q`
- `git diff --check`