### PR TITLE
fix: enforce subscriptions/listen ack ordering and numeric subscriptionId (SEP-2575)

### DIFF
--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp20260728/SubscriptionsListenTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp20260728/SubscriptionsListenTest.java
@@ -44,9 +44,26 @@ class SubscriptionsListenTest extends AbstractStatelessMcpE2eTest {
             await().atMost(Duration.ofSeconds(10))
                     .untilAsserted(() -> assertThat(payloads(lines)).isNotEmpty());
 
-            var first = payloads(lines).getFirst();
-            assertThat(first).contains("\"notifications/subscriptions/acknowledged\"");
-            assertThat(first).contains("\"io.modelcontextprotocol/subscriptionId\":\"1\"");
+            // Raw, unfiltered first "data:" line — proves the ack is the actual first SSE frame on
+            // the wire, not just the first non-blank one (payloads() strips blank data lines, which
+            // would hide a leading blank priming frame arriving before the ack).
+            var firstDataLine = lines.stream()
+                    .filter(l -> l.startsWith("data:"))
+                    .findFirst()
+                    .orElseThrow();
+            var firstPayload =
+                    firstDataLine.startsWith("data: ") ? firstDataLine.substring(6) : firstDataLine.substring(5);
+            // language=JSON
+            assertThatJson(firstPayload).isEqualTo("""
+                {
+                  "jsonrpc": "2.0",
+                  "method": "notifications/subscriptions/acknowledged",
+                  "params": {
+                    "notifications": {"toolsListChanged": true},
+                    "_meta": {"io.modelcontextprotocol/subscriptionId": 1}
+                  }
+                }
+                """);
 
             response.body().close();
             awaitQuietly(consume);
@@ -145,12 +162,31 @@ class SubscriptionsListenTest extends AbstractStatelessMcpE2eTest {
                             (ctx, req) -> ToolResult.text("x"));
 
             await().atMost(Duration.ofSeconds(10)).untilAsserted(() -> {
-                assertThat(payloads(linesA))
-                        .anyMatch(l -> l.contains("notifications/tools/list_changed")
-                                && l.contains("\"io.modelcontextprotocol/subscriptionId\":\"10\""));
-                assertThat(payloads(linesB))
-                        .anyMatch(l -> l.contains("notifications/tools/list_changed")
-                                && l.contains("\"io.modelcontextprotocol/subscriptionId\":\"20\""));
+                var notifA = payloads(linesA).stream()
+                        .filter(l -> l.contains("notifications/tools/list_changed"))
+                        .findFirst();
+                assertThat(notifA).isPresent();
+                // language=JSON
+                assertThatJson(notifA.get()).isEqualTo("""
+                    {
+                      "jsonrpc": "2.0",
+                      "method": "notifications/tools/list_changed",
+                      "params": {"_meta": {"io.modelcontextprotocol/subscriptionId": 10}}
+                    }
+                    """);
+
+                var notifB = payloads(linesB).stream()
+                        .filter(l -> l.contains("notifications/tools/list_changed"))
+                        .findFirst();
+                assertThat(notifB).isPresent();
+                // language=JSON
+                assertThatJson(notifB.get()).isEqualTo("""
+                    {
+                      "jsonrpc": "2.0",
+                      "method": "notifications/tools/list_changed",
+                      "params": {"_meta": {"io.modelcontextprotocol/subscriptionId": 20}}
+                    }
+                    """);
             });
 
             responseA.body().close();
@@ -211,7 +247,7 @@ class SubscriptionsListenTest extends AbstractStatelessMcpE2eTest {
                     {"jsonrpc":"2.0",
                     "id":1,
                     "result":{
-                      "_meta": {"io.modelcontextprotocol/subscriptionId":"1"},
+                      "_meta": {"io.modelcontextprotocol/subscriptionId":1},
                       "resultType":"complete"
                       }
                     }

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/mcp/v2026_07_28/codecs/McpResponseMapper.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/mcp/v2026_07_28/codecs/McpResponseMapper.java
@@ -348,8 +348,12 @@ public final class McpResponseMapper extends dev.tachyonmcp.core.protocol.mcp.v2
     }
 
     private static Map<String, JsonNode> subscriptionIdMeta(RequestId subscriptionId) {
-        return Objects.requireNonNull(
-                JsonUtils.toJsonNodeMap(Map.of(SUBSCRIPTION_ID_META_KEY, subscriptionId.toString())));
+        Object rawId =
+                switch (subscriptionId) {
+                    case RequestId.StringValue(var v) -> v;
+                    case RequestId.NumericValue(var v) -> v;
+                };
+        return Objects.requireNonNull(JsonUtils.toJsonNodeMap(Map.of(SUBSCRIPTION_ID_META_KEY, rawId)));
     }
 
     /**

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/handlers/SubscriptionsListenHandler.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/handlers/SubscriptionsListenHandler.java
@@ -52,9 +52,9 @@ public final class SubscriptionsListenHandler implements RpcMethodHandler {
         }
         var filter = requestMapper.subscriptionsListen(params);
 
-        stream.start();
         var pending = new CompletableFuture<>();
         var key = registry.activate(subscriptionId, stream, filter, context.responseMapper(), pending);
+        stream.start();
         stream.onClose(() -> {
             registry.remove(key);
             pending.cancel(false);

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/transport/netty/sse/PostSseStream.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/transport/netty/sse/PostSseStream.java
@@ -162,16 +162,21 @@ public final class PostSseStream implements OutboundSseStream {
         HttpHelpers.setSseStreamHeaders(response, origin);
         channel.write(response);
         SseHeartbeat.enable(channel, heartbeatInterval);
-        // Priming event: gives the client a Last-Event-ID baseline for reconnection (SEP-1699).
-        // Carries this stream's key so a resume from the priming id replays only this stream.
-        var primingId = eventIdSupplier.getAsLong();
-        var priming = new SseEvent(ServerEngine.wireEventId(primingId, streamKey), "message", "");
-        channel.write(new DefaultHttpContent(SseSerializer.encode(channel.alloc(), priming)));
-        logger.trace("POST-SSE stream started, priming event id={}, channel={}", primingId, channel.id());
-        for (var event : queued) {
-            channel.write(new DefaultHttpContent(SseSerializer.encode(channel.alloc(), event)));
+        if (queued.isEmpty()) {
+            // Priming event: gives the client a Last-Event-ID baseline for reconnection (SEP-1699).
+            // Carries this stream's key so a resume from the priming id replays only this stream.
+            // Skipped when an event is already queued (e.g. subscriptions/listen's ack, which SEP-2575
+            // requires to be the stream's first message) — that queued event is itself a valid baseline.
+            var primingId = eventIdSupplier.getAsLong();
+            var priming = new SseEvent(ServerEngine.wireEventId(primingId, streamKey), "message", "");
+            channel.write(new DefaultHttpContent(SseSerializer.encode(channel.alloc(), priming)));
+            logger.trace("POST-SSE stream started, priming event id={}, channel={}", primingId, channel.id());
+        } else {
+            for (var event : queued) {
+                channel.write(new DefaultHttpContent(SseSerializer.encode(channel.alloc(), event)));
+            }
+            queued.clear();
         }
-        queued.clear();
         channel.flush();
     }
 

--- a/tachyon-core/src/test/java/dev/tachyonmcp/core/protocol/mcp/v2026_07_28/codecs/McpResponseMapperTest.java
+++ b/tachyon-core/src/test/java/dev/tachyonmcp/core/protocol/mcp/v2026_07_28/codecs/McpResponseMapperTest.java
@@ -221,6 +221,22 @@ class McpResponseMapperTest {
     }
 
     @Test
+    void subscriptionIdPreservesNumericTypeFromTheRequestId() {
+        var id = RequestId.of(1);
+        var filter = new SubscriptionListenRequest(true, false, false, Set.of());
+
+        var ack = mapper.encode(mapper.subscriptionsAcknowledgedParams(id, filter));
+
+        // language=JSON
+        assertThatJson(ack).isEqualTo("""
+            {
+              "notifications": {"toolsListChanged": true},
+              "_meta": {"io.modelcontextprotocol/subscriptionId": 1}
+            }
+            """);
+    }
+
+    @Test
     void loggingMessageParamsSerializesLevelLoggerAndData() {
         var json = mapper.encode(mapper.loggingMessageParams(LoggingLevel.WARNING, "logger.x", "boom"));
 


### PR DESCRIPTION
## Summary


PostSseStream.doStart() was always writing a blank legacy priming SSE event before flushing any queued event, so notifications/subscriptions/acknowledged never actually was the stream's first message as SEP-2575 requires. Skip the priming write when a real event is already queued (only possible for subscriptions/listen, since every other caller starts the stream before writing); other POST-SSE streams and the GET-stream priming are unaffected and remain spec-compliant for 2025-11-25.

McpResponseMapper.subscriptionIdMeta also stringified the subscriptionId via RequestId.toString(), turning a numeric request id into a JSON string in _meta. Pattern-match RequestId's variants instead, mirroring how JsonRpcCodec.writeId already preserves string vs. numeric ids.


### Bug Fixes

- Subscription acknowledgements and notifications now preserve numeric subscription IDs as JSON numbers instead of converting them to strings.
- Server-sent event streams now deliver queued subscription events immediately without an unnecessary preliminary event.
- Improved stream startup sequencing for more reliable subscription handling.

### Tests

- Added coverage for numeric subscription IDs, exact event ordering, concurrent subscriptions, and graceful shutdown behavior.