### PR TITLE
refactor: make ExtensionNegotiator a stateless static utility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -494,6 +494,12 @@
                                     </include>
                                 </archives>
                             </revapi.filter>
+                            <revapi.java.filter.annotated>
+                                <regex>false</regex>
+                                <exclude>
+                                    <item>dev.tachyonmcp.api.annotations.InternalApi</item>
+                                </exclude>
+                            </revapi.java.filter.annotated>
                             <revapi.differences>
                                 <ignore>true</ignore>
                                 <differences>

--- a/tachyon-core/revapi.json
+++ b/tachyon-core/revapi.json
@@ -711,6 +711,59 @@
           "attachments": {
             "since": "1.0.0-beta.20"
           }
+        },
+        {
+          "ignore": true,
+          "code": "java.method.parameterTypeChanged",
+          "old": "parameter void dev.tachyonmcp.core.protocol.mcp.v2026_07_28.transport.ExtensionNegotiationHandler::<init>(===dev.tachyonmcp.core.server.handlers.ExtensionNegotiator===)",
+          "new": "parameter void dev.tachyonmcp.core.protocol.mcp.v2026_07_28.transport.ExtensionNegotiationHandler::<init>(===java.util.List<dev.tachyonmcp.api.server.extensions.ServerExtension>===)",
+          "parameterIndex": "0",
+          "justification": "ExtensionNegotiator became a stateless static utility; the handler now carries the extension list directly instead of holding an instance",
+          "attachments": {
+            "since": "1.0.0-beta.20"
+          }
+        },
+        {
+          "ignore": true,
+          "code": "java.method.visibilityReduced",
+          "old": "method void dev.tachyonmcp.core.server.handlers.ExtensionNegotiator::<init>(java.util.List<dev.tachyonmcp.api.server.extensions.ServerExtension>)",
+          "new": "method void dev.tachyonmcp.core.server.handlers.ExtensionNegotiator::<init>()",
+          "oldVisibility": "public",
+          "newVisibility": "private",
+          "justification": "ExtensionNegotiator holds no state; it is now a non-instantiable static utility class",
+          "attachments": {
+            "since": "1.0.0-beta.20"
+          }
+        },
+        {
+          "ignore": true,
+          "code": "java.method.numberOfParametersChanged",
+          "old": "method void dev.tachyonmcp.core.server.handlers.ExtensionNegotiator::negotiate(dev.tachyonmcp.core.runtime.ChannelContext, java.util.Map<java.lang.String, dev.tachyonmcp.api.json.JsonObject>)",
+          "new": "method void dev.tachyonmcp.core.server.handlers.ExtensionNegotiator::negotiate(java.util.List<dev.tachyonmcp.api.server.extensions.ServerExtension>, dev.tachyonmcp.core.runtime.ChannelContext, java.util.Map<java.lang.String, dev.tachyonmcp.api.json.JsonObject>)",
+          "justification": "ExtensionNegotiator became a stateless static utility; negotiate() now takes the extension list as a parameter instead of reading it from instance state",
+          "attachments": {
+            "since": "1.0.0-beta.20"
+          }
+        },
+        {
+          "ignore": true,
+          "code": "java.method.nowStatic",
+          "old": "method void dev.tachyonmcp.core.server.handlers.ExtensionNegotiator::negotiate(dev.tachyonmcp.core.runtime.ChannelContext, java.util.Map<java.lang.String, dev.tachyonmcp.api.json.JsonObject>)",
+          "new": "method void dev.tachyonmcp.core.server.handlers.ExtensionNegotiator::negotiate(java.util.List<dev.tachyonmcp.api.server.extensions.ServerExtension>, dev.tachyonmcp.core.runtime.ChannelContext, java.util.Map<java.lang.String, dev.tachyonmcp.api.json.JsonObject>)",
+          "justification": "ExtensionNegotiator became a stateless static utility; negotiate() is now a static method",
+          "attachments": {
+            "since": "1.0.0-beta.20"
+          }
+        },
+        {
+          "ignore": true,
+          "code": "java.method.numberOfParametersChanged",
+          "old": "method void dev.tachyonmcp.core.server.handlers.InitializeHandler::<init>(dev.tachyonmcp.core.server.internal.ServerEngine, dev.tachyonmcp.core.server.handlers.ExtensionNegotiator)",
+          "new": "method void dev.tachyonmcp.core.server.handlers.InitializeHandler::<init>(dev.tachyonmcp.core.server.internal.ServerEngine)",
+          "justification": "ExtensionNegotiator became a stateless static utility; InitializeHandler no longer needs an injected instance",
+          "attachments": {
+            "since": "1.0.0-beta.20"
+          }
         }
       ]
     }

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/mcp/v2026_07_28/McpProtocol.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/mcp/v2026_07_28/McpProtocol.java
@@ -8,7 +8,6 @@ import dev.tachyonmcp.core.protocol.mcp.McpHeaderNames;
 import dev.tachyonmcp.core.protocol.mcp.v2026_07_28.codecs.McpResponseMapper;
 import dev.tachyonmcp.core.protocol.mcp.v2026_07_28.transport.ExtensionNegotiationHandler;
 import dev.tachyonmcp.core.protocol.mcp.v2026_07_28.transport.RequestValidationHandler;
-import dev.tachyonmcp.core.server.handlers.ExtensionNegotiator;
 import dev.tachyonmcp.core.server.internal.ServerEngine;
 import io.netty.channel.ChannelHandler;
 import io.netty.handler.codec.http.HttpMethod;
@@ -64,7 +63,6 @@ public final class McpProtocol implements Protocol {
 
     @Override
     public List<ChannelHandler> requestHandlers(ServerEngine server) {
-        var negotiator = new ExtensionNegotiator(server.extensions());
-        return List.of(new RequestValidationHandler(server), new ExtensionNegotiationHandler(negotiator));
+        return List.of(new RequestValidationHandler(server), new ExtensionNegotiationHandler(server.extensions()));
     }
 }

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/mcp/v2026_07_28/transport/ExtensionNegotiationHandler.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/mcp/v2026_07_28/transport/ExtensionNegotiationHandler.java
@@ -1,6 +1,7 @@
 /* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
 package dev.tachyonmcp.core.protocol.mcp.v2026_07_28.transport;
 
+import dev.tachyonmcp.api.server.extensions.ServerExtension;
 import dev.tachyonmcp.core.protocol.mcp.v2026_07_28.McpProtocol;
 import dev.tachyonmcp.core.server.handlers.ExtensionNegotiator;
 import dev.tachyonmcp.core.transport.jsonrpc.JsonRpcCodec;
@@ -11,6 +12,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.HttpMethod;
+import java.util.List;
 
 /**
  * Negotiates MCP extensions for 2026-07-28: this revision removed {@code initialize} (no session to
@@ -32,10 +34,10 @@ import io.netty.handler.codec.http.HttpMethod;
 @Sharable
 public final class ExtensionNegotiationHandler extends ChannelInboundHandlerAdapter {
 
-    private final ExtensionNegotiator negotiator;
+    private final List<ServerExtension> extensions;
 
-    public ExtensionNegotiationHandler(ExtensionNegotiator negotiator) {
-        this.negotiator = negotiator;
+    public ExtensionNegotiationHandler(List<ServerExtension> extensions) {
+        this.extensions = extensions;
     }
 
     @Override
@@ -62,7 +64,7 @@ public final class ExtensionNegotiationHandler extends ChannelInboundHandlerAdap
         }
         if (message instanceof JsonRpcMessage.Request<?> request) {
             var declared = interaction.protocol().requestMapper().declaredExtensions(request.params());
-            negotiator.negotiate(interaction, declared);
+            ExtensionNegotiator.negotiate(extensions, interaction, declared);
         }
         ctx.fireChannelRead(msg);
     }

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/DefaultTachyonServer.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/DefaultTachyonServer.java
@@ -42,7 +42,6 @@ import dev.tachyonmcp.core.server.features.tasks.TaskRegistry;
 import dev.tachyonmcp.core.server.features.tools.DefaultToolRegistry;
 import dev.tachyonmcp.core.server.features.tools.ToolMethodHandlers;
 import dev.tachyonmcp.core.server.handlers.DiscoverHandler;
-import dev.tachyonmcp.core.server.handlers.ExtensionNegotiator;
 import dev.tachyonmcp.core.server.handlers.InitializeHandler;
 import dev.tachyonmcp.core.server.handlers.LoggingHandlers;
 import dev.tachyonmcp.core.server.handlers.PingHandler;
@@ -420,7 +419,7 @@ final class DefaultTachyonServer implements ServerEngine, ExtensionContext {
     }
 
     private void registerDefaults() {
-        methodHandlers.put("initialize", new InitializeHandler(this, new ExtensionNegotiator(extensions)));
+        methodHandlers.put("initialize", new InitializeHandler(this));
         methodHandlers.put("server/discover", new DiscoverHandler(this));
         methodHandlers.put("ping", new PingHandler());
         ToolMethodHandlers.register(

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/handlers/DiscoverHandler.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/handlers/DiscoverHandler.java
@@ -12,11 +12,9 @@ import java.util.Comparator;
 public final class DiscoverHandler implements RpcMethodHandler {
 
     private final ServerEngine server;
-    private final ExtensionNegotiator negotiator;
 
     public DiscoverHandler(ServerEngine server) {
         this.server = server;
-        this.negotiator = new ExtensionNegotiator(server.extensions());
     }
 
     @Override
@@ -35,6 +33,6 @@ public final class DiscoverHandler implements RpcMethodHandler {
                         supportedVersions,
                         server.resolveCapabilities(),
                         server.config().identity(),
-                        negotiator.registeredExtensions(context));
+                        ExtensionNegotiator.registeredExtensions(server.extensions(), context));
     }
 }

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/handlers/ExtensionNegotiator.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/handlers/ExtensionNegotiator.java
@@ -19,20 +19,19 @@ import java.util.stream.Collectors;
  * {@code DispatchContext} exists.
  *
  * <p>Shared by 2025-11-25's {@link InitializeHandler} (declared once via {@code initialize}, matches
- * {@link dev.tachyonmcp.core.protocol.ProtocolRequestMapper.InitializeRequest#extensions()}) and
+ * {@link dev.tachyonmcp.core.protocol.ProtocolRequestMapper.InitializeRequest#extensions()}),
  * 2026-07-28's {@code ExtensionNegotiationHandler} (declared per request, matches {@link
- * dev.tachyonmcp.core.protocol.ProtocolRequestMapper#declaredExtensions}).
+ * dev.tachyonmcp.core.protocol.ProtocolRequestMapper#declaredExtensions}), and {@link
+ * DiscoverHandler}. Stateless — the registered extension list is a parameter, not instance state,
+ * since there's nothing per-caller to own.
  */
 public final class ExtensionNegotiator {
 
-    private final List<ServerExtension> extensions;
-
-    public ExtensionNegotiator(List<ServerExtension> extensions) {
-        this.extensions = extensions;
-    }
+    private ExtensionNegotiator() {}
 
     /** Enables each registered extension the client declared, and fires its {@code onConnectionInit}. */
-    public void negotiate(ChannelContext context, Map<String, JsonObject> declared) {
+    public static void negotiate(
+            List<ServerExtension> extensions, ChannelContext context, Map<String, JsonObject> declared) {
         for (var ext : extensions) {
             var clientSettings = declared.get(ext.extensionId());
             if (clientSettings != null) {
@@ -48,7 +47,8 @@ public final class ExtensionNegotiator {
      * {@code NEGOTIATED}-mode extensions only if this request already enabled them on {@code
      * context} (see {@link #negotiate}), and never {@code NEVER}-mode extensions.
      */
-    public Map<String, JsonObject> registeredExtensions(ChannelContext context) {
+    public static Map<String, JsonObject> registeredExtensions(
+            List<ServerExtension> extensions, ChannelContext context) {
         return extensions.stream()
                 .filter(e -> switch (e.advertiseMode()) {
                     case ALWAYS -> true;

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/handlers/InitializeHandler.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/handlers/InitializeHandler.java
@@ -19,11 +19,9 @@ public final class InitializeHandler implements RpcMethodHandler {
 
     private static final String MCP_VERSION = McpProtocol.VERSION;
     private final ServerEngine server;
-    private final ExtensionNegotiator negotiator;
 
-    public InitializeHandler(ServerEngine server, ExtensionNegotiator negotiator) {
+    public InitializeHandler(ServerEngine server) {
         this.server = server;
-        this.negotiator = negotiator;
     }
 
     @Override
@@ -42,8 +40,9 @@ public final class InitializeHandler implements RpcMethodHandler {
 
         var capabilities = server.resolveCapabilities();
 
-        negotiator.negotiate(context, initializeRequest.extensions());
-        var registeredExtensions = negotiator.registeredExtensions(context);
+        var extensions = server.extensions();
+        ExtensionNegotiator.negotiate(extensions, context, initializeRequest.extensions());
+        var registeredExtensions = ExtensionNegotiator.registeredExtensions(extensions, context);
 
         final var serverConfig = server.config();
         var domainResponse = new InitializeResponse(


### PR DESCRIPTION
### Refactor

- Streamlined extension negotiation and registration across server initialization and discovery.
- Improved handling of configured server extensions during protocol setup.
- Removed obsolete extension negotiation wiring and simplified internal configuration.

### Chores

- Updated API compatibility checks to account for the revised extension negotiation behavior.

---

It only ever wrapped the server's List<ServerExtension> with no other state, so InitializeHandler, DiscoverHandler, and ExtensionNegotiationHandler each constructed their own instance for the same underlying list. Converts negotiate()/registeredExtensions() to static methods taking the extension list as a parameter (matching ServerInfoMapper's existing private-constructor + static-methods shape) so there's nothing left to construct or share.