### PR TITLE
feat: mcp subscriptions

### DIFF
--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp20260728/SubscriptionsListenTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp20260728/SubscriptionsListenTest.java
@@ -1,0 +1,235 @@
+/* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
+package dev.tachyonmcp.e2e.mcp20260728;
+
+import dev.tachyonmcp.api.server.domain.TextResourceContents;
+import dev.tachyonmcp.api.server.features.tools.ToolResult;
+import dev.tachyonmcp.e2e.AbstractStatelessMcpE2eTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
+
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+/**
+ * MCP 2026-07-28 {@code subscriptions/listen} (SEP-2575): the request-scoped SSE stream that
+ * replaces {@code resources/subscribe} and the plain HTTP GET stream for the stateless transport.
+ */
+class SubscriptionsListenTest extends AbstractStatelessMcpE2eTest {
+
+    @BeforeEach
+    void freshServer() {
+        startServer(
+            b -> b.capabilities(c -> c.tools(true).resources(false, true).prompts(true)));
+    }
+
+    @Test
+    void acknowledgesFirstWithMatchingSubscriptionId() throws Exception {
+        var lines = new CopyOnWriteArrayList<String>();
+        try (var client = createModernTestClient()) {
+            var response = client.sendStreamingRequest(null, """
+                {"jsonrpc":"2.0","id":1,"method":"subscriptions/listen",
+                 "params":{"notifications":{"toolsListChanged":true}}}
+                """);
+            assertThat(response.statusCode()).isEqualTo(200);
+            var consume = CompletableFuture.runAsync(() -> response.body().forEach(lines::add));
+            await().atMost(Duration.ofSeconds(10))
+                .untilAsserted(() -> assertThat(payloads(lines)).isNotEmpty());
+
+            var first = payloads(lines).getFirst();
+            assertThat(first).contains("\"notifications/subscriptions/acknowledged\"");
+            assertThat(first).contains("\"io.modelcontextprotocol/subscriptionId\":\"1\"");
+
+            response.body().close();
+            awaitQuietly(consume);
+        }
+    }
+
+    @Test
+    void enforcesRequestedFilterNoUnrequestedNotificationsLeak() throws Exception {
+        var lines = new CopyOnWriteArrayList<String>();
+        try (var client = createModernTestClient()) {
+            var response = client.sendStreamingRequest(null, """
+                {"jsonrpc":"2.0","id":1,"method":"subscriptions/listen",
+                 "params":{"notifications":{"toolsListChanged":true}}}
+                """);
+            var consume = CompletableFuture.runAsync(() -> response.body().forEach(lines::add));
+            await().atMost(Duration.ofSeconds(10))
+                .untilAsserted(() -> assertThat(payloads(lines))
+                    .anyMatch(l -> l.contains("notifications/subscriptions/acknowledged")));
+
+            // Trigger a resources change (not requested) then a tools change (requested). Because
+            // both go through the same per-stream event loop in submission order, observing the
+            // tools notification proves the server already had its chance to (wrongly) deliver the
+            // resources one first.
+            server.resources().register(r -> r
+                    .name("trigger-resource")
+                    .uri("test://trigger"),
+                (ctx, req) -> TextResourceContents.of(req.uri(), "anything", "text/plain"));
+            server.tools()
+                .register(
+                    t -> t.name("trigger-tool").description("d").inputSchema("{\"type\":\"object\"}"),
+                    (ctx, req) -> ToolResult.text("x"));
+
+            await().atMost(Duration.ofSeconds(10))
+                .untilAsserted(() ->
+                    assertThat(payloads(lines)).anyMatch(l -> l.contains("notifications/tools/list_changed")));
+
+            assertThat(payloads(lines)).noneMatch(l -> l.contains("notifications/resources/list_changed"));
+
+            response.body().close();
+            awaitQuietly(consume);
+        }
+    }
+
+    @Test
+    void pushesResourceUpdatedOnlyForSubscribedUri() throws Exception {
+        var lines = new CopyOnWriteArrayList<String>();
+        try (var client = createModernTestClient()) {
+            var response = client.sendStreamingRequest(null, """
+                {"jsonrpc":"2.0","id":1,"method":"subscriptions/listen",
+                 "params":{"notifications":{"resourceSubscriptions":["test://a"]}}}
+                """);
+            var consume = CompletableFuture.runAsync(() -> response.body().forEach(lines::add));
+            await().atMost(Duration.ofSeconds(10))
+                .untilAsserted(() -> assertThat(payloads(lines))
+                    .anyMatch(l -> l.contains("notifications/subscriptions/acknowledged")));
+
+            server.resources().notifyResourceUpdated("test://b");
+            server.resources().notifyResourceUpdated("test://a");
+
+            await().atMost(Duration.ofSeconds(10))
+                .untilAsserted(() -> assertThat(payloads(lines))
+                    .anyMatch(l -> l.contains("notifications/resources/updated") && l.contains("test://a")));
+
+            assertThat(payloads(lines))
+                .filteredOn(l -> l.contains("notifications/resources/updated"))
+                .noneMatch(l -> l.contains("test://b"));
+
+            response.body().close();
+            awaitQuietly(consume);
+        }
+    }
+
+    @Test
+    void demultiplexesConcurrentSubscriptionsById() throws Exception {
+        var linesA = new CopyOnWriteArrayList<String>();
+        var linesB = new CopyOnWriteArrayList<String>();
+        try (var client = createModernTestClient()) {
+            var responseA = client.sendStreamingRequest(null, """
+                {"jsonrpc":"2.0","id":10,"method":"subscriptions/listen",
+                 "params":{"notifications":{"toolsListChanged":true}}}
+                """);
+            var responseB = client.sendStreamingRequest(null, """
+                {"jsonrpc":"2.0","id":20,"method":"subscriptions/listen",
+                 "params":{"notifications":{"toolsListChanged":true}}}
+                """);
+            var consumeA = CompletableFuture.runAsync(() -> responseA.body().forEach(linesA::add));
+            var consumeB = CompletableFuture.runAsync(() -> responseB.body().forEach(linesB::add));
+            await().atMost(Duration.ofSeconds(10)).untilAsserted(() -> {
+                assertThat(payloads(linesA)).anyMatch(l -> l.contains("acknowledged"));
+                assertThat(payloads(linesB)).anyMatch(l -> l.contains("acknowledged"));
+            });
+
+            server.tools()
+                .register(
+                    t -> t.name("trigger-tool-2").description("d").inputSchema("{\"type\":\"object\"}"),
+                    (ctx, req) -> ToolResult.text("x"));
+
+            await().atMost(Duration.ofSeconds(10)).untilAsserted(() -> {
+                assertThat(payloads(linesA))
+                    .anyMatch(l -> l.contains("notifications/tools/list_changed")
+                        && l.contains("\"io.modelcontextprotocol/subscriptionId\":\"10\""));
+                assertThat(payloads(linesB))
+                    .anyMatch(l -> l.contains("notifications/tools/list_changed")
+                        && l.contains("\"io.modelcontextprotocol/subscriptionId\":\"20\""));
+            });
+
+            responseA.body().close();
+            responseB.body().close();
+            awaitQuietly(consumeA);
+            awaitQuietly(consumeB);
+        }
+    }
+
+    @Test
+    void serverStaysResponsiveAfterClientDisconnect() throws Exception {
+        var lines = new CopyOnWriteArrayList<String>();
+        try (var client = createModernTestClient()) {
+            var response = client.sendStreamingRequest(null, """
+                {"jsonrpc":"2.0","id":1,"method":"subscriptions/listen",
+                 "params":{"notifications":{"toolsListChanged":true}}}
+                """);
+            var consume = CompletableFuture.runAsync(() -> response.body().forEach(lines::add));
+            await().atMost(Duration.ofSeconds(10))
+                .untilAsserted(() -> assertThat(payloads(lines)).anyMatch(l -> l.contains("acknowledged")));
+
+            response.body().close();
+            awaitQuietly(consume);
+
+            // A dropped subscriber must not wedge the server: a list-change fired after disconnect,
+            // and a fresh unrelated request, must both still succeed.
+            server.tools()
+                .register(
+                    t -> t.name("trigger-tool-3").description("d").inputSchema("{\"type\":\"object\"}"),
+                    (ctx, req) -> ToolResult.text("x"));
+            await().atMost(Duration.ofSeconds(10)).untilAsserted(() -> {
+                var pingResponse = client.sendRpc(null, """
+                    {"jsonrpc":"2.0","id":99,"method":"tools/list","params":{}}
+                    """);
+                assertThat(pingResponse).contains("\"trigger-tool-3\"");
+            });
+        }
+    }
+
+    @Test
+    void gracefullyClosesOnServerShutdown() throws Exception {
+        var lines = new CopyOnWriteArrayList<String>();
+        try (var client = createModernTestClient()) {
+            var response = client.sendStreamingRequest(null, """
+                {"jsonrpc":"2.0","id":1,"method":"subscriptions/listen",
+                 "params":{"notifications":{"toolsListChanged":true}}}
+                """);
+            var consume = CompletableFuture.runAsync(() -> response.body().forEach(lines::add));
+            await().atMost(Duration.ofSeconds(10))
+                .untilAsserted(() -> assertThat(payloads(lines)).anyMatch(l -> l.contains("acknowledged")));
+
+            stopServer();
+            consume.get(15, TimeUnit.SECONDS);
+
+            var last = payloads(lines).getLast();
+            // language=json
+            assertThatJson(last).isEqualTo("""
+                    {"jsonrpc":"2.0",
+                    "id":1,
+                    "result":{
+                      "_meta": {"io.modelcontextprotocol/subscriptionId":"1"},
+                      "resultType":"complete"
+                      }
+                    }
+                    """
+            );
+        }
+    }
+
+    private static void awaitQuietly(CompletableFuture<Void> future) {
+        try {
+            future.get(5, TimeUnit.SECONDS);
+        } catch (Exception ignored) {
+            // Expected: closing the client-side stream makes the background line reader fail.
+        }
+    }
+
+    private static List<String> payloads(List<String> lines) {
+        return lines.stream()
+            .map(l -> l.startsWith("data: ") ? l.substring(6) : l.startsWith("data:") ? l.substring(5) : "")
+            .filter(p -> !p.isBlank())
+            .toList();
+    }
+}

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp20260728/SubscriptionsListenTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp20260728/SubscriptionsListenTest.java
@@ -8,10 +8,13 @@ import static org.awaitility.Awaitility.await;
 import dev.tachyonmcp.api.server.domain.TextResourceContents;
 import dev.tachyonmcp.api.server.features.tools.ToolResult;
 import dev.tachyonmcp.e2e.AbstractStatelessMcpE2eTest;
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -216,11 +219,16 @@ class SubscriptionsListenTest extends AbstractStatelessMcpE2eTest {
         }
     }
 
-    private static void awaitQuietly(CompletableFuture<Void> future) {
+    private static void awaitQuietly(CompletableFuture<Void> future) throws Exception {
         try {
             future.get(5, TimeUnit.SECONDS);
-        } catch (Exception ignored) {
-            // Expected: closing the client-side stream makes the background line reader fail.
+        } catch (ExecutionException e) {
+            // Expected: closing the client-side stream mid-read makes the background line reader
+            // fail with an I/O-shaped exception. Anything else is a real bug — let it fail the test.
+            var cause = e.getCause();
+            if (!(cause instanceof IOException) && !(cause instanceof UncheckedIOException)) {
+                throw e;
+            }
         }
     }
 

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp20260728/SubscriptionsListenTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp20260728/SubscriptionsListenTest.java
@@ -1,21 +1,20 @@
 /* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
 package dev.tachyonmcp.e2e.mcp20260728;
 
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
 import dev.tachyonmcp.api.server.domain.TextResourceContents;
 import dev.tachyonmcp.api.server.features.tools.ToolResult;
 import dev.tachyonmcp.e2e.AbstractStatelessMcpE2eTest;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-
 import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
-
-import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.awaitility.Awaitility.await;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * MCP 2026-07-28 {@code subscriptions/listen} (SEP-2575): the request-scoped SSE stream that
@@ -26,7 +25,7 @@ class SubscriptionsListenTest extends AbstractStatelessMcpE2eTest {
     @BeforeEach
     void freshServer() {
         startServer(
-            b -> b.capabilities(c -> c.tools(true).resources(false, true).prompts(true)));
+                b -> b.capabilities(c -> c.tools(true).resources(false, true).prompts(true)));
     }
 
     @Test
@@ -40,7 +39,7 @@ class SubscriptionsListenTest extends AbstractStatelessMcpE2eTest {
             assertThat(response.statusCode()).isEqualTo(200);
             var consume = CompletableFuture.runAsync(() -> response.body().forEach(lines::add));
             await().atMost(Duration.ofSeconds(10))
-                .untilAsserted(() -> assertThat(payloads(lines)).isNotEmpty());
+                    .untilAsserted(() -> assertThat(payloads(lines)).isNotEmpty());
 
             var first = payloads(lines).getFirst();
             assertThat(first).contains("\"notifications/subscriptions/acknowledged\"");
@@ -61,25 +60,25 @@ class SubscriptionsListenTest extends AbstractStatelessMcpE2eTest {
                 """);
             var consume = CompletableFuture.runAsync(() -> response.body().forEach(lines::add));
             await().atMost(Duration.ofSeconds(10))
-                .untilAsserted(() -> assertThat(payloads(lines))
-                    .anyMatch(l -> l.contains("notifications/subscriptions/acknowledged")));
+                    .untilAsserted(() -> assertThat(payloads(lines))
+                            .anyMatch(l -> l.contains("notifications/subscriptions/acknowledged")));
 
             // Trigger a resources change (not requested) then a tools change (requested). Because
             // both go through the same per-stream event loop in submission order, observing the
             // tools notification proves the server already had its chance to (wrongly) deliver the
             // resources one first.
-            server.resources().register(r -> r
-                    .name("trigger-resource")
-                    .uri("test://trigger"),
-                (ctx, req) -> TextResourceContents.of(req.uri(), "anything", "text/plain"));
+            server.resources()
+                    .register(
+                            r -> r.name("trigger-resource").uri("test://trigger"),
+                            (ctx, req) -> TextResourceContents.of(req.uri(), "anything", "text/plain"));
             server.tools()
-                .register(
-                    t -> t.name("trigger-tool").description("d").inputSchema("{\"type\":\"object\"}"),
-                    (ctx, req) -> ToolResult.text("x"));
+                    .register(
+                            t -> t.name("trigger-tool").description("d").inputSchema("{\"type\":\"object\"}"),
+                            (ctx, req) -> ToolResult.text("x"));
 
             await().atMost(Duration.ofSeconds(10))
-                .untilAsserted(() ->
-                    assertThat(payloads(lines)).anyMatch(l -> l.contains("notifications/tools/list_changed")));
+                    .untilAsserted(() ->
+                            assertThat(payloads(lines)).anyMatch(l -> l.contains("notifications/tools/list_changed")));
 
             assertThat(payloads(lines)).noneMatch(l -> l.contains("notifications/resources/list_changed"));
 
@@ -98,19 +97,19 @@ class SubscriptionsListenTest extends AbstractStatelessMcpE2eTest {
                 """);
             var consume = CompletableFuture.runAsync(() -> response.body().forEach(lines::add));
             await().atMost(Duration.ofSeconds(10))
-                .untilAsserted(() -> assertThat(payloads(lines))
-                    .anyMatch(l -> l.contains("notifications/subscriptions/acknowledged")));
+                    .untilAsserted(() -> assertThat(payloads(lines))
+                            .anyMatch(l -> l.contains("notifications/subscriptions/acknowledged")));
 
             server.resources().notifyResourceUpdated("test://b");
             server.resources().notifyResourceUpdated("test://a");
 
             await().atMost(Duration.ofSeconds(10))
-                .untilAsserted(() -> assertThat(payloads(lines))
-                    .anyMatch(l -> l.contains("notifications/resources/updated") && l.contains("test://a")));
+                    .untilAsserted(() -> assertThat(payloads(lines))
+                            .anyMatch(l -> l.contains("notifications/resources/updated") && l.contains("test://a")));
 
             assertThat(payloads(lines))
-                .filteredOn(l -> l.contains("notifications/resources/updated"))
-                .noneMatch(l -> l.contains("test://b"));
+                    .filteredOn(l -> l.contains("notifications/resources/updated"))
+                    .noneMatch(l -> l.contains("test://b"));
 
             response.body().close();
             awaitQuietly(consume);
@@ -138,17 +137,17 @@ class SubscriptionsListenTest extends AbstractStatelessMcpE2eTest {
             });
 
             server.tools()
-                .register(
-                    t -> t.name("trigger-tool-2").description("d").inputSchema("{\"type\":\"object\"}"),
-                    (ctx, req) -> ToolResult.text("x"));
+                    .register(
+                            t -> t.name("trigger-tool-2").description("d").inputSchema("{\"type\":\"object\"}"),
+                            (ctx, req) -> ToolResult.text("x"));
 
             await().atMost(Duration.ofSeconds(10)).untilAsserted(() -> {
                 assertThat(payloads(linesA))
-                    .anyMatch(l -> l.contains("notifications/tools/list_changed")
-                        && l.contains("\"io.modelcontextprotocol/subscriptionId\":\"10\""));
+                        .anyMatch(l -> l.contains("notifications/tools/list_changed")
+                                && l.contains("\"io.modelcontextprotocol/subscriptionId\":\"10\""));
                 assertThat(payloads(linesB))
-                    .anyMatch(l -> l.contains("notifications/tools/list_changed")
-                        && l.contains("\"io.modelcontextprotocol/subscriptionId\":\"20\""));
+                        .anyMatch(l -> l.contains("notifications/tools/list_changed")
+                                && l.contains("\"io.modelcontextprotocol/subscriptionId\":\"20\""));
             });
 
             responseA.body().close();
@@ -168,7 +167,7 @@ class SubscriptionsListenTest extends AbstractStatelessMcpE2eTest {
                 """);
             var consume = CompletableFuture.runAsync(() -> response.body().forEach(lines::add));
             await().atMost(Duration.ofSeconds(10))
-                .untilAsserted(() -> assertThat(payloads(lines)).anyMatch(l -> l.contains("acknowledged")));
+                    .untilAsserted(() -> assertThat(payloads(lines)).anyMatch(l -> l.contains("acknowledged")));
 
             response.body().close();
             awaitQuietly(consume);
@@ -176,9 +175,9 @@ class SubscriptionsListenTest extends AbstractStatelessMcpE2eTest {
             // A dropped subscriber must not wedge the server: a list-change fired after disconnect,
             // and a fresh unrelated request, must both still succeed.
             server.tools()
-                .register(
-                    t -> t.name("trigger-tool-3").description("d").inputSchema("{\"type\":\"object\"}"),
-                    (ctx, req) -> ToolResult.text("x"));
+                    .register(
+                            t -> t.name("trigger-tool-3").description("d").inputSchema("{\"type\":\"object\"}"),
+                            (ctx, req) -> ToolResult.text("x"));
             await().atMost(Duration.ofSeconds(10)).untilAsserted(() -> {
                 var pingResponse = client.sendRpc(null, """
                     {"jsonrpc":"2.0","id":99,"method":"tools/list","params":{}}
@@ -198,7 +197,7 @@ class SubscriptionsListenTest extends AbstractStatelessMcpE2eTest {
                 """);
             var consume = CompletableFuture.runAsync(() -> response.body().forEach(lines::add));
             await().atMost(Duration.ofSeconds(10))
-                .untilAsserted(() -> assertThat(payloads(lines)).anyMatch(l -> l.contains("acknowledged")));
+                    .untilAsserted(() -> assertThat(payloads(lines)).anyMatch(l -> l.contains("acknowledged")));
 
             stopServer();
             consume.get(15, TimeUnit.SECONDS);
@@ -213,8 +212,7 @@ class SubscriptionsListenTest extends AbstractStatelessMcpE2eTest {
                       "resultType":"complete"
                       }
                     }
-                    """
-            );
+                    """);
         }
     }
 
@@ -228,8 +226,8 @@ class SubscriptionsListenTest extends AbstractStatelessMcpE2eTest {
 
     private static List<String> payloads(List<String> lines) {
         return lines.stream()
-            .map(l -> l.startsWith("data: ") ? l.substring(6) : l.startsWith("data:") ? l.substring(5) : "")
-            .filter(p -> !p.isBlank())
-            .toList();
+                .map(l -> l.startsWith("data: ") ? l.substring(6) : l.startsWith("data:") ? l.substring(5) : "")
+                .filter(p -> !p.isBlank())
+                .toList();
     }
 }

--- a/tachyon-core/revapi.json
+++ b/tachyon-core/revapi.json
@@ -764,6 +764,15 @@
           "attachments": {
             "since": "1.0.0-beta.20"
           }
+        },
+        {
+          "ignore": true,
+          "code": "java.method.removed",
+          "old": "method java.util.Map<java.lang.String, java.lang.Object> dev.tachyonmcp.core.server.internal.NotificationLogSupport::logParams(dev.tachyonmcp.api.server.domain.LoggingLevel, java.lang.String, java.lang.Object)",
+          "justification": "Superseded by ProtocolResponseMapper.loggingMessageParams(), which builds the generated LoggingMessageNotificationParams model and serializes it through the protocol version's own codec instead of a hand-built Map",
+          "attachments": {
+            "since": "1.0.0-beta.20"
+          }
         }
       ]
     }

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/ProtocolRequestMapper.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/ProtocolRequestMapper.java
@@ -12,6 +12,7 @@ import dev.tachyonmcp.api.server.features.tasks.TaskState;
 import dev.tachyonmcp.api.server.features.tools.ToolRequest;
 import java.time.Duration;
 import java.util.Map;
+import java.util.Set;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -88,6 +89,19 @@ public interface ProtocolRequestMapper {
     /** Maps {@code tasks/status} notification params, or {@code null} if unparseable. */
     @Nullable
     TaskStatusRequest taskStatus(@Nullable Object params);
+
+    /**
+     * Whether this protocol supports {@code subscriptions/listen} (2026-07-28's replacement for
+     * {@code resources/subscribe} and the plain HTTP GET stream).
+     */
+    default boolean supportsSubscriptionsListen() {
+        return false;
+    }
+
+    /** Maps {@code subscriptions/listen} params into the requested notification filter. */
+    default SubscriptionListenRequest subscriptionsListen(@Nullable Object params) {
+        throw new UnsupportedOperationException("subscriptions/listen is not supported by this protocol version");
+    }
 
     /**
      * A page request.
@@ -168,4 +182,18 @@ public interface ProtocolRequestMapper {
      */
     record TaskStatusRequest(
             String taskId, TaskState state, @Nullable String message) {}
+
+    /**
+     * The notification filter requested on a {@code subscriptions/listen} call.
+     *
+     * @param toolsListChanged whether to receive {@code notifications/tools/list_changed}
+     * @param promptsListChanged whether to receive {@code notifications/prompts/list_changed}
+     * @param resourcesListChanged whether to receive {@code notifications/resources/list_changed}
+     * @param resourceSubscriptions resource URIs to receive {@code notifications/resources/updated} for
+     */
+    record SubscriptionListenRequest(
+            boolean toolsListChanged,
+            boolean promptsListChanged,
+            boolean resourcesListChanged,
+            Set<String> resourceSubscriptions) {}
 }

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/ProtocolResponseMapper.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/ProtocolResponseMapper.java
@@ -4,6 +4,8 @@ package dev.tachyonmcp.core.protocol;
 import dev.tachyonmcp.api.json.JsonObject;
 import dev.tachyonmcp.api.server.config.ServerIdentity;
 import dev.tachyonmcp.api.server.domain.InputRequest;
+import dev.tachyonmcp.api.server.domain.LoggingLevel;
+import dev.tachyonmcp.api.server.domain.ProgressToken;
 import dev.tachyonmcp.api.server.domain.PromptMessage;
 import dev.tachyonmcp.api.server.domain.RequestId;
 import dev.tachyonmcp.api.server.domain.ResourceContents;
@@ -20,8 +22,10 @@ import dev.tachyonmcp.api.server.features.tools.ToolResult;
 import dev.tachyonmcp.core.protocol.ProtocolRequestMapper.SubscriptionListenRequest;
 import dev.tachyonmcp.core.server.domain.InitializeResponse;
 import dev.tachyonmcp.core.server.features.tasks.TaskEntry;
+import dev.tachyonmcp.core.server.json.JsonUtils;
 import dev.tachyonmcp.core.transport.jsonrpc.JsonRpcCodec;
 import dev.tachyonmcp.core.transport.jsonrpc.JsonRpcError;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import org.jspecify.annotations.Nullable;
@@ -116,6 +120,31 @@ public interface ProtocolResponseMapper {
 
     /** Builds the params object for a tasks/status notification from a task entry. */
     Object taskStatusNotificationParams(TaskEntry entry);
+
+    /** Builds the params for a {@code notifications/message} notification. */
+    Object loggingMessageParams(LoggingLevel level, @Nullable String logger, @Nullable Object data);
+
+    /**
+     * Builds the params for a {@code notifications/progress} notification. The same wire shape is
+     * shared by every protocol version, so this has one implementation for all of them, built with
+     * {@link JsonUtils#toObjectNode} rather than a generated model: the generated
+     * {@code ProgressNotificationParams.progressToken} field is typed {@code String}-only in every
+     * version's codegen output, narrower than the spec's {@code string | number} — converting a
+     * numeric token through it would silently turn a JSON number into a JSON string on the wire.
+     */
+    default Object progressNotificationParams(ProgressToken token, double progress, double total, String message) {
+        Object wireToken =
+                switch (token) {
+                    case ProgressToken.StringValue(var v) -> v;
+                    case ProgressToken.NumericValue(var v) -> v;
+                };
+        var fields = new LinkedHashMap<String, Object>(4);
+        fields.put("progressToken", wireToken);
+        fields.put("progress", progress);
+        fields.put("total", total);
+        fields.put("message", message);
+        return JsonUtils.toObjectNode(fields);
+    }
 
     /**
      * Builds the ack-first {@code notifications/subscriptions/acknowledged} params sent when a new

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/ProtocolResponseMapper.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/ProtocolResponseMapper.java
@@ -5,6 +5,7 @@ import dev.tachyonmcp.api.json.JsonObject;
 import dev.tachyonmcp.api.server.config.ServerIdentity;
 import dev.tachyonmcp.api.server.domain.InputRequest;
 import dev.tachyonmcp.api.server.domain.PromptMessage;
+import dev.tachyonmcp.api.server.domain.RequestId;
 import dev.tachyonmcp.api.server.domain.ResourceContents;
 import dev.tachyonmcp.api.server.domain.ServerCapabilities;
 import dev.tachyonmcp.api.server.domain.ServerError;
@@ -16,6 +17,7 @@ import dev.tachyonmcp.api.server.features.resources.ResourceDescriptor;
 import dev.tachyonmcp.api.server.features.resources.ResourceTemplateDescriptor;
 import dev.tachyonmcp.api.server.features.tools.ToolDescriptor;
 import dev.tachyonmcp.api.server.features.tools.ToolResult;
+import dev.tachyonmcp.core.protocol.ProtocolRequestMapper.SubscriptionListenRequest;
 import dev.tachyonmcp.core.server.domain.InitializeResponse;
 import dev.tachyonmcp.core.server.features.tasks.TaskEntry;
 import dev.tachyonmcp.core.transport.jsonrpc.JsonRpcError;
@@ -100,4 +102,36 @@ public interface ProtocolResponseMapper {
 
     /** Builds the params object for a tasks/status notification from a task entry. */
     Object taskStatusNotificationParams(TaskEntry entry);
+
+    /**
+     * Builds the ack-first {@code notifications/subscriptions/acknowledged} params sent when a new
+     * {@code subscriptions/listen} stream is opened.
+     */
+    default Object subscriptionsAcknowledgedParams(RequestId subscriptionId, SubscriptionListenRequest filter) {
+        throw new UnsupportedOperationException("subscriptions/listen is not supported by this protocol version");
+    }
+
+    /**
+     * Builds the params for a {@code notifications/tools|prompts|resources/list_changed} notification
+     * pushed on a {@code subscriptions/listen} stream.
+     */
+    default Object subscriptionListChangedParams(RequestId subscriptionId) {
+        throw new UnsupportedOperationException("subscriptions/listen is not supported by this protocol version");
+    }
+
+    /**
+     * Builds the params for a {@code notifications/resources/updated} notification pushed on a
+     * {@code subscriptions/listen} stream.
+     */
+    default Object subscriptionResourceUpdatedParams(RequestId subscriptionId, String uri) {
+        throw new UnsupportedOperationException("subscriptions/listen is not supported by this protocol version");
+    }
+
+    /**
+     * Builds the graceful-closure result sent when the server tears down a {@code
+     * subscriptions/listen} stream on its own initiative (e.g. shutdown).
+     */
+    default Object subscriptionsListenGracefulResult(RequestId subscriptionId) {
+        throw new UnsupportedOperationException("subscriptions/listen is not supported by this protocol version");
+    }
 }

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/ProtocolResponseMapper.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/ProtocolResponseMapper.java
@@ -20,6 +20,7 @@ import dev.tachyonmcp.api.server.features.tools.ToolResult;
 import dev.tachyonmcp.core.protocol.ProtocolRequestMapper.SubscriptionListenRequest;
 import dev.tachyonmcp.core.server.domain.InitializeResponse;
 import dev.tachyonmcp.core.server.features.tasks.TaskEntry;
+import dev.tachyonmcp.core.transport.jsonrpc.JsonRpcCodec;
 import dev.tachyonmcp.core.transport.jsonrpc.JsonRpcError;
 import java.util.List;
 import java.util.Map;
@@ -35,6 +36,19 @@ public interface ProtocolResponseMapper {
 
     /** Returns {@code true} when this mapper handles the given protocol family and version. */
     boolean supports(String protocolName, String protocolVersion);
+
+    /**
+     * Serializes a value this mapper produced into its JSON wire form. Values built from a protocol
+     * version's generated models are only encoded correctly by that version's codecs, so callers
+     * hand the value back to the mapper that produced it instead of serializing it themselves. The
+     * default handles JSON trees, maps, lists and scalars.
+     *
+     * @param value the mapped response, notification params or result
+     * @return the value's JSON representation
+     */
+    default String encode(Object value) {
+        return JsonRpcCodec.toJsonParams(value);
+    }
 
     /** Returns the protocol-specific empty result sent for methods that return no data. */
     Object emptyResult();

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/mcp/v2025_11_25/codecs/McpRequestMapper.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/mcp/v2025_11_25/codecs/McpRequestMapper.java
@@ -14,32 +14,40 @@ import dev.tachyonmcp.api.server.features.tasks.TaskState;
 import dev.tachyonmcp.api.server.features.tools.ToolRequest;
 import dev.tachyonmcp.core.protocol.ProtocolRequestMapper;
 import dev.tachyonmcp.core.protocol.RequestMappingException;
+import dev.tachyonmcp.core.protocol.mcp.v2025_11_25.models.CallToolRequestParams;
+import dev.tachyonmcp.core.protocol.mcp.v2025_11_25.models.CancelledNotificationParams;
+import dev.tachyonmcp.core.protocol.mcp.v2025_11_25.models.CompleteRequestParams;
+import dev.tachyonmcp.core.protocol.mcp.v2025_11_25.models.GetPromptRequestParams;
+import dev.tachyonmcp.core.protocol.mcp.v2025_11_25.models.InitializeRequestParams;
+import dev.tachyonmcp.core.protocol.mcp.v2025_11_25.models.PaginatedRequestParams;
+import dev.tachyonmcp.core.protocol.mcp.v2025_11_25.models.ReadResourceRequestParams;
+import dev.tachyonmcp.core.protocol.mcp.v2025_11_25.models.TaskStatus;
 import dev.tachyonmcp.core.server.domain.ServerErrors;
+import dev.tachyonmcp.core.server.json.JsonUtils;
 import java.time.Duration;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import org.jspecify.annotations.Nullable;
-import tools.jackson.databind.json.JsonMapper;
 
 /**
  * Request mapper for MCP 2025-11-25 and its backward-compatible request shapes.
  *
  * <p>Also parses the 2026-07-28 {@code inputResponses}/{@code requestState} fields (SEP-2322)
  * unconditionally: they're simply absent on 2025-11-25 wire payloads, so this is a no-op for that
- * version.
+ * version. Because these fields aren't part of this version's generated {@code *RequestParams}
+ * models, they're read from the raw params map rather than through {@link #convert}.
  */
 public class McpRequestMapper implements ProtocolRequestMapper {
 
     private static final String META_LOG_LEVEL_KEY = "io.modelcontextprotocol/logLevel";
     private static final String META_CLIENT_CAPABILITIES_KEY = "io.modelcontextprotocol/clientCapabilities";
-    private static final JsonMapper JSON = new JsonMapper();
 
     @Override
     public PageRequest page(@Nullable Object params) {
         var map = asMap(params);
         var limit = map.get("limit") instanceof Number number ? number.intValue() : 0;
-        var cursor = map.get("cursor") instanceof String text ? text : null;
-        return new PageRequest(limit, cursor);
+        var paginated = convert(map, PaginatedRequestParams.class);
+        return new PageRequest(limit, paginated.cursor());
     }
 
     @Override
@@ -47,20 +55,29 @@ public class McpRequestMapper implements ProtocolRequestMapper {
         return callTool(params, payloadDeserializer, true);
     }
 
-    /** Maps a tool call, optionally preserving MCP 2025-11-25's legacy task augmentation fields. */
+    /**
+     * Maps a tool call, optionally preserving MCP 2025-11-25's legacy task augmentation fields.
+     *
+     * <p>{@code task} is excluded before conversion and read from the raw params map instead, even
+     * though the generated record declares it: 2026-07-28 payloads may carry a garbage or
+     * differently-shaped {@code task} value there since that version ignores the field entirely
+     * (see the class javadoc), and converting it as part of {@link CallToolRequestParams} would
+     * fail on such payloads regardless of {@code legacyTaskAugmentation}.
+     */
     protected final ToolCallRequest callTool(
             @Nullable Object params, PayloadDeserializer payloadDeserializer, boolean legacyTaskAugmentation) {
         var map = asMap(params);
-        var name = requiredString(map, "name", "Missing tool name");
-        var arguments = optionalMap(map, "arguments", "Invalid arguments");
-        var meta = optionalMap(map, "_meta", "Invalid _meta");
+        var callToolMap = new LinkedHashMap<>(map);
+        callToolMap.remove("task");
+        var callParams = convert(callToolMap, CallToolRequestParams.class);
+        var meta = JsonUtils.toObjectMap(callParams._meta());
         var inputResponses = optionalMap(map, "inputResponses", "Invalid inputResponses");
         var requestState = optionalString(map, "requestState", "Invalid requestState");
         var task = legacyTaskAugmentation ? optionalMap(map, "task", "Invalid task metadata") : null;
         var ttl = task != null && task.get("ttl") instanceof Number value ? Duration.ofMillis(value.longValue()) : null;
         var request = ToolRequest.builder()
-                .name(name)
-                .arguments(Args.of(arguments, payloadDeserializer))
+                .name(required(callParams.name(), "Missing tool name"))
+                .arguments(Args.of(JsonUtils.toObjectMap(callParams.arguments()), payloadDeserializer))
                 .meta(meta)
                 .progressToken(progressToken(meta))
                 .payloadDeserializer(payloadDeserializer)
@@ -73,23 +90,26 @@ public class McpRequestMapper implements ProtocolRequestMapper {
     @Override
     public PromptCallRequest getPrompt(@Nullable Object params) {
         var map = asMap(params);
-        var name = requiredString(map, "name", "Missing prompt name");
-        var arguments = optionalMap(map, "arguments", "Invalid arguments");
+        var promptParams = convert(map, GetPromptRequestParams.class);
         var inputResponses = optionalMap(map, "inputResponses", "Invalid inputResponses");
         var requestState = optionalString(map, "requestState", "Invalid requestState");
-        var meta = optionalMap(map, "_meta", "Invalid _meta");
+        var arguments = JsonUtils.toObjectMap(promptParams.arguments());
         return new PromptCallRequest(
-                name,
+                required(promptParams.name(), "Missing prompt name"),
                 new PromptRequest(
-                        arguments != null ? Args.of(arguments) : Args.empty(), inputResponses, requestState, meta));
+                        arguments != null ? Args.of(arguments) : Args.empty(),
+                        inputResponses,
+                        requestState,
+                        JsonUtils.toObjectMap(promptParams._meta())));
     }
 
     @Override
     public ResourceRequest readResource(@Nullable Object params) {
         var map = asMap(params);
+        var resourceParams = convert(map, ReadResourceRequestParams.class);
         return ResourceRequest.builder()
-                .uri(requiredString(map, "uri", "Missing resource URI"))
-                .meta(optionalMap(map, "_meta", "Invalid _meta"))
+                .uri(required(resourceParams.uri(), "Missing resource URI"))
+                .meta(JsonUtils.toObjectMap(resourceParams._meta()))
                 .inputResponses(optionalMap(map, "inputResponses", "Invalid inputResponses"))
                 .requestState(optionalString(map, "requestState", "Invalid requestState"))
                 .build();
@@ -99,9 +119,10 @@ public class McpRequestMapper implements ProtocolRequestMapper {
     public CompletionCallRequest complete(@Nullable Object params) {
         var map = asMap(params);
         var ref = requiredMap(map, "ref", "Missing or invalid ref parameter");
-        var argument = requiredMap(map, "argument", "Missing or invalid argument parameter");
-        var argumentName = requiredString(argument, "name", "argument.name and argument.value are required");
-        var argumentValue = requiredString(argument, "value", "argument.name and argument.value are required");
+        var argumentMap = requiredMap(map, "argument", "argument.name and argument.value are required");
+        var argument = convert(argumentMap, CompleteRequestParams.Argument.class);
+        var argumentName = required(argument.name(), "argument.name and argument.value are required");
+        var argumentValue = required(argument.value(), "argument.name and argument.value are required");
         var refType = ref.get("type");
         final CompletionReference reference;
         if ("ref/prompt".equals(refType)) {
@@ -141,7 +162,8 @@ public class McpRequestMapper implements ProtocolRequestMapper {
     public LoggingLevel loggingLevel(@Nullable Object params) {
         var value = requiredString(asMap(params), "level", "Missing level parameter");
         try {
-            return LoggingLevel.fromValue(value);
+            return LoggingLevelMapper.toDomain(
+                    dev.tachyonmcp.core.protocol.mcp.v2025_11_25.models.LoggingLevel.fromValue(value));
         } catch (IllegalArgumentException e) {
             throw invalidParams("Invalid logging level: " + value);
         }
@@ -149,8 +171,9 @@ public class McpRequestMapper implements ProtocolRequestMapper {
 
     @Override
     public InitializeRequest initialize(@Nullable Object params) {
-        var capabilities = optionalMap(asMap(params), "capabilities", "Invalid capabilities");
-        var extensions = capabilities != null ? optionalMap(capabilities, "extensions", "Invalid extensions") : null;
+        var initParams = convert(asMap(params), InitializeRequestParams.class);
+        var capabilities = initParams.capabilities();
+        var extensions = capabilities != null ? JsonUtils.toObjectMap(capabilities.extensions()) : null;
         return new InitializeRequest(mapExtensions(extensions));
     }
 
@@ -195,35 +218,62 @@ public class McpRequestMapper implements ProtocolRequestMapper {
         var map = asMap(params);
         var rawId = map.get("requestId");
         if (!(rawId instanceof CharSequence) && !(rawId instanceof Number)) return null;
-        var reason = map.get("reason") instanceof String text ? text : null;
-        return new CancellationRequest(RequestId.of(rawId), reason);
+        var cancelParams = convert(map, CancelledNotificationParams.class);
+        return new CancellationRequest(RequestId.of(rawId), cancelParams.reason());
     }
 
     @Override
     public @Nullable TaskStatusRequest taskStatus(@Nullable Object params) {
         var map = asMap(params);
         if (!(map.get("taskId") instanceof String taskId)) return null;
-        var status = map.get("status");
-        var state = "input_required".equals(status)
-                ? TaskState.INPUT_REQUIRED
-                : "completed".equals(status)
-                        ? TaskState.COMPLETED
-                        : "failed".equals(status)
-                                ? TaskState.FAILED
-                                : "cancelled".equals(status) ? TaskState.CANCELLED : TaskState.WORKING;
+        var state = map.get("status") instanceof String text ? toTaskState(parseTaskStatus(text)) : TaskState.WORKING;
         var message = map.get("statusMessage") instanceof String text ? text : null;
         return new TaskStatusRequest(taskId, state, message);
+    }
+
+    /** Parses a {@code status} string via the generated enum, defaulting unknown values to {@code WORKING}. */
+    private static TaskStatus parseTaskStatus(String value) {
+        try {
+            return TaskStatus.fromValue(value);
+        } catch (IllegalArgumentException e) {
+            return TaskStatus.WORKING;
+        }
+    }
+
+    private static TaskState toTaskState(TaskStatus status) {
+        return switch (status) {
+            case INPUT_REQUIRED -> TaskState.INPUT_REQUIRED;
+            case COMPLETED -> TaskState.COMPLETED;
+            case FAILED -> TaskState.FAILED;
+            case CANCELLED -> TaskState.CANCELLED;
+            case WORKING -> TaskState.WORKING;
+        };
     }
 
     protected Map<String, Object> asMap(@Nullable Object params) {
         if (params == null) return Map.of();
         if (params instanceof Map<?, ?> map) return stringKeyed(map);
         try {
-            Map<?, ?> decoded = JSON.convertValue(params, Map.class);
+            Map<?, ?> decoded = JsonUtils.mapper().convertValue(params, Map.class);
             return stringKeyed(decoded);
         } catch (RuntimeException ignored) {
             return Map.of();
         }
+    }
+
+    /** Deserializes a normalized params map into a generated model, or throws {@code invalid_params}. */
+    protected static <T> T convert(Map<String, Object> map, Class<T> type) {
+        try {
+            return JsonUtils.mapper().convertValue(map, type);
+        } catch (RuntimeException e) {
+            throw invalidParams("Invalid " + type.getSimpleName());
+        }
+    }
+
+    /** Requires a field extracted from a generated model to be non-null, or throws {@code invalid_params}. */
+    private static <T> T required(@Nullable T value, String message) {
+        if (value == null) throw invalidParams(message);
+        return value;
     }
 
     private static Map<String, Object> stringKeyed(Map<?, ?> source) {

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/mcp/v2025_11_25/codecs/McpResponseMapper.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/mcp/v2025_11_25/codecs/McpResponseMapper.java
@@ -5,6 +5,7 @@ import dev.tachyonmcp.api.json.JsonDocument;
 import dev.tachyonmcp.api.server.domain.ContentBlock;
 import dev.tachyonmcp.api.server.domain.FormInputRequest;
 import dev.tachyonmcp.api.server.domain.InputRequest;
+import dev.tachyonmcp.api.server.domain.LoggingLevel;
 import dev.tachyonmcp.api.server.domain.PromptMessage;
 import dev.tachyonmcp.api.server.domain.ResourceContents;
 import dev.tachyonmcp.api.server.domain.RpcMethodRequest;
@@ -36,6 +37,7 @@ import dev.tachyonmcp.core.protocol.mcp.v2025_11_25.models.ListResourceTemplates
 import dev.tachyonmcp.core.protocol.mcp.v2025_11_25.models.ListResourcesResult;
 import dev.tachyonmcp.core.protocol.mcp.v2025_11_25.models.ListTasksResult;
 import dev.tachyonmcp.core.protocol.mcp.v2025_11_25.models.ListToolsResult;
+import dev.tachyonmcp.core.protocol.mcp.v2025_11_25.models.LoggingMessageNotificationParams;
 import dev.tachyonmcp.core.protocol.mcp.v2025_11_25.models.ReadResourceResult;
 import dev.tachyonmcp.core.server.domain.InitializeResponse;
 import dev.tachyonmcp.core.server.features.tasks.TaskEntry;
@@ -256,6 +258,15 @@ public class McpResponseMapper implements ProtocolResponseMapper {
     @Override
     public Object taskStatusNotificationParams(TaskEntry entry) {
         return McpTaskMapper.toStatusNotification(entry);
+    }
+
+    @Override
+    public Object loggingMessageParams(LoggingLevel level, @Nullable String logger, @Nullable Object data) {
+        return new LoggingMessageNotificationParams(
+                LoggingLevelMapper.toProtocol(level),
+                logger,
+                JsonUtils.parseJsonNode(JsonRpcCodec.writeValueAsString(data)),
+                null);
     }
 
     @Override

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/mcp/v2025_11_25/codecs/McpResponseMapper.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/mcp/v2025_11_25/codecs/McpResponseMapper.java
@@ -71,6 +71,15 @@ public class McpResponseMapper implements ProtocolResponseMapper {
     }
 
     @Override
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public String encode(Object value) {
+        var codec = (Codec) CodecRegistry.codecFor(value.getClass());
+        return codec == null
+                ? ProtocolResponseMapper.super.encode(value)
+                : JsonRpcCodec.writeAsString(gen -> codec.encode(gen, value));
+    }
+
+    @Override
     public Object emptyResult() {
         return EMPTY;
     }

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/mcp/v2026_07_28/codecs/McpRequestMapper.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/mcp/v2026_07_28/codecs/McpRequestMapper.java
@@ -2,7 +2,12 @@
 package dev.tachyonmcp.core.protocol.mcp.v2026_07_28.codecs;
 
 import dev.tachyonmcp.api.json.PayloadDeserializer;
+import dev.tachyonmcp.core.protocol.ProtocolRequestMapper.SubscriptionListenRequest;
 import dev.tachyonmcp.core.protocol.ProtocolRequestMapper.ToolCallRequest;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -21,5 +26,29 @@ public final class McpRequestMapper extends dev.tachyonmcp.core.protocol.mcp.v20
     @Override
     public boolean supportsLegacyTaskAugmentation() {
         return false;
+    }
+
+    @Override
+    public boolean supportsSubscriptionsListen() {
+        return true;
+    }
+
+    @Override
+    public SubscriptionListenRequest subscriptionsListen(@Nullable Object params) {
+        var map = asMap(params);
+        if (!(map.get("notifications") instanceof Map<?, ?> filter)) {
+            return new SubscriptionListenRequest(false, false, false, Set.of());
+        }
+        Set<String> resourceSubscriptions = filter.get("resourceSubscriptions") instanceof List<?> uris
+                ? uris.stream()
+                        .filter(String.class::isInstance)
+                        .map(String.class::cast)
+                        .collect(Collectors.toUnmodifiableSet())
+                : Set.of();
+        return new SubscriptionListenRequest(
+                Boolean.TRUE.equals(filter.get("toolsListChanged")),
+                Boolean.TRUE.equals(filter.get("promptsListChanged")),
+                Boolean.TRUE.equals(filter.get("resourcesListChanged")),
+                resourceSubscriptions);
     }
 }

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/mcp/v2026_07_28/codecs/McpRequestMapper.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/mcp/v2026_07_28/codecs/McpRequestMapper.java
@@ -4,8 +4,8 @@ package dev.tachyonmcp.core.protocol.mcp.v2026_07_28.codecs;
 import dev.tachyonmcp.api.json.PayloadDeserializer;
 import dev.tachyonmcp.core.protocol.ProtocolRequestMapper.SubscriptionListenRequest;
 import dev.tachyonmcp.core.protocol.ProtocolRequestMapper.ToolCallRequest;
-import java.util.List;
-import java.util.Map;
+import dev.tachyonmcp.core.protocol.mcp.v2026_07_28.models.SubscriptionsListenRequestParams;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.jspecify.annotations.Nullable;
@@ -35,20 +35,20 @@ public final class McpRequestMapper extends dev.tachyonmcp.core.protocol.mcp.v20
 
     @Override
     public SubscriptionListenRequest subscriptionsListen(@Nullable Object params) {
-        var map = asMap(params);
-        if (!(map.get("notifications") instanceof Map<?, ?> filter)) {
+        var listenParams = convert(asMap(params), SubscriptionsListenRequestParams.class);
+        var filter = listenParams.notifications();
+        if (filter == null) {
             return new SubscriptionListenRequest(false, false, false, Set.of());
         }
-        Set<String> resourceSubscriptions = filter.get("resourceSubscriptions") instanceof List<?> uris
-                ? uris.stream()
-                        .filter(String.class::isInstance)
-                        .map(String.class::cast)
+        var resourceSubscriptions = filter.resourceSubscriptions() != null
+                ? filter.resourceSubscriptions().stream()
+                        .filter(Objects::nonNull)
                         .collect(Collectors.toUnmodifiableSet())
-                : Set.of();
+                : Set.<String>of();
         return new SubscriptionListenRequest(
-                Boolean.TRUE.equals(filter.get("toolsListChanged")),
-                Boolean.TRUE.equals(filter.get("promptsListChanged")),
-                Boolean.TRUE.equals(filter.get("resourcesListChanged")),
+                Boolean.TRUE.equals(filter.toolsListChanged()),
+                Boolean.TRUE.equals(filter.promptsListChanged()),
+                Boolean.TRUE.equals(filter.resourcesListChanged()),
                 resourceSubscriptions);
     }
 }

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/mcp/v2026_07_28/codecs/McpResponseMapper.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/mcp/v2026_07_28/codecs/McpResponseMapper.java
@@ -9,6 +9,7 @@ import dev.tachyonmcp.api.server.domain.Annotations;
 import dev.tachyonmcp.api.server.domain.ContentBlock;
 import dev.tachyonmcp.api.server.domain.FormInputRequest;
 import dev.tachyonmcp.api.server.domain.InputRequest;
+import dev.tachyonmcp.api.server.domain.LoggingLevel;
 import dev.tachyonmcp.api.server.domain.PromptMessage;
 import dev.tachyonmcp.api.server.domain.RequestId;
 import dev.tachyonmcp.api.server.domain.RpcMethodRequest;
@@ -42,6 +43,7 @@ import dev.tachyonmcp.core.protocol.mcp.v2026_07_28.models.ListPromptsResult;
 import dev.tachyonmcp.core.protocol.mcp.v2026_07_28.models.ListResourceTemplatesResult;
 import dev.tachyonmcp.core.protocol.mcp.v2026_07_28.models.ListResourcesResult;
 import dev.tachyonmcp.core.protocol.mcp.v2026_07_28.models.ListToolsResult;
+import dev.tachyonmcp.core.protocol.mcp.v2026_07_28.models.LoggingMessageNotificationParams;
 import dev.tachyonmcp.core.protocol.mcp.v2026_07_28.models.NotificationParams;
 import dev.tachyonmcp.core.protocol.mcp.v2026_07_28.models.Prompt;
 import dev.tachyonmcp.core.protocol.mcp.v2026_07_28.models.PromptArgument;
@@ -302,6 +304,15 @@ public final class McpResponseMapper extends dev.tachyonmcp.core.protocol.mcp.v2
     @Override
     public Object taskStatusNotificationParams(TaskEntry entry) {
         return McpTaskMapper.toStatusNotification(entry);
+    }
+
+    @Override
+    public Object loggingMessageParams(LoggingLevel level, @Nullable String logger, @Nullable Object data) {
+        return new LoggingMessageNotificationParams(
+                dev.tachyonmcp.core.protocol.mcp.v2026_07_28.models.LoggingLevel.valueOf(level.name()),
+                logger,
+                JsonUtils.parseJsonNode(JsonRpcCodec.writeValueAsString(data)),
+                null);
     }
 
     @Override

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/mcp/v2026_07_28/codecs/McpResponseMapper.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/mcp/v2026_07_28/codecs/McpResponseMapper.java
@@ -10,6 +10,7 @@ import dev.tachyonmcp.api.server.domain.ContentBlock;
 import dev.tachyonmcp.api.server.domain.FormInputRequest;
 import dev.tachyonmcp.api.server.domain.InputRequest;
 import dev.tachyonmcp.api.server.domain.PromptMessage;
+import dev.tachyonmcp.api.server.domain.RequestId;
 import dev.tachyonmcp.api.server.domain.RpcMethodRequest;
 import dev.tachyonmcp.api.server.domain.ServerCapabilities;
 import dev.tachyonmcp.api.server.domain.ServerError;
@@ -23,6 +24,7 @@ import dev.tachyonmcp.api.server.features.resources.ResourceDescriptor;
 import dev.tachyonmcp.api.server.features.resources.ResourceTemplateDescriptor;
 import dev.tachyonmcp.api.server.features.tools.ToolDescriptor;
 import dev.tachyonmcp.api.server.features.tools.ToolResult;
+import dev.tachyonmcp.core.protocol.ProtocolRequestMapper.SubscriptionListenRequest;
 import dev.tachyonmcp.core.protocol.mcp.v2026_07_28.McpProtocol;
 import dev.tachyonmcp.core.protocol.mcp.v2026_07_28.models.BlobResourceContents;
 import dev.tachyonmcp.core.protocol.mcp.v2026_07_28.models.CallToolResult;
@@ -75,6 +77,7 @@ public final class McpResponseMapper extends dev.tachyonmcp.core.protocol.mcp.v2
     private static final String COMPLETE = "complete";
     private static final String PUBLIC = "public";
     private static final String INPUT_REQUIRED = "input_required";
+    private static final String SUBSCRIPTION_ID_META_KEY = "io.modelcontextprotocol/subscriptionId";
 
     static {
         register(DiscoverResult.class, new DiscoverResultCodec());
@@ -297,6 +300,54 @@ public final class McpResponseMapper extends dev.tachyonmcp.core.protocol.mcp.v2
     @Override
     public Object taskStatusNotificationParams(TaskEntry entry) {
         return McpTaskMapper.toStatusNotification(entry);
+    }
+
+    // Hand-built via JsonUtils.toObjectNode rather than the generated Subscriptions* models: those
+    // models' generated codecs aren't wired into CodecRegistry (unlike DiscoverResult/EmptyResult/etc,
+    // which are explicitly `register`ed above), so returning them as plain Objects falls through
+    // ValueSerializer's generic path and serializes as their Java toString(). JsonNode sidesteps that
+    // — same approach McpTaskMapper already uses for hand-shaped 2026-07-28 payloads.
+
+    @Override
+    public Object subscriptionsAcknowledgedParams(RequestId subscriptionId, SubscriptionListenRequest filter) {
+        var notifications = new LinkedHashMap<String, Object>();
+        if (filter.toolsListChanged()) notifications.put("toolsListChanged", true);
+        if (filter.promptsListChanged()) notifications.put("promptsListChanged", true);
+        if (filter.resourcesListChanged()) notifications.put("resourcesListChanged", true);
+        if (!filter.resourceSubscriptions().isEmpty()) {
+            notifications.put("resourceSubscriptions", List.copyOf(filter.resourceSubscriptions()));
+        }
+        var fields = new LinkedHashMap<String, Object>();
+        fields.put("notifications", notifications);
+        fields.put("_meta", subscriptionIdMeta(subscriptionId));
+        return JsonUtils.toObjectNode(fields);
+    }
+
+    @Override
+    public Object subscriptionListChangedParams(RequestId subscriptionId) {
+        var fields = new LinkedHashMap<String, Object>();
+        fields.put("_meta", subscriptionIdMeta(subscriptionId));
+        return JsonUtils.toObjectNode(fields);
+    }
+
+    @Override
+    public Object subscriptionResourceUpdatedParams(RequestId subscriptionId, String uri) {
+        var fields = new LinkedHashMap<String, Object>();
+        fields.put("uri", uri);
+        fields.put("_meta", subscriptionIdMeta(subscriptionId));
+        return JsonUtils.toObjectNode(fields);
+    }
+
+    @Override
+    public Object subscriptionsListenGracefulResult(RequestId subscriptionId) {
+        var fields = new LinkedHashMap<String, Object>();
+        fields.put("_meta", subscriptionIdMeta(subscriptionId));
+        fields.put("resultType", COMPLETE);
+        return JsonUtils.toObjectNode(fields);
+    }
+
+    private static Map<String, JsonNode> subscriptionIdMeta(RequestId subscriptionId) {
+        return JsonUtils.toJsonNodeMap(Map.of(SUBSCRIPTION_ID_META_KEY, subscriptionId.toString()));
     }
 
     /**

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/mcp/v2026_07_28/codecs/McpResponseMapper.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/mcp/v2026_07_28/codecs/McpResponseMapper.java
@@ -42,16 +42,22 @@ import dev.tachyonmcp.core.protocol.mcp.v2026_07_28.models.ListPromptsResult;
 import dev.tachyonmcp.core.protocol.mcp.v2026_07_28.models.ListResourceTemplatesResult;
 import dev.tachyonmcp.core.protocol.mcp.v2026_07_28.models.ListResourcesResult;
 import dev.tachyonmcp.core.protocol.mcp.v2026_07_28.models.ListToolsResult;
+import dev.tachyonmcp.core.protocol.mcp.v2026_07_28.models.NotificationParams;
 import dev.tachyonmcp.core.protocol.mcp.v2026_07_28.models.Prompt;
 import dev.tachyonmcp.core.protocol.mcp.v2026_07_28.models.PromptArgument;
 import dev.tachyonmcp.core.protocol.mcp.v2026_07_28.models.ReadResourceResult;
 import dev.tachyonmcp.core.protocol.mcp.v2026_07_28.models.Resource;
 import dev.tachyonmcp.core.protocol.mcp.v2026_07_28.models.ResourceContents;
 import dev.tachyonmcp.core.protocol.mcp.v2026_07_28.models.ResourceTemplate;
+import dev.tachyonmcp.core.protocol.mcp.v2026_07_28.models.ResourceUpdatedNotificationParams;
+import dev.tachyonmcp.core.protocol.mcp.v2026_07_28.models.SubscriptionFilter;
+import dev.tachyonmcp.core.protocol.mcp.v2026_07_28.models.SubscriptionsAcknowledgedNotificationParams;
+import dev.tachyonmcp.core.protocol.mcp.v2026_07_28.models.SubscriptionsListenResult;
 import dev.tachyonmcp.core.protocol.mcp.v2026_07_28.models.TextResourceContents;
 import dev.tachyonmcp.core.protocol.mcp.v2026_07_28.models.Tool;
 import dev.tachyonmcp.core.server.features.tasks.TaskEntry;
 import dev.tachyonmcp.core.server.json.JsonUtils;
+import dev.tachyonmcp.core.transport.jsonrpc.JsonRpcCodec;
 import dev.tachyonmcp.core.transport.jsonrpc.JsonRpcError;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -64,8 +70,6 @@ import java.util.Map;
 import java.util.Objects;
 import org.jspecify.annotations.Nullable;
 import tools.jackson.core.JsonEncoding;
-import tools.jackson.core.JsonGenerator;
-import tools.jackson.core.JsonParser;
 import tools.jackson.core.ObjectWriteContext;
 import tools.jackson.databind.JsonNode;
 
@@ -79,23 +83,21 @@ public final class McpResponseMapper extends dev.tachyonmcp.core.protocol.mcp.v2
     private static final String INPUT_REQUIRED = "input_required";
     private static final String SUBSCRIPTION_ID_META_KEY = "io.modelcontextprotocol/subscriptionId";
 
-    static {
-        register(DiscoverResult.class, new DiscoverResultCodec());
-        register(EmptyResult.class, new EmptyResultCodec());
-        register(ListToolsResult.class, new ListToolsResultCodec());
-        register(ListResourcesResult.class, new ListResourcesResultCodec());
-        register(ListResourceTemplatesResult.class, new ListResourceTemplatesResultCodec());
-        register(ReadResourceResult.class, new ReadResourceResultCodec());
-        register(ListPromptsResult.class, new ListPromptsResultCodec());
-        register(CompleteResult.class, new CompleteResultCodec());
-        register(CallToolResult.class, new CallToolResultCodec());
-        register(GetPromptResult.class, new GetPromptResultCodec());
-        register(InputRequiredResult.class, new InputRequiredResultCodec());
-    }
-
     @Override
     public boolean supports(String protocolName, String protocolVersion) {
         return "mcp".equalsIgnoreCase(protocolName) && McpProtocol.VERSION.equals(protocolVersion);
+    }
+
+    /**
+     * Encodes with this version's codecs, falling back to 2025-11-25's for the responses inherited
+     * unchanged from the superclass ({@code initialize}, {@code tasks/list}, {@code tasks/result}),
+     * which are still built from that version's models.
+     */
+    @Override
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public String encode(Object value) {
+        var codec = (Codec) CodecRegistry.codecFor(value.getClass());
+        return codec == null ? super.encode(value) : JsonRpcCodec.writeAsString(gen -> codec.encode(gen, value));
     }
 
     @Override
@@ -302,52 +304,41 @@ public final class McpResponseMapper extends dev.tachyonmcp.core.protocol.mcp.v2
         return McpTaskMapper.toStatusNotification(entry);
     }
 
-    // Hand-built via JsonUtils.toObjectNode rather than the generated Subscriptions* models: those
-    // models' generated codecs aren't wired into CodecRegistry (unlike DiscoverResult/EmptyResult/etc,
-    // which are explicitly `register`ed above), so returning them as plain Objects falls through
-    // ValueSerializer's generic path and serializes as their Java toString(). JsonNode sidesteps that
-    // — same approach McpTaskMapper already uses for hand-shaped 2026-07-28 payloads.
-
     @Override
     public Object subscriptionsAcknowledgedParams(RequestId subscriptionId, SubscriptionListenRequest filter) {
-        var notifications = new LinkedHashMap<String, Object>();
-        if (filter.toolsListChanged()) notifications.put("toolsListChanged", true);
-        if (filter.promptsListChanged()) notifications.put("promptsListChanged", true);
-        if (filter.resourcesListChanged()) notifications.put("resourcesListChanged", true);
-        if (!filter.resourceSubscriptions().isEmpty()) {
-            notifications.put("resourceSubscriptions", List.copyOf(filter.resourceSubscriptions()));
-        }
-        var fields = new LinkedHashMap<String, Object>();
-        fields.put("notifications", notifications);
-        fields.put("_meta", subscriptionIdMeta(subscriptionId));
-        return JsonUtils.toObjectNode(fields);
+        var uris = filter.resourceSubscriptions();
+        return new SubscriptionsAcknowledgedNotificationParams(
+                new SubscriptionFilter(
+                        trueOrNull(filter.toolsListChanged()),
+                        trueOrNull(filter.promptsListChanged()),
+                        trueOrNull(filter.resourcesListChanged()),
+                        uris.isEmpty() ? null : List.copyOf(uris)),
+                subscriptionIdMeta(subscriptionId));
     }
 
     @Override
     public Object subscriptionListChangedParams(RequestId subscriptionId) {
-        var fields = new LinkedHashMap<String, Object>();
-        fields.put("_meta", subscriptionIdMeta(subscriptionId));
-        return JsonUtils.toObjectNode(fields);
+        return new NotificationParams(subscriptionIdMeta(subscriptionId));
     }
 
     @Override
     public Object subscriptionResourceUpdatedParams(RequestId subscriptionId, String uri) {
-        var fields = new LinkedHashMap<String, Object>();
-        fields.put("uri", uri);
-        fields.put("_meta", subscriptionIdMeta(subscriptionId));
-        return JsonUtils.toObjectNode(fields);
+        return new ResourceUpdatedNotificationParams(uri, subscriptionIdMeta(subscriptionId));
     }
 
     @Override
     public Object subscriptionsListenGracefulResult(RequestId subscriptionId) {
-        var fields = new LinkedHashMap<String, Object>();
-        fields.put("_meta", subscriptionIdMeta(subscriptionId));
-        fields.put("resultType", COMPLETE);
-        return JsonUtils.toObjectNode(fields);
+        return new SubscriptionsListenResult(subscriptionIdMeta(subscriptionId), COMPLETE, null);
+    }
+
+    /** Opted-out filter flags are omitted from the wire, not sent as {@code false}. */
+    private static @Nullable Boolean trueOrNull(boolean requested) {
+        return requested ? Boolean.TRUE : null;
     }
 
     private static Map<String, JsonNode> subscriptionIdMeta(RequestId subscriptionId) {
-        return JsonUtils.toJsonNodeMap(Map.of(SUBSCRIPTION_ID_META_KEY, subscriptionId.toString()));
+        return Objects.requireNonNull(
+                JsonUtils.toJsonNodeMap(Map.of(SUBSCRIPTION_ID_META_KEY, subscriptionId.toString())));
     }
 
     /**
@@ -568,20 +559,5 @@ public final class McpResponseMapper extends dev.tachyonmcp.core.protocol.mcp.v2
         } catch (IOException e) {
             throw new UncheckedIOException("Failed to encode " + type.getSimpleName(), e);
         }
-    }
-
-    private static <T> void register(Class<T> type, Codec<T> codec) {
-        dev.tachyonmcp.core.protocol.mcp.v2025_11_25.codecs.CodecRegistry.registerOverride(
-                type, new dev.tachyonmcp.core.protocol.mcp.v2025_11_25.codecs.Codec<>() {
-                    @Override
-                    public T decode(JsonParser parser) throws IOException {
-                        return codec.decode(parser);
-                    }
-
-                    @Override
-                    public void encode(JsonGenerator generator, T value) throws IOException {
-                        codec.encode(generator, value);
-                    }
-                });
     }
 }

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/mcp/v2026_07_28/codecs/ServerInfoMapper.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/mcp/v2026_07_28/codecs/ServerInfoMapper.java
@@ -65,9 +65,9 @@ class ServerInfoMapper {
             if (src.resources().listChanged()) {
                 resourcesBuilder.listChanged(true);
             }
-            if (src.resources().subscribe()) {
-                resourcesBuilder.subscribe(true);
-            }
+            // No `subscribe` flag here: `resources/subscribe` is a removed method under 2026-07-28
+            // (RequestValidationHandler.REMOVED_METHODS) — subscriptions/listen replaces it and isn't
+            // gated by a capability flag.
             builder.resources(resourcesBuilder.build());
         }
 

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/DefaultTachyonServer.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/DefaultTachyonServer.java
@@ -440,7 +440,7 @@ final class DefaultTachyonServer implements ServerEngine, ExtensionContext {
         methodHandlers.put("initialize", new InitializeHandler(this));
         methodHandlers.put("server/discover", new DiscoverHandler(this));
         methodHandlers.put("ping", new PingHandler());
-        methodHandlers.put("subscriptions/listen", new SubscriptionsListenHandler(this, subscriptionRegistry));
+        methodHandlers.put("subscriptions/listen", new SubscriptionsListenHandler(subscriptionRegistry));
         ToolMethodHandlers.register(
                 methodHandlers, toolRegistry, inputValidator, outputValidator, payloadSerializer, payloadDeserializer);
         ResourceMethodHandlers.register(methodHandlers, resourceRegistry);
@@ -586,7 +586,8 @@ final class DefaultTachyonServer implements ServerEngine, ExtensionContext {
         if (!config.capabilities().logging()) {
             return;
         }
-        var paramsStr = JsonRpcCodec.toJsonParams(NotificationLogSupport.logParams(level, logger, data));
+        var mapper = Protocols.list().getFirst().responseMapper();
+        var paramsStr = mapper.encode(mapper.loggingMessageParams(level, logger, data));
         var notificationJson = JsonRpcCodec.serializeNotificationAsString(NotificationLogSupport.LOG_METHOD, paramsStr);
         for (var session : sessionManager.allSessions()) {
             if (session.state() != SessionState.ACTIVE) {

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/DefaultTachyonServer.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/DefaultTachyonServer.java
@@ -35,6 +35,7 @@ import dev.tachyonmcp.core.server.features.prompts.DefaultPromptRegistry;
 import dev.tachyonmcp.core.server.features.prompts.PromptMethodHandlers;
 import dev.tachyonmcp.core.server.features.resources.DefaultResourceRegistry;
 import dev.tachyonmcp.core.server.features.resources.ResourceMethodHandlers;
+import dev.tachyonmcp.core.server.features.subscriptions.SubscriptionRegistry;
 import dev.tachyonmcp.core.server.features.tasks.DefaultTaskRegistry;
 import dev.tachyonmcp.core.server.features.tasks.TaskEntry;
 import dev.tachyonmcp.core.server.features.tasks.TaskMethodHandlers;
@@ -45,6 +46,7 @@ import dev.tachyonmcp.core.server.handlers.DiscoverHandler;
 import dev.tachyonmcp.core.server.handlers.InitializeHandler;
 import dev.tachyonmcp.core.server.handlers.LoggingHandlers;
 import dev.tachyonmcp.core.server.handlers.PingHandler;
+import dev.tachyonmcp.core.server.handlers.SubscriptionsListenHandler;
 import dev.tachyonmcp.core.server.internal.NotificationLogSupport;
 import dev.tachyonmcp.core.server.internal.ServerEngine;
 import dev.tachyonmcp.core.server.json.JacksonPayloadSerde;
@@ -99,6 +101,7 @@ final class DefaultTachyonServer implements ServerEngine, ExtensionContext {
     private final DefaultTaskRegistry taskRegistry;
     private final DefaultPromptRegistry promptRegistry;
     private final DefaultCompletionRegistry completionRegistry;
+    private final SubscriptionRegistry subscriptionRegistry;
     private final JsonSchemaValidator inputValidator;
     private final JsonSchemaValidator outputValidator;
     private final PayloadSerializer payloadSerializer;
@@ -279,6 +282,7 @@ final class DefaultTachyonServer implements ServerEngine, ExtensionContext {
                 new DefaultTaskRegistry(this, caps.tasks(), config.runtime().clock());
         this.promptRegistry = new DefaultPromptRegistry(caps.prompts());
         this.completionRegistry = new DefaultCompletionRegistry(caps.completions());
+        this.subscriptionRegistry = new SubscriptionRegistry(this);
         registerDefaults();
         bootstrapExtensions();
         setupChangeListeners(config);
@@ -366,13 +370,22 @@ final class DefaultTachyonServer implements ServerEngine, ExtensionContext {
     private void setupChangeListeners(ServerConfig config) {
         var caps = config.capabilities();
         if (caps.tools().listChanged()) {
-            toolRegistry.onChange(() -> broadcastNotification("notifications/tools/list_changed"));
+            toolRegistry.onChange(() -> {
+                broadcastNotification("notifications/tools/list_changed");
+                subscriptionRegistry.notifyToolsListChanged();
+            });
         }
         if (caps.resources().listChanged()) {
-            resourceRegistry.onChange(() -> broadcastNotification("notifications/resources/list_changed"));
+            resourceRegistry.onChange(() -> {
+                broadcastNotification("notifications/resources/list_changed");
+                subscriptionRegistry.notifyResourcesListChanged();
+            });
         }
         if (caps.prompts().listChanged()) {
-            promptRegistry.onChange(() -> broadcastNotification("notifications/prompts/list_changed"));
+            promptRegistry.onChange(() -> {
+                broadcastNotification("notifications/prompts/list_changed");
+                subscriptionRegistry.notifyPromptsListChanged();
+            });
         }
         if (caps.tasks().list()) {
             taskRegistry.onChange(() -> broadcastNotification("notifications/tasks/list_changed"));
@@ -409,6 +422,11 @@ final class DefaultTachyonServer implements ServerEngine, ExtensionContext {
         }
     }
 
+    @Override
+    public void notifyResourceSubscriptions(String uri) {
+        subscriptionRegistry.notifyResourceUpdated(uri);
+    }
+
     private void notifyTaskStatus(Session session, TaskEntry entry) {
         var protocol = session.protocol();
         var params =
@@ -422,6 +440,7 @@ final class DefaultTachyonServer implements ServerEngine, ExtensionContext {
         methodHandlers.put("initialize", new InitializeHandler(this));
         methodHandlers.put("server/discover", new DiscoverHandler(this));
         methodHandlers.put("ping", new PingHandler());
+        methodHandlers.put("subscriptions/listen", new SubscriptionsListenHandler(this, subscriptionRegistry));
         ToolMethodHandlers.register(
                 methodHandlers, toolRegistry, inputValidator, outputValidator, payloadSerializer, payloadDeserializer);
         ResourceMethodHandlers.register(methodHandlers, resourceRegistry);
@@ -819,6 +838,7 @@ final class DefaultTachyonServer implements ServerEngine, ExtensionContext {
         }
         try {
             logger.info("Shutting down TachyonMCP Server");
+            subscriptionRegistry.closeAll();
             shutdownExtensions();
             executor.shutdown();
             try {

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/McpDispatcher.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/McpDispatcher.java
@@ -462,7 +462,7 @@ public class McpDispatcher {
             return JsonRpcCodec.serializeResponse(id, s);
         }
         try {
-            var resultJson = JsonRpcCodec.writeValueAsString(result);
+            var resultJson = mapper.encode(result);
             return JsonRpcCodec.serializeResponse(id, resultJson);
         } catch (Exception e) {
             logger.error(

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/McpDispatcher.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/McpDispatcher.java
@@ -67,6 +67,14 @@ public class McpDispatcher {
     public static final AttributeKey<HttpRequest> ATTR_INIT_REQUEST = AttributeKey.of("init.request");
 
     /**
+     * Interaction-context attribute key under which the current request's JSON-RPC {@code id} is
+     * stashed before dispatch, so a handler with no other access to it (e.g. {@code
+     * subscriptions/listen}, which must echo it back as {@code subscriptionId}) can read it back via
+     * {@code context.get(ATTR_REQUEST_ID)}.
+     */
+    public static final AttributeKey<RequestId> ATTR_REQUEST_ID = AttributeKey.of("request.id");
+
+    /**
      * Placeholder request for programmatic dispatch with no channel (the default generator ignores it).
      */
     private static final HttpRequest EMPTY_INIT_REQUEST =
@@ -164,6 +172,7 @@ public class McpDispatcher {
         Objects.requireNonNull(method, "method");
 
         var requestCtx = dispatchContext(channelContext);
+        requestCtx.set(ATTR_REQUEST_ID, id);
         try {
             requestCtx.setPermittedLogLevel(requestCtx.requestMapper().permittedLogLevel(params));
         } catch (RequestMappingException e) {

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/OutboundSseStream.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/OutboundSseStream.java
@@ -73,4 +73,14 @@ public interface OutboundSseStream {
      * Closes the SSE stream. Idempotent — subsequent calls are no-ops.
      */
     void close();
+
+    /**
+     * Registers a callback invoked when the underlying transport connection closes, however that
+     * happens — client disconnect, {@link #close()}, or a dead socket detected on write. Used by a
+     * long-lived handler (e.g. {@code subscriptions/listen}) to clean up stream-scoped state it
+     * cannot otherwise learn about. Default is a no-op for transports with no close signal.
+     *
+     * @param callback invoked at most once, on an unspecified thread
+     */
+    default void onClose(Runnable callback) {}
 }

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/features/resources/DefaultResourceRegistry.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/features/resources/DefaultResourceRegistry.java
@@ -436,6 +436,7 @@ public class DefaultResourceRegistry implements Resources {
      */
     @Override
     public void notifyResourceUpdated(String uri) {
+        server.notifyResourceSubscriptions(uri);
         var subscribedSessionIds = subscriptions.get(uri);
         if (subscribedSessionIds == null || subscribedSessionIds.isEmpty()) {
             return;

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/features/subscriptions/SubscriptionRegistry.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/features/subscriptions/SubscriptionRegistry.java
@@ -91,7 +91,8 @@ public final class SubscriptionRegistry {
     }
 
     private void push(Entry entry, String method, Object params) {
-        var notificationJson = JsonRpcCodec.serializeNotificationAsString(method, JsonRpcCodec.toJsonParams(params));
+        var notificationJson = JsonRpcCodec.serializeNotificationAsString(
+                method, entry.responseMapper().encode(params));
         var sseEvent = new SseEvent(
                 ServerEngine.wireEventId(server.nextEventId(), entry.stream().streamKey()),
                 "message",

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/features/subscriptions/SubscriptionRegistry.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/features/subscriptions/SubscriptionRegistry.java
@@ -1,0 +1,115 @@
+/* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
+package dev.tachyonmcp.core.server.features.subscriptions;
+
+import dev.tachyonmcp.api.annotations.InternalApi;
+import dev.tachyonmcp.api.server.domain.RequestId;
+import dev.tachyonmcp.core.protocol.ProtocolRequestMapper.SubscriptionListenRequest;
+import dev.tachyonmcp.core.protocol.ProtocolResponseMapper;
+import dev.tachyonmcp.core.runtime.SseEvent;
+import dev.tachyonmcp.core.server.OutboundSseStream;
+import dev.tachyonmcp.core.server.internal.ServerEngine;
+import dev.tachyonmcp.core.transport.jsonrpc.JsonRpcCodec;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Predicate;
+
+/**
+ * Tracks active {@code subscriptions/listen} streams (2026-07-28), independent of any session,
+ * and pushes {@code notifications/tools|prompts|resources/list_changed} and {@code
+ * notifications/resources/updated} to each stream whose filter opted in.
+ *
+ * <p>Keyed by an internal counter, not the wire {@code subscriptionId} — two different stateless
+ * connections may legally reuse the same JSON-RPC request id, so the registry's own key and the id
+ * echoed back to clients are kept distinct.
+ */
+@InternalApi
+public final class SubscriptionRegistry {
+
+    /** A live {@code subscriptions/listen} stream: its filter, transport, and deferred response. */
+    private record Entry(
+            RequestId subscriptionId,
+            OutboundSseStream stream,
+            SubscriptionListenRequest filter,
+            ProtocolResponseMapper responseMapper,
+            CompletableFuture<Object> pendingResponse) {}
+
+    private final ServerEngine server;
+    private final ConcurrentHashMap<Long, Entry> entries = new ConcurrentHashMap<>();
+    private final AtomicLong nextKey = new AtomicLong();
+
+    public SubscriptionRegistry(ServerEngine server) {
+        this.server = server;
+    }
+
+    /** Registers a new subscription, returning its registry key for a later {@link #remove}. */
+    public long add(
+            RequestId subscriptionId,
+            OutboundSseStream stream,
+            SubscriptionListenRequest filter,
+            ProtocolResponseMapper responseMapper,
+            CompletableFuture<Object> pendingResponse) {
+        var key = nextKey.incrementAndGet();
+        entries.put(key, new Entry(subscriptionId, stream, filter, responseMapper, pendingResponse));
+        return key;
+    }
+
+    /** Removes a subscription without completing its response, e.g. on client disconnect. */
+    public void remove(long key) {
+        entries.remove(key);
+    }
+
+    public void notifyToolsListChanged() {
+        pushListChanged(SubscriptionListenRequest::toolsListChanged, "notifications/tools/list_changed");
+    }
+
+    public void notifyPromptsListChanged() {
+        pushListChanged(SubscriptionListenRequest::promptsListChanged, "notifications/prompts/list_changed");
+    }
+
+    public void notifyResourcesListChanged() {
+        pushListChanged(SubscriptionListenRequest::resourcesListChanged, "notifications/resources/list_changed");
+    }
+
+    /** Pushes {@code notifications/resources/updated} to every subscription that opted into {@code uri}. */
+    public void notifyResourceUpdated(String uri) {
+        for (var entry : entries.values()) {
+            if (!entry.filter().resourceSubscriptions().contains(uri)) continue;
+            push(
+                    entry,
+                    "notifications/resources/updated",
+                    entry.responseMapper().subscriptionResourceUpdatedParams(entry.subscriptionId(), uri));
+        }
+    }
+
+    private void pushListChanged(Predicate<SubscriptionListenRequest> wants, String method) {
+        for (var entry : entries.values()) {
+            if (!wants.test(entry.filter())) continue;
+            push(entry, method, entry.responseMapper().subscriptionListChangedParams(entry.subscriptionId()));
+        }
+    }
+
+    private void push(Entry entry, String method, Object params) {
+        var notificationJson = JsonRpcCodec.serializeNotificationAsString(method, JsonRpcCodec.toJsonParams(params));
+        var sseEvent = new SseEvent(
+                ServerEngine.wireEventId(server.nextEventId(), entry.stream().streamKey()),
+                "message",
+                notificationJson);
+        entry.stream().writeEvent(sseEvent);
+    }
+
+    /**
+     * Gracefully tears down every open subscription: completes each deferred response with a
+     * protocol-specific {@code resultType: "complete"} result, which the dispatcher then writes as
+     * the stream's final response before closing it. Called on server shutdown.
+     */
+    public void closeAll() {
+        for (var key : List.copyOf(entries.keySet())) {
+            var entry = entries.remove(key);
+            if (entry == null) continue;
+            entry.pendingResponse()
+                    .complete(entry.responseMapper().subscriptionsListenGracefulResult(entry.subscriptionId()));
+        }
+    }
+}

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/features/subscriptions/SubscriptionRegistry.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/features/subscriptions/SubscriptionRegistry.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Predicate;
 
 /**
@@ -39,20 +40,44 @@ public final class SubscriptionRegistry {
     private final ConcurrentHashMap<Long, Entry> entries = new ConcurrentHashMap<>();
     private final AtomicLong nextKey = new AtomicLong();
 
+    /**
+     * Guards {@link #activate} against a concurrent {@code notifyXxx}/{@link #closeAll}: making the
+     * subscription visible in {@code entries} and enqueueing its ack event must happen as one
+     * atomic step, or a matching change firing in the gap between them is either dropped (never
+     * delivered to this subscriber, because {@code entries} didn't have it yet) or delivered ahead
+     * of the ack (forbidden — SEP-2575 requires the ack to be the first message on the stream).
+     * Held only across cheap, non-blocking work (a map put, building a small JSON object, and
+     * submitting an SSE write to the channel's event loop — never a network wait), so contention is
+     * a non-issue.
+     */
+    private final ReentrantLock lock = new ReentrantLock();
+
     public SubscriptionRegistry(ServerEngine server) {
         this.server = server;
     }
 
-    /** Registers a new subscription, returning its registry key for a later {@link #remove}. */
-    public long add(
+    /**
+     * Registers a new subscription and sends its ack-first {@code
+     * notifications/subscriptions/acknowledged} event, atomically with respect to concurrent {@code
+     * notifyXxx}/{@link #closeAll} calls — see {@link #lock}. Returns the registry key for a later
+     * {@link #remove}.
+     */
+    public long activate(
             RequestId subscriptionId,
             OutboundSseStream stream,
             SubscriptionListenRequest filter,
             ProtocolResponseMapper responseMapper,
             CompletableFuture<Object> pendingResponse) {
-        var key = nextKey.incrementAndGet();
-        entries.put(key, new Entry(subscriptionId, stream, filter, responseMapper, pendingResponse));
-        return key;
+        lock.lock();
+        try {
+            var key = nextKey.incrementAndGet();
+            entries.put(key, new Entry(subscriptionId, stream, filter, responseMapper, pendingResponse));
+            var ackParams = responseMapper.subscriptionsAcknowledgedParams(subscriptionId, filter);
+            push(stream, responseMapper, "notifications/subscriptions/acknowledged", ackParams);
+            return key;
+        } finally {
+            lock.unlock();
+        }
     }
 
     /** Removes a subscription without completing its response, e.g. on client disconnect. */
@@ -74,30 +99,42 @@ public final class SubscriptionRegistry {
 
     /** Pushes {@code notifications/resources/updated} to every subscription that opted into {@code uri}. */
     public void notifyResourceUpdated(String uri) {
-        for (var entry : entries.values()) {
-            if (!entry.filter().resourceSubscriptions().contains(uri)) continue;
-            push(
-                    entry,
-                    "notifications/resources/updated",
-                    entry.responseMapper().subscriptionResourceUpdatedParams(entry.subscriptionId(), uri));
+        lock.lock();
+        try {
+            for (var entry : entries.values()) {
+                if (!entry.filter().resourceSubscriptions().contains(uri)) continue;
+                push(
+                        entry.stream(),
+                        entry.responseMapper(),
+                        "notifications/resources/updated",
+                        entry.responseMapper().subscriptionResourceUpdatedParams(entry.subscriptionId(), uri));
+            }
+        } finally {
+            lock.unlock();
         }
     }
 
     private void pushListChanged(Predicate<SubscriptionListenRequest> wants, String method) {
-        for (var entry : entries.values()) {
-            if (!wants.test(entry.filter())) continue;
-            push(entry, method, entry.responseMapper().subscriptionListChangedParams(entry.subscriptionId()));
+        lock.lock();
+        try {
+            for (var entry : entries.values()) {
+                if (!wants.test(entry.filter())) continue;
+                push(
+                        entry.stream(),
+                        entry.responseMapper(),
+                        method,
+                        entry.responseMapper().subscriptionListChangedParams(entry.subscriptionId()));
+            }
+        } finally {
+            lock.unlock();
         }
     }
 
-    private void push(Entry entry, String method, Object params) {
-        var notificationJson = JsonRpcCodec.serializeNotificationAsString(
-                method, entry.responseMapper().encode(params));
+    private void push(OutboundSseStream stream, ProtocolResponseMapper responseMapper, String method, Object params) {
+        var notificationJson = JsonRpcCodec.serializeNotificationAsString(method, responseMapper.encode(params));
         var sseEvent = new SseEvent(
-                ServerEngine.wireEventId(server.nextEventId(), entry.stream().streamKey()),
-                "message",
-                notificationJson);
-        entry.stream().writeEvent(sseEvent);
+                ServerEngine.wireEventId(server.nextEventId(), stream.streamKey()), "message", notificationJson);
+        stream.writeEvent(sseEvent);
     }
 
     /**
@@ -106,11 +143,16 @@ public final class SubscriptionRegistry {
      * the stream's final response before closing it. Called on server shutdown.
      */
     public void closeAll() {
-        for (var key : List.copyOf(entries.keySet())) {
-            var entry = entries.remove(key);
-            if (entry == null) continue;
-            entry.pendingResponse()
-                    .complete(entry.responseMapper().subscriptionsListenGracefulResult(entry.subscriptionId()));
+        lock.lock();
+        try {
+            for (var key : List.copyOf(entries.keySet())) {
+                var entry = entries.remove(key);
+                if (entry == null) continue;
+                entry.pendingResponse()
+                        .complete(entry.responseMapper().subscriptionsListenGracefulResult(entry.subscriptionId()));
+            }
+        } finally {
+            lock.unlock();
         }
     }
 }

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/handlers/SubscriptionsListenHandler.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/handlers/SubscriptionsListenHandler.java
@@ -1,0 +1,76 @@
+/* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
+package dev.tachyonmcp.core.server.handlers;
+
+import dev.tachyonmcp.api.annotations.InternalApi;
+import dev.tachyonmcp.core.protocol.ProtocolResponseMapper;
+import dev.tachyonmcp.core.runtime.SseEvent;
+import dev.tachyonmcp.core.server.McpDispatcher;
+import dev.tachyonmcp.core.server.RpcMethodHandler;
+import dev.tachyonmcp.core.server.domain.ServerErrors;
+import dev.tachyonmcp.core.server.features.subscriptions.SubscriptionRegistry;
+import dev.tachyonmcp.core.server.internal.ServerEngine;
+import dev.tachyonmcp.core.server.session.DispatchContext;
+import dev.tachyonmcp.core.transport.jsonrpc.JsonRpcCodec;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Handles MCP 2026-07-28's {@code subscriptions/listen} (replaces {@code resources/subscribe} and
+ * the plain HTTP GET stream, SEP-2575): acknowledges the subscription on its request-scoped SSE
+ * stream, registers it with {@link SubscriptionRegistry}, and defers the JSON-RPC response until
+ * the client disconnects (no response) or the server shuts down (graceful {@code
+ * resultType: "complete"} response) — see {@link SubscriptionRegistry#closeAll()}.
+ */
+@InternalApi
+public final class SubscriptionsListenHandler implements RpcMethodHandler {
+
+    private final ServerEngine server;
+    private final SubscriptionRegistry registry;
+
+    public SubscriptionsListenHandler(ServerEngine server, SubscriptionRegistry registry) {
+        this.server = server;
+        this.registry = registry;
+    }
+
+    @Override
+    public String method() {
+        return "subscriptions/listen";
+    }
+
+    @Override
+    public Object handle(DispatchContext context, @Nullable Object params) {
+        throw new UnsupportedOperationException("subscriptions/listen is stream-based; see handleAsync");
+    }
+
+    @Override
+    public CompletionStage<Object> handleAsync(DispatchContext context, @Nullable Object params) {
+        var requestMapper = context.requestMapper();
+        if (!requestMapper.supportsSubscriptionsListen()) {
+            return CompletableFuture.completedFuture(ServerErrors.methodNotFound("Method not found"));
+        }
+        var stream = context.outboundStream();
+        if (stream == null) {
+            return CompletableFuture.completedFuture(ServerErrors.internalError("No SSE stream available"));
+        }
+        var subscriptionId = context.get(McpDispatcher.ATTR_REQUEST_ID)
+                .orElseThrow(() -> new IllegalStateException("subscriptions/listen dispatched without a request id"));
+        var filter = requestMapper.subscriptionsListen(params);
+
+        final var responseMapper = context.responseMapper();
+        var ackParams = responseMapper.subscriptionsAcknowledgedParams(subscriptionId, filter);
+        var ackJson = JsonRpcCodec.serializeNotificationAsString(
+                "notifications/subscriptions/acknowledged", JsonRpcCodec.toJsonParams(ackParams));
+        stream.start();
+        stream.writeEvent(
+                new SseEvent(ServerEngine.wireEventId(server.nextEventId(), stream.streamKey()), "message", ackJson));
+
+        var pending = new CompletableFuture<>();
+        var key = registry.add(subscriptionId, stream, filter, responseMapper, pending);
+        stream.onClose(() -> {
+            registry.remove(key);
+            pending.cancel(false);
+        });
+        return pending;
+    }
+}

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/handlers/SubscriptionsListenHandler.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/handlers/SubscriptionsListenHandler.java
@@ -2,14 +2,11 @@
 package dev.tachyonmcp.core.server.handlers;
 
 import dev.tachyonmcp.api.annotations.InternalApi;
-import dev.tachyonmcp.core.runtime.SseEvent;
 import dev.tachyonmcp.core.server.McpDispatcher;
 import dev.tachyonmcp.core.server.RpcMethodHandler;
 import dev.tachyonmcp.core.server.domain.ServerErrors;
 import dev.tachyonmcp.core.server.features.subscriptions.SubscriptionRegistry;
-import dev.tachyonmcp.core.server.internal.ServerEngine;
 import dev.tachyonmcp.core.server.session.DispatchContext;
-import dev.tachyonmcp.core.transport.jsonrpc.JsonRpcCodec;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import org.jspecify.annotations.Nullable;
@@ -24,11 +21,9 @@ import org.jspecify.annotations.Nullable;
 @InternalApi
 public final class SubscriptionsListenHandler implements RpcMethodHandler {
 
-    private final ServerEngine server;
     private final SubscriptionRegistry registry;
 
-    public SubscriptionsListenHandler(ServerEngine server, SubscriptionRegistry registry) {
-        this.server = server;
+    public SubscriptionsListenHandler(SubscriptionRegistry registry) {
         this.registry = registry;
     }
 
@@ -56,16 +51,9 @@ public final class SubscriptionsListenHandler implements RpcMethodHandler {
                 .orElseThrow(() -> new IllegalStateException("subscriptions/listen dispatched without a request id"));
         var filter = requestMapper.subscriptionsListen(params);
 
-        final var responseMapper = context.responseMapper();
-        var ackParams = responseMapper.subscriptionsAcknowledgedParams(subscriptionId, filter);
-        var ackJson = JsonRpcCodec.serializeNotificationAsString(
-                "notifications/subscriptions/acknowledged", responseMapper.encode(ackParams));
         stream.start();
-        stream.writeEvent(
-                new SseEvent(ServerEngine.wireEventId(server.nextEventId(), stream.streamKey()), "message", ackJson));
-
         var pending = new CompletableFuture<>();
-        var key = registry.add(subscriptionId, stream, filter, responseMapper, pending);
+        var key = registry.activate(subscriptionId, stream, filter, context.responseMapper(), pending);
         stream.onClose(() -> {
             registry.remove(key);
             pending.cancel(false);

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/handlers/SubscriptionsListenHandler.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/handlers/SubscriptionsListenHandler.java
@@ -2,7 +2,6 @@
 package dev.tachyonmcp.core.server.handlers;
 
 import dev.tachyonmcp.api.annotations.InternalApi;
-import dev.tachyonmcp.core.protocol.ProtocolResponseMapper;
 import dev.tachyonmcp.core.runtime.SseEvent;
 import dev.tachyonmcp.core.server.McpDispatcher;
 import dev.tachyonmcp.core.server.RpcMethodHandler;
@@ -60,7 +59,7 @@ public final class SubscriptionsListenHandler implements RpcMethodHandler {
         final var responseMapper = context.responseMapper();
         var ackParams = responseMapper.subscriptionsAcknowledgedParams(subscriptionId, filter);
         var ackJson = JsonRpcCodec.serializeNotificationAsString(
-                "notifications/subscriptions/acknowledged", JsonRpcCodec.toJsonParams(ackParams));
+                "notifications/subscriptions/acknowledged", responseMapper.encode(ackParams));
         stream.start();
         stream.writeEvent(
                 new SseEvent(ServerEngine.wireEventId(server.nextEventId(), stream.streamKey()), "message", ackJson));

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/internal/NotificationLogSupport.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/internal/NotificationLogSupport.java
@@ -1,16 +1,12 @@
 /* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
 package dev.tachyonmcp.core.server.internal;
 
-import dev.tachyonmcp.api.server.domain.LoggingLevel;
-import java.util.LinkedHashMap;
-import java.util.Map;
-import org.jspecify.annotations.Nullable;
-
 /**
- * Shared {@code notifications/message} wire-shape helpers for the two independent notification
- * senders — {@code DefaultDispatchContext.NotificationsImpl} (per-request) and
- * {@code DefaultTachyonServer.broadcastLog} (server-wide) — which live in different packages and
- * gate emission with their own, unrelated {@code shouldEmit} logic.
+ * Shared {@code notifications/message} method name for the two independent notification senders —
+ * {@code DefaultDispatchContext.NotificationsImpl} (per-request) and {@code
+ * DefaultTachyonServer.broadcastLog} (server-wide) — which live in different packages and gate
+ * emission with their own, unrelated {@code shouldEmit} logic. Each builds its wire params via
+ * {@link dev.tachyonmcp.core.protocol.ProtocolResponseMapper#loggingMessageParams}.
  */
 public final class NotificationLogSupport {
 
@@ -18,19 +14,4 @@ public final class NotificationLogSupport {
     public static final String LOG_METHOD = "notifications/message";
 
     private NotificationLogSupport() {}
-
-    /**
-     * Builds the {@code notifications/message} params in wire order. Uses a {@link LinkedHashMap} so
-     * a {@code null} {@code data} value is retained (spec-legal) rather than rejected by
-     * {@code Map.of}, and an absent {@code logger} is omitted entirely.
-     */
-    public static Map<String, Object> logParams(LoggingLevel level, @Nullable String logger, @Nullable Object data) {
-        var params = new LinkedHashMap<String, Object>(3);
-        params.put("level", level.getValue());
-        if (logger != null) {
-            params.put("logger", logger);
-        }
-        params.put("data", data);
-        return params;
-    }
 }

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/internal/ServerEngine.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/internal/ServerEngine.java
@@ -99,6 +99,9 @@ public interface ServerEngine extends TachyonServer {
     /** Maps and sends a task status notification. */
     void notifyTaskStatus(TaskEntry entry);
 
+    /** Pushes {@code notifications/resources/updated} to every stateless {@code subscriptions/listen} stream subscribed to {@code uri}. */
+    void notifyResourceSubscriptions(String uri);
+
     /** Sends a request to the client and returns a future that completes with the response. */
     CompletableFuture<String> sendRequest(Session session, String method, Object params);
 

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/json/JsonUtils.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/json/JsonUtils.java
@@ -10,22 +10,30 @@ import dev.tachyonmcp.api.server.features.tools.ToolResult;
 import dev.tachyonmcp.core.transport.jsonrpc.JsonRpcCodec;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.time.Duration;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import org.jspecify.annotations.Nullable;
+import tools.jackson.core.JacksonException;
 import tools.jackson.core.JsonParser;
+import tools.jackson.core.JsonToken;
 import tools.jackson.core.ObjectReadContext;
 import tools.jackson.core.TreeNode;
 import tools.jackson.core.json.JsonFactory;
+import tools.jackson.databind.DeserializationContext;
 import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.deser.std.StdDeserializer;
 import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.module.SimpleModule;
 import tools.jackson.databind.node.JsonNodeFactory;
 
 @InternalApi
 public final class JsonUtils {
 
-    private static final JsonMapper MAPPER = new JsonMapper();
+    private static final JsonMapper MAPPER = JsonMapper.builder()
+            .addModule(new SimpleModule().addDeserializer(Duration.class, new MillisDurationDeserializer()))
+            .build();
     public static final JsonFactory FACTORY = new JsonFactory();
 
     public static final ObjectReadContext TREE_READ_CONTEXT = new ObjectReadContext.Base() {
@@ -42,8 +50,26 @@ public final class JsonUtils {
 
     private JsonUtils() {}
 
-    static JsonMapper mapper() {
+    /**
+     * The shared Jackson mapper used for converting between raw JSON-ish values (maps, lists,
+     * scalars, trees) and generated protocol model records. Deserializes {@link Duration} from a
+     * bare wire number as milliseconds, matching the generated {@code Codec} classes' semantics
+     * (e.g. {@code TaskMetadata.ttl}) rather than jackson-databind's default (seconds).
+     */
+    public static JsonMapper mapper() {
         return MAPPER;
+    }
+
+    /** Deserializes a bare JSON number as milliseconds, matching the generated {@code Codec} classes. */
+    private static final class MillisDurationDeserializer extends StdDeserializer<Duration> {
+        MillisDurationDeserializer() {
+            super(Duration.class);
+        }
+
+        @Override
+        public @Nullable Duration deserialize(JsonParser p, DeserializationContext ctxt) throws JacksonException {
+            return p.currentToken() == JsonToken.VALUE_NULL ? null : Duration.ofMillis(p.getLongValue());
+        }
     }
 
     public static JsonNode parse(String json) {

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/session/DefaultDispatchContext.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/session/DefaultDispatchContext.java
@@ -18,7 +18,6 @@ import dev.tachyonmcp.core.server.OutboundSseStream;
 import dev.tachyonmcp.core.server.internal.NotificationLogSupport;
 import dev.tachyonmcp.core.server.internal.ServerEngine;
 import dev.tachyonmcp.core.transport.jsonrpc.JsonRpcCodec;
-import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import org.jspecify.annotations.Nullable;
@@ -204,7 +203,10 @@ public class DefaultDispatchContext implements DispatchContext {
         @Override
         public void log(LoggingLevel level, @Nullable String logger, @Nullable Object data) {
             if (shouldEmit(level)) {
-                send(NotificationLogSupport.LOG_METHOD, NotificationLogSupport.logParams(level, logger, data));
+                var mapper = responseMapper();
+                send(
+                        NotificationLogSupport.LOG_METHOD,
+                        mapper.encode(mapper.loggingMessageParams(level, logger, data)));
             }
         }
 
@@ -214,17 +216,10 @@ public class DefaultDispatchContext implements DispatchContext {
                 logger.debug("Dropping progress notification: no progressToken (client did not opt into progress)");
                 return;
             }
-            Object wireToken =
-                    switch (progressToken) {
-                        case ProgressToken.StringValue(var v) -> v;
-                        case ProgressToken.NumericValue(var v) -> v;
-                    };
-            var paramsMap = Map.of(
-                    "progressToken", wireToken,
-                    "progress", progress,
-                    "total", total,
-                    "message", message);
-            send("notifications/progress", paramsMap);
+            var mapper = responseMapper();
+            send(
+                    "notifications/progress",
+                    mapper.encode(mapper.progressNotificationParams(progressToken, progress, total, message)));
         }
 
         @Override

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/transport/jsonrpc/JsonRpcCodec.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/transport/jsonrpc/JsonRpcCodec.java
@@ -4,8 +4,6 @@ package dev.tachyonmcp.core.transport.jsonrpc;
 import static dev.tachyonmcp.core.server.json.JsonUtils.FACTORY;
 
 import dev.tachyonmcp.api.server.domain.RequestId;
-import dev.tachyonmcp.core.protocol.mcp.v2025_11_25.codecs.Codec;
-import dev.tachyonmcp.core.protocol.mcp.v2025_11_25.codecs.CodecRegistry;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufInputStream;
 import java.io.ByteArrayOutputStream;
@@ -316,32 +314,21 @@ public final class JsonRpcCodec {
         };
     }
 
-    /** Serializes a Java object to a JSON string, using registered codecs when available. */
-    @Nullable
-    @SuppressWarnings({"unchecked", "rawtypes"})
-    public static String writeValueAsString(@Nullable Object value) {
-        if (value == null) {
-            return "null";
-        }
-        if (value instanceof String
-                || value instanceof Number
-                || value instanceof Boolean
-                || value instanceof List
-                || value instanceof Map) {
-            return ValueSerializer.writeValueAsString(value);
-        }
-        var codec = CodecRegistry.codecFor(value.getClass());
-        if (codec != null) {
-            try (var out = new ByteArrayOutputStream(256);
-                    var gen = FACTORY.createGenerator(ObjectWriteContext.empty(), out, JsonEncoding.UTF8)) {
-                ((Codec) codec).encode(gen, value);
-                gen.flush();
-                return out.toString(StandardCharsets.UTF_8);
-            } catch (IOException e) {
-                throw new UncheckedIOException("Failed to write value via codec for " + value.getClass(), e);
-            }
-        }
+    /**
+     * Serializes a Java object to a JSON string generically — maps, lists, scalars and JSON trees.
+     * Protocol models carry no annotations here; they are serialized by the codecs of the protocol
+     * version that built them, via {@code ProtocolResponseMapper.encode}.
+     */
+    public static @Nullable String writeValueAsString(@Nullable Object value) {
         return ValueSerializer.writeValueAsString(value);
+    }
+
+    /**
+     * Serializes whatever {@code writer} emits into a JSON string, e.g. one protocol version's codec
+     * writing a generated model.
+     */
+    public static String writeAsString(JsonWriter writer) {
+        return new String(serialize(writer), StandardCharsets.UTF_8);
     }
 
     /** Writes a Java object as a JSON value via the given generator. */
@@ -362,8 +349,17 @@ public final class JsonRpcCodec {
         }
     }
 
+    /**
+     * Writes JSON into a generator; see {@link #writeAsString(JsonWriter)}.
+     */
     @FunctionalInterface
-    private interface JsonWriter {
+    public interface JsonWriter {
+        /**
+         * Writes one JSON value.
+         *
+         * @param gen the generator to write to
+         * @throws IOException on write failure
+         */
         void write(JsonGenerator gen) throws IOException;
     }
 }

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/transport/netty/sse/PostSseStream.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/transport/netty/sse/PostSseStream.java
@@ -134,6 +134,11 @@ public final class PostSseStream implements OutboundSseStream {
         runOnEventLoop(() -> doClose(false));
     }
 
+    @Override
+    public void onClose(Runnable callback) {
+        channel.closeFuture().addListener(f -> callback.run());
+    }
+
     private void runOnEventLoop(Runnable task) {
         var eventLoop = channel.eventLoop();
         if (eventLoop.inEventLoop()) {

--- a/tachyon-core/src/test/java/dev/tachyonmcp/core/protocol/mcp/v2025_11_25/codecs/McpResponseMapperTest.java
+++ b/tachyon-core/src/test/java/dev/tachyonmcp/core/protocol/mcp/v2025_11_25/codecs/McpResponseMapperTest.java
@@ -5,6 +5,8 @@ import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import dev.tachyonmcp.api.server.domain.ContentBlock;
+import dev.tachyonmcp.api.server.domain.LoggingLevel;
+import dev.tachyonmcp.api.server.domain.ProgressToken;
 import dev.tachyonmcp.api.server.domain.ServerError;
 import dev.tachyonmcp.api.server.domain.TaskResult;
 import dev.tachyonmcp.api.server.domain.TextContent;
@@ -194,6 +196,47 @@ class McpResponseMapperTest {
         var audience = ((List<?>) ann.get("audience"))
                 .stream().map(s -> Role.fromValue((String) s)).toList();
         assertThat(audience).containsExactly(Role.USER, Role.ASSISTANT);
+    }
+
+    @Test
+    void loggingMessageParamsSerializesLevelLoggerAndData() {
+        var json = mapper.encode(mapper.loggingMessageParams(LoggingLevel.WARNING, "logger.x", "boom"));
+
+        // language=JSON
+        assertThatJson(json).isEqualTo("""
+            {"level":"warning","logger":"logger.x","data":"boom"}
+            """);
+    }
+
+    @Test
+    void loggingMessageParamsOmitsAbsentLoggerAndRetainsNullData() {
+        var json = mapper.encode(mapper.loggingMessageParams(LoggingLevel.NOTICE, null, null));
+
+        // language=JSON
+        assertThatJson(json).isEqualTo("""
+            {"level":"notice","data":null}
+            """);
+        assertThat(json).doesNotContain("logger");
+    }
+
+    @Test
+    void progressNotificationParamsPreservesNumericTokenType() {
+        var json = mapper.encode(mapper.progressNotificationParams(ProgressToken.of(42), 1.0, 2.0, "working"));
+
+        // language=JSON
+        assertThatJson(json).isEqualTo("""
+            {"progressToken":42,"progress":1.0,"total":2.0,"message":"working"}
+            """);
+    }
+
+    @Test
+    void progressNotificationParamsPreservesStringToken() {
+        var json = mapper.encode(mapper.progressNotificationParams(ProgressToken.of("token-1"), 0.5, 1.0, "halfway"));
+
+        // language=JSON
+        assertThatJson(json).isEqualTo("""
+            {"progressToken":"token-1","progress":0.5,"total":1.0,"message":"halfway"}
+            """);
     }
 
     private static String relatedTaskId(CallToolResult payload) {

--- a/tachyon-core/src/test/java/dev/tachyonmcp/core/protocol/mcp/v2025_11_25/codecs/McpResponseMapperTest.java
+++ b/tachyon-core/src/test/java/dev/tachyonmcp/core/protocol/mcp/v2025_11_25/codecs/McpResponseMapperTest.java
@@ -1,6 +1,7 @@
 /* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
 package dev.tachyonmcp.core.protocol.mcp.v2025_11_25.codecs;
 
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import dev.tachyonmcp.api.server.domain.ContentBlock;
@@ -12,6 +13,7 @@ import dev.tachyonmcp.api.server.features.prompts.PromptDescriptor;
 import dev.tachyonmcp.api.server.features.resources.ResourceDescriptor;
 import dev.tachyonmcp.api.server.features.resources.ResourceTemplateDescriptor;
 import dev.tachyonmcp.api.server.features.tools.ToolDescriptor;
+import dev.tachyonmcp.core.protocol.mcp.v2025_11_25.models.Annotations;
 import dev.tachyonmcp.core.protocol.mcp.v2025_11_25.models.CallToolResult;
 import dev.tachyonmcp.core.protocol.mcp.v2025_11_25.models.CompleteResult;
 import dev.tachyonmcp.core.protocol.mcp.v2025_11_25.models.GetPromptResult;
@@ -19,6 +21,9 @@ import dev.tachyonmcp.core.protocol.mcp.v2025_11_25.models.ListPromptsResult;
 import dev.tachyonmcp.core.protocol.mcp.v2025_11_25.models.ListResourceTemplatesResult;
 import dev.tachyonmcp.core.protocol.mcp.v2025_11_25.models.ListResourcesResult;
 import dev.tachyonmcp.core.protocol.mcp.v2025_11_25.models.ListToolsResult;
+import dev.tachyonmcp.core.protocol.mcp.v2025_11_25.models.Resource;
+import dev.tachyonmcp.core.protocol.mcp.v2025_11_25.models.Role;
+import dev.tachyonmcp.core.transport.jsonrpc.JsonRpcCodec;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -142,6 +147,53 @@ class McpResponseMapperTest {
         assertThat(resources.resources().getFirst()._meta()).containsEntry("kind", JSON.textNode("resource"));
         assertThat(templates.resourceTemplates().getFirst()._meta()).containsEntry("kind", JSON.textNode("template"));
         assertThat(prompts.prompts().getFirst()._meta()).containsEntry("kind", JSON.textNode("prompt"));
+    }
+
+    @Test
+    void encodeSerializesProtocolModelsAsJsonNotToString() {
+        var result = CallToolResult.ofText("ok");
+
+        var json = mapper.encode(result);
+
+        // language=JSON
+        assertThatJson(json).isEqualTo("""
+            {"content":[{"type":"text","text":"ok"}]}
+            """);
+    }
+
+    @Test
+    void encodeSerializesEnumLists() {
+        var annotations = new Annotations(List.of(Role.USER, Role.ASSISTANT), 0.8, "2026-07-23T00:00:00Z");
+        var resource = Resource.builder()
+                .uri("weather://prediction/article")
+                .name("prediction-article")
+                .annotations(annotations)
+                .build();
+
+        var json = mapper.encode(
+                ListResourcesResult.builder().resources(List.of(resource)).build());
+
+        // language=JSON
+        assertThatJson(json).isEqualTo("""
+            {
+              "resources": [{
+                "uri": "weather://prediction/article",
+                "name": "prediction-article",
+                "annotations": {
+                  "audience": ["user", "assistant"],
+                  "priority": 0.8,
+                  "lastModified": "2026-07-23T00:00:00Z"
+                }
+              }]
+            }
+            """);
+
+        var decoded = (Map<String, ?>) JsonRpcCodec.readValue(json);
+        var resources = (List<Map<String, ?>>) decoded.get("resources");
+        var ann = (Map<String, ?>) resources.get(0).get("annotations");
+        var audience = ((List<?>) ann.get("audience"))
+                .stream().map(s -> Role.fromValue((String) s)).toList();
+        assertThat(audience).containsExactly(Role.USER, Role.ASSISTANT);
     }
 
     private static String relatedTaskId(CallToolResult payload) {

--- a/tachyon-core/src/test/java/dev/tachyonmcp/core/protocol/mcp/v2026_07_28/codecs/McpResponseMapperTest.java
+++ b/tachyon-core/src/test/java/dev/tachyonmcp/core/protocol/mcp/v2026_07_28/codecs/McpResponseMapperTest.java
@@ -7,6 +7,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import dev.tachyonmcp.api.json.JsonDocument;
 import dev.tachyonmcp.api.server.domain.Annotations;
 import dev.tachyonmcp.api.server.domain.Icon;
+import dev.tachyonmcp.api.server.domain.LoggingLevel;
+import dev.tachyonmcp.api.server.domain.ProgressToken;
 import dev.tachyonmcp.api.server.domain.PromptArgument;
 import dev.tachyonmcp.api.server.domain.PromptMessage;
 import dev.tachyonmcp.api.server.domain.RequestId;
@@ -215,6 +217,26 @@ class McpResponseMapperTest {
         // language=JSON
         assertThatJson(graceful).isEqualTo("""
             {"_meta": {"io.modelcontextprotocol/subscriptionId": "sub-1"}, "resultType": "complete"}
+            """);
+    }
+
+    @Test
+    void loggingMessageParamsSerializesLevelLoggerAndData() {
+        var json = mapper.encode(mapper.loggingMessageParams(LoggingLevel.WARNING, "logger.x", "boom"));
+
+        // language=JSON
+        assertThatJson(json).isEqualTo("""
+            {"level":"warning","logger":"logger.x","data":"boom"}
+            """);
+    }
+
+    @Test
+    void progressNotificationParamsPreservesNumericTokenType() {
+        var json = mapper.encode(mapper.progressNotificationParams(ProgressToken.of(42), 1.0, 2.0, "working"));
+
+        // language=JSON
+        assertThatJson(json).isEqualTo("""
+            {"progressToken":42,"progress":1.0,"total":2.0,"message":"working"}
             """);
     }
 

--- a/tachyon-core/src/test/java/dev/tachyonmcp/core/protocol/mcp/v2026_07_28/codecs/McpResponseMapperTest.java
+++ b/tachyon-core/src/test/java/dev/tachyonmcp/core/protocol/mcp/v2026_07_28/codecs/McpResponseMapperTest.java
@@ -1,6 +1,7 @@
 /* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
 package dev.tachyonmcp.core.protocol.mcp.v2026_07_28.codecs;
 
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import dev.tachyonmcp.api.json.JsonDocument;
@@ -8,6 +9,7 @@ import dev.tachyonmcp.api.server.domain.Annotations;
 import dev.tachyonmcp.api.server.domain.Icon;
 import dev.tachyonmcp.api.server.domain.PromptArgument;
 import dev.tachyonmcp.api.server.domain.PromptMessage;
+import dev.tachyonmcp.api.server.domain.RequestId;
 import dev.tachyonmcp.api.server.domain.Role;
 import dev.tachyonmcp.api.server.domain.ServerError;
 import dev.tachyonmcp.api.server.domain.TextContent;
@@ -18,6 +20,7 @@ import dev.tachyonmcp.api.server.features.resources.ResourceDescriptor;
 import dev.tachyonmcp.api.server.features.resources.ResourceTemplateDescriptor;
 import dev.tachyonmcp.api.server.features.tools.ToolDescriptor;
 import dev.tachyonmcp.api.server.features.tools.ToolResult;
+import dev.tachyonmcp.core.protocol.ProtocolRequestMapper.SubscriptionListenRequest;
 import dev.tachyonmcp.core.protocol.mcp.v2026_07_28.models.CallToolResult;
 import dev.tachyonmcp.core.protocol.mcp.v2026_07_28.models.CompleteResult;
 import dev.tachyonmcp.core.protocol.mcp.v2026_07_28.models.GetPromptResult;
@@ -25,9 +28,11 @@ import dev.tachyonmcp.core.protocol.mcp.v2026_07_28.models.ListPromptsResult;
 import dev.tachyonmcp.core.protocol.mcp.v2026_07_28.models.ListResourceTemplatesResult;
 import dev.tachyonmcp.core.protocol.mcp.v2026_07_28.models.ListResourcesResult;
 import dev.tachyonmcp.core.protocol.mcp.v2026_07_28.models.ListToolsResult;
+import dev.tachyonmcp.core.protocol.mcp.v2026_07_28.models.NotificationParams;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 import tools.jackson.databind.node.JsonNodeFactory;
 
@@ -179,5 +184,43 @@ class McpResponseMapperTest {
                 .doesNotContain("\"audience\"")
                 .doesNotContain("\"sizes\"");
         assertThat(promptJson).doesNotContain("\"arguments\"");
+    }
+
+    @Test
+    void subscriptionPayloadsSerializeThroughTheProtocolVersionsCodecs() {
+        var id = RequestId.of("sub-1");
+        var filter = new SubscriptionListenRequest(true, false, false, Set.of("memory://one"));
+
+        var ack = mapper.encode(mapper.subscriptionsAcknowledgedParams(id, filter));
+        var listChanged = mapper.encode(mapper.subscriptionListChangedParams(id));
+        var updated = mapper.encode(mapper.subscriptionResourceUpdatedParams(id, "memory://one"));
+        var graceful = mapper.encode(mapper.subscriptionsListenGracefulResult(id));
+
+        // language=JSON
+        assertThatJson(ack).isEqualTo("""
+            {
+              "notifications": {"toolsListChanged": true, "resourceSubscriptions": ["memory://one"]},
+              "_meta": {"io.modelcontextprotocol/subscriptionId": "sub-1"}
+            }
+            """);
+        assertThat(ack).doesNotContain("promptsListChanged").doesNotContain("resourcesListChanged");
+        // language=JSON
+        assertThatJson(listChanged).isEqualTo("""
+            {"_meta": {"io.modelcontextprotocol/subscriptionId": "sub-1"}}
+            """);
+        // language=JSON
+        assertThatJson(updated).isEqualTo("""
+            {"uri": "memory://one", "_meta": {"io.modelcontextprotocol/subscriptionId": "sub-1"}}
+            """);
+        // language=JSON
+        assertThatJson(graceful).isEqualTo("""
+            {"_meta": {"io.modelcontextprotocol/subscriptionId": "sub-1"}, "resultType": "complete"}
+            """);
+    }
+
+    @Test
+    void modelsReferencedByGeneratedCodecsAreRegistered() {
+        assertThat(CodecRegistry.codecFor(NotificationParams.class)).isNotNull();
+        assertThat(CodecRegistry.codecFor(ListToolsResult.class)).isNotNull();
     }
 }

--- a/tachyon-core/src/test/java/dev/tachyonmcp/core/runtime/NotificationsTest.java
+++ b/tachyon-core/src/test/java/dev/tachyonmcp/core/runtime/NotificationsTest.java
@@ -23,19 +23,8 @@ class NotificationsTest {
     }
 
     @Test
-    void logParamsBuildsWireShapeOmittingAbsentLogger() {
-        var params = NotificationLogSupport.logParams(LoggingLevel.NOTICE, null, null);
-
-        assertThat(params).containsEntry("level", "notice").containsEntry("data", null);
-        assertThat(params).doesNotContainKey("logger");
+    void logMethodConstantMatchesTheSpec() {
         assertThat(NotificationLogSupport.LOG_METHOD).isEqualTo("notifications/message");
-    }
-
-    @Test
-    void logParamsIncludesLoggerWhenPresent() {
-        var params = NotificationLogSupport.logParams(LoggingLevel.WARNING, "logger.x", "boom");
-
-        assertThat(params).containsEntry("level", "warning").containsEntry("logger", "logger.x");
     }
 
     private record Logged(LoggingLevel level, String logger, Object data) {}

--- a/tachyon-core/src/test/java/dev/tachyonmcp/core/server/features/subscriptions/SubscriptionRegistryTest.java
+++ b/tachyon-core/src/test/java/dev/tachyonmcp/core/server/features/subscriptions/SubscriptionRegistryTest.java
@@ -1,0 +1,133 @@
+/* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
+package dev.tachyonmcp.core.server.features.subscriptions;
+
+import static dev.tachyonmcp.core.test.TestUtils.newEngine;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.tachyonmcp.api.server.domain.RequestId;
+import dev.tachyonmcp.core.protocol.Protocol;
+import dev.tachyonmcp.core.protocol.ProtocolRequestMapper.SubscriptionListenRequest;
+import dev.tachyonmcp.core.protocol.ProtocolResponseMapper;
+import dev.tachyonmcp.core.protocol.Protocols;
+import dev.tachyonmcp.core.runtime.SseEvent;
+import dev.tachyonmcp.core.server.OutboundSseStream;
+import dev.tachyonmcp.core.server.internal.ServerEngine;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+/**
+ * A real network round-trip can't exercise the race {@link SubscriptionRegistry#activate} guards
+ * against: by the time an e2e client observes the ack, {@code activate} has already returned
+ * server-side, so the window is only reachable with a directly-injected concurrent caller.
+ */
+class SubscriptionRegistryTest {
+
+    private final ServerEngine engine = newEngine(b -> {});
+    private final SubscriptionRegistry registry = new SubscriptionRegistry(engine);
+    private final ProtocolResponseMapper responseMapper = Protocols.list().stream()
+            .map(Protocol::responseMapper)
+            .filter(m -> m.supports("mcp", "2026-07-28"))
+            .findFirst()
+            .orElseThrow();
+
+    @AfterEach
+    void tearDown() {
+        engine.close();
+    }
+
+    /**
+     * Fires {@code notifyToolsListChanged} from a second thread exactly while the ack event for a
+     * brand-new subscription is being written — the tightest possible window between "subscription
+     * exists" and "ack visible". If {@link SubscriptionRegistry#activate} ever again split those
+     * into two unsynchronized steps, this reproduces the original bug: either the change is dropped
+     * (subscription wasn't registered when the notifier ran) or arrives before the ack.
+     */
+    @Test
+    @Timeout(10)
+    void concurrentChangeDuringActivationIsNotLostAndFollowsTheAck() throws Exception {
+        var notifierStarted = new CountDownLatch(1);
+        var notifierDone = new CountDownLatch(1);
+        var events = new CopyOnWriteArrayList<SseEvent>();
+
+        Consumer<SseEvent> onAckWrite = event -> {
+            var notifier = new Thread(
+                    () -> {
+                        notifierStarted.countDown();
+                        registry.notifyToolsListChanged();
+                        notifierDone.countDown();
+                    },
+                    "concurrent-notifier");
+            notifier.setDaemon(true);
+            notifier.start();
+            // Give the notifier a real chance to reach registry.notifyToolsListChanged() and block
+            // on the activation lock before this thread releases it — otherwise the test could pass
+            // vacuously just because the notifier never got scheduled in time.
+            awaitLatch(notifierStarted);
+        };
+        var stream = new RecordingStream(events, onAckWrite);
+
+        var pending = new CompletableFuture<Object>();
+        registry.activate(
+                RequestId.of(1L),
+                stream,
+                new SubscriptionListenRequest(true, false, false, Set.of()),
+                responseMapper,
+                pending);
+
+        awaitLatch(notifierDone);
+
+        assertThat(events).hasSize(2);
+        assertThat(events.get(0).data()).contains("notifications/subscriptions/acknowledged");
+        assertThat(events.get(1).data()).contains("notifications/tools/list_changed");
+    }
+
+    private static void awaitLatch(CountDownLatch latch) {
+        try {
+            assertThat(latch.await(5, TimeUnit.SECONDS))
+                    .as("latch reached within timeout")
+                    .isTrue();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new AssertionError("Interrupted while awaiting latch", e);
+        }
+    }
+
+    /** Records every event written, invoking {@code onAck} synchronously when the ack event lands. */
+    private static final class RecordingStream implements OutboundSseStream {
+        private final CopyOnWriteArrayList<SseEvent> events;
+        private final Consumer<SseEvent> onAckWrite;
+
+        RecordingStream(CopyOnWriteArrayList<SseEvent> events, Consumer<SseEvent> onAckWrite) {
+            this.events = events;
+            this.onAckWrite = onAckWrite;
+        }
+
+        @Override
+        public void start() {}
+
+        @Override
+        public boolean started() {
+            return true;
+        }
+
+        @Override
+        public void writeEvent(@Nullable SseEvent event) {
+            if (event == null) return;
+            events.add(event);
+            if (event.data().contains("acknowledged")) {
+                onAckWrite.accept(event);
+            }
+        }
+
+        @Override
+        public void close() {}
+    }
+}

--- a/tachyon-core/src/test/java/dev/tachyonmcp/core/server/json/JsonUtilsTest.java
+++ b/tachyon-core/src/test/java/dev/tachyonmcp/core/server/json/JsonUtilsTest.java
@@ -4,9 +4,11 @@ package dev.tachyonmcp.core.server.json;
 import static dev.tachyonmcp.core.test.TestUtils.parseJson;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import dev.tachyonmcp.api.json.JsonDocument;
 import dev.tachyonmcp.api.json.PayloadSerializer;
 import dev.tachyonmcp.api.server.features.tools.ToolResult;
+import java.time.Duration;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -17,6 +19,20 @@ import tools.jackson.databind.node.JsonNodeFactory;
 class JsonUtilsTest {
 
     private static final PayloadSerializer SERDE = new JacksonPayloadSerde();
+
+    @Test
+    void mapperConvertsBareMillisecondsNumberToDuration() {
+        var result = JsonUtils.mapper().convertValue(Map.of("ttl", 5000), WithTtl.class);
+
+        assertThat(result.ttl()).isEqualTo(Duration.ofMillis(5000));
+    }
+
+    @Test
+    void mapperConvertsAbsentTtlToNullDuration() {
+        var result = JsonUtils.mapper().convertValue(Map.of(), WithTtl.class);
+
+        assertThat(result.ttl()).isNull();
+    }
 
     @Test
     void valueToObjectNodeNullReturnsNull() {
@@ -144,6 +160,8 @@ class JsonUtilsTest {
     }
 
     public record SamplePojo(String name, int value) {}
+
+    private record WithTtl(@JsonProperty("ttl") Duration ttl) {}
 
     private record RetainedDocument(String json, JsonNode node) implements JsonDocument {
         @Override

--- a/tachyon-core/src/test/java/dev/tachyonmcp/core/transport/jsonrpc/JsonRpcCodecTest.java
+++ b/tachyon-core/src/test/java/dev/tachyonmcp/core/transport/jsonrpc/JsonRpcCodecTest.java
@@ -5,13 +5,6 @@ import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import dev.tachyonmcp.api.server.domain.RequestId;
-import dev.tachyonmcp.core.protocol.mcp.v2025_11_25.models.Annotations;
-import dev.tachyonmcp.core.protocol.mcp.v2025_11_25.models.CallToolResult;
-import dev.tachyonmcp.core.protocol.mcp.v2025_11_25.models.ListResourcesResult;
-import dev.tachyonmcp.core.protocol.mcp.v2025_11_25.models.Resource;
-import dev.tachyonmcp.core.protocol.mcp.v2025_11_25.models.Role;
-import java.util.List;
-import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 class JsonRpcCodecTest {
@@ -78,52 +71,5 @@ class JsonRpcCodecTest {
         assertThatJson(json).isEqualTo("""
             {"key":"value"}
             """);
-    }
-
-    @Test
-    void writeValueAsStringWithProtocolModelReturnsJsonNotToString() {
-        var result = CallToolResult.ofText("ok");
-
-        var json = JsonRpcCodec.writeValueAsString(result);
-
-        // language=JSON
-        assertThatJson(json).isEqualTo("""
-            {"content":[{"type":"text","text":"ok"}]}
-            """);
-    }
-
-    @Test
-    void writeValueAsStringSerializesEnumLists() {
-        var annotations = new Annotations(List.of(Role.USER, Role.ASSISTANT), 0.8, "2026-07-23T00:00:00Z");
-        var resource = Resource.builder()
-                .uri("weather://prediction/article")
-                .name("prediction-article")
-                .annotations(annotations)
-                .build();
-
-        var json = JsonRpcCodec.writeValueAsString(
-                ListResourcesResult.builder().resources(List.of(resource)).build());
-
-        // language=JSON
-        assertThatJson(json).isEqualTo("""
-            {
-              "resources": [{
-                "uri": "weather://prediction/article",
-                "name": "prediction-article",
-                "annotations": {
-                  "audience": ["user", "assistant"],
-                  "priority": 0.8,
-                  "lastModified": "2026-07-23T00:00:00Z"
-                }
-              }]
-            }
-            """);
-
-        var decoded = (Map<String, ?>) JsonRpcCodec.readValue(json);
-        var resources = (List<Map<String, ?>>) decoded.get("resources");
-        var ann = (Map<String, ?>) resources.get(0).get("annotations");
-        var audience = ((List<?>) ann.get("audience"))
-                .stream().map(s -> Role.fromValue((String) s)).toList();
-        assertThat(audience).containsExactly(Role.USER, Role.ASSISTANT);
     }
 }

--- a/tachyon-core/ts2java.py
+++ b/tachyon-core/ts2java.py
@@ -1215,9 +1215,9 @@ class Generator:
         out = []
         out.append(self.pkg(self.pkg_models))
         out.append("\n")
-        out.append("import javax.annotation.processing.Generated;\n")
         out.append("import com.fasterxml.jackson.annotation.JsonSubTypes;\n")
         out.append("import com.fasterxml.jackson.annotation.JsonTypeInfo;\n")
+        out.append("import javax.annotation.processing.Generated;\n")
         out.append("\n")
         class_desc = JavadocFormatter.format_jsdoc(jsdoc) if jsdoc else ""
         jd_block = JavadocFormatter.make_javadoc(class_desc)
@@ -1309,9 +1309,9 @@ class Generator:
         out = []
         out.append(self.pkg(self.pkg_models))
         out.append("\n")
-        out.append("import javax.annotation.processing.Generated;\n")
         out.append("import com.fasterxml.jackson.annotation.JsonSubTypes;\n")
         out.append("import com.fasterxml.jackson.annotation.JsonTypeInfo;\n")
+        out.append("import javax.annotation.processing.Generated;\n")
         out.append("\n")
         class_desc = JavadocFormatter.format_jsdoc(jsdoc) if jsdoc else ""
         jd_block = JavadocFormatter.make_javadoc(class_desc)
@@ -1339,8 +1339,8 @@ class Generator:
             return
         out = []
         out.append(self.pkg(self.pkg_models))
-        out.append("\nimport javax.annotation.processing.Generated;\n")
-        out.append("import com.fasterxml.jackson.annotation.JsonValue;\n\n")
+        out.append("\nimport com.fasterxml.jackson.annotation.JsonValue;\n")
+        out.append("import javax.annotation.processing.Generated;\n\n")
         class_desc = JavadocFormatter.format_jsdoc(jsdoc) if jsdoc else ""
         jd_block = JavadocFormatter.make_javadoc(class_desc)
         if jd_block:
@@ -1539,34 +1539,39 @@ class Generator:
         out = []
         out.append(self.pkg(self.pkg_codecs))
         out.append("\n")
-        out.append("import tools.jackson.core.JsonGenerator;\n")
-        out.append("import tools.jackson.core.JsonParser;\n")
-        out.append("import tools.jackson.core.JsonToken;\n")
-        out.append("import tools.jackson.databind.JsonNode;\n")
+
+        imported = set()
+
+        def emit_import(fqcn):
+            imported.add(fqcn)
+
+        emit_import("tools.jackson.core.JsonGenerator")
+        emit_import("tools.jackson.core.JsonParser")
+        emit_import("tools.jackson.core.JsonToken")
+        emit_import("tools.jackson.databind.JsonNode")
         if self.unknown_type == "TokenBuffer":
-            out.append("import tools.jackson.databind.util.TokenBuffer;\n")
+            emit_import("tools.jackson.databind.util.TokenBuffer")
         if self.unknown_type == "byte[]":
-            out.append("import tools.jackson.databind.util.TokenBuffer;\n")
-            out.append("import java.io.ByteArrayOutputStream;\n")
-            out.append("import java.io.ByteArrayInputStream;\n")
-            out.append("import tools.jackson.core.ObjectReadContext;\n")
-            out.append("import tools.jackson.core.ObjectWriteContext;\n")
-            out.append("import tools.jackson.core.json.JsonFactory;\n")
+            emit_import("tools.jackson.databind.util.TokenBuffer")
+            emit_import("java.io.ByteArrayOutputStream")
+            emit_import("java.io.ByteArrayInputStream")
+            emit_import("tools.jackson.core.ObjectReadContext")
+            emit_import("tools.jackson.core.ObjectWriteContext")
+            emit_import("tools.jackson.core.json.JsonFactory")
         if any("java.util.List" in c[0] for c in components):
-            out.append("import java.util.ArrayList;\n")
-            out.append("import java.util.List;\n")
+            emit_import("java.util.ArrayList")
+            emit_import("java.util.List")
         if has_additional or any("java.util.Map" in c[0] for c in components):
-            out.append("import java.util.LinkedHashMap;\n")
-            out.append("import java.util.Map;\n")
-        out.append("import java.io.IOException;\n")
-        out.append("import javax.annotation.processing.Generated;\n")
-        out.append("\n")
+            emit_import("java.util.LinkedHashMap")
+            emit_import("java.util.Map")
+        emit_import("java.io.IOException")
+        emit_import("javax.annotation.processing.Generated")
         if is_inner:
             owner = self.top_owner(model_name)
-            out.append(f"import {self.pkg_models}.{owner};\n")
+            emit_import(f"{self.pkg_models}.{owner}")
         else:
             owner = model_name
-            out.append(f"import {self.pkg_models}.{model_name};\n")
+            emit_import(f"{self.pkg_models}.{model_name}")
 
         # Imports for referenced model types and FQN from type mappings
         refs = set()
@@ -1603,9 +1608,12 @@ class Generator:
         refs.discard(self.pkg_models + "." + owner)
         for r in sorted(refs):
             if "." in r:
-                out.append(f"import {r};\n")
+                emit_import(r)
             else:
-                out.append(f"import {self.pkg_models}.{r};\n")
+                emit_import(f"{self.pkg_models}.{r}")
+
+        for i in sorted(imported):
+            out.append(f"import {i};\n")
 
         out.append("\n")
         out.append("/** Codec for {@link " + qname + "}. */\n")
@@ -2125,18 +2133,19 @@ class Generator:
         if codec_name in self.codec_files:
             return
         out = [self.pkg(self.pkg_codecs), "\n"]
-        out.append("import tools.jackson.core.JsonGenerator;\n")
-        out.append("import tools.jackson.core.JsonParser;\n")
-        out.append("import tools.jackson.core.JsonToken;\n")
-        out.append("import tools.jackson.databind.util.TokenBuffer;\n")
-        out.append("import java.io.IOException;\n")
-        out.append("import javax.annotation.processing.Generated;\n\n")
-        out.append(f"import {self.pkg_models}.{union_name};\n")
-        seen = set()
+        imported = {
+            "tools.jackson.core.JsonGenerator",
+            "tools.jackson.core.JsonParser",
+            "tools.jackson.core.JsonToken",
+            "tools.jackson.databind.util.TokenBuffer",
+            "java.io.IOException",
+            "javax.annotation.processing.Generated",
+            f"{self.pkg_models}.{union_name}",
+        }
         for vn, _ in variants:
-            if vn not in seen:
-                out.append(f"import {self.pkg_models}.{vn};\n")
-                seen.add(vn)
+            imported.add(f"{self.pkg_models}.{vn}")
+        for i in sorted(imported):
+            out.append(f"import {i};\n")
         out.append("\n")
         out.append("/** Codec for {@link " + union_name + "}. */\n")
         out.append('@Generated("ts2java")\n')
@@ -2191,18 +2200,19 @@ class Generator:
         if codec_name in self.codec_files:
             return
         out = [self.pkg(self.pkg_codecs), "\n"]
-        out.append("import tools.jackson.core.JsonGenerator;\n")
-        out.append("import tools.jackson.core.JsonParser;\n")
-        out.append("import tools.jackson.core.JsonToken;\n")
-        out.append("import tools.jackson.databind.util.TokenBuffer;\n")
-        out.append("import java.io.IOException;\n")
-        out.append("import javax.annotation.processing.Generated;\n\n")
-        out.append(f"import {self.pkg_models}.{union_name};\n")
-        seen = set()
+        imported = {
+            "tools.jackson.core.JsonGenerator",
+            "tools.jackson.core.JsonParser",
+            "tools.jackson.core.JsonToken",
+            "tools.jackson.databind.util.TokenBuffer",
+            "java.io.IOException",
+            "javax.annotation.processing.Generated",
+            f"{self.pkg_models}.{union_name}",
+        }
         for vn in variant_field_map:
-            if vn not in seen:
-                out.append(f"import {self.pkg_models}.{vn};\n")
-                seen.add(vn)
+            imported.add(f"{self.pkg_models}.{vn}")
+        for i in sorted(imported):
+            out.append(f"import {i};\n")
         out.append("/** Codec for {@link " + union_name + "}. */\n")
         out.append('@Generated("ts2java")\n')
         out.append(f"public class {codec_name} implements Codec<{union_name}> {{\n\n")
@@ -2255,16 +2265,22 @@ class Generator:
         if name in self.codec_files:
             return
         out = [self.pkg(self.pkg_codecs), "\n"]
-        out.append("import tools.jackson.core.JsonGenerator;\n")
-        out.append("import tools.jackson.core.JsonParser;\n")
-        out.append("import tools.jackson.core.JsonToken;\n")
-        out.append("import tools.jackson.core.ObjectReadContext;\n")
-        out.append("import tools.jackson.core.ObjectWriteContext;\n")
-        out.append("import tools.jackson.core.json.JsonFactory;\n")
-        out.append("import java.io.ByteArrayOutputStream;\n")
-        out.append("import java.io.IOException;\n")
-        out.append("import java.io.UncheckedIOException;\n")
-        out.append("import javax.annotation.processing.Generated;\n\n")
+        for i in sorted(
+            [
+                "tools.jackson.core.JsonGenerator",
+                "tools.jackson.core.JsonParser",
+                "tools.jackson.core.JsonToken",
+                "tools.jackson.core.ObjectReadContext",
+                "tools.jackson.core.ObjectWriteContext",
+                "tools.jackson.core.json.JsonFactory",
+                "java.io.ByteArrayOutputStream",
+                "java.io.IOException",
+                "java.io.UncheckedIOException",
+                "javax.annotation.processing.Generated",
+            ]
+        ):
+            out.append(f"import {i};\n")
+        out.append("\n")
         out.append('@Generated("ts2java")\n')
         out.append("/** Codec for serializing and deserializing model types. */\n")
         out.append("public interface Codec<T> {\n")

--- a/tachyon-core/ts2java.py
+++ b/tachyon-core/ts2java.py
@@ -2682,9 +2682,11 @@ class Generator:
                     self.add_discriminated_codec(model_name, disc, variants)
                     continue
                 if model_name in self.interface_extends:
-                    # Only generate deduction codecs for polymorphic extends parents
-                    # that are actually referenced as field types (e.g., ResourceContents).
-                    # Others (BaseMetadata, Icons) are not used polymorphically.
+                    # Polymorphic extends parents referenced as field types get a deduction codec
+                    # (e.g. ResourceContents). The rest are plain records that codecs still
+                    # reference by their declared type (NotificationParams, RequestParams, Result,
+                    # Error), so they fall through to a plain codec below — without one,
+                    # CodecRegistry.codecFor returns null and the caller NPEs.
                     if model_name == "ResourceContents":
                         children = self.interface_extends[model_name]
                         variant_field_map = OrderedDict()
@@ -2703,7 +2705,7 @@ class Generator:
                                         break
                         if variant_field_map:
                             self.add_deduction_codec(model_name, variant_field_map)
-                    continue
+                        continue
                 if model_name in (
                     "McpMessage",
                     "McpRequest",


### PR DESCRIPTION
## Summary

Adds MCP 2026-07-28 subscriptions/listen support over stateless SSE. The server parses filters, sends acknowledgements, routes matching tool, prompt, and resource notifications, removes disconnected streams, and completes subscriptions during shutdown. Response encoding now uses protocol mappers. Tests cover codec output and end-to-end subscription behavior.

### New Features

- Added support for MCP subscriptions/listen over stateless SSE.
- Subscribe to tool, prompt, and resource list changes, including updates for specific resource URIs.
- Receive subscription acknowledgements, filtered notifications, and graceful completion on disconnect or server shutdown.

### Bug Fixes

- Improved protocol response serialization for generated models and enum values.

### Tests

- Added comprehensive end-to-end and serialization coverage for subscription behavior.
