### PR TITLE
fix: advertise extensions in server/discover, add NEGOTIATED mode

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -80,10 +80,12 @@ The older `.extension(ServerExtension)` still works but is deprecated.
 
 ## How negotiation works
 
-1. Tachyon advertises every registered extension whose `advertiseMode()` is `AdvertiseMode.ALWAYS`, along with its
-   `serverSettings()`, in the `initialize` response. Extensions with `AdvertiseMode.NEVER` are omitted from
-   `capabilities.extensions` — useful for internal-only extensions, e.g. `tachyon-kotlin`'s coroutine runtime
-   (`dev.tachyonmcp/kotlin-coroutines`), that clients aren't expected to know about or negotiate directly.
+1. Tachyon advertises each registered extension's `serverSettings()` in `capabilities.extensions` — in the `initialize` response (MCP 2025-11-25) and in the `server/discover` response (MCP 2026-07-28 and later) — subject to that extension's `AdvertiseMode advertiseMode()`:
+
+   - `ALWAYS` - Unconditionally.
+   - `NEVER` - useful for internal-only extensions, e.g. `tachyon-kotlin`'s coroutine runtime (`dev.tachyonmcp/kotlin-coroutines`), that clients aren't expected to know about or negotiate directly. |
+   - `NEGOTIATED` - Only if the client already declared the extension's ID in the same request — `capabilities.extensions` on `initialize`, or `_meta."io.modelcontextprotocol/clientCapabilities".extensions` on any 2026-07-28 request including `server/discover`. |
+
 2. The client sends `initialize` with the extensions it supports, such as `"extensions": {"com.example/audit": {}}`.
 3. Tachyon calls `onConnectionInit` for each extension declared by both client and server — this still works for
    `NEVER`-mode extensions if a client already knows the ID, since hiding only affects advertisement, not negotiation.

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/ExtensionsTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/ExtensionsTest.java
@@ -23,6 +23,7 @@ class ExtensionsTest extends AbstractStatefulMcpE2eTest {
 
     private static final String TEST_EXT_ID = "com.example/test";
     private static final String INTERNAL_EXT_ID = "com.example/internal";
+    private static final String NEGOTIATED_EXT_ID = "com.example/negotiated";
 
     @Test
     void serverAdvertisesExtensionInCapabilities() throws Exception {
@@ -102,6 +103,35 @@ class ExtensionsTest extends AbstractStatefulMcpE2eTest {
                   "result": {"message": "Hi!"}
                 }
                 """);
+        }
+    }
+
+    @Test
+    void negotiatedExtensionAdvertisedWhenClientDeclaresIt() throws Exception {
+        startServer(it -> it.withExtensions(new NegotiatedTestExtension()));
+
+        try (var client = createTestClient()) {
+            var initBody = buildInitializeJson(Map.of(NEGOTIATED_EXT_ID, JsonNodeFactory.instance.objectNode()));
+            var response = client.post(null, initBody);
+            assertThatJson(response.body())
+                    .inPath("$.result.capabilities.extensions")
+                    // language=JSON
+                    .isEqualTo("""
+                            {"com.example/negotiated": {"version": "1.0"}}
+                            """);
+        }
+    }
+
+    @Test
+    void negotiatedExtensionNotAdvertisedWhenClientDoesNotDeclareIt() throws Exception {
+        startServer(it -> it.withExtensions(new NegotiatedTestExtension()));
+
+        try (var client = createTestClient()) {
+            var initBody = buildInitializeJson(Map.of());
+            var response = client.post(null, initBody);
+            assertThatJson(response.body())
+                    .node("result.capabilities.extensions")
+                    .isAbsent();
         }
     }
 
@@ -291,6 +321,24 @@ class ExtensionsTest extends AbstractStatefulMcpE2eTest {
         @Override
         public void bootstrap(ExtensionContext context) {
             context.registerHandler("internal/hello", (interaction, params) -> Map.of("message", "Hi!"));
+        }
+    }
+
+    private static class NegotiatedTestExtension implements ServerExtension {
+
+        @Override
+        public String extensionId() {
+            return NEGOTIATED_EXT_ID;
+        }
+
+        @Override
+        public AdvertiseMode advertiseMode() {
+            return AdvertiseMode.NEGOTIATED;
+        }
+
+        @Override
+        public ExtensionSettings serverSettings() {
+            return ExtensionSettings.of(Map.of("version", "1.0"));
         }
     }
 

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp20260728/DiscoverExtensionsTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp20260728/DiscoverExtensionsTest.java
@@ -1,0 +1,130 @@
+/* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
+package dev.tachyonmcp.e2e.mcp20260728;
+
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.tachyonmcp.api.server.extensions.AdvertiseMode;
+import dev.tachyonmcp.api.server.extensions.ExtensionSettings;
+import dev.tachyonmcp.api.server.extensions.ServerExtension;
+import dev.tachyonmcp.e2e.AbstractStatelessMcpE2eTest;
+import java.util.Map;
+import net.javacrumbs.jsonunit.core.Option;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.node.JsonNodeFactory;
+
+/** {@code server/discover} (2026-07-28) must advertise registered extensions the same way {@code initialize} does. */
+class DiscoverExtensionsTest extends AbstractStatelessMcpE2eTest {
+
+    private static final String ALWAYS_EXT_ID = "com.example/always";
+    private static final String NEVER_EXT_ID = "com.example/never";
+    private static final String NEGOTIATED_EXT_ID = "com.example/negotiated";
+
+    @Test
+    void extensionAdvertisedInDiscoverCapabilities() throws Exception {
+        startServer(it -> it.withExtensions(new TestExtension(ALWAYS_EXT_ID, AdvertiseMode.ALWAYS)));
+
+        try (var client = createModernTestClient()) {
+            var response = client.post("""
+                    {"jsonrpc": "2.0", "id": 1, "method": "server/discover"}
+                    """);
+
+            assertThat(response.statusCode()).as(response.body()).isEqualTo(200);
+            assertThatJson(response.body())
+                    .inPath("$.result.capabilities.extensions")
+                    // language=JSON
+                    .isEqualTo("""
+                            {"com.example/always": {"version": "1.0"}}
+                            """);
+        }
+    }
+
+    @Test
+    void neverAdvertisedExtensionExcludedFromDiscoverCapabilities() throws Exception {
+        startServer(it -> it.withExtensions(
+                new TestExtension(ALWAYS_EXT_ID, AdvertiseMode.ALWAYS),
+                new TestExtension(NEVER_EXT_ID, AdvertiseMode.NEVER)));
+
+        try (var client = createModernTestClient()) {
+            var response = client.post("""
+                    {"jsonrpc": "2.0", "id": 1, "method": "server/discover"}
+                    """);
+
+            assertThat(response.statusCode()).as(response.body()).isEqualTo(200);
+            assertThatJson(response.body())
+                    .when(Option.IGNORING_EXTRA_FIELDS)
+                    // language=JSON
+                    .isEqualTo("""
+                            {
+                              "result": {
+                                "capabilities": {
+                                  "extensions": {"com.example/always": {"version": "1.0"}}
+                                }
+                              }
+                            }
+                            """);
+        }
+    }
+
+    @Test
+    void negotiatedExtensionAdvertisedWhenDiscoverRequestDeclaresIt() throws Exception {
+        startServer(it -> it.withExtensions(new TestExtension(NEGOTIATED_EXT_ID, AdvertiseMode.NEGOTIATED)));
+
+        try (var client = createModernTestClient()) {
+            client.withExtensions(Map.of(NEGOTIATED_EXT_ID, JsonNodeFactory.instance.objectNode()));
+            var response = client.post("""
+                    {"jsonrpc": "2.0", "id": 1, "method": "server/discover"}
+                    """);
+
+            assertThat(response.statusCode()).as(response.body()).isEqualTo(200);
+            assertThatJson(response.body())
+                    .inPath("$.result.capabilities.extensions")
+                    // language=JSON
+                    .isEqualTo("""
+                            {"com.example/negotiated": {"version": "1.0"}}
+                            """);
+        }
+    }
+
+    @Test
+    void negotiatedExtensionNotAdvertisedWhenDiscoverRequestDoesNotDeclareIt() throws Exception {
+        startServer(it -> it.withExtensions(new TestExtension(NEGOTIATED_EXT_ID, AdvertiseMode.NEGOTIATED)));
+
+        try (var client = createModernTestClient()) {
+            var response = client.post("""
+                    {"jsonrpc": "2.0", "id": 1, "method": "server/discover"}
+                    """);
+
+            assertThat(response.statusCode()).as(response.body()).isEqualTo(200);
+            assertThatJson(response.body())
+                    .node("result.capabilities.extensions")
+                    .isAbsent();
+        }
+    }
+
+    private static final class TestExtension implements ServerExtension {
+
+        private final String id;
+        private final AdvertiseMode advertiseMode;
+
+        TestExtension(String id, AdvertiseMode advertiseMode) {
+            this.id = id;
+            this.advertiseMode = advertiseMode;
+        }
+
+        @Override
+        public String extensionId() {
+            return id;
+        }
+
+        @Override
+        public AdvertiseMode advertiseMode() {
+            return advertiseMode;
+        }
+
+        @Override
+        public ExtensionSettings serverSettings() {
+            return ExtensionSettings.of(Map.of("version", "1.0"));
+        }
+    }
+}

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp20260728/ExtensionNegotiationTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp20260728/ExtensionNegotiationTest.java
@@ -24,7 +24,7 @@ class ExtensionNegotiationTest extends AbstractStatelessMcpE2eTest {
     @Test
     void onConnectionInitFiresForPerRequestDeclaration() throws Exception {
         var extension = new RecordingExtension();
-        startServer(builder -> builder.extension(extension), registrar -> {});
+        startServer(builder -> builder.withExtensions(extension), registrar -> {});
 
         try (var client = createModernTestClient()) {
             var response = client.post("""
@@ -43,7 +43,7 @@ class ExtensionNegotiationTest extends AbstractStatelessMcpE2eTest {
     @Test
     void onConnectionInitNotCalledWhenNotDeclared() throws Exception {
         var extension = new RecordingExtension();
-        startServer(builder -> builder.extension(extension), registrar -> {});
+        startServer(builder -> builder.withExtensions(extension), registrar -> {});
 
         try (var client = createModernTestClient()) {
             var response = client.post("""

--- a/tachyon-api/src/main/java/dev/tachyonmcp/api/server/extensions/AdvertiseMode.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/api/server/extensions/AdvertiseMode.java
@@ -2,8 +2,9 @@
 package dev.tachyonmcp.api.server.extensions;
 
 /**
- * Controls whether a {@link ServerExtension} is listed in the {@code initialize} response's
- * {@code capabilities.extensions}.
+ * Controls whether a {@link ServerExtension} is listed in {@code capabilities.extensions} —
+ * advertised to clients via {@code initialize} (MCP 2025-11-25) or {@code server/discover} (MCP
+ * 2026-07-28 and later).
  */
 public enum AdvertiseMode {
     /** Always listed in {@code capabilities.extensions}. */
@@ -15,5 +16,15 @@ public enum AdvertiseMode {
      * methods — this only hides it from capability discovery, e.g. for internal-only extensions
      * clients aren't expected to know about.
      */
-    NEVER
+    NEVER,
+
+    /**
+     * Listed in {@code capabilities.extensions} only when the client also declares this
+     * extension's ID in the same request — {@code capabilities.extensions} on an {@code
+     * initialize} request (2025-11-25), or {@code _meta."io.modelcontextprotocol/clientCapabilities".extensions}
+     * on any per-request declaration including {@code server/discover} (2026-07-28 and later).
+     * Useful for extensions that should stay invisible to clients that don't already know to ask
+     * for them.
+     */
+    NEGOTIATED
 }

--- a/tachyon-api/src/main/java/dev/tachyonmcp/api/server/extensions/ServerExtension.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/api/server/extensions/ServerExtension.java
@@ -9,12 +9,12 @@ import java.util.Set;
 /** Pluggable server extension that can add custom methods, capabilities, and lifecycle hooks. */
 @ExperimentalApi
 public interface ServerExtension extends Extension<InteractionContext> {
-    /** Returns the server settings to advertise in the initialize response. */
+    /** Returns the server settings to advertise for this extension, e.g. in {@code initialize} or {@code server/discover}. */
     default ExtensionSettings serverSettings() {
         return ExtensionSettings.empty();
     }
 
-    /** Controls whether this extension is listed in the {@code initialize} response. See {@link AdvertiseMode}. */
+    /** Controls whether this extension is advertised to clients (e.g. in {@code initialize} or {@code server/discover}). See {@link AdvertiseMode}. */
     AdvertiseMode advertiseMode();
 
     /** Returns the set of JSON-RPC methods this extension handles. */

--- a/tachyon-core/revapi.json
+++ b/tachyon-core/revapi.json
@@ -691,6 +691,26 @@
           "attachments": {
             "since": "1.0.0-beta.20"
           }
+        },
+        {
+          "ignore": true,
+          "code": "java.method.numberOfParametersChanged",
+          "old": "method java.lang.Object dev.tachyonmcp.core.protocol.ProtocolResponseMapper::discoverResult(java.util.List<java.lang.String>, dev.tachyonmcp.api.server.domain.ServerCapabilities, dev.tachyonmcp.api.server.config.ServerIdentity)",
+          "new": "method java.lang.Object dev.tachyonmcp.core.protocol.ProtocolResponseMapper::discoverResult(java.util.List<java.lang.String>, dev.tachyonmcp.api.server.domain.ServerCapabilities, dev.tachyonmcp.api.server.config.ServerIdentity, java.util.Map<java.lang.String, dev.tachyonmcp.api.json.JsonObject>)",
+          "justification": "server/discover must advertise registered extensions the same way initialize does",
+          "attachments": {
+            "since": "1.0.0-beta.20"
+          }
+        },
+        {
+          "ignore": true,
+          "code": "java.method.numberOfParametersChanged",
+          "old": "method java.lang.Object dev.tachyonmcp.core.protocol.mcp.v2026_07_28.codecs.McpResponseMapper::discoverResult(java.util.List<java.lang.String>, dev.tachyonmcp.api.server.domain.ServerCapabilities, dev.tachyonmcp.api.server.config.ServerIdentity)",
+          "new": "method java.lang.Object dev.tachyonmcp.core.protocol.mcp.v2026_07_28.codecs.McpResponseMapper::discoverResult(java.util.List<java.lang.String>, dev.tachyonmcp.api.server.domain.ServerCapabilities, dev.tachyonmcp.api.server.config.ServerIdentity, java.util.Map<java.lang.String, dev.tachyonmcp.api.json.JsonObject>)",
+          "justification": "server/discover must advertise registered extensions the same way initialize does",
+          "attachments": {
+            "since": "1.0.0-beta.20"
+          }
         }
       ]
     }

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/ProtocolResponseMapper.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/ProtocolResponseMapper.java
@@ -1,6 +1,7 @@
 /* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
 package dev.tachyonmcp.core.protocol;
 
+import dev.tachyonmcp.api.json.JsonObject;
 import dev.tachyonmcp.api.server.config.ServerIdentity;
 import dev.tachyonmcp.api.server.domain.InputRequest;
 import dev.tachyonmcp.api.server.domain.PromptMessage;
@@ -41,7 +42,10 @@ public interface ProtocolResponseMapper {
 
     /** Maps the server discovery response into a protocol-specific shape. */
     default Object discoverResult(
-            List<String> supportedVersions, ServerCapabilities capabilities, ServerIdentity serverIdentity) {
+            List<String> supportedVersions,
+            ServerCapabilities capabilities,
+            ServerIdentity serverIdentity,
+            Map<String, JsonObject> registeredExtensions) {
         throw new UnsupportedOperationException("server/discover is not supported by this protocol version");
     }
 

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/mcp/v2026_07_28/codecs/McpResponseMapper.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/mcp/v2026_07_28/codecs/McpResponseMapper.java
@@ -2,6 +2,7 @@
 package dev.tachyonmcp.core.protocol.mcp.v2026_07_28.codecs;
 
 import dev.tachyonmcp.api.json.JsonDocument;
+import dev.tachyonmcp.api.json.JsonObject;
 import dev.tachyonmcp.api.json.JsonSchema;
 import dev.tachyonmcp.api.server.config.ServerIdentity;
 import dev.tachyonmcp.api.server.domain.Annotations;
@@ -124,7 +125,16 @@ public final class McpResponseMapper extends dev.tachyonmcp.core.protocol.mcp.v2
 
     @Override
     public Object discoverResult(
-            List<String> supportedVersions, ServerCapabilities capabilities, ServerIdentity serverIdentity) {
+            List<String> supportedVersions,
+            ServerCapabilities capabilities,
+            ServerIdentity serverIdentity,
+            Map<String, JsonObject> registeredExtensions) {
+        var capsBuilder = ServerInfoMapper.toServerCapabilities(capabilities);
+        if (!registeredExtensions.isEmpty()) {
+            capsBuilder.extensions(registeredExtensions.entrySet().stream()
+                    .collect(java.util.stream.Collectors.toMap(
+                            Map.Entry::getKey, entry -> JsonUtils.parse(entry.getValue()))));
+        }
         var implementation = ServerInfoMapper.toImplementation(serverIdentity);
         var meta = Map.of("io.modelcontextprotocol/serverInfo", encodeToTree(Implementation.class, implementation));
         // The schema models server identity only via the optional
@@ -135,7 +145,7 @@ public final class McpResponseMapper extends dev.tachyonmcp.core.protocol.mcp.v2
         var additionalProperties = Map.of("serverInfo", encodeToTree(Implementation.class, implementation));
         return new DiscoverResult(
                 supportedVersions,
-                ServerInfoMapper.toServerCapabilities(capabilities).build(),
+                capsBuilder.build(),
                 serverIdentity.instructions(),
                 meta,
                 COMPLETE,

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/mcp/v2026_07_28/codecs/ServerInfoMapper.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/mcp/v2026_07_28/codecs/ServerInfoMapper.java
@@ -80,8 +80,9 @@ class ServerInfoMapper {
         }
 
         // Note: unlike 2025-11-25, this schema has no dedicated `tasks` capability field —
-        // task support is advertised generically via `extensions["io.modelcontextprotocol/tasks"]`.
-        // Not populated here; no caller currently threads task capability into a discover response.
+        // task support (and every other extension) is advertised generically via
+        // `extensions["<extension-id>"]`. Not populated here — McpResponseMapper#discoverResult applies
+        // the registered-extensions map to the builder this method returns.
 
         return builder;
     }

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/handlers/DiscoverHandler.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/handlers/DiscoverHandler.java
@@ -12,9 +12,11 @@ import java.util.Comparator;
 public final class DiscoverHandler implements RpcMethodHandler {
 
     private final ServerEngine server;
+    private final ExtensionNegotiator negotiator;
 
     public DiscoverHandler(ServerEngine server) {
         this.server = server;
+        this.negotiator = new ExtensionNegotiator(server.extensions());
     }
 
     @Override
@@ -32,6 +34,7 @@ public final class DiscoverHandler implements RpcMethodHandler {
                 .discoverResult(
                         supportedVersions,
                         server.resolveCapabilities(),
-                        server.config().identity());
+                        server.config().identity(),
+                        negotiator.registeredExtensions(context));
     }
 }

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/handlers/ExtensionNegotiator.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/handlers/ExtensionNegotiator.java
@@ -3,7 +3,6 @@ package dev.tachyonmcp.core.server.handlers;
 
 import dev.tachyonmcp.api.json.JsonObject;
 import dev.tachyonmcp.api.runtime.Extension;
-import dev.tachyonmcp.api.server.extensions.AdvertiseMode;
 import dev.tachyonmcp.api.server.extensions.ExtensionSettings;
 import dev.tachyonmcp.api.server.extensions.ServerExtension;
 import dev.tachyonmcp.core.runtime.ChannelContext;
@@ -43,10 +42,19 @@ public final class ExtensionNegotiator {
         }
     }
 
-    /** Returns every {@code ALWAYS}-mode registered extension and its server settings for capability advertisement. */
-    public Map<String, JsonObject> registeredExtensions() {
+    /**
+     * Returns every registered extension eligible for capability advertisement in this request's
+     * response, along with its server settings: {@code ALWAYS}-mode extensions unconditionally,
+     * {@code NEGOTIATED}-mode extensions only if this request already enabled them on {@code
+     * context} (see {@link #negotiate}), and never {@code NEVER}-mode extensions.
+     */
+    public Map<String, JsonObject> registeredExtensions(ChannelContext context) {
         return extensions.stream()
-                .filter(e -> e.advertiseMode() == AdvertiseMode.ALWAYS)
+                .filter(e -> switch (e.advertiseMode()) {
+                    case ALWAYS -> true;
+                    case NEVER -> false;
+                    case NEGOTIATED -> context.isExtensionEnabled(e.extensionId());
+                })
                 .collect(Collectors.toMap(
                         Extension::extensionId, e -> e.serverSettings().values()));
     }

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/handlers/InitializeHandler.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/handlers/InitializeHandler.java
@@ -43,7 +43,7 @@ public final class InitializeHandler implements RpcMethodHandler {
         var capabilities = server.resolveCapabilities();
 
         negotiator.negotiate(context, initializeRequest.extensions());
-        var registeredExtensions = negotiator.registeredExtensions();
+        var registeredExtensions = negotiator.registeredExtensions(context);
 
         final var serverConfig = server.config();
         var domainResponse = new InitializeResponse(


### PR DESCRIPTION

### New Features

- Added support for negotiating extensions through both initialization and server discovery.
- Added NEGOTIATED advertisement mode for extensions requested by the client.
- Extensions can now be consistently advertised as always available, hidden, or conditionally negotiated.

### Bug Fixes

- Corrected discovery responses to include only extensions allowed by their advertisement mode.

### Documentation

- Updated extension documentation to explain advertisement and negotiation behavior across supported protocol interactions.

## Details

- ProtocolResponseMapper.discoverResult(...) now takes a Map<String, JsonObject> registeredExtensions param.
- DiscoverHandler builds its own ExtensionNegotiator from server.extensions() (mirroring McpProtocol.requestHandlers()'s existing pattern) and threads registeredExtensions() through — no change needed to DefaultTachyonServer.registerDefaults().
- v2026_07_28.codecs.McpResponseMapper.discoverResult() now populates capsBuilder.extensions(...) inline, mirroring the 2025-11-25 sibling's initializeResult() exactly.
- Fixed the stale comment in ServerInfoMapper.java that admitted extensions weren't threaded into discovery.
- Added AdvertiseMode.NEGOTIATED: advertised only when the client also declares the extension's ID in the same request (initialize's capabilities.extensions, or a 2026-07-28 request's _meta clientCapabilities.extensions). ExtensionNegotiator.registeredExtensions(ChannelContext) now takes the request context to check it.
- Broadened AdvertiseMode/ServerExtension.advertiseMode()/serverSettings() javadoc from "initialize response" to cover both initialize and server/discover, plus docs/extensions.md.
- New DiscoverExtensionsTest (e2e, 2026-07-28) verifies ALWAYS/NEVER/NEGOTIATED extension advertisement in server/discover; ExtensionsTest gained matching NEGOTIATED coverage for initialize.
- Updated tachyon-core/revapi.json to acknowledge discoverResult's new parameter.

Issue #234 