### PR TITLE
fix: handle Detekt path separators on Windows

### DIFF
--- a/tachyon-kotlin-kt-schema/pom.xml
+++ b/tachyon-kotlin-kt-schema/pom.xml
@@ -127,9 +127,9 @@
                                 <argument>--config</argument>
                                 <argument>${project.basedir}/../detekt.yml</argument>
                                 <argument>--input</argument>
-                                <argument>${project.basedir}/src/main/kotlin:${project.basedir}/src/test/kotlin</argument>
+                                <argument>${project.basedir}/src/main/kotlin;${project.basedir}/src/test/kotlin</argument>
                                 <argument>--excludes</argument>
-                                <argument>**/build/**:**/.gradle/**</argument>
+                                <argument>**/build/**;**/.gradle/**</argument>
                                 <argument>--jvm-target</argument>
                                 <argument>${java.version}</argument>
                                 <argument>--language-version</argument>
@@ -155,9 +155,9 @@
                                 <argument>--config</argument>
                                 <argument>${project.basedir}/../detekt.yml</argument>
                                 <argument>--input</argument>
-                                <argument>${project.basedir}/src/main/kotlin:${project.basedir}/src/test/kotlin</argument>
+                                <argument>${project.basedir}/src/main/kotlin;${project.basedir}/src/test/kotlin</argument>
                                 <argument>--excludes</argument>
-                                <argument>**/build/**:**/.gradle/**</argument>
+                                <argument>**/build/**;**/.gradle/**</argument>
                                 <argument>--jvm-target</argument>
                                 <argument>${java.version}</argument>
                                 <argument>--language-version</argument>

--- a/tachyon-kotlin-kt-schema/pom.xml
+++ b/tachyon-kotlin-kt-schema/pom.xml
@@ -126,6 +126,7 @@
                                 <argument>--build-upon-default-config</argument>
                                 <argument>--config</argument>
                                 <argument>${project.basedir}/../detekt.yml</argument>
+                                <!-- Detekt uses ';' to separate multiple input paths on Windows. -->
                                 <argument>--input</argument>
                                 <argument>${project.basedir}/src/main/kotlin;${project.basedir}/src/test/kotlin</argument>
                                 <argument>--excludes</argument>
@@ -154,6 +155,7 @@
                                 <argument>--build-upon-default-config</argument>
                                 <argument>--config</argument>
                                 <argument>${project.basedir}/../detekt.yml</argument>
+                                <!-- Detekt uses ';' to separate multiple input paths on Windows. -->
                                 <argument>--input</argument>
                                 <argument>${project.basedir}/src/main/kotlin;${project.basedir}/src/test/kotlin</argument>
                                 <argument>--excludes</argument>

--- a/tachyon-kotlin/pom.xml
+++ b/tachyon-kotlin/pom.xml
@@ -176,9 +176,9 @@
                                 <argument>--config</argument>
                                 <argument>${project.basedir}/../detekt.yml</argument>
                                 <argument>--input</argument>
-                                <argument>${project.basedir}/src/main/kotlin:${project.basedir}/src/test/kotlin</argument>
+                                <argument>${project.basedir}/src/main/kotlin;${project.basedir}/src/test/kotlin</argument>
                                 <argument>--excludes</argument>
-                                <argument>**/build/**:**/.gradle/**</argument>
+                                <argument>**/build/**;**/.gradle/**</argument>
                                 <argument>--jvm-target</argument>
                                 <argument>${java.version}</argument>
                                 <argument>--language-version</argument>
@@ -204,9 +204,9 @@
                                 <argument>--config</argument>
                                 <argument>${project.basedir}/../detekt.yml</argument>
                                 <argument>--input</argument>
-                                <argument>${project.basedir}/src/main/kotlin:${project.basedir}/src/test/kotlin</argument>
+                                <argument>${project.basedir}/src/main/kotlin;${project.basedir}/src/test/kotlin</argument>
                                 <argument>--excludes</argument>
-                                <argument>**/build/**:**/.gradle/**</argument>
+                                <argument>**/build/**;**/.gradle/**</argument>
                                 <argument>--jvm-target</argument>
                                 <argument>${java.version}</argument>
                                 <argument>--language-version</argument>

--- a/tachyon-kotlin/pom.xml
+++ b/tachyon-kotlin/pom.xml
@@ -175,6 +175,7 @@
                                 <argument>--build-upon-default-config</argument>
                                 <argument>--config</argument>
                                 <argument>${project.basedir}/../detekt.yml</argument>
+                                <!-- Detekt uses ';' to separate multiple input paths on Windows. -->
                                 <argument>--input</argument>
                                 <argument>${project.basedir}/src/main/kotlin;${project.basedir}/src/test/kotlin</argument>
                                 <argument>--excludes</argument>
@@ -203,6 +204,7 @@
                                 <argument>--build-upon-default-config</argument>
                                 <argument>--config</argument>
                                 <argument>${project.basedir}/../detekt.yml</argument>
+                                <!-- Detekt uses ';' to separate multiple input paths on Windows. -->
                                 <argument>--input</argument>
                                 <argument>${project.basedir}/src/main/kotlin;${project.basedir}/src/test/kotlin</argument>
                                 <argument>--excludes</argument>


### PR DESCRIPTION
## Description

Fixes the Detekt Maven configuration for Windows by using `;` as the path separator instead of `:`.

The existing configuration used `:` for multiple `--input` and `--excludes` paths, which caused Detekt to interpret the Windows paths incorrectly.

Updated:
- `tachyon-kotlin/pom.xml`
- `tachyon-kotlin-kt-schema/pom.xml`

## Verification

- Maven build succeeds on Windows
- Detekt completes successfully with the Windows path separator fix
- `git diff --check` passes