### PR TITLE
Validate duplicate extension IDs

### DIFF
--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/DefaultServerBuilder.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/DefaultServerBuilder.java
@@ -23,13 +23,14 @@ import dev.tachyonmcp.core.server.session.InMemorySessionEventStore;
 import dev.tachyonmcp.core.server.session.InMemorySessionStore;
 import io.netty.channel.ChannelPipeline;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 import java.util.function.Consumer;
 import org.jspecify.annotations.Nullable;
-import java.util.HashSet;
 
 /**
  * Fluent builder for {@link TachyonServer} configuration.
@@ -43,6 +44,7 @@ final class DefaultServerBuilder implements ServerBuilder {
     private final RuntimeConfig.Builder runtimeBuilder = RuntimeConfig.builder();
     private final MonitoringConfig.Builder monitoringBuilder = MonitoringConfig.builder();
     private final List<ServerExtension> extensions = new ArrayList<>();
+    private final Set<String> extensionIds = new HashSet<>();
     private final List<Consumer<TachyonServer>> bootstrapRegistrations = new ArrayList<>();
 
     private JsonSchemaValidator inputSchemaValidator = new NetworkntJsonSchemaValidator();
@@ -223,14 +225,24 @@ final class DefaultServerBuilder implements ServerBuilder {
     @Override
     @Deprecated
     public ServerBuilder extension(ServerExtension extension) {
-        this.extensions.add(extension);
+        addExtension(extension);
         return this;
     }
 
     @Override
     public ServerBuilder withExtensions(ServerExtension... extensions) {
-        this.extensions.addAll(List.of(extensions));
+        for (var extension : extensions) {
+            addExtension(extension);
+        }
         return this;
+    }
+
+    private void addExtension(ServerExtension extension) {
+        if (!extensionIds.add(extension.extensionId())) {
+            throw new IllegalArgumentException("Duplicate extension ID: " + extension.extensionId());
+        }
+
+        extensions.add(extension);
     }
 
     /**
@@ -267,7 +279,6 @@ final class DefaultServerBuilder implements ServerBuilder {
      */
     @Override
     public TachyonServer build() {
-        validateExtensions();
         var sessionConfig = sessionBuilder.build();
         var sessionEventStore = sessionConfig.sessionEventStore() != null
                 ? sessionConfig.sessionEventStore()
@@ -309,15 +320,5 @@ final class DefaultServerBuilder implements ServerBuilder {
                 networkBuilder.build(),
                 runtimeBuilder.build(),
                 monitoringBuilder.build());
-    }
-
-    private void validateExtensions() {
-        var ids = new HashSet<String>();
-        for (var extension : extensions) {
-            if (!ids.add(extension.extensionId())) {
-                throw new IllegalStateException(
-                    "Duplicate extension ID: " + extension.extensionId());
-            }
-        }
     }
 }

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/DefaultServerBuilder.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/DefaultServerBuilder.java
@@ -29,6 +29,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 import java.util.function.Consumer;
 import org.jspecify.annotations.Nullable;
+import java.util.HashSet;
 
 /**
  * Fluent builder for {@link TachyonServer} configuration.
@@ -266,6 +267,7 @@ final class DefaultServerBuilder implements ServerBuilder {
      */
     @Override
     public TachyonServer build() {
+        validateExtensions();
         var sessionConfig = sessionBuilder.build();
         var sessionEventStore = sessionConfig.sessionEventStore() != null
                 ? sessionConfig.sessionEventStore()
@@ -307,5 +309,15 @@ final class DefaultServerBuilder implements ServerBuilder {
                 networkBuilder.build(),
                 runtimeBuilder.build(),
                 monitoringBuilder.build());
+    }
+
+    private void validateExtensions() {
+        var ids = new HashSet<String>();
+        for (var extension : extensions) {
+            if (!ids.add(extension.extensionId())) {
+                throw new IllegalStateException(
+                    "Duplicate extension ID: " + extension.extensionId());
+            }
+        }
     }
 }

--- a/tachyon-core/src/test/java/dev/tachyonmcp/core/server/ServerBuilderTest.java
+++ b/tachyon-core/src/test/java/dev/tachyonmcp/core/server/ServerBuilderTest.java
@@ -2,6 +2,7 @@
 package dev.tachyonmcp.core.server;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 
 import dev.tachyonmcp.api.server.domain.PromptMessage;
@@ -198,7 +199,7 @@ class ServerBuilderTest {
         var extension1 = new TestExtension("duplicate");
         var extension2 = new TestExtension("duplicate");
 
-        assertThatIllegalStateException()
+        assertThatIllegalArgumentException()
                 .isThrownBy(() -> TachyonServer.builder()
                         .withExtensions(extension1, extension2)
                         .build())

--- a/tachyon-core/src/test/java/dev/tachyonmcp/core/server/ServerBuilderTest.java
+++ b/tachyon-core/src/test/java/dev/tachyonmcp/core/server/ServerBuilderTest.java
@@ -15,6 +15,7 @@ import dev.tachyonmcp.api.server.features.tools.ToolResult;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.Test;
+import dev.tachyonmcp.api.server.extensions.ServerExtension;
 
 /**
  * Verifies {@link ServerBuilder} configures a server-owned virtual-thread-per-task executor for
@@ -189,6 +190,29 @@ class ServerBuilderTest {
     void portThrowsBeforeStart() {
         try (var server = TachyonServer.builder().build()) {
             assertThatIllegalStateException().isThrownBy(server::port);
+        }
+    }
+    @Test
+    void rejectsDuplicateExtensionIds() {
+        var extension1 = new TestExtension("duplicate");
+        var extension2 = new TestExtension("duplicate");
+
+        assertThatIllegalStateException()
+            .isThrownBy(() -> TachyonServer.builder()
+                .withExtensions(extension1, extension2)
+                .build())
+            .withMessageContaining("Duplicate extension ID: duplicate");
+    }
+    private static class TestExtension implements ServerExtension {
+        private final String id;
+
+        TestExtension(String id) {
+            this.id = id;
+        }
+
+        @Override
+        public String extensionId() {
+            return id;
         }
     }
 }

--- a/tachyon-core/src/test/java/dev/tachyonmcp/core/server/ServerBuilderTest.java
+++ b/tachyon-core/src/test/java/dev/tachyonmcp/core/server/ServerBuilderTest.java
@@ -7,6 +7,7 @@ import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 import dev.tachyonmcp.api.server.domain.PromptMessage;
 import dev.tachyonmcp.api.server.domain.TextResourceContents;
 import dev.tachyonmcp.api.server.domain.UriTemplateValue;
+import dev.tachyonmcp.api.server.extensions.ServerExtension;
 import dev.tachyonmcp.api.server.features.completions.AsyncCompletionFn;
 import dev.tachyonmcp.api.server.features.completions.CompletionFn;
 import dev.tachyonmcp.api.server.features.completions.CompletionResult;
@@ -15,7 +16,6 @@ import dev.tachyonmcp.api.server.features.tools.ToolResult;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.Test;
-import dev.tachyonmcp.api.server.extensions.ServerExtension;
 
 /**
  * Verifies {@link ServerBuilder} configures a server-owned virtual-thread-per-task executor for
@@ -192,17 +192,19 @@ class ServerBuilderTest {
             assertThatIllegalStateException().isThrownBy(server::port);
         }
     }
+
     @Test
     void rejectsDuplicateExtensionIds() {
         var extension1 = new TestExtension("duplicate");
         var extension2 = new TestExtension("duplicate");
 
         assertThatIllegalStateException()
-            .isThrownBy(() -> TachyonServer.builder()
-                .withExtensions(extension1, extension2)
-                .build())
-            .withMessageContaining("Duplicate extension ID: duplicate");
+                .isThrownBy(() -> TachyonServer.builder()
+                        .withExtensions(extension1, extension2)
+                        .build())
+                .withMessageContaining("Duplicate extension ID: duplicate");
     }
+
     private static class TestExtension implements ServerExtension {
         private final String id;
 

--- a/tachyon-kotlin/src/test/kotlin/dev/tachyonmcp/kotlin/server/TachyonServerTest.kt
+++ b/tachyon-kotlin/src/test/kotlin/dev/tachyonmcp/kotlin/server/TachyonServerTest.kt
@@ -286,7 +286,7 @@ internal class TachyonServerTest {
                 override fun extensionId(): String = id
             }
 
-        shouldThrow<IllegalStateException> {
+        shouldThrow<IllegalArgumentException> {
             buildServer {
                 name("duplicate-extension-test")
                 extensions(

--- a/tachyon-kotlin/src/test/kotlin/dev/tachyonmcp/kotlin/server/TachyonServerTest.kt
+++ b/tachyon-kotlin/src/test/kotlin/dev/tachyonmcp/kotlin/server/TachyonServerTest.kt
@@ -20,6 +20,7 @@ import dev.tachyonmcp.kotlin.server.features.prompts.PromptDescriptor
 import dev.tachyonmcp.kotlin.server.features.resources.ResourceDescriptor
 import dev.tachyonmcp.kotlin.server.features.resources.ResourceTemplateDescriptor
 import dev.tachyonmcp.kotlin.server.features.tools.ToolDescriptor
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.string.shouldContain
@@ -276,6 +277,24 @@ internal class TachyonServerTest {
         }.use {
             bootstrapped shouldBe setOf("one", "two")
         }
+    }
+
+    @Test
+    fun `duplicate extension IDs are rejected`() {
+        fun extensionNamed(id: String) =
+            object : ServerExtension {
+                override fun extensionId(): String = id
+            }
+
+        shouldThrow<IllegalStateException> {
+            buildServer {
+                name("duplicate-extension-test")
+                extensions(
+                    extensionNamed("duplicate"),
+                    extensionNamed("duplicate"),
+                )
+            }
+        }.message shouldContain "Duplicate extension ID: duplicate"
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Reject duplicate extension IDs during server construction.
- Added a test covering duplicate extension IDs.

## Testing

- `git diff --check` passes.
- Full Maven build could not be completed because the MCP code-generation step fails with exit code 9009 in my environment.