### PR TITLE
feat(testkit): fluent JSON-RPC assertions and initialized-client builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Opt into sessions for SSE resumability, `Last-Event-ID` replay, and TTL cleanup.
 - [FAQ](docs/faq.md) - Java, frameworks, concurrency, deployment, and compatibility
 - [Kotlin DSL](docs/kotlin.md) - Coroutine-first DSL, `TachyonServer { }`, scope reference
 - [Kotlin module](tachyon-kotlin/README.md) - `tachyon-kotlin` module overview
-- [Testkit](tachyon-testkit/README.md) - Test harness: shaping clients, dynamic-port servers
+- [Testkit](docs/testkit.md) - Test harness: shaping clients, dynamic-port servers, fluent JSON-RPC assertions
 - [Examples](examples/README.md) - Runnable Java & Kotlin example servers
 - [Migrate from Kotlin MCP SDK](docs/migrate-from-kotlin-mcp-to-tachyon.md) - Moving an existing Kotlin MCP SDK server
   to Tachyon

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,10 @@
 - [Extensions](extensions.md)
 - [JSON and JSON Schema](json.md)
 
+## Testing
+
+- [Testkit](testkit.md)
+
 ## Kotlin
 
 - [Kotlin DSL](kotlin.md)

--- a/docs/testkit.md
+++ b/docs/testkit.md
@@ -1,0 +1,85 @@
+# MCP TestKit
+
+`tachyon-testkit` drives a running Tachyon server from tests: protocol-shaping HTTP clients,
+in-process port-0 server helpers, and fluent JSON-RPC assertions.
+
+```xml
+<dependency>
+    <groupId>dev.tachyonmcp</groupId>
+    <artifactId>tachyon-testkit</artifactId>
+    <version>${tachyon.version}</version>
+    <scope>test</scope>
+</dependency>
+```
+
+## Servers
+
+`McpTestServers.start` builds a port-0 server, registers handlers, and starts it — closing the
+transport if anything fails, so a broken test never leaks a listener:
+
+```java
+var server = McpTestServers.start(
+    b -> b.session(c -> c.enabled(true)),
+    s -> s.tools().register(descriptor, handler));
+var port = server.port();
+```
+
+## Clients
+
+`McpTestClients` builds a raw JSON-over-HTTP client for a protocol version — `Mcp20251125Client`
+(session-based, `initialize` handshake) or `Mcp20260728Client` (sessionless, self-describing
+requests):
+
+```java
+try (var client = McpTestClients.latest(port)) {
+    client.post("""{"jsonrpc":"2.0","id":1,"method":"tools/list"}""");
+}
+```
+
+`McpTestClients.builder(port)` skips the manual `initialize()` dance and returns an
+already-initialized client for the chosen protocol version:
+
+```java
+try (var client = McpTestClients.builder(port).protocolVersion("2025-11-25").build()) {
+    client.sendRpc("""{"jsonrpc":"2.0","id":1,"method":"ping"}""");
+}
+```
+
+Pass a `URI` instead of a port (`McpTestClients.builder(URI.create("https://staging.example.com/mcp"))`)
+to drive a remote server instead of a local one.
+
+## Assertions
+
+`JsonRpcResponseAssert` gives AssertJ-style assertions over a JSON-RPC response envelope —
+success/error branch, tool content, and JSON-RPC error code/message:
+
+```java
+import static dev.tachyonmcp.testkit.JsonRpcResponseAssert.assertThat;
+
+var response = client.post("""
+    {"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"echo","arguments":{"message":"hi"}}}
+    """);
+
+assertThat(response).hasTextContent("echo:hi");
+```
+
+For raw JSON-RPC error responses, use `assertThatJsonRpcResponse(String)` (avoids an ambiguous
+overload against AssertJ's own `assertThat(String)`):
+
+```java
+import static dev.tachyonmcp.testkit.JsonRpcResponseAssert.assertThatJsonRpcResponse;
+
+var raw = client.sendRpc("""{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"missing","arguments":{}}}""");
+
+assertThatJsonRpcResponse(raw).hasErrorCode(-32602).hasErrorMessageContaining("missing");
+```
+
+## Notifications
+
+Every client captures server-to-client notifications delivered over SSE; await one by method
+name, or take a snapshot of everything received so far:
+
+```java
+client.awaitNotification("notifications/progress")
+    .satisfies(params -> assertThat(params.path("progressToken").asString()).isEqualTo("tok-1"));
+```

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/CompletionTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/CompletionTest.java
@@ -1,6 +1,7 @@
 /* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
 package dev.tachyonmcp.e2e;
 
+import static dev.tachyonmcp.testkit.JsonRpcResponseAssert.assertThat;
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -94,7 +95,7 @@ class CompletionTest extends AbstractStatelessMcpE2eTest {
                 }}
                 """);
 
-            assertThatJson(response.body()).inPath("$.error.code").isEqualTo(-32602);
+            assertThat(response).hasErrorCode(-32602);
         }
     }
 

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/StringSchemaTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/StringSchemaTest.java
@@ -1,6 +1,7 @@
 /* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
 package dev.tachyonmcp.e2e;
 
+import static dev.tachyonmcp.testkit.JsonRpcResponseAssert.assertThat;
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -117,7 +118,7 @@ class StringSchemaTest extends AbstractStatelessMcpE2eTest {
                 """);
 
             assertThat(response.statusCode()).isEqualTo(200);
-            assertThatJson(response.body()).inPath("$.result.content[0].text").isEqualTo("called");
+            assertThat(response).hasTextContent("called");
         }
     }
 }

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/TasksCoreTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/TasksCoreTest.java
@@ -1,6 +1,7 @@
 /* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
 package dev.tachyonmcp.e2e;
 
+import static dev.tachyonmcp.testkit.JsonRpcResponseAssert.assertThatJsonRpcResponse;
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 
 import dev.tachyonmcp.api.server.domain.TaskResult;
@@ -125,10 +126,9 @@ class TasksCoreTest extends AbstractStatefulMcpE2eTest {
             var resultJson = client.sendRpc("""
                     {"jsonrpc":"2.0","id":3,"method":"tasks/result","params":{"taskId":"%s"}}
                     """.formatted(task.id()));
-            assertThatJson(resultJson).inPath("$.result.content").isArray();
-            assertThatJson(resultJson)
-                    .inPath("$.result.structuredContent.output")
-                    .isEqualTo("success");
+            assertThatJsonRpcResponse(resultJson)
+                    .hasContent()
+                    .hasStructuredContent(JsonNodeFactory.instance.objectNode().put("output", "success"));
         }
     }
 

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/mcp/v2026_07_28/transport/ExtensionNegotiationHandler.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/mcp/v2026_07_28/transport/ExtensionNegotiationHandler.java
@@ -1,6 +1,7 @@
 /* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
 package dev.tachyonmcp.core.protocol.mcp.v2026_07_28.transport;
 
+import dev.tachyonmcp.api.annotations.InternalApi;
 import dev.tachyonmcp.api.server.extensions.ServerExtension;
 import dev.tachyonmcp.core.protocol.mcp.v2026_07_28.McpProtocol;
 import dev.tachyonmcp.core.server.handlers.ExtensionNegotiator;
@@ -32,6 +33,7 @@ import java.util.List;
  * shape checks.
  */
 @Sharable
+@InternalApi
 public final class ExtensionNegotiationHandler extends ChannelInboundHandlerAdapter {
 
     private final List<ServerExtension> extensions;

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/handlers/ExtensionNegotiator.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/handlers/ExtensionNegotiator.java
@@ -1,6 +1,7 @@
 /* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
 package dev.tachyonmcp.core.server.handlers;
 
+import dev.tachyonmcp.api.annotations.InternalApi;
 import dev.tachyonmcp.api.json.JsonObject;
 import dev.tachyonmcp.api.runtime.Extension;
 import dev.tachyonmcp.api.server.extensions.ExtensionSettings;
@@ -25,6 +26,7 @@ import java.util.stream.Collectors;
  * DiscoverHandler}. Stateless — the registered extension list is a parameter, not instance state,
  * since there's nothing per-caller to own.
  */
+@InternalApi
 public final class ExtensionNegotiator {
 
     private ExtensionNegotiator() {}

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/handlers/InitializeHandler.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/handlers/InitializeHandler.java
@@ -1,6 +1,7 @@
 /* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
 package dev.tachyonmcp.core.server.handlers;
 
+import dev.tachyonmcp.api.annotations.InternalApi;
 import dev.tachyonmcp.core.protocol.ProtocolRequestMapper;
 import dev.tachyonmcp.core.protocol.RequestMappingException;
 import dev.tachyonmcp.core.protocol.mcp.v2025_11_25.McpProtocol;
@@ -15,6 +16,7 @@ import dev.tachyonmcp.core.server.session.DispatchContext;
  * which redeclares extensions per request through {@code ExtensionNegotiationHandler}), and maps
  * the result back through the negotiated protocol's response mapper.
  */
+@InternalApi
 public final class InitializeHandler implements RpcMethodHandler {
 
     private static final String MCP_VERSION = McpProtocol.VERSION;

--- a/tachyon-testkit/README.md
+++ b/tachyon-testkit/README.md
@@ -1,7 +1,6 @@
-# Tachyon Testkit
+# Tachyon TestKit
 
-Test harness for driving a running Tachyon MCP server: protocol-shaping HTTP clients and
-in-process, port-0 server lifecycle helpers.
+Test harness for driving a running Tachyon MCP server: protocol-shaping HTTP clients, in-process server lifecycle helpers, and fluent JSON-RPC assertions.
 
 ```xml
 <dependency>
@@ -12,40 +11,6 @@ in-process, port-0 server lifecycle helpers.
 </dependency>
 ```
 
-## Clients
+## Documentation
 
-`McpTestClients` builds a client for a protocol version:
-
-```java
-try (var client = McpTestClients.latest(port)) {        // 2026-07-28
-    var list = client.post("""
-        {"jsonrpc":"2.0","id":1,"method":"tools/list"}
-    """.trim());
-};
-
-try (var client = McpTestClients.forVersion(port, "2025-11-25")) {
-    var sessionId = client.initialize();
-    client.sendRpc("""
-        {"jsonrpc":"2.0","id":2,"method":"ping"}
-    """.trim());
-};
-```
-
-- `Mcp20260728Client` shapes each request for MCP 2026-07-28 automatically: the required
-  `_meta` (`io.modelcontextprotocol/protocolVersion` matching the `MCP-Protocol-Version` header,
-  `clientInfo`, `clientCapabilities`) plus `Mcp-Method`/`Mcp-Name` headers. Declare negotiated
-  extensions with `withExtensions(Map)`; pass extra headers (e.g. `Mcp-Param-*`) via
-  `post(body, headers)`.
-- `Mcp20251125Client` adds the `initialize`/`notifications/initialized` handshake and session
-  tracking.
-
-## Servers
-
-```java
-var server = McpTestServers.start(
-    b -> b.session(c -> c.enabled(true)),
-    s -> s.tools().register(descriptor, handler));   // port 0 -> bound port()
-```
-
-`McpTestServers.start`/`startSafely` build, register, start on an ephemeral port, and close the
-transport if startup or registration fails so nothing leaks.
+Full reference: [docs/testkit.md](../docs/testkit.md)

--- a/tachyon-testkit/pom.xml
+++ b/tachyon-testkit/pom.xml
@@ -14,8 +14,8 @@
 
     <artifactId>tachyon-testkit</artifactId>
 
-    <name>Tachyon MCP Testkit</name>
-    <description>Test harness: MCP clients with protocol request shaping and in-process port-0 server helpers</description>
+    <name>Tachyon MCP TestKit</name>
+    <description>Test harness: MCP clients with protocol request shaping and in-process server helpers</description>
 
     <dependencies>
         <dependency>
@@ -122,7 +122,7 @@
                     </execution>
                 </executions>
             </plugin>
-        <plugin>
+            <plugin>
                 <groupId>org.revapi</groupId>
                 <artifactId>revapi-maven-plugin</artifactId>
             </plugin>

--- a/tachyon-testkit/src/main/java/dev/tachyonmcp/testkit/JsonRpcResponseAssert.java
+++ b/tachyon-testkit/src/main/java/dev/tachyonmcp/testkit/JsonRpcResponseAssert.java
@@ -1,0 +1,216 @@
+/* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
+package dev.tachyonmcp.testkit;
+
+import java.net.http.HttpResponse;
+import java.util.function.Consumer;
+import org.assertj.core.api.AbstractAssert;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Fluent AssertJ assertions over a JSON-RPC response envelope ({@code {jsonrpc, id, result|error}}),
+ * as produced by {@link McpClient#post} / {@link McpClient#sendRpc}.
+ *
+ * <pre>{@code
+ * var response = client.post("""
+ *     {"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"echo","arguments":{"message":"hi"}}}
+ *     """);
+ *
+ * assertThat(response).hasTextContent("echo:hi");
+ * }</pre>
+ */
+public final class JsonRpcResponseAssert extends AbstractAssert<JsonRpcResponseAssert, JsonNode> {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private JsonRpcResponseAssert(JsonNode envelope) {
+        super(envelope, JsonRpcResponseAssert.class);
+    }
+
+    /**
+     * Creates assertions for an already-parsed JSON-RPC response envelope.
+     *
+     * @param envelope the JSON-RPC response envelope
+     * @return a new assertion object
+     */
+    public static JsonRpcResponseAssert assertThat(JsonNode envelope) {
+        return new JsonRpcResponseAssert(envelope);
+    }
+
+    /**
+     * Creates assertions for an HTTP response carrying a JSON-RPC response envelope as its body.
+     *
+     * @param httpResponse the HTTP response
+     * @return a new assertion object
+     */
+    public static JsonRpcResponseAssert assertThat(HttpResponse<String> httpResponse) {
+        return assertThatJsonRpcResponse(httpResponse.body());
+    }
+
+    /**
+     * Creates assertions for a raw JSON-RPC response body, e.g. as returned by {@link
+     * McpClient#sendRpc}. Named distinctly from {@code assertThat} to avoid an ambiguous overload
+     * against {@code org.assertj.core.api.Assertions.assertThat(String)} when both are statically
+     * imported.
+     *
+     * @param json the JSON-RPC response body
+     * @return a new assertion object
+     */
+    public static JsonRpcResponseAssert assertThatJsonRpcResponse(String json) {
+        return new JsonRpcResponseAssert(MAPPER.readTree(json));
+    }
+
+    /**
+     * Asserts the envelope carries a {@code result} and no {@code error}.
+     *
+     * @return {@code this}
+     */
+    public JsonRpcResponseAssert isSuccess() {
+        isNotNull();
+        if (!actual.path("error").isMissingNode()) {
+            failWithMessage("Expected a successful JSON-RPC response but found an error: %s", actual.path("error"));
+        }
+        if (actual.path("result").isMissingNode()) {
+            failWithMessage(
+                    "Expected a successful JSON-RPC response with a 'result' but found neither 'result' nor"
+                            + " 'error': %s",
+                    actual);
+        }
+        return this;
+    }
+
+    /**
+     * Asserts the envelope carries an {@code error}.
+     *
+     * @return {@code this}
+     */
+    public JsonRpcResponseAssert isJsonRpcError() {
+        isNotNull();
+        if (actual.path("error").isMissingNode()) {
+            failWithMessage("Expected a JSON-RPC error response but 'error' is missing: %s", actual);
+        }
+        return this;
+    }
+
+    /**
+     * Asserts the JSON-RPC error code equals {@code expectedCode}.
+     *
+     * @param expectedCode the expected {@code error.code}
+     * @return {@code this}
+     */
+    public JsonRpcResponseAssert hasErrorCode(int expectedCode) {
+        isJsonRpcError();
+        var actualCode = actual.path("error").path("code").asInt();
+        if (actualCode != expectedCode) {
+            failWithMessage("Expected JSON-RPC error code <%s> but was <%s> in: %s", expectedCode, actualCode, actual);
+        }
+        return this;
+    }
+
+    /**
+     * Asserts the JSON-RPC error message equals {@code expectedMessage} exactly.
+     *
+     * @param expectedMessage the expected {@code error.message}
+     * @return {@code this}
+     */
+    public JsonRpcResponseAssert hasErrorMessage(String expectedMessage) {
+        isJsonRpcError();
+        var actualMessage = actual.path("error").path("message").asString(null);
+        if (!expectedMessage.equals(actualMessage)) {
+            failWithMessage(
+                    "Expected JSON-RPC error message <%s> but was <%s> in: %s", expectedMessage, actualMessage, actual);
+        }
+        return this;
+    }
+
+    /**
+     * Asserts the JSON-RPC error message contains {@code substring}.
+     *
+     * @param substring the expected substring of {@code error.message}
+     * @return {@code this}
+     */
+    public JsonRpcResponseAssert hasErrorMessageContaining(String substring) {
+        isJsonRpcError();
+        var actualMessage = actual.path("error").path("message").asString("");
+        if (!actualMessage.contains(substring)) {
+            failWithMessage(
+                    "Expected JSON-RPC error message containing <%s> but was <%s> in: %s",
+                    substring, actualMessage, actual);
+        }
+        return this;
+    }
+
+    /**
+     * Runs {@code assertion} against the JSON-RPC error's {@code data} field.
+     *
+     * @param assertion the assertion to run against {@code error.data}
+     * @return {@code this}
+     */
+    public JsonRpcResponseAssert hasErrorDataSatisfying(Consumer<JsonNode> assertion) {
+        isJsonRpcError();
+        assertion.accept(actual.path("error").path("data"));
+        return this;
+    }
+
+    /**
+     * Asserts a successful tool call result has {@code isError: true} — the MCP tool-execution
+     * failure channel, distinct from a JSON-RPC-level error.
+     *
+     * @return {@code this}
+     */
+    public JsonRpcResponseAssert isToolError() {
+        isSuccess();
+        var isError = actual.path("result").path("isError");
+        if (!(isError.isBoolean() && isError.asBoolean())) {
+            failWithMessage("Expected tool result 'isError' to be true in: %s", actual);
+        }
+        return this;
+    }
+
+    /**
+     * Asserts the result's content blocks include a text block equal to {@code expectedText}.
+     *
+     * @param expectedText the expected text content
+     * @return {@code this}
+     */
+    public JsonRpcResponseAssert hasTextContent(String expectedText) {
+        isSuccess();
+        var content = actual.path("result").path("content");
+        for (var block : content) {
+            if ("text".equals(block.path("type").asString())
+                    && expectedText.equals(block.path("text").asString())) {
+                return this;
+            }
+        }
+        failWithMessage("Expected result content to contain text <%s> but was: %s", expectedText, content);
+        return this;
+    }
+
+    /**
+     * Asserts the result's {@code content} field is present and is an array.
+     *
+     * @return {@code this}
+     */
+    public JsonRpcResponseAssert hasContent() {
+        isSuccess();
+        if (!actual.path("result").path("content").isArray()) {
+            failWithMessage("Expected result 'content' to be an array in: %s", actual);
+        }
+        return this;
+    }
+
+    /**
+     * Asserts the result's {@code structuredContent} equals {@code expected}.
+     *
+     * @param expected the expected structured content
+     * @return {@code this}
+     */
+    public JsonRpcResponseAssert hasStructuredContent(JsonNode expected) {
+        isSuccess();
+        var actualStructured = actual.path("result").path("structuredContent");
+        if (!actualStructured.equals(expected)) {
+            failWithMessage("Expected structuredContent <%s> but was <%s> in: %s", expected, actualStructured, actual);
+        }
+        return this;
+    }
+}

--- a/tachyon-testkit/src/main/java/dev/tachyonmcp/testkit/Mcp20251125Client.java
+++ b/tachyon-testkit/src/main/java/dev/tachyonmcp/testkit/Mcp20251125Client.java
@@ -1,6 +1,8 @@
 /* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
 package dev.tachyonmcp.testkit;
 
+import java.net.URI;
+
 /**
  * {@link McpClient} for MCP protocol version 2025-11-25 (session-based, {@code initialize}
  * handshake).
@@ -17,6 +19,15 @@ public final class Mcp20251125Client extends McpClient {
      */
     public Mcp20251125Client(int port) {
         super(port);
+    }
+
+    /**
+     * Creates a client against an arbitrary MCP endpoint (local or remote, http or https).
+     *
+     * @param mcpEndpoint the MCP endpoint URI, e.g. {@code https://staging.example.com/mcp}
+     */
+    public Mcp20251125Client(URI mcpEndpoint) {
+        super(mcpEndpoint);
     }
 
     @Override

--- a/tachyon-testkit/src/main/java/dev/tachyonmcp/testkit/Mcp20260728Client.java
+++ b/tachyon-testkit/src/main/java/dev/tachyonmcp/testkit/Mcp20260728Client.java
@@ -2,6 +2,7 @@
 package dev.tachyonmcp.testkit;
 
 import dev.tachyonmcp.core.protocol.mcp.McpHeaderNames;
+import java.net.URI;
 import java.net.http.HttpRequest;
 import java.util.Map;
 import org.jspecify.annotations.Nullable;
@@ -31,6 +32,15 @@ public final class Mcp20260728Client extends McpClient {
      */
     public Mcp20260728Client(int port) {
         super(port);
+    }
+
+    /**
+     * Creates a client against an arbitrary MCP endpoint (local or remote, http or https).
+     *
+     * @param mcpEndpoint the MCP endpoint URI, e.g. {@code https://staging.example.com/mcp}
+     */
+    public Mcp20260728Client(URI mcpEndpoint) {
+        super(mcpEndpoint);
     }
 
     /**

--- a/tachyon-testkit/src/main/java/dev/tachyonmcp/testkit/McpClient.java
+++ b/tachyon-testkit/src/main/java/dev/tachyonmcp/testkit/McpClient.java
@@ -16,6 +16,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 import me.kpavlov.finchly.queue.MessageAggregator;
+import org.intellij.lang.annotations.Language;
 import org.jspecify.annotations.Nullable;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
@@ -35,15 +36,25 @@ public abstract class McpClient implements Closeable {
     private static final Duration DEFAULT_NOTIFICATION_TIMEOUT = Duration.ofSeconds(5);
     protected static final ObjectMapper MAPPER = new ObjectMapper();
 
-    private final int serverPort;
+    private final URI mcpEndpoint;
     private final HttpClient httpClient;
     private final MessageAggregator<JsonNode> notifications = new MessageAggregator<>();
     private volatile @Nullable String sessionId;
     private volatile boolean closed;
 
+    /** Creates a client against a local, port-0-style Tachyon server ({@code http://localhost:<port>/mcp}). */
     protected McpClient(int port) {
-        this.serverPort = port;
+        this(localEndpoint(port));
+    }
+
+    /** Creates a client against an arbitrary MCP endpoint (local or remote, http or https). */
+    protected McpClient(URI mcpEndpoint) {
+        this.mcpEndpoint = mcpEndpoint;
         this.httpClient = HttpClient.newHttpClient();
+    }
+
+    static URI localEndpoint(int port) {
+        return URI.create("http://localhost:" + port + "/mcp");
     }
 
     /** The MCP protocol version this client speaks; sent as {@code MCP-Protocol-Version}. */
@@ -115,14 +126,14 @@ public abstract class McpClient implements Closeable {
     }
 
     /** POSTs an MCP request without a session. */
-    public HttpResponse<String> post(String body) throws Exception {
+    public HttpResponse<String> post(@Language("json") String body) throws Exception {
         return post(null, body);
     }
 
     /**
      * POSTs an MCP request carrying extra HTTP headers (e.g. {@code Mcp-Param-*} custom headers).
      */
-    public HttpResponse<String> post(String body, Map<String, String> extraHeaders) throws Exception {
+    public HttpResponse<String> post(@Language("json") String body, Map<String, String> extraHeaders) throws Exception {
         return post(null, body, extraHeaders);
     }
 
@@ -243,7 +254,8 @@ public abstract class McpClient implements Closeable {
     }
 
     /** POSTs a request and returns the raw response line stream (for SSE responses). */
-    public HttpResponse<Stream<String>> sendStreamingRequest(@Nullable String sessionId, String body) throws Exception {
+    public HttpResponse<Stream<String>> sendStreamingRequest(@Nullable String sessionId, @Language("json") String body)
+            throws Exception {
         body = requestBody(body);
         var builder = requestBuilder(body);
         if (sessionId != null) builder.header("MCP-Session-Id", sessionId);
@@ -335,7 +347,7 @@ public abstract class McpClient implements Closeable {
 
     private HttpRequest.Builder baseRequest() {
         return HttpRequest.newBuilder()
-                .uri(URI.create("http://localhost:" + serverPort + "/mcp"))
+                .uri(mcpEndpoint)
                 .header("Content-Type", "application/json")
                 .header("Accept", "application/json, text/event-stream")
                 .header("MCP-Protocol-Version", protocolVersion());

--- a/tachyon-testkit/src/main/java/dev/tachyonmcp/testkit/McpTestClientBuilder.java
+++ b/tachyon-testkit/src/main/java/dev/tachyonmcp/testkit/McpTestClientBuilder.java
@@ -1,0 +1,61 @@
+/* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
+package dev.tachyonmcp.testkit;
+
+import java.net.URI;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Fluent builder for an initialized {@link McpClient}: pick a protocol version, {@link #build()},
+ * and get back a client that has already completed the {@code initialize} handshake (where the
+ * chosen protocol version has one — protocol versions without a handshake, e.g. 2026-07-28,
+ * propagate {@link UnsupportedOperationException} from {@code build()}).
+ *
+ * <p>Obtained via {@link McpTestClients#builder(int)} (local port-0 server) or {@link
+ * McpTestClients#builder(URI)} (arbitrary endpoint, local or remote).
+ *
+ * <pre>{@code
+ * try (var client = McpTestClients.builder(port).protocolVersion("2025-11-25").build()) {
+ *     var ping = client.sendRpc("""
+ *             {"jsonrpc":"2.0","id":1,"method":"ping"}
+ *             """);
+ * }
+ * }</pre>
+ */
+public final class McpTestClientBuilder {
+
+    private final URI mcpEndpoint;
+    private @Nullable String protocolVersion;
+
+    McpTestClientBuilder(URI mcpEndpoint) {
+        this.mcpEndpoint = mcpEndpoint;
+    }
+
+    /**
+     * Sets the MCP protocol version the built client will speak.
+     *
+     * @param protocolVersion the MCP protocol version, e.g. {@code "2025-11-25"}
+     * @return {@code this}
+     */
+    public McpTestClientBuilder protocolVersion(String protocolVersion) {
+        this.protocolVersion = protocolVersion;
+        return this;
+    }
+
+    /**
+     * Resolves the client for the configured protocol version and completes its {@code
+     * initialize} handshake.
+     *
+     * @return an initialized client
+     * @throws IllegalStateException if {@link #protocolVersion(String)} was never called
+     * @throws IllegalArgumentException for an unsupported protocol version
+     * @throws Exception if the {@code initialize} handshake fails
+     */
+    public McpClient build() throws Exception {
+        if (protocolVersion == null) {
+            throw new IllegalStateException("protocolVersion() must be set before build()");
+        }
+        var client = McpTestClients.forVersion(mcpEndpoint, protocolVersion);
+        client.initialize();
+        return client;
+    }
+}

--- a/tachyon-testkit/src/main/java/dev/tachyonmcp/testkit/McpTestClients.java
+++ b/tachyon-testkit/src/main/java/dev/tachyonmcp/testkit/McpTestClients.java
@@ -1,6 +1,8 @@
 /* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
 package dev.tachyonmcp.testkit;
 
+import java.net.URI;
+
 /**
  * Factory for {@link McpClient} instances by protocol version.
  */
@@ -19,6 +21,17 @@ public final class McpTestClients {
     }
 
     /**
+     * Returns a client for the newest supported MCP protocol version, against an arbitrary MCP
+     * endpoint (local or remote, http or https).
+     *
+     * @param mcpEndpoint the MCP endpoint URI, e.g. {@code https://staging.example.com/mcp}
+     * @return the latest protocol client
+     */
+    public static Mcp20260728Client latest(URI mcpEndpoint) {
+        return new Mcp20260728Client(mcpEndpoint);
+    }
+
+    /**
      * Returns a client speaking the given MCP protocol version.
      *
      * @param port the port of the running Tachyon server
@@ -27,11 +40,45 @@ public final class McpTestClients {
      * @throws IllegalArgumentException for an unsupported protocol version
      */
     public static McpClient forVersion(int port, String protocolVersion) {
+        return forVersion(McpClient.localEndpoint(port), protocolVersion);
+    }
+
+    /**
+     * Returns a client speaking the given MCP protocol version, against an arbitrary MCP endpoint
+     * (local or remote, http or https).
+     *
+     * @param mcpEndpoint the MCP endpoint URI, e.g. {@code https://staging.example.com/mcp}
+     * @param protocolVersion the MCP protocol version
+     * @return the matching client
+     * @throws IllegalArgumentException for an unsupported protocol version
+     */
+    public static McpClient forVersion(URI mcpEndpoint, String protocolVersion) {
         // ponytail: explicit switch; add a case when the next protocol revision ships
         return switch (protocolVersion) {
-            case Mcp20260728Client.PROTOCOL_VERSION -> new Mcp20260728Client(port);
-            case Mcp20251125Client.PROTOCOL_VERSION -> new Mcp20251125Client(port);
+            case Mcp20260728Client.PROTOCOL_VERSION -> new Mcp20260728Client(mcpEndpoint);
+            case Mcp20251125Client.PROTOCOL_VERSION -> new Mcp20251125Client(mcpEndpoint);
             default -> throw new IllegalArgumentException("Unsupported protocol version: " + protocolVersion);
         };
+    }
+
+    /**
+     * Returns a fluent builder for an initialized client, against a local port-0-style server.
+     *
+     * @param port the port of the running Tachyon server
+     * @return a new builder
+     */
+    public static McpTestClientBuilder builder(int port) {
+        return builder(McpClient.localEndpoint(port));
+    }
+
+    /**
+     * Returns a fluent builder for an initialized client, against an arbitrary MCP endpoint (local
+     * or remote, http or https).
+     *
+     * @param mcpEndpoint the MCP endpoint URI, e.g. {@code https://staging.example.com/mcp}
+     * @return a new builder
+     */
+    public static McpTestClientBuilder builder(URI mcpEndpoint) {
+        return new McpTestClientBuilder(mcpEndpoint);
     }
 }

--- a/tachyon-testkit/src/test/java/dev/tachyonmcp/testkit/JsonRpcResponseAssertTest.java
+++ b/tachyon-testkit/src/test/java/dev/tachyonmcp/testkit/JsonRpcResponseAssertTest.java
@@ -1,17 +1,17 @@
 /* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
 package dev.tachyonmcp.testkit;
 
+import static dev.tachyonmcp.testkit.JsonRpcResponseAssert.assertThat;
+import static dev.tachyonmcp.testkit.JsonRpcResponseAssert.assertThatJsonRpcResponse;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import dev.tachyonmcp.api.server.features.tools.ToolResult;
 import dev.tachyonmcp.core.server.TachyonServer;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import tools.jackson.databind.ObjectMapper;
-
-import static dev.tachyonmcp.testkit.JsonRpcResponseAssert.assertThat;
-import static dev.tachyonmcp.testkit.JsonRpcResponseAssert.assertThatJsonRpcResponse;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Verifies {@link JsonRpcResponseAssert} against a real port-0 server and inline JSON-RPC envelopes.
@@ -27,19 +27,19 @@ class JsonRpcResponseAssertTest {
     static void startServer() {
         server = McpTestServers.start(b -> b.session(c -> c.enabled(true)), s -> {
             s.tools()
-                .register(
-                    d -> d.name("echo").description("Echo back the input"),
-                    (ctx, request) -> ToolResult.text(
-                        "echo:" + request.arguments().stringOr("message", "")));
+                    .register(
+                            d -> d.name("echo").description("Echo back the input"),
+                            (ctx, request) -> ToolResult.text(
+                                    "echo:" + request.arguments().stringOr("message", "")));
             s.tools()
-                .register(
-                    d -> d.name("boom").description("Always fails"),
-                    (ctx, request) -> ToolResult.error("boom"));
+                    .register(
+                            d -> d.name("boom").description("Always fails"),
+                            (ctx, request) -> ToolResult.error("boom"));
             s.tools()
-                .register(
-                    d -> d.name("structured").description("Returns structured content"),
-                    (ctx, request) -> ToolResult.structured(
-                        JSON.createObjectNode().put("output", "success"), "done"));
+                    .register(
+                            d -> d.name("structured").description("Returns structured content"),
+                            (ctx, request) -> ToolResult.structured(
+                                    JSON.createObjectNode().put("output", "success"), "done"));
         });
         port = server.port();
     }
@@ -52,31 +52,31 @@ class JsonRpcResponseAssertTest {
     @Test
     void toolCallSuccessExposesTextContent() throws Exception {
         try (var client =
-                 McpTestClients.builder(port).protocolVersion("2025-11-25").build()) {
-            var response = client.post("""
+                McpTestClients.builder(port).protocolVersion("2025-11-25").build()) {
+            var response = client.sendRpc("""
                 {"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"echo","arguments":{"message":"hi"}}}
                 """);
 
-            assertThat(response).isSuccess().hasContent().hasTextContent("echo:hi");
+            assertThatJsonRpcResponse(response).isSuccess().hasContent().hasTextContent("echo:hi");
         }
     }
 
     @Test
     void toolExecutionFailureIsToolErrorNotJsonRpcError() throws Exception {
         try (var client =
-                 McpTestClients.builder(port).protocolVersion("2025-11-25").build()) {
-            var response = client.post("""
+                McpTestClients.builder(port).protocolVersion("2025-11-25").build()) {
+            var response = client.sendRpc("""
                 {"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"boom","arguments":{}}}
                 """);
 
-            assertThat(response).isSuccess().isToolError();
+            assertThatJsonRpcResponse(response).isSuccess().isToolError();
         }
     }
 
     @Test
     void jsonRpcErrorForUnknownMethodExposesCodeAndMessage() throws Exception {
         try (var client =
-                 McpTestClients.builder(port).protocolVersion("2025-11-25").build()) {
+                McpTestClients.builder(port).protocolVersion("2025-11-25").build()) {
             var raw = client.sendRpc("""
                 {"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"missing","arguments":{}}}
                 """);
@@ -88,12 +88,13 @@ class JsonRpcResponseAssertTest {
     @Test
     void structuredContentIsExposedAsJsonNode() throws Exception {
         try (var client =
-                 McpTestClients.builder(port).protocolVersion("2025-11-25").build()) {
-            var response = client.post("""
+                McpTestClients.builder(port).protocolVersion("2025-11-25").build()) {
+            var response = client.sendRpc("""
                 {"jsonrpc":"2.0","id":5,"method":"tools/call","params":{"name":"structured","arguments":{}}}
                 """);
 
-            assertThat(response).hasStructuredContent(JSON.createObjectNode().put("output", "success"));
+            assertThatJsonRpcResponse(response)
+                    .hasStructuredContent(JSON.createObjectNode().put("output", "success"));
         }
     }
 
@@ -122,7 +123,7 @@ class JsonRpcResponseAssertTest {
             """);
 
         assertThat(envelope)
-            .hasErrorDataSatisfying(
-                data -> assertThat(data.path("field").asString()).isEqualTo("name"));
+                .hasErrorDataSatisfying(
+                        data -> assertThat(data.path("field").asString()).isEqualTo("name"));
     }
 }

--- a/tachyon-testkit/src/test/java/dev/tachyonmcp/testkit/JsonRpcResponseAssertTest.java
+++ b/tachyon-testkit/src/test/java/dev/tachyonmcp/testkit/JsonRpcResponseAssertTest.java
@@ -1,0 +1,128 @@
+/* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
+package dev.tachyonmcp.testkit;
+
+import dev.tachyonmcp.api.server.features.tools.ToolResult;
+import dev.tachyonmcp.core.server.TachyonServer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
+
+import static dev.tachyonmcp.testkit.JsonRpcResponseAssert.assertThat;
+import static dev.tachyonmcp.testkit.JsonRpcResponseAssert.assertThatJsonRpcResponse;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Verifies {@link JsonRpcResponseAssert} against a real port-0 server and inline JSON-RPC envelopes.
+ */
+class JsonRpcResponseAssertTest {
+
+    private static final ObjectMapper JSON = new ObjectMapper();
+
+    private static TachyonServer server;
+    private static int port;
+
+    @BeforeAll
+    static void startServer() {
+        server = McpTestServers.start(b -> b.session(c -> c.enabled(true)), s -> {
+            s.tools()
+                .register(
+                    d -> d.name("echo").description("Echo back the input"),
+                    (ctx, request) -> ToolResult.text(
+                        "echo:" + request.arguments().stringOr("message", "")));
+            s.tools()
+                .register(
+                    d -> d.name("boom").description("Always fails"),
+                    (ctx, request) -> ToolResult.error("boom"));
+            s.tools()
+                .register(
+                    d -> d.name("structured").description("Returns structured content"),
+                    (ctx, request) -> ToolResult.structured(
+                        JSON.createObjectNode().put("output", "success"), "done"));
+        });
+        port = server.port();
+    }
+
+    @AfterAll
+    static void stopServer() {
+        server.close();
+    }
+
+    @Test
+    void toolCallSuccessExposesTextContent() throws Exception {
+        try (var client =
+                 McpTestClients.builder(port).protocolVersion("2025-11-25").build()) {
+            var response = client.post("""
+                {"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"echo","arguments":{"message":"hi"}}}
+                """);
+
+            assertThat(response).isSuccess().hasContent().hasTextContent("echo:hi");
+        }
+    }
+
+    @Test
+    void toolExecutionFailureIsToolErrorNotJsonRpcError() throws Exception {
+        try (var client =
+                 McpTestClients.builder(port).protocolVersion("2025-11-25").build()) {
+            var response = client.post("""
+                {"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"boom","arguments":{}}}
+                """);
+
+            assertThat(response).isSuccess().isToolError();
+        }
+    }
+
+    @Test
+    void jsonRpcErrorForUnknownMethodExposesCodeAndMessage() throws Exception {
+        try (var client =
+                 McpTestClients.builder(port).protocolVersion("2025-11-25").build()) {
+            var raw = client.sendRpc("""
+                {"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"missing","arguments":{}}}
+                """);
+
+            assertThatJsonRpcResponse(raw).isJsonRpcError().hasErrorCode(-32602).hasErrorMessageContaining("missing");
+        }
+    }
+
+    @Test
+    void structuredContentIsExposedAsJsonNode() throws Exception {
+        try (var client =
+                 McpTestClients.builder(port).protocolVersion("2025-11-25").build()) {
+            var response = client.post("""
+                {"jsonrpc":"2.0","id":5,"method":"tools/call","params":{"name":"structured","arguments":{}}}
+                """);
+
+            assertThat(response).hasStructuredContent(JSON.createObjectNode().put("output", "success"));
+        }
+    }
+
+    @Test
+    void isSuccessFailsOnAnErrorEnvelope() {
+        var envelope = JSON.readTree("""
+            {"jsonrpc":"2.0","id":1,"error":{"code":-32602,"message":"Invalid params"}}
+            """);
+
+        assertThatThrownBy(() -> assertThat(envelope).isSuccess()).isInstanceOf(AssertionError.class);
+    }
+
+    @Test
+    void hasErrorCodeFailsOnASuccessEnvelope() {
+        var envelope = JSON.readTree("""
+            {"jsonrpc":"2.0","id":1,"result":{"content":[]}}
+            """);
+
+        assertThatThrownBy(() -> assertThat(envelope).hasErrorCode(-32602)).isInstanceOf(AssertionError.class);
+    }
+
+    @Test
+    void hasErrorDataSatisfyingRunsTheGivenAssertionAgainstErrorData() {
+        var envelope = JSON.readTree("""
+            {"jsonrpc":"2.0","id":1,"error":{"code":-32602,"message":"Invalid params","data":{"field":"name"}}}
+            """);
+
+        assertThat(envelope)
+            .hasErrorDataSatisfying(
+                data -> assertThat(data.path("field").asString()).isEqualTo("name"));
+    }
+}

--- a/tachyon-testkit/src/test/java/dev/tachyonmcp/testkit/McpTestClientBuilderTest.java
+++ b/tachyon-testkit/src/test/java/dev/tachyonmcp/testkit/McpTestClientBuilderTest.java
@@ -1,0 +1,78 @@
+/* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
+package dev.tachyonmcp.testkit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import dev.tachyonmcp.core.server.TachyonServer;
+import java.net.URI;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/** Verifies {@link McpTestClientBuilder} against a real port-0 server. */
+class McpTestClientBuilderTest {
+
+    private static TachyonServer server;
+    private static int port;
+
+    @BeforeAll
+    static void startServer() {
+        server = McpTestServers.start(b -> b.session(c -> c.enabled(true)), s -> {});
+        port = server.port();
+    }
+
+    @AfterAll
+    static void stopServer() {
+        server.close();
+    }
+
+    @Test
+    void buildReturnsAnAlreadyInitializedClient() throws Exception {
+        try (var client =
+                McpTestClients.builder(port).protocolVersion("2025-11-25").build()) {
+            var ping = client.sendRpc("""
+                    {"jsonrpc":"2.0","id":1,"method":"ping"}
+                    """);
+
+            assertThat(ping).contains("\"result\"");
+        }
+    }
+
+    @Test
+    void buildAgainstAnExplicitEndpointReturnsAnInitializedClient() throws Exception {
+        var endpoint = URI.create("http://localhost:" + port + "/mcp");
+
+        try (var client =
+                McpTestClients.builder(endpoint).protocolVersion("2025-11-25").build()) {
+            var ping = client.sendRpc("""
+                    {"jsonrpc":"2.0","id":1,"method":"ping"}
+                    """);
+
+            assertThat(ping).contains("\"result\"");
+        }
+    }
+
+    @Test
+    void buildPropagatesUnsupportedOperationForAProtocolVersionWithoutInitialize() {
+        var builder = McpTestClients.builder(port).protocolVersion("2026-07-28");
+
+        assertThatThrownBy(builder::build).isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void buildFailsFastWhenProtocolVersionWasNeverSet() {
+        var builder = McpTestClients.builder(port);
+
+        assertThatThrownBy(builder::build).isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void buildRejectsAnUnsupportedProtocolVersion() {
+        var builder = McpTestClients.builder(port).protocolVersion("2024-11-05");
+
+        assertThatThrownBy(builder::build)
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("2024-11-05");
+    }
+}


### PR DESCRIPTION
## Summary
- Add `JsonRpcResponseAssert`: AssertJ-style fluent assertions over a JSON-RPC response envelope — success/error branch, tool call content, structured content, and JSON-RPC error code/message/data.
- Add `McpTestClientBuilder` (via `McpTestClients.builder(...)`): a protocol-version-parameterized, already-initialized test client, buildable against a local port or an arbitrary remote `URI` (http/https).
- Add `docs/testkit.md` and trim `tachyon-testkit/README.md` to point to it, avoiding duplication between the module README and the docs site.
- Migrate a few representative e2e call sites (`StringSchemaTest`, `CompletionTest`, `TasksCoreTest`) to the new assertions as proof of concept.
- chore: mark `ExtensionNegotiator`/`ExtensionNegotiationHandler`/`InitializeHandler` as `@InternalApi`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)