### PR TITLE
feat!: FormInputSchema to use JsonSchema

### DIFF
--- a/e2e/src/test/java/dev/tachyonmcp/e2e/InputRequiredResultTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/InputRequiredResultTest.java
@@ -4,6 +4,7 @@ package dev.tachyonmcp.e2e;
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import dev.tachyonmcp.api.json.JsonSchema;
 import dev.tachyonmcp.api.runtime.InteractionContext;
 import dev.tachyonmcp.api.server.domain.FormInputRequest;
 import dev.tachyonmcp.api.server.domain.InputRequest;
@@ -214,7 +215,7 @@ class InputRequiredResultTest extends AbstractStatelessMcpE2eTest {
         schemaMap.put("type", "object");
         schemaMap.put("properties", Map.of(propName, Map.of("type", propType)));
         schemaMap.put("required", List.of(propName));
-        return FormInputRequest.of(message, schemaMap);
+        return FormInputRequest.of(message, JsonSchema.from(schemaMap));
     }
 
     private static UrlInputRequest buildUrlElicitation(String message, String elicitationId, String url) {

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/TaskAugmentedToolTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/TaskAugmentedToolTest.java
@@ -367,7 +367,10 @@ class TaskAugmentedToolTest extends AbstractStatelessMcpE2eTest {
                 .register(
                         b -> b.name("needs-input").taskSupport(TaskSupport.OPTIONAL),
                         (context, request) -> ToolResult.inputRequired(
-                                Map.of("user_name", FormInputRequest.of("What is your name?", Map.of())), null)));
+                                Map.of(
+                                        "user_name",
+                                        FormInputRequest.of("What is your name?", JsonSchema.objectSchema())),
+                                null)));
         try (var client = createTestClient()) {
             client.initialize();
 
@@ -405,7 +408,9 @@ class TaskAugmentedToolTest extends AbstractStatelessMcpE2eTest {
                     var inputResponses = request.inputResponses();
                     if (inputResponses == null || !inputResponses.containsKey("user_name")) {
                         return ToolResult.inputRequired(
-                                Map.of("user_name", FormInputRequest.of("What is your name?", Map.of())),
+                                Map.of(
+                                        "user_name",
+                                        FormInputRequest.of("What is your name?", JsonSchema.objectSchema())),
                                 "greet-state");
                     }
                     var name = stringField(inputResponses.get("user_name"), "name", "World");

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp20260728/InputRequiredResultTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp20260728/InputRequiredResultTest.java
@@ -31,7 +31,7 @@ class InputRequiredResultTest extends AbstractStatelessMcpE2eTest {
         var schema = new LinkedHashMap<String, Object>();
         schema.put("type", "object");
         schema.put("properties", Map.of(prop, Map.of("type", "string")));
-        return FormInputRequest.of(message, schema);
+        return FormInputRequest.of(message, JsonSchema.from(schema));
     }
 
     private static RpcMethodRequest samplingRequest() {

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp20260728/MetadataE2eTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp20260728/MetadataE2eTest.java
@@ -5,6 +5,7 @@ import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import dev.tachyonmcp.api.json.JsonDocument;
+import dev.tachyonmcp.api.json.JsonSchema;
 import dev.tachyonmcp.api.server.domain.FormInputRequest;
 import dev.tachyonmcp.api.server.domain.PromptMessage;
 import dev.tachyonmcp.api.server.domain.TextResourceContents;
@@ -35,7 +36,7 @@ class MetadataE2eTest extends AbstractStatelessMcpE2eTest {
         var schema = new LinkedHashMap<String, Object>();
         schema.put("type", "object");
         schema.put("properties", Map.of(prop, Map.of("type", "string")));
-        return FormInputRequest.of(message, schema);
+        return FormInputRequest.of(message, JsonSchema.from(schema));
     }
 
     private static Object field(Object value, String name) {

--- a/tachyon-api/revapi.json
+++ b/tachyon-api/revapi.json
@@ -86,6 +86,16 @@
           "attachments": {
             "since": "1.0.0-beta.19"
           }
+        },
+        {
+          "ignore": true,
+          "code": "java.method.returnTypeChanged",
+          "old": "method java.util.Map<java.lang.String, java.lang.Object> dev.tachyonmcp.api.server.domain.FormInputRequest::requestedSchema()",
+          "new": "method dev.tachyonmcp.api.json.JsonSchema dev.tachyonmcp.api.server.domain.FormInputRequest::requestedSchema()",
+          "justification": "Form schema is now a validated JsonSchema instead of a raw Map; Map-based construction stays available via the deprecated FormInputRequest.of(String, Map) and Builder.requestedSchema(Map) overloads, which route through JsonSchema.from(Map.class)/MapJsonFactory",
+          "attachments": {
+            "since": "1.0.0-beta.21"
+          }
         }
       ]
     }

--- a/tachyon-api/src/main/java/dev/tachyonmcp/api/json/JsonSchema.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/api/json/JsonSchema.java
@@ -3,6 +3,7 @@ package dev.tachyonmcp.api.json;
 
 import dev.tachyonmcp.api.annotations.ExperimentalApi;
 import dev.tachyonmcp.api.json.spi.JsonSchemaFactory;
+import java.util.Map;
 
 /**
  * An immutable, encoded JSON Schema.
@@ -53,6 +54,14 @@ public interface JsonSchema extends JsonDocument {
     @ExperimentalApi
     static <T> JsonSchema from(T source, Class<T> type) {
         return JsonSchemas.from(source, type);
+    }
+
+    /**
+     * Creates a schema from Map representing
+     */
+    @ExperimentalApi(since = "1.0.0-beta.21")
+    static <T> JsonSchema from(Map<String, Object> source) {
+        return JsonSchemas.from(source, Map.class);
     }
 
     /**

--- a/tachyon-api/src/main/java/dev/tachyonmcp/api/server/domain/FormInputRequest.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/api/server/domain/FormInputRequest.java
@@ -1,6 +1,7 @@
 /* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
 package dev.tachyonmcp.api.server.domain;
 
+import dev.tachyonmcp.api.json.JsonSchema;
 import java.util.Map;
 import org.immutables.value.Value;
 
@@ -16,7 +17,7 @@ public non-sealed interface FormInputRequest extends InputRequest {
     String message();
 
     /** JSON schema describing the expected form fields. */
-    Map<String, Object> requestedSchema();
+    JsonSchema requestedSchema();
 
     @Value.Check
     default void check() {
@@ -27,8 +28,19 @@ public non-sealed interface FormInputRequest extends InputRequest {
         return DefaultFormInputRequest.builder();
     }
 
+    @Deprecated
     static FormInputRequest of(String message, Map<String, Object> requestedSchema) {
-        return DefaultFormInputRequest.of(message, requestedSchema);
+        return DefaultFormInputRequest.builder()
+                .message(message)
+                .requestedSchema(requestedSchema)
+                .build();
+    }
+
+    static FormInputRequest of(String message, JsonSchema requestedSchema) {
+        return DefaultFormInputRequest.builder()
+                .message(message)
+                .requestedSchema(requestedSchema)
+                .build();
     }
 
     interface Builder {
@@ -37,7 +49,15 @@ public non-sealed interface FormInputRequest extends InputRequest {
 
         Builder message(String message);
 
-        Builder requestedSchema(Map<String, ?> entries);
+        /**
+         * @deprecated use {@link #requestedSchema(JsonSchema)} instead
+         */
+        @Deprecated
+        default Builder requestedSchema(Map<String, ?> entries) {
+            return requestedSchema(JsonSchema.from(entries, Map.class));
+        }
+
+        Builder requestedSchema(JsonSchema jsonSchema);
 
         FormInputRequest build();
     }

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/mcp/v2025_11_25/codecs/McpResponseMapper.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/mcp/v2025_11_25/codecs/McpResponseMapper.java
@@ -364,7 +364,7 @@ public class McpResponseMapper implements ProtocolResponseMapper {
                     paramsCodec.encode(
                             gen,
                             new ElicitRequestFormParams(
-                                    null, f.message(), JsonUtils.writeString(f.requestedSchema()), null, null));
+                                    null, f.message(), f.requestedSchema().json(), null, null));
                 }
                 case UrlInputRequest u -> {
                     gen.writeStringProperty("method", "elicitation/create");

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/mcp/v2026_07_28/codecs/McpResponseMapper.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/mcp/v2026_07_28/codecs/McpResponseMapper.java
@@ -264,7 +264,7 @@ public final class McpResponseMapper extends dev.tachyonmcp.core.protocol.mcp.v2
                         new ElicitRequest(
                                 "elicitation/create",
                                 new ElicitRequestFormParams(
-                                        null, f.message(), JsonUtils.writeString(f.requestedSchema()))));
+                                        null, f.message(), f.requestedSchema().json())));
             case UrlInputRequest u ->
                 encodeToTree(
                         ElicitRequest.class,

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/json/MapJsonFactory.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/json/MapJsonFactory.java
@@ -1,0 +1,37 @@
+/* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
+package dev.tachyonmcp.core.server.json;
+
+import dev.tachyonmcp.api.annotations.InternalApi;
+import dev.tachyonmcp.api.json.JsonSchema;
+import dev.tachyonmcp.api.json.spi.JsonSchemaFactory;
+import java.util.Map;
+import java.util.Optional;
+import tools.jackson.databind.node.ObjectNode;
+
+/**
+ * {@link Map}-backed {@link JsonSchemaFactory}: converts a plain {@code Map<String, Object>} into
+ * an {@link JsonSchema}.
+ *
+ * @author Konstantin Pavlov
+ */
+@InternalApi
+public final class MapJsonFactory implements JsonSchemaFactory<Map<String, Object>> {
+
+    public static final MapJsonFactory INSTANCE = new MapJsonFactory();
+
+    @SuppressWarnings("unchecked")
+    private static final Class<Map<String, Object>> SOURCE_TYPE = (Class<Map<String, Object>>) (Class<?>) Map.class;
+
+    public MapJsonFactory() {}
+
+    @Override
+    public Class<Map<String, Object>> sourceType() {
+        return SOURCE_TYPE;
+    }
+
+    @Override
+    public Optional<JsonSchema> toJsonSchema(Map<String, Object> source) {
+        ObjectNode node = JsonUtils.mapper().valueToTree(source);
+        return Optional.of(new JacksonObjectJsonSchema(node));
+    }
+}

--- a/tachyon-core/src/main/resources/META-INF/services/dev.tachyonmcp.api.json.spi.JsonSchemaFactory
+++ b/tachyon-core/src/main/resources/META-INF/services/dev.tachyonmcp.api.json.spi.JsonSchemaFactory
@@ -2,3 +2,4 @@ dev.tachyonmcp.core.server.json.Jackson3JsonFactory
 dev.tachyonmcp.core.server.json.JacksonNodeJsonFactory
 dev.tachyonmcp.core.server.json.JacksonObjectJsonFactory
 dev.tachyonmcp.core.server.json.KtSchemaResourceFactory
+dev.tachyonmcp.core.server.json.MapJsonFactory

--- a/tachyon-core/src/test/java/dev/tachyonmcp/core/protocol/mcp/v2025_11_25/codecs/McpResponseMapperTest.java
+++ b/tachyon-core/src/test/java/dev/tachyonmcp/core/protocol/mcp/v2025_11_25/codecs/McpResponseMapperTest.java
@@ -4,7 +4,9 @@ package dev.tachyonmcp.core.protocol.mcp.v2025_11_25.codecs;
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import dev.tachyonmcp.api.json.JsonSchema;
 import dev.tachyonmcp.api.server.domain.ContentBlock;
+import dev.tachyonmcp.api.server.domain.FormInputRequest;
 import dev.tachyonmcp.api.server.domain.LoggingLevel;
 import dev.tachyonmcp.api.server.domain.ProgressToken;
 import dev.tachyonmcp.api.server.domain.ServerError;
@@ -161,6 +163,23 @@ class McpResponseMapperTest {
         assertThatJson(json).isEqualTo("""
             {"content":[{"type":"text","text":"ok"}]}
             """);
+    }
+
+    @Test
+    void inputRequiredEncodesRequestedSchemaAsRawJsonNotWrappedInJsonSchemaObject() {
+        var schema = JsonSchema.unchecked("""
+                {"type":"object","properties":{"name":{"type":"string"}}}
+                """);
+        var request = FormInputRequest.of("What is your name?", schema);
+
+        var payload = mapper.inputRequiredResult(Map.of("user_name", request), null, null);
+        var json = mapper.encode(payload);
+
+        assertThatJson(json)
+                .inPath("$.inputRequests.user_name.params.requestedSchema")
+                .isEqualTo("""
+                        {"type":"object","properties":{"name":{"type":"string"}}}
+                        """);
     }
 
     @Test

--- a/tachyon-core/src/test/java/dev/tachyonmcp/core/protocol/mcp/v2026_07_28/codecs/McpResponseMapperTest.java
+++ b/tachyon-core/src/test/java/dev/tachyonmcp/core/protocol/mcp/v2026_07_28/codecs/McpResponseMapperTest.java
@@ -5,7 +5,9 @@ import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import dev.tachyonmcp.api.json.JsonDocument;
+import dev.tachyonmcp.api.json.JsonSchema;
 import dev.tachyonmcp.api.server.domain.Annotations;
+import dev.tachyonmcp.api.server.domain.FormInputRequest;
 import dev.tachyonmcp.api.server.domain.Icon;
 import dev.tachyonmcp.api.server.domain.LoggingLevel;
 import dev.tachyonmcp.api.server.domain.ProgressToken;
@@ -71,6 +73,23 @@ class McpResponseMapperTest {
         assertThat(result.completion().values()).containsExactly("one");
         assertThat(result.completion().total()).isEqualTo(100500);
         assertThat(result._meta()).containsEntry("trace", JsonNodeFactory.instance.textNode("complete-1"));
+    }
+
+    @Test
+    void inputRequiredEncodesRequestedSchemaAsRawJsonNotWrappedInJsonSchemaObject() {
+        var schema = JsonSchema.unchecked("""
+                {"type":"object","properties":{"name":{"type":"string"}}}
+                """);
+        var request = FormInputRequest.of("What is your name?", schema);
+
+        var payload = mapper.inputRequiredResult(Map.of("user_name", request), null, null);
+        var json = mapper.encode(payload);
+
+        assertThatJson(json)
+                .inPath("$.inputRequests.user_name.params.requestedSchema")
+                .isEqualTo("""
+                        {"type":"object","properties":{"name":{"type":"string"}}}
+                        """);
     }
 
     @Test

--- a/tachyon-core/src/test/java/dev/tachyonmcp/core/server/features/tasks/DefaultTaskRegistryTest.java
+++ b/tachyon-core/src/test/java/dev/tachyonmcp/core/server/features/tasks/DefaultTaskRegistryTest.java
@@ -5,6 +5,7 @@ import static dev.tachyonmcp.core.test.TestUtils.newEngine;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import dev.tachyonmcp.api.json.JsonSchema;
 import dev.tachyonmcp.api.server.domain.FormInputRequest;
 import dev.tachyonmcp.api.server.domain.InputRequestBundle;
 import dev.tachyonmcp.api.server.domain.ServerError;
@@ -276,7 +277,8 @@ class DefaultTaskRegistryTest {
         // per the FSM, so it's the server-facing way to leave SUBMITTED before requireInput().
         task.resume(null);
         var bundle = new InputRequestBundle(
-                Map.of("user_name", FormInputRequest.of("What is your name?", Map.of())), "state-token");
+                Map.of("user_name", FormInputRequest.of("What is your name?", JsonSchema.objectSchema())),
+                "state-token");
 
         assertThat(task.requireInput(bundle, "need more info")).isTrue();
 
@@ -289,8 +291,8 @@ class DefaultTaskRegistryTest {
     void pendingInputClearsOnceTaskLeavesInputRequired() {
         var task = registry.create();
         task.resume(null);
-        var bundle =
-                new InputRequestBundle(Map.of("user_name", FormInputRequest.of("What is your name?", Map.of())), null);
+        var bundle = new InputRequestBundle(
+                Map.of("user_name", FormInputRequest.of("What is your name?", JsonSchema.objectSchema())), null);
         task.requireInput(bundle, null);
 
         assertThat(task.resume(null)).isTrue();
@@ -301,8 +303,8 @@ class DefaultTaskRegistryTest {
     @Test
     void requireInputFailsFromSubmittedWithoutReachingWorkingFirst() {
         var task = registry.create();
-        var bundle =
-                new InputRequestBundle(Map.of("user_name", FormInputRequest.of("What is your name?", Map.of())), null);
+        var bundle = new InputRequestBundle(
+                Map.of("user_name", FormInputRequest.of("What is your name?", JsonSchema.objectSchema())), null);
 
         assertThat(task.requireInput(bundle, null)).isFalse();
 

--- a/tachyon-core/src/test/java/dev/tachyonmcp/core/server/json/MapJsonFactoryTest.java
+++ b/tachyon-core/src/test/java/dev/tachyonmcp/core/server/json/MapJsonFactoryTest.java
@@ -1,0 +1,123 @@
+/* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
+package dev.tachyonmcp.core.server.json;
+
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.tachyonmcp.api.json.JsonSchema;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.node.ObjectNode;
+
+class MapJsonFactoryTest {
+
+    private final MapJsonFactory factory = MapJsonFactory.INSTANCE;
+
+    @Test
+    void shouldReportMapAsSourceType() {
+        assertThat(factory.sourceType()).isEqualTo(Map.class);
+    }
+
+    @Test
+    void shouldBuildComplexSchemaFromMapOfStandardJavaTypes() {
+        Map<String, Object> address = new LinkedHashMap<>();
+        address.put("type", "object");
+        address.put(
+                "properties",
+                Map.of(
+                        "city", Map.of("type", "string"),
+                        "zip", Map.of("type", "string", "pattern", "^[0-9]{5}$")));
+        address.put("required", List.of("city"));
+
+        Map<String, Object> score = new LinkedHashMap<>();
+        score.put("type", "number");
+        score.put("minimum", 0.0);
+        score.put("maximum", 100L);
+
+        Map<String, Object> role = new LinkedHashMap<>();
+        role.put("type", "string");
+        role.put("enum", List.of("ADMIN", "USER", "GUEST"));
+
+        Map<String, Object> properties = new LinkedHashMap<>();
+        properties.put("name", Map.of("type", "string", "minLength", 1));
+        properties.put("age", Map.of("type", "integer", "minimum", 0));
+        properties.put("active", Map.of("type", "boolean"));
+        properties.put("role", role);
+        properties.put("address", address);
+        properties.put("scores", Map.of("type", "array", "items", score));
+        properties.put("nickname", Map.of("type", List.of("string", "null")));
+
+        Map<String, Object> map = new LinkedHashMap<>();
+        map.put("$schema", "https://json-schema.org/draft/2020-12/schema");
+        map.put("type", "object");
+        map.put("additionalProperties", false);
+        map.put("required", List.of("name", "age"));
+        map.put("properties", properties);
+        map.put("oneOf", List.of(Map.of("required", List.of("role")), Map.of("required", List.of("address"))));
+        map.put("default", null);
+
+        var schema = factory.toJsonSchema(map).orElseThrow();
+
+        assertThatJson(schema.json())
+                // language=json
+                .isEqualTo("""
+                        {
+                          "$schema": "https://json-schema.org/draft/2020-12/schema",
+                          "type": "object",
+                          "additionalProperties": false,
+                          "required": ["name", "age"],
+                          "properties": {
+                            "name": {"type": "string", "minLength": 1},
+                            "age": {"type": "integer", "minimum": 0},
+                            "active": {"type": "boolean"},
+                            "role": {"type": "string", "enum": ["ADMIN", "USER", "GUEST"]},
+                            "address": {
+                              "type": "object",
+                              "properties": {
+                                "city": {"type": "string"},
+                                "zip": {"type": "string", "pattern": "^[0-9]{5}$"}
+                              },
+                              "required": ["city"]
+                            },
+                            "scores": {
+                              "type": "array",
+                              "items": {"type": "number", "minimum": 0.0, "maximum": 100}
+                            },
+                            "nickname": {"type": ["string", "null"]}
+                          },
+                          "oneOf": [
+                            {"required": ["role"]},
+                            {"required": ["address"]}
+                          ],
+                          "default": null
+                        }
+                        """);
+    }
+
+    @Test
+    void shouldUnwrapToObjectNode() {
+        var schema = factory.toJsonSchema(Map.of("type", "object")).orElseThrow();
+
+        assertThat(schema.unwrap(ObjectNode.class)).isPresent();
+    }
+
+    @Test
+    void shouldResolveViaJsonSchemaFrom() {
+        Map<String, Object> map = Map.of("type", "object");
+
+        var schema = JsonSchema.from(map, factory.sourceType());
+
+        assertThatJson(schema.json()).isEqualTo("{\"type\": \"object\"}");
+    }
+
+    @Test
+    void shouldResolveViaJsonSchemaFromMapConvenienceOverload() {
+        Map<String, Object> map = Map.of("type", "object");
+
+        var schema = JsonSchema.from(map);
+
+        assertThatJson(schema.json()).isEqualTo("{\"type\": \"object\"}");
+    }
+}

--- a/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/domain/RequestFactories.kt
+++ b/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/domain/RequestFactories.kt
@@ -6,6 +6,7 @@
 
 package dev.tachyonmcp.kotlin.server.domain
 
+import dev.tachyonmcp.api.json.JsonSchema
 import dev.tachyonmcp.api.server.domain.FormInputRequest
 import dev.tachyonmcp.api.server.domain.RpcMethodRequest
 import dev.tachyonmcp.api.server.domain.UrlInputRequest
@@ -44,12 +45,32 @@ public fun RpcMethodRequest(
  * @param message         prompt shown to the user
  * @param requestedSchema JSON schema describing the expected form fields
  */
+@Deprecated(
+    message = "use `FormInputRequest` with JsonSchema instead",
+    replaceWith =
+        ReplaceWith(
+            "FormInputRequest.of(message, JsonSchema.from(requestedSchema, Map::class.java))",
+            "dev.tachyonmcp.api.server.domain.FormInputRequest",
+            "dev.tachyonmcp.api.json.JsonSchema",
+        ),
+)
 public fun FormInputRequest(
     message: String,
     requestedSchema: Map<String, Any>,
 ): FormInputRequest =
     FormInputRequest
-        .of(message, requestedSchema)
+        .of(message, JsonSchema.from(requestedSchema, Map::class.java))
+
+/**
+ * Creates a [FormInputRequest] — requests user input via a form described by a JSON schema.
+ *
+ * @param message         prompt shown to the user
+ * @param requestedSchema JSON schema describing the expected form fields
+ */
+public fun FormInputRequest(
+    message: String,
+    requestedSchema: JsonSchema,
+): FormInputRequest = FormInputRequest.of(message, requestedSchema)
 
 /**
  * Creates a [UrlInputRequest] — requests user input by opening a URL.

--- a/tachyon-kotlin/src/test/kotlin/dev/tachyonmcp/kotlin/server/domain/RequestFactoriesTest.kt
+++ b/tachyon-kotlin/src/test/kotlin/dev/tachyonmcp/kotlin/server/domain/RequestFactoriesTest.kt
@@ -1,0 +1,29 @@
+// Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors.
+package dev.tachyonmcp.kotlin.server.domain
+
+import dev.tachyonmcp.api.json.JsonSchema
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+internal class RequestFactoriesTest {
+    @Test
+    fun `FormInputRequest accepts a JsonSchema directly`() {
+        val schema = JsonSchema.unchecked("""{"type":"object"}""")
+
+        val request = FormInputRequest("Enter details", schema)
+
+        request.message() shouldBe "Enter details"
+        request.requestedSchema() shouldBe schema
+    }
+
+    @Test
+    @Suppress("DEPRECATION")
+    fun `FormInputRequest from Map builds an equivalent JsonSchema`() {
+        val schemaMap = mapOf("type" to "string", "minLength" to 1)
+
+        val request = FormInputRequest("Enter your name", schemaMap)
+
+        request.message() shouldBe "Enter your name"
+        request.requestedSchema().json() shouldBe """{"type":"string","minLength":1}"""
+    }
+}


### PR DESCRIPTION

The change replaces form request schema maps with JsonSchema values. Map-based Java and Kotlin factories remain available as deprecated compatibility paths. MapJsonFactory converts maps into JSON schemas through service loading. MCP response mappers now encode schemas as raw JSON nodes. Tests cover conversion, factory compatibility, response encoding, task fixtures, and end-to-end elicitation flows.

### New Features

- Added direct support for JSON Schema objects when creating form input requests.
- Added equivalent JSON Schema support to Kotlin request factories.
- Form schemas are now encoded as raw JSON in elicitation responses.

### Bug Fixes

- Corrected schema serialization to prevent unnecessary JSON wrapping.
- Preserved compatibility for existing map-based request creation, with deprecated APIs converting maps automatically.

