### PR TITLE
fix(protocol): omit URL elicitation id in 2026 responses

### DIFF
--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp20260728/InputRequiredResultTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp20260728/InputRequiredResultTest.java
@@ -48,9 +48,7 @@ class InputRequiredResultTest extends AbstractStatelessMcpE2eTest {
 
     private static UrlInputRequest urlElicitation() {
         return UrlInputRequest.of(
-                "Please authenticate via the provided URL.",
-                "auth-elicitation-1",
-                "https://example.com/auth");
+                "Please authenticate via the provided URL.", "auth-elicitation-1", "https://example.com/auth");
     }
 
     @BeforeEach

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp20260728/InputRequiredResultTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp20260728/InputRequiredResultTest.java
@@ -7,6 +7,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import dev.tachyonmcp.api.server.domain.FormInputRequest;
 import dev.tachyonmcp.api.server.domain.InputRequest;
 import dev.tachyonmcp.api.server.domain.RpcMethodRequest;
+import dev.tachyonmcp.api.server.domain.UrlInputRequest;
 import dev.tachyonmcp.api.server.features.tools.ToolResult;
 import dev.tachyonmcp.e2e.AbstractStatelessMcpE2eTest;
 import java.util.LinkedHashMap;
@@ -43,6 +44,13 @@ class InputRequiredResultTest extends AbstractStatelessMcpE2eTest {
 
     private static RpcMethodRequest rootsListRequest() {
         return RpcMethodRequest.of("roots/list", Map.of());
+    }
+
+    private static UrlInputRequest urlElicitation() {
+        return UrlInputRequest.of(
+                "Please authenticate via the provided URL.",
+                "auth-elicitation-1",
+                "https://example.com/auth");
     }
 
     @BeforeEach
@@ -87,6 +95,17 @@ class InputRequiredResultTest extends AbstractStatelessMcpE2eTest {
                                     return ToolResult.text("roots received");
                                 }
                                 return ToolResult.inputRequired(Map.of("client_roots", rootsListRequest()), null);
+                            })
+                    .register(
+                            tool -> tool.name("ask_url")
+                                    .description("Requests URL-mode authentication")
+                                    .inputSchema(NO_ARGS_SCHEMA),
+                            (ctx, request) -> {
+                                var responses = request.inputResponses();
+                                if (responses != null && responses.containsKey("auth")) {
+                                    return ToolResult.text("authenticated");
+                                }
+                                return ToolResult.inputRequired(Map.of("auth", urlElicitation()), null);
                             })
                     .register(
                             tool -> tool.name("respect_capabilities")
@@ -201,6 +220,24 @@ class InputRequiredResultTest extends AbstractStatelessMcpE2eTest {
             assertThatJson(round1.body())
                     .inPath("$.result.inputRequests.client_roots.method")
                     .isEqualTo("roots/list");
+        }
+    }
+
+    @Test
+    void urlModeElicitationOmitsRemovedElicitationId() throws Exception {
+        try (var client = createModernTestClient()) {
+            var response = client.post(toolCallBody(8, "ask_url", ""));
+            assertThat(response.statusCode()).as(response.body()).isEqualTo(200);
+            assertThatJson(response.body()).inPath("$.result.resultType").isEqualTo("input_required");
+            assertThatJson(response.body())
+                    .inPath("$.result.inputRequests.auth.params.mode")
+                    .isEqualTo("url");
+            assertThatJson(response.body())
+                    .inPath("$.result.inputRequests.auth.params.url")
+                    .isEqualTo("https://example.com/auth");
+            assertThatJson(response.body())
+                    .inPath("$.result.inputRequests.auth.params.elicitationId")
+                    .isAbsent();
         }
     }
 

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp20260728/InputRequiredResultTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp20260728/InputRequiredResultTest.java
@@ -4,6 +4,7 @@ package dev.tachyonmcp.e2e.mcp20260728;
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import dev.tachyonmcp.api.json.JsonSchema;
 import dev.tachyonmcp.api.server.domain.FormInputRequest;
 import dev.tachyonmcp.api.server.domain.InputRequest;
 import dev.tachyonmcp.api.server.domain.RpcMethodRequest;
@@ -25,9 +26,6 @@ import org.junit.jupiter.api.Test;
  * tool (see {@code StatelessDispatchTest}).
  */
 class InputRequiredResultTest extends AbstractStatelessMcpE2eTest {
-
-    // language=JSON
-    private static final String NO_ARGS_SCHEMA = "{\"type\": \"object\", \"properties\": {}}";
 
     private static FormInputRequest elicitation(String message, String prop) {
         var schema = new LinkedHashMap<String, Object>();
@@ -58,7 +56,7 @@ class InputRequiredResultTest extends AbstractStatelessMcpE2eTest {
                     .register(
                             tool -> tool.name("elicit_name")
                                     .description("Elicits a name")
-                                    .inputSchema(NO_ARGS_SCHEMA),
+                                    .inputSchema(JsonSchema.objectSchema()),
                             (ctx, request) -> {
                                 var responses = request.inputResponses();
                                 if (responses != null && responses.containsKey("user_name")) {
@@ -72,7 +70,7 @@ class InputRequiredResultTest extends AbstractStatelessMcpE2eTest {
                     .register(
                             tool -> tool.name("ask_sampling")
                                     .description("Requests sampling")
-                                    .inputSchema(NO_ARGS_SCHEMA),
+                                    .inputSchema(JsonSchema.objectSchema()),
                             (ctx, request) -> {
                                 var responses = request.inputResponses();
                                 if (responses != null && responses.containsKey("capital_question")) {
@@ -86,7 +84,7 @@ class InputRequiredResultTest extends AbstractStatelessMcpE2eTest {
                     .register(
                             tool -> tool.name("ask_roots")
                                     .description("Requests roots/list")
-                                    .inputSchema(NO_ARGS_SCHEMA),
+                                    .inputSchema(JsonSchema.objectSchema()),
                             (ctx, request) -> {
                                 var responses = request.inputResponses();
                                 if (responses != null && responses.containsKey("client_roots")) {
@@ -97,7 +95,7 @@ class InputRequiredResultTest extends AbstractStatelessMcpE2eTest {
                     .register(
                             tool -> tool.name("ask_url")
                                     .description("Requests URL-mode authentication")
-                                    .inputSchema(NO_ARGS_SCHEMA),
+                                    .inputSchema(JsonSchema.objectSchema()),
                             (ctx, request) -> {
                                 var responses = request.inputResponses();
                                 if (responses != null && responses.containsKey("auth")) {
@@ -108,7 +106,7 @@ class InputRequiredResultTest extends AbstractStatelessMcpE2eTest {
                     .register(
                             tool -> tool.name("respect_capabilities")
                                     .description("Only asks for declared capabilities")
-                                    .inputSchema(NO_ARGS_SCHEMA),
+                                    .inputSchema(JsonSchema.objectSchema()),
                             (ctx, request) -> {
                                 var meta = request.meta();
                                 var capabilities =
@@ -122,7 +120,7 @@ class InputRequiredResultTest extends AbstractStatelessMcpE2eTest {
                     .register(
                             tool -> tool.name("ask_multiple")
                                     .description("Requests multiple inputs at once")
-                                    .inputSchema(NO_ARGS_SCHEMA),
+                                    .inputSchema(JsonSchema.objectSchema()),
                             (ctx, request) -> {
                                 var responses = request.inputResponses();
                                 if (responses != null
@@ -222,20 +220,28 @@ class InputRequiredResultTest extends AbstractStatelessMcpE2eTest {
     }
 
     @Test
-    void urlModeElicitationOmitsRemovedElicitationId() throws Exception {
+    void urlModeElicitationOmitsElicitationId() throws Exception {
         try (var client = createModernTestClient()) {
-            var response = client.post(toolCallBody(8, "ask_url", ""));
-            assertThat(response.statusCode()).as(response.body()).isEqualTo(200);
-            assertThatJson(response.body()).inPath("$.result.resultType").isEqualTo("input_required");
-            assertThatJson(response.body())
+            var round1 = client.post(toolCallBody(8, "ask_url", ""));
+            assertThat(round1.statusCode()).as(round1.body()).isEqualTo(200);
+            assertThatJson(round1.body()).inPath("$.result.resultType").isEqualTo("input_required");
+            assertThatJson(round1.body())
+                    .inPath("$.result.inputRequests.auth.method")
+                    .isEqualTo("elicitation/create");
+            assertThatJson(round1.body())
                     .inPath("$.result.inputRequests.auth.params.mode")
                     .isEqualTo("url");
-            assertThatJson(response.body())
+            assertThatJson(round1.body())
                     .inPath("$.result.inputRequests.auth.params.url")
                     .isEqualTo("https://example.com/auth");
-            assertThatJson(response.body())
+            assertThatJson(round1.body())
                     .inPath("$.result.inputRequests.auth.params.elicitationId")
                     .isAbsent();
+
+            var round2 =
+                    client.post(toolCallBody(9, "ask_url", "\"inputResponses\": {\"auth\": {\"action\": \"accept\"}}"));
+            assertThat(round2.statusCode()).as(round2.body()).isEqualTo(200);
+            assertThatJson(round2.body()).inPath("$.result.content[0].text").isEqualTo("authenticated");
         }
     }
 

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/mcp/v2026_07_28/codecs/McpResponseMapper.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/mcp/v2026_07_28/codecs/McpResponseMapper.java
@@ -27,12 +27,14 @@ import dev.tachyonmcp.core.protocol.mcp.v2026_07_28.models.BlobResourceContents;
 import dev.tachyonmcp.core.protocol.mcp.v2026_07_28.models.CallToolResult;
 import dev.tachyonmcp.core.protocol.mcp.v2026_07_28.models.CompleteResult;
 import dev.tachyonmcp.core.protocol.mcp.v2026_07_28.models.DiscoverResult;
-import dev.tachyonmcp.core.protocol.mcp.v2026_07_28.models.EmptyResult;
+import dev.tachyonmcp.core.protocol.mcp.v2026_07_28.models.ElicitRequest;
 import dev.tachyonmcp.core.protocol.mcp.v2026_07_28.models.ElicitRequestFormParams;
-import dev.tachyonmcp.core.protocol.mcp.v2026_07_28.models.ElicitRequestParams;
 import dev.tachyonmcp.core.protocol.mcp.v2026_07_28.models.ElicitRequestURLParams;
+import dev.tachyonmcp.core.protocol.mcp.v2026_07_28.models.EmptyResult;
 import dev.tachyonmcp.core.protocol.mcp.v2026_07_28.models.GetPromptResult;
 import dev.tachyonmcp.core.protocol.mcp.v2026_07_28.models.Implementation;
+import dev.tachyonmcp.core.protocol.mcp.v2026_07_28.models.InputRequests;
+import dev.tachyonmcp.core.protocol.mcp.v2026_07_28.models.InputRequiredResult;
 import dev.tachyonmcp.core.protocol.mcp.v2026_07_28.models.ListPromptsResult;
 import dev.tachyonmcp.core.protocol.mcp.v2026_07_28.models.ListResourceTemplatesResult;
 import dev.tachyonmcp.core.protocol.mcp.v2026_07_28.models.ListResourcesResult;
@@ -82,7 +84,7 @@ public final class McpResponseMapper extends dev.tachyonmcp.core.protocol.mcp.v2
         register(CompleteResult.class, new CompleteResultCodec());
         register(CallToolResult.class, new CallToolResultCodec());
         register(GetPromptResult.class, new GetPromptResultCodec());
-        register(InputRequiredPayload.class, new InputRequiredPayloadCodec());
+        register(InputRequiredResult.class, new InputRequiredResultCodec());
     }
 
     @Override
@@ -188,8 +190,11 @@ public final class McpResponseMapper extends dev.tachyonmcp.core.protocol.mcp.v2
     @Override
     public Object callToolResult(ToolResult result) {
         return switch (result) {
-            case ToolResult.InputRequired ir ->
-                new InputRequiredPayload(ir.inputRequests(), ir.requestState(), resolveMeta(result));
+            case ToolResult.InputRequired ir -> {
+                var meta = resolveMeta(result);
+                yield inputRequiredResult(
+                        ir.inputRequests(), ir.requestState(), meta != null ? new LinkedHashMap<>(meta) : null);
+            }
             case ToolResult.Error error -> buildCallToolResult(error.content(), null, true, resolveMeta(result));
             case ToolResult.Success success ->
                 buildCallToolResult(success.content(), success.structuredValue(), null, resolveMeta(result));
@@ -201,76 +206,54 @@ public final class McpResponseMapper extends dev.tachyonmcp.core.protocol.mcp.v2
             Map<String, ? extends InputRequest> inputRequests,
             @Nullable String requestState,
             @Nullable Map<String, Object> meta) {
-        return new InputRequiredPayload(inputRequests, requestState, JsonUtils.toJsonNodeMap(meta));
+        return new InputRequiredResult(
+                encodedInputRequests(inputRequests),
+                requestState,
+                meta != null ? JsonUtils.toJsonNodeMap(meta) : null,
+                "input_required",
+                null);
     }
 
-    private record InputRequiredPayload(
-            @Nullable Map<String, ? extends InputRequest> inputRequests,
-            @Nullable String requestState,
-            @Nullable Map<String, JsonNode> meta) {}
-
-    private static final class InputRequiredPayloadCodec implements Codec<InputRequiredPayload> {
-
-        @Override
-        public InputRequiredPayload decode(JsonParser parser) {
-            throw new UnsupportedOperationException("server-side only");
+    /**
+     * Encodes each domain {@link InputRequest} into a generated 2026-07-28 {@link InputRequest}
+     * payload (or, for generic RPC methods, a minimal {@code method}/{@code params} object), so the
+     * generated {@link InputRequiredResult}/{@link InputRequests} codecs can serialize the
+     * {@code input_required} response without hand-written mapping.
+     */
+    private static @Nullable InputRequests encodedInputRequests(
+            @Nullable Map<String, ? extends InputRequest> inputRequests) {
+        if (inputRequests == null) {
+            return null;
         }
-
-        @Override
-        public void encode(JsonGenerator gen, InputRequiredPayload value) throws IOException {
-            gen.writeStartObject();
-            gen.writeStringProperty("resultType", "input_required");
-            if (value.inputRequests() != null) {
-                gen.writeObjectPropertyStart("inputRequests");
-                for (var entry : value.inputRequests().entrySet()) {
-                    gen.writeObjectPropertyStart(entry.getKey());
-                    writeInputRequest(gen, entry.getValue());
-                    gen.writeEndObject();
-                }
-                gen.writeEndObject();
-            }
-            if (value.requestState() != null) {
-                gen.writeStringProperty("requestState", value.requestState());
-            }
-            if (value.meta() != null) {
-                gen.writeObjectPropertyStart("_meta");
-                for (var entry : value.meta().entrySet()) {
-                    gen.writeName(entry.getKey());
-                    gen.writeRawValue(entry.getValue().toString());
-                }
-                gen.writeEndObject();
-            }
-            gen.writeEndObject();
+        Map<String, JsonNode> encoded = new LinkedHashMap<>();
+        for (var entry : inputRequests.entrySet()) {
+            encoded.put(entry.getKey(), encodeInputRequest(entry.getValue()));
         }
+        return new InputRequests(encoded);
+    }
 
-        private static void writeInputRequest(JsonGenerator gen, InputRequest req) throws IOException {
-            switch (req) {
-                case RpcMethodRequest r -> {
-                    gen.writeStringProperty("method", r.method());
-                    if (r.params() != null) {
-                        gen.writeName("params");
-                        gen.writeRawValue(JsonUtils.writeString(r.params()));
-                    } else {
-                        gen.writeObjectPropertyStart("params");
-                        gen.writeEndObject();
-                    }
-                }
-                case FormInputRequest f -> {
-                    gen.writeStringProperty("method", "elicitation/create");
-                    gen.writeName("params");
-                    var paramsCodec = CodecRegistry.codecFor(ElicitRequestParams.class);
-                    paramsCodec.encode(
-                            gen,
-                            new ElicitRequestFormParams(null, f.message(), JsonUtils.writeString(f.requestedSchema())));
-                }
-                case UrlInputRequest u -> {
-                    gen.writeStringProperty("method", "elicitation/create");
-                    gen.writeName("params");
-                    var paramsCodec = CodecRegistry.codecFor(ElicitRequestParams.class);
-                    paramsCodec.encode(gen, new ElicitRequestURLParams("url", u.message(), u.url()));
-                }
+    private static JsonNode encodeInputRequest(InputRequest req) {
+        return switch (req) {
+            case RpcMethodRequest r -> {
+                var fields = new LinkedHashMap<String, Object>();
+                fields.put("method", r.method());
+                fields.put("params", r.params() != null ? r.params() : Map.of());
+                yield JsonUtils.toObjectNode(fields);
             }
-        }
+            case FormInputRequest f ->
+                encodeToTree(
+                        ElicitRequest.class,
+                        new ElicitRequest(
+                                "elicitation/create",
+                                new ElicitRequestFormParams(
+                                        null, f.message(), JsonUtils.writeString(f.requestedSchema()))));
+            case UrlInputRequest u ->
+                encodeToTree(
+                        ElicitRequest.class,
+                        // 2026-07-28 removed the `elicitationId` field; only mode/message/url are serialized.
+                        new ElicitRequest(
+                                "elicitation/create", new ElicitRequestURLParams("url", u.message(), u.url())));
+        };
     }
 
     @Override

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/mcp/v2026_07_28/codecs/McpResponseMapper.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/mcp/v2026_07_28/codecs/McpResponseMapper.java
@@ -6,12 +6,16 @@ import dev.tachyonmcp.api.json.JsonSchema;
 import dev.tachyonmcp.api.server.config.ServerIdentity;
 import dev.tachyonmcp.api.server.domain.Annotations;
 import dev.tachyonmcp.api.server.domain.ContentBlock;
+import dev.tachyonmcp.api.server.domain.FormInputRequest;
+import dev.tachyonmcp.api.server.domain.InputRequest;
 import dev.tachyonmcp.api.server.domain.PromptMessage;
+import dev.tachyonmcp.api.server.domain.RpcMethodRequest;
 import dev.tachyonmcp.api.server.domain.ServerCapabilities;
 import dev.tachyonmcp.api.server.domain.ServerError;
 import dev.tachyonmcp.api.server.domain.TaskResult;
 import dev.tachyonmcp.api.server.domain.TextContent;
 import dev.tachyonmcp.api.server.domain.ToolAnnotations;
+import dev.tachyonmcp.api.server.domain.UrlInputRequest;
 import dev.tachyonmcp.api.server.features.completions.CompletionResult;
 import dev.tachyonmcp.api.server.features.prompts.PromptDescriptor;
 import dev.tachyonmcp.api.server.features.resources.ResourceDescriptor;
@@ -24,6 +28,9 @@ import dev.tachyonmcp.core.protocol.mcp.v2026_07_28.models.CallToolResult;
 import dev.tachyonmcp.core.protocol.mcp.v2026_07_28.models.CompleteResult;
 import dev.tachyonmcp.core.protocol.mcp.v2026_07_28.models.DiscoverResult;
 import dev.tachyonmcp.core.protocol.mcp.v2026_07_28.models.EmptyResult;
+import dev.tachyonmcp.core.protocol.mcp.v2026_07_28.models.ElicitRequestFormParams;
+import dev.tachyonmcp.core.protocol.mcp.v2026_07_28.models.ElicitRequestParams;
+import dev.tachyonmcp.core.protocol.mcp.v2026_07_28.models.ElicitRequestURLParams;
 import dev.tachyonmcp.core.protocol.mcp.v2026_07_28.models.GetPromptResult;
 import dev.tachyonmcp.core.protocol.mcp.v2026_07_28.models.Implementation;
 import dev.tachyonmcp.core.protocol.mcp.v2026_07_28.models.ListPromptsResult;
@@ -75,6 +82,7 @@ public final class McpResponseMapper extends dev.tachyonmcp.core.protocol.mcp.v2
         register(CompleteResult.class, new CompleteResultCodec());
         register(CallToolResult.class, new CallToolResultCodec());
         register(GetPromptResult.class, new GetPromptResultCodec());
+        register(InputRequiredPayload.class, new InputRequiredPayloadCodec());
     }
 
     @Override
@@ -180,11 +188,89 @@ public final class McpResponseMapper extends dev.tachyonmcp.core.protocol.mcp.v2
     @Override
     public Object callToolResult(ToolResult result) {
         return switch (result) {
-            case ToolResult.InputRequired ignored -> super.callToolResult(result);
+            case ToolResult.InputRequired ir ->
+                new InputRequiredPayload(ir.inputRequests(), ir.requestState(), resolveMeta(result));
             case ToolResult.Error error -> buildCallToolResult(error.content(), null, true, resolveMeta(result));
             case ToolResult.Success success ->
                 buildCallToolResult(success.content(), success.structuredValue(), null, resolveMeta(result));
         };
+    }
+
+    @Override
+    public Object inputRequiredResult(
+            Map<String, ? extends InputRequest> inputRequests,
+            @Nullable String requestState,
+            @Nullable Map<String, Object> meta) {
+        return new InputRequiredPayload(inputRequests, requestState, JsonUtils.toJsonNodeMap(meta));
+    }
+
+    private record InputRequiredPayload(
+            @Nullable Map<String, ? extends InputRequest> inputRequests,
+            @Nullable String requestState,
+            @Nullable Map<String, JsonNode> meta) {}
+
+    private static final class InputRequiredPayloadCodec implements Codec<InputRequiredPayload> {
+
+        @Override
+        public InputRequiredPayload decode(JsonParser parser) {
+            throw new UnsupportedOperationException("server-side only");
+        }
+
+        @Override
+        public void encode(JsonGenerator gen, InputRequiredPayload value) throws IOException {
+            gen.writeStartObject();
+            gen.writeStringProperty("resultType", "input_required");
+            if (value.inputRequests() != null) {
+                gen.writeObjectPropertyStart("inputRequests");
+                for (var entry : value.inputRequests().entrySet()) {
+                    gen.writeObjectPropertyStart(entry.getKey());
+                    writeInputRequest(gen, entry.getValue());
+                    gen.writeEndObject();
+                }
+                gen.writeEndObject();
+            }
+            if (value.requestState() != null) {
+                gen.writeStringProperty("requestState", value.requestState());
+            }
+            if (value.meta() != null) {
+                gen.writeObjectPropertyStart("_meta");
+                for (var entry : value.meta().entrySet()) {
+                    gen.writeName(entry.getKey());
+                    gen.writeRawValue(entry.getValue().toString());
+                }
+                gen.writeEndObject();
+            }
+            gen.writeEndObject();
+        }
+
+        private static void writeInputRequest(JsonGenerator gen, InputRequest req) throws IOException {
+            switch (req) {
+                case RpcMethodRequest r -> {
+                    gen.writeStringProperty("method", r.method());
+                    if (r.params() != null) {
+                        gen.writeName("params");
+                        gen.writeRawValue(JsonUtils.writeString(r.params()));
+                    } else {
+                        gen.writeObjectPropertyStart("params");
+                        gen.writeEndObject();
+                    }
+                }
+                case FormInputRequest f -> {
+                    gen.writeStringProperty("method", "elicitation/create");
+                    gen.writeName("params");
+                    var paramsCodec = CodecRegistry.codecFor(ElicitRequestParams.class);
+                    paramsCodec.encode(
+                            gen,
+                            new ElicitRequestFormParams(null, f.message(), JsonUtils.writeString(f.requestedSchema())));
+                }
+                case UrlInputRequest u -> {
+                    gen.writeStringProperty("method", "elicitation/create");
+                    gen.writeName("params");
+                    var paramsCodec = CodecRegistry.codecFor(ElicitRequestParams.class);
+                    paramsCodec.encode(gen, new ElicitRequestURLParams("url", u.message(), u.url()));
+                }
+            }
+        }
     }
 
     @Override

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/mcp/v2026_07_28/codecs/McpResponseMapper.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/mcp/v2026_07_28/codecs/McpResponseMapper.java
@@ -58,6 +58,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import org.jspecify.annotations.Nullable;
 import tools.jackson.core.JsonEncoding;
 import tools.jackson.core.JsonGenerator;
@@ -72,6 +73,7 @@ public final class McpResponseMapper extends dev.tachyonmcp.core.protocol.mcp.v2
 
     private static final String COMPLETE = "complete";
     private static final String PUBLIC = "public";
+    private static final String INPUT_REQUIRED = "input_required";
 
     static {
         register(DiscoverResult.class, new DiscoverResultCodec());
@@ -190,11 +192,8 @@ public final class McpResponseMapper extends dev.tachyonmcp.core.protocol.mcp.v2
     @Override
     public Object callToolResult(ToolResult result) {
         return switch (result) {
-            case ToolResult.InputRequired ir -> {
-                var meta = resolveMeta(result);
-                yield inputRequiredResult(
-                        ir.inputRequests(), ir.requestState(), meta != null ? new LinkedHashMap<>(meta) : null);
-            }
+            case ToolResult.InputRequired ir ->
+                inputRequired(ir.inputRequests(), ir.requestState(), resolveMeta(result));
             case ToolResult.Error error -> buildCallToolResult(error.content(), null, true, resolveMeta(result));
             case ToolResult.Success success ->
                 buildCallToolResult(success.content(), success.structuredValue(), null, resolveMeta(result));
@@ -206,12 +205,14 @@ public final class McpResponseMapper extends dev.tachyonmcp.core.protocol.mcp.v2
             Map<String, ? extends InputRequest> inputRequests,
             @Nullable String requestState,
             @Nullable Map<String, Object> meta) {
-        return new InputRequiredResult(
-                encodedInputRequests(inputRequests),
-                requestState,
-                meta != null ? JsonUtils.toJsonNodeMap(meta) : null,
-                "input_required",
-                null);
+        return inputRequired(inputRequests, requestState, JsonUtils.toJsonNodeMap(meta));
+    }
+
+    private static Object inputRequired(
+            @Nullable Map<String, ? extends InputRequest> inputRequests,
+            @Nullable String requestState,
+            @Nullable Map<String, JsonNode> meta) {
+        return new InputRequiredResult(encodedInputRequests(inputRequests), requestState, meta, INPUT_REQUIRED, null);
     }
 
     /**
@@ -237,7 +238,7 @@ public final class McpResponseMapper extends dev.tachyonmcp.core.protocol.mcp.v2
             case RpcMethodRequest r -> {
                 var fields = new LinkedHashMap<String, Object>();
                 fields.put("method", r.method());
-                fields.put("params", r.params() != null ? r.params() : Map.of());
+                fields.put("params", Objects.requireNonNullElseGet(r.params(), Map::of));
                 yield JsonUtils.toObjectNode(fields);
             }
             case FormInputRequest f ->


### PR DESCRIPTION
Fixes #237

## What changed

The 2026-07-28 response mapper no longer delegates `InputRequired` results to the 2025-11-25 mapper. It now uses a version-specific payload codec:

- form elicitation keeps the 2026 fields;
- URL elicitation serializes only `mode`, `message`, and `url`;
- RPC method requests and `_meta`/`requestState` behavior remain unchanged.

Added an MCP 2026 end-to-end regression test that verifies URL-mode responses omit the removed `elicitationId` field.

## Verification

```text
./mvnw -pl e2e -am -Dtest=InputRequiredResultTest -Dsurefire.failIfNoSpecifiedTests=false test -q
git diff --check
```
