### PR TITLE
fix(protocol): capture request context synchronously to close pipeline races

### DIFF
--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/McpDispatcher.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/McpDispatcher.java
@@ -67,14 +67,6 @@ public class McpDispatcher {
     public static final AttributeKey<HttpRequest> ATTR_INIT_REQUEST = AttributeKey.of("init.request");
 
     /**
-     * Interaction-context attribute key under which the current request's JSON-RPC {@code id} is
-     * stashed before dispatch, so a handler with no other access to it (e.g. {@code
-     * subscriptions/listen}, which must echo it back as {@code subscriptionId}) can read it back via
-     * {@code context.get(ATTR_REQUEST_ID)}.
-     */
-    public static final AttributeKey<RequestId> ATTR_REQUEST_ID = AttributeKey.of("request.id");
-
-    /**
      * Placeholder request for programmatic dispatch with no channel (the default generator ignores it).
      */
     private static final HttpRequest EMPTY_INIT_REQUEST =
@@ -98,10 +90,14 @@ public class McpDispatcher {
      * context (direct invocation, tests), fresh channel state is created for the default protocol.
      */
     private DispatchContext dispatchContext(@Nullable ChannelContext channelContext) {
+        return dispatchContext(channelContext, null);
+    }
+
+    private DispatchContext dispatchContext(@Nullable ChannelContext channelContext, @Nullable RequestId id) {
         var channel = channelContext != null
                 ? channelContext
                 : Protocols.list().getFirst().createInteractionContext();
-        return new DefaultDispatchContext(channel, server);
+        return new DefaultDispatchContext(channel, server, id);
     }
 
     public sealed interface DispatchResult
@@ -171,8 +167,7 @@ public class McpDispatcher {
         Objects.requireNonNull(id, "id");
         Objects.requireNonNull(method, "method");
 
-        var requestCtx = dispatchContext(channelContext);
-        requestCtx.set(ATTR_REQUEST_ID, id);
+        var requestCtx = dispatchContext(channelContext, id);
         try {
             requestCtx.setPermittedLogLevel(requestCtx.requestMapper().permittedLogLevel(params));
         } catch (RequestMappingException e) {

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/handlers/SubscriptionsListenHandler.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/handlers/SubscriptionsListenHandler.java
@@ -2,7 +2,6 @@
 package dev.tachyonmcp.core.server.handlers;
 
 import dev.tachyonmcp.api.annotations.InternalApi;
-import dev.tachyonmcp.core.server.McpDispatcher;
 import dev.tachyonmcp.core.server.RpcMethodHandler;
 import dev.tachyonmcp.core.server.domain.ServerErrors;
 import dev.tachyonmcp.core.server.features.subscriptions.SubscriptionRegistry;
@@ -47,8 +46,10 @@ public final class SubscriptionsListenHandler implements RpcMethodHandler {
         if (stream == null) {
             return CompletableFuture.completedFuture(ServerErrors.internalError("No SSE stream available"));
         }
-        var subscriptionId = context.get(McpDispatcher.ATTR_REQUEST_ID)
-                .orElseThrow(() -> new IllegalStateException("subscriptions/listen dispatched without a request id"));
+        var subscriptionId = context.requestId();
+        if (subscriptionId == null) {
+            throw new IllegalStateException("subscriptions/listen dispatched without a request id");
+        }
         var filter = requestMapper.subscriptionsListen(params);
 
         stream.start();

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/session/DefaultDispatchContext.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/session/DefaultDispatchContext.java
@@ -7,6 +7,7 @@ import dev.tachyonmcp.api.runtime.ClientContext;
 import dev.tachyonmcp.api.runtime.ContextNotifications;
 import dev.tachyonmcp.api.server.domain.LoggingLevel;
 import dev.tachyonmcp.api.server.domain.ProgressToken;
+import dev.tachyonmcp.api.server.domain.RequestId;
 import dev.tachyonmcp.core.protocol.Protocol;
 import dev.tachyonmcp.core.protocol.ProtocolRequestMapper;
 import dev.tachyonmcp.core.protocol.ProtocolResponseMapper;
@@ -31,13 +32,19 @@ public class DefaultDispatchContext implements DispatchContext {
 
     private final ChannelContext channel;
     private final ServerEngine server;
+    private final @Nullable RequestId requestId;
     private final ContextNotifications notifications = new NotificationsImpl();
     private volatile @Nullable OutboundSseStream outboundStream;
     private volatile @Nullable LoggingLevel permittedLogLevel;
 
     public DefaultDispatchContext(ChannelContext channel, ServerEngine server) {
+        this(channel, server, null);
+    }
+
+    public DefaultDispatchContext(ChannelContext channel, ServerEngine server, @Nullable RequestId requestId) {
         this.channel = channel;
         this.server = server;
+        this.requestId = requestId;
     }
 
     public static DispatchContext create(Protocol protocol, ServerEngine server) {
@@ -139,6 +146,12 @@ public class DefaultDispatchContext implements DispatchContext {
     @Nullable
     public LoggingLevel getPermittedLogLevel() {
         return permittedLogLevel;
+    }
+
+    @Override
+    @Nullable
+    public RequestId requestId() {
+        return requestId;
     }
 
     @Override

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/session/DispatchContext.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/session/DispatchContext.java
@@ -3,6 +3,7 @@ package dev.tachyonmcp.core.server.session;
 
 import dev.tachyonmcp.api.annotations.InternalApi;
 import dev.tachyonmcp.api.server.domain.LoggingLevel;
+import dev.tachyonmcp.api.server.domain.RequestId;
 import dev.tachyonmcp.core.protocol.ProtocolRequestMapper;
 import dev.tachyonmcp.core.protocol.ProtocolResponseMapper;
 import dev.tachyonmcp.core.runtime.ChannelContext;
@@ -32,6 +33,13 @@ public interface DispatchContext extends ChannelContext {
     /** Returns the log level this specific request permits, or {@code null} if it set none. */
     @Nullable
     LoggingLevel getPermittedLogLevel();
+
+    /**
+     * Returns the id of the request currently being dispatched, or {@code null} for dispatches with
+     * no request id (notifications, stateless helper contexts).
+     */
+    @Nullable
+    RequestId requestId();
 
     /** Returns the protocol response mapper for the current protocol version. */
     ProtocolResponseMapper responseMapper();

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/session/NoopInteractionContext.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/session/NoopInteractionContext.java
@@ -6,6 +6,7 @@ import dev.tachyonmcp.api.runtime.AttributeKey;
 import dev.tachyonmcp.api.runtime.ClientContext;
 import dev.tachyonmcp.api.runtime.ContextNotifications;
 import dev.tachyonmcp.api.server.domain.LoggingLevel;
+import dev.tachyonmcp.api.server.domain.RequestId;
 import dev.tachyonmcp.core.protocol.Protocol;
 import dev.tachyonmcp.core.protocol.ProtocolMappers;
 import dev.tachyonmcp.core.protocol.ProtocolRequestMapper;
@@ -101,6 +102,11 @@ public class NoopInteractionContext implements DispatchContext {
 
     @Override
     public @Nullable LoggingLevel getPermittedLogLevel() {
+        return null;
+    }
+
+    @Override
+    public @Nullable RequestId requestId() {
         return null;
     }
 

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/transport/netty/McpOperationHandler.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/transport/netty/McpOperationHandler.java
@@ -30,6 +30,7 @@ import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.timeout.IdleStateEvent;
 import java.nio.charset.StandardCharsets;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.Executor;
@@ -115,6 +116,13 @@ public class McpOperationHandler extends ChannelInboundHandlerAdapter {
             // the operation phase); preserve the request for a custom SessionIdGenerator.
             captureInitRequest(ctx, req, server);
         }
+        // Captured synchronously, before the async hop below: a pipelined next request's
+        // channelRead cannot run until this method returns, so this pins the interaction
+        // context this request actually arrived on instead of racing a later re-fetch
+        // against ProtocolVersionHandler rebinding a fresh one for the next request. May be
+        // null (e.g. no InteractionHandler configured); enforced non-null only where the
+        // original code enforced it, in handlePostRequest.
+        final @Nullable ChannelContext ic = ChannelHandlerUtils.getInteractionContext(ctx);
         var body = req.content().retain();
         try {
             CompletableFuture.runAsync(
@@ -125,7 +133,7 @@ public class McpOperationHandler extends ChannelInboundHandlerAdapter {
                                 } finally {
                                     body.release();
                                 }
-                                dispatchPostMessage(ctx, sessionId, message, origin);
+                                dispatchPostMessage(ctx, sessionId, message, origin, ic);
                             },
                             executor)
                     .exceptionally(ex -> {
@@ -135,7 +143,7 @@ public class McpOperationHandler extends ChannelInboundHandlerAdapter {
                                         ctx,
                                         HttpResponseStatus.BAD_REQUEST,
                                         "application/json",
-                                        dispatcher.parseError(ChannelHandlerUtils.getInteractionContext(ctx)),
+                                        dispatcher.parseError(ic),
                                         origin));
                         return null;
                     });
@@ -149,47 +157,49 @@ public class McpOperationHandler extends ChannelInboundHandlerAdapter {
             ChannelHandlerContext ctx,
             @Nullable String sessionId,
             @Nullable JsonRpcMessage message,
-            @Nullable String origin) {
+            @Nullable String origin,
+            @Nullable ChannelContext ic) {
+        final var executor = ctx.executor();
         if (message == null) {
-            ctx.executor()
-                    .execute(() -> sendResponseAndClose(
-                            ctx,
-                            HttpResponseStatus.BAD_REQUEST,
-                            "application/json",
-                            dispatcher.parseError(ChannelHandlerUtils.getInteractionContext(ctx)),
-                            origin));
+            executor.execute(() -> sendResponseAndClose(
+                    ctx, HttpResponseStatus.BAD_REQUEST, "application/json", dispatcher.parseError(ic), origin));
             return;
         }
         if (!server.isStateless() && sessionId == null && !(message instanceof JsonRpcMessage.Request<?>)) {
-            ctx.executor()
-                    .execute(() -> sendPlainTextAndClose(
-                            ctx, HttpResponseStatus.BAD_REQUEST, "Missing MCP-Session-Id header", origin));
+            executor.execute(() -> sendPlainTextAndClose(
+                    ctx, HttpResponseStatus.BAD_REQUEST, "Missing MCP-Session-Id header", origin));
             return;
         }
         switch (message) {
-            case JsonRpcMessage.Request<?> reqMsg -> handlePostRequest(ctx, sessionId, reqMsg, origin);
+            case JsonRpcMessage.Request<?> reqMsg ->
+                handlePostRequest(
+                        ctx,
+                        sessionId,
+                        reqMsg,
+                        origin,
+                        Objects.requireNonNull(
+                                ic,
+                                "InteractionContext is null. Check if InteractionHandler is configured correctly."));
             case JsonRpcMessage.Response resp ->
                 handlePostResponse(ctx, sessionId, ctx.channel().id().asLongText(), resp, origin);
             case JsonRpcMessage.Error err ->
                 handlePostError(ctx, sessionId, ctx.channel().id().asLongText(), err, origin);
             case JsonRpcMessage.Notification<?> not -> {
-                var channelContext = ChannelHandlerUtils.getInteractionContext(ctx);
                 if (McpDispatcher.NOTIFICATIONS_INITIALIZED.equals(not.method())) {
                     // Activate the session synchronously before acking so a client that waits
                     // for this 202 observes an ACTIVE session on its next request, closing the
                     // INITIALIZING race. Guarded so a handler failure still produces the ack.
                     try {
-                        dispatcher.dispatchNotification(not.method(), not.params(), sessionId, channelContext);
+                        dispatcher.dispatchNotification(not.method(), not.params(), sessionId, ic);
                     } catch (RuntimeException e) {
                         logger.warn("Failed to process {} notification", not.method(), e);
                     }
-                    ctx.executor().execute(() -> sendAccepted(ctx, origin));
+                    executor.execute(() -> sendAccepted(ctx, origin));
                 } else {
-                    ctx.executor().execute(() -> sendAccepted(ctx, origin));
+                    executor.execute(() -> sendAccepted(ctx, origin));
                     CompletableFuture.runAsync(
-                                    () -> dispatcher.dispatchNotification(
-                                            not.method(), not.params(), sessionId, channelContext),
-                                    executor)
+                                    () -> dispatcher.dispatchNotification(not.method(), not.params(), sessionId, ic),
+                                    this.executor)
                             .whenComplete((unused, e) -> {
                                 var cause = e instanceof CompletionException ce ? ce.getCause() : e;
                                 if (cause instanceof RuntimeException re) {
@@ -200,7 +210,7 @@ public class McpOperationHandler extends ChannelInboundHandlerAdapter {
             }
             default -> {
                 logger.warn("Unexpected message type: {}", message);
-                ctx.executor().execute(() -> sendAccepted(ctx, origin));
+                executor.execute(() -> sendAccepted(ctx, origin));
             }
         }
     }
@@ -237,20 +247,29 @@ public class McpOperationHandler extends ChannelInboundHandlerAdapter {
             ChannelHandlerContext ctx,
             @Nullable String sessionId,
             JsonRpcMessage.Request req,
-            @Nullable String origin) {
+            @Nullable String origin,
+            ChannelContext ic) {
         var heartbeatInterval = server.config().network().heartbeatInterval();
         var postStream = new PostSseStream(ctx.channel(), origin, server::nextEventId, heartbeatInterval);
         final var requestId = req.id();
         final var method = req.method();
         final var startNs = System.nanoTime();
-        final ChannelContext ic = ChannelHandlerUtils.requireInteractionContext(ctx);
         dispatcher
                 .dispatchRequestAsync(requestId, method, req.params(), sessionId, postStream, ic)
                 .whenComplete((result, ex) -> {
                     try {
                         ctx.executor()
                                 .execute(() -> completePostRequest(
-                                        ctx, requestId, method, sessionId, origin, postStream, startNs, result, ex));
+                                        ctx,
+                                        requestId,
+                                        method,
+                                        sessionId,
+                                        origin,
+                                        postStream,
+                                        startNs,
+                                        result,
+                                        ex,
+                                        ic));
                     } catch (RejectedExecutionException e) {
                         logger.debug(
                                 "Event loop rejected response marshal during shutdown: id={}, method={}",
@@ -269,7 +288,8 @@ public class McpOperationHandler extends ChannelInboundHandlerAdapter {
             PostSseStream postStream,
             long startNs,
             McpDispatcher.@Nullable DispatchResult result,
-            @Nullable Throwable ex) {
+            @Nullable Throwable ex,
+            ChannelContext ic) {
         var elapsedMs = (System.nanoTime() - startNs) / 1_000_000;
         var m = server.config().monitoring();
         if (ex != null) {
@@ -280,13 +300,7 @@ public class McpOperationHandler extends ChannelInboundHandlerAdapter {
                 // Neutralize the stream so a late server→client message cannot start a
                 // second HTTP response on this channel, then send the JSON error.
                 postStream.terminate();
-                sendInternalError(
-                        ctx,
-                        requestId,
-                        origin,
-                        ChannelHandlerUtils.requireInteractionContext(ctx)
-                                .protocol()
-                                .responseMapper());
+                sendInternalError(ctx, requestId, origin, ic.protocol().responseMapper());
             }
             return;
         }


### PR DESCRIPTION
A pipelined request could overwrite the previous request's protocol, session, attributes, or enabled extensions while it was still parsing or executing asynchronously, since request-scoped data was being read from channel-owned, mutable, lazily re-fetched storage instead of captured once at request-arrival time.

- McpOperationHandler now captures the interaction context synchronously, before handing dispatch off to the executor, and threads that single reference through the whole request lifecycle instead of re-resolving it from the channel attribute after each async hop.
- The request id gets its own per-request field on DefaultDispatchContext (like permittedLogLevel/outboundStream) instead of aliasing the channel-scoped attribute map via ATTR_REQUEST_ID, which a pipelined request could stomp before subscriptions/listen read it back.