### PR TITLE
feat: Resuming tasks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,7 @@ mvn spotless:apply  # auto-fix
 
 ## Rules
 
+- **No cheating!**
 - **Unattended `git commit/push` is prohibited.** Always confirm with user.
 - TDD + SOLID. TachyonServer is SUT in unit tests.
 - **Tests**: JUnit 6 + Kotest (Kotlin) / AssertJ (Java) + Awaitility. `@TempDir` for unit, port 0 for E2E. Prefer E2E, esp. long scenarios; unit only when E2E can't cover, drop unit if E2E already does. No tautologies. Many asserts per test.

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -134,10 +134,31 @@ value, well-formed or not), and clients instead declare readiness to receive a t
   error content inlined into `result`), not `failed` — `failed` is reserved for genuine JSON-RPC
   protocol errors.
 
-Not yet implemented: `tasks/update` (SEP-2663's replacement for submitting `inputResponses` to a
-task in `input_required` state), inlining `inputRequests` into `tasks/get` for that same state, and
-server-to-client `notifications/tasks` push (needs `subscriptions/listen` over the stateless
-2026-07-28 transport, which doesn't exist yet).
+### `tasks/update` — submitting input to a paused task
+
+When a task-augmented tool moves to `input_required`, `tasks/get` inlines the outstanding
+`inputRequests`. The client answers them with `tasks/update`, keyed to the same `taskId`:
+
+```json
+{"jsonrpc":"2.0","id":1,"method":"tasks/update","params":{
+  "taskId":"tid_...","inputResponses":{"user_name":{"name":"Alice"}}}}
+```
+
+The server always acknowledges immediately with an empty result (`{"resultType":"complete"}`) —
+resumption happens asynchronously afterward, not as part of the `tasks/update` response. The task
+resumes (re-invoking the same handler, `requestState` intact) only once every currently-outstanding
+`inputRequests` key has a response; a client may spread the answers across multiple `tasks/update`
+calls for a multi-key bundle, and the task stays `input_required` until the last one arrives.
+Unknown or already-satisfied keys in a submission are silently ignored, not rejected.
+
+`tasks/update` and `inputRequests`-on-`tasks/get` are **2026-07-28 only**. MCP 2025-11-25's task
+model predates SEP-2663 and has no wire field for either — an `input_required` task under that
+protocol version has no way to resume by `taskId` at all; a client on that version can only retry
+the original request with `inputResponses`/`requestState`, which creates an unrelated new task
+rather than resuming the original (see `TaskAugmentedToolTest` for this documented limitation).
+
+Not yet implemented: server-to-client `notifications/tasks` push (needs `subscriptions/listen` over
+the stateless 2026-07-28 transport, which doesn't exist yet).
 
 ## TasksExtension
 
@@ -178,9 +199,10 @@ A background janitor sweeps every 30s and does two independent things:
 | Method | Description | 2026-07-28 |
 |---|---|---|
 | `tasks/list` | List tasks, paginated | removed (`-32601`) |
-| `tasks/get` | Get a task by ID | kept, gated by the tasks extension |
+| `tasks/get` | Get a task by ID | kept, gated by the tasks extension; inlines `inputRequests` while `input_required` |
 | `tasks/cancel` | Cancel a running task | kept, gated by the tasks extension |
 | `tasks/result` | Get the task payload result | removed (`-32601`) unconditionally, even for a valid, unexpired task ID — outcome inlined into `tasks/get` instead |
+| `tasks/update` | Submit `inputResponses` to a paused task | not available under 2025-11-25 (`-32601` — predates SEP-2663's wire shape); gated by the tasks extension under 2026-07-28, same as `tasks/get`/`tasks/cancel` |
 
 Notifications: `notifications/tasks/list_changed`, `notifications/tasks/status` — 2025-11-25 only.
 Not implemented for 2026-07-28 (no session to push to; see "Not yet implemented" above).

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/TaskAugmentedToolTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/TaskAugmentedToolTest.java
@@ -402,7 +402,15 @@ class TaskAugmentedToolTest extends AbstractStatelessMcpE2eTest {
     }
 
     @Test
-    void taskAugmentedToolInputRequiredThenClientAnswersAndTaskCompletes() throws Exception {
+    void legacyTaskAugmentedInputRequiredHasNoWireResumeAffordance() throws Exception {
+        // MCP 2025-11-25's task model predates SEP-2663's tasks extension and its `tasks/update`
+        // method (which doesn't exist on this wire schema at all -- no field for it on the
+        // generated Task/GetTaskResult models). A client with only this protocol version has no
+        // way to resume an input_required task by its taskId; it can only retry the original
+        // request with inputResponses + requestState, which -- since retrying tools/call always
+        // creates a fresh task -- mints an unrelated new task rather than resuming this one. This
+        // is a permanent limitation of the 2025-11-25 wire shape, not a bug: see
+        // dev.tachyonmcp.e2e.mcp20260728.TasksExtensionTest for the real fix under 2026-07-28.
         startServerWith(s -> s.tools()
                 .register(b -> b.name("greet").taskSupport(TaskSupport.OPTIONAL), (context, request) -> {
                     var inputResponses = request.inputResponses();
@@ -426,10 +434,8 @@ class TaskAugmentedToolTest extends AbstractStatelessMcpE2eTest {
             var firstTaskId = extractTaskId(round1);
             client.awaitTaskStatus(firstTaskId, "input_required");
 
-            // Round 2: client answers, re-issuing the call with inputResponses + requestState.
-            // Task-augmented tools/call has no "resume this task" wire affordance (task id isn't
-            // echoed back on input_required) -- resuming means a fresh task carries the answered
-            // call to completion, same as the non-task-augmented elicitation flow.
+            // Round 2: client answers, re-issuing the call with inputResponses + requestState --
+            // the only mechanism this protocol version has (no tasks/update method exists).
             var round2 = client.sendRpc("""
                 {"jsonrpc":"2.0","id":3,"method":"tools/call","params":{
                   "name":"greet","arguments":{},"task":{},
@@ -449,6 +455,20 @@ class TaskAugmentedToolTest extends AbstractStatelessMcpE2eTest {
                 {"jsonrpc":"2.0","id":5,"method":"tasks/get","params":{"taskId":"%s"}}
                 """.formatted(firstTaskId));
             assertThatJson(firstAfter).inPath("$.result.status").isEqualTo("input_required");
+        }
+    }
+
+    @Test
+    void tasksUpdateNotAvailableUnder20251125() throws Exception {
+        startServerWith(s -> {});
+        try (var client = createTestClient()) {
+            client.initialize();
+
+            var response = client.sendRpc("""
+                {"jsonrpc":"2.0","id":2,"method":"tasks/update","params":{"taskId":"task-1","inputResponses":{}}}
+                """);
+
+            assertThatJson(response).inPath("$.error.code").isEqualTo(-32601);
         }
     }
 

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/TasksExtensionTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/TasksExtensionTest.java
@@ -38,12 +38,12 @@ class TasksExtensionTest extends AbstractStatefulMcpE2eTest {
 
     @Override
     protected void startDefaultServer() {
-        startServer(it -> it.extension(TasksExtension.instance()));
+        startServer(it -> it.withExtensions(TasksExtension.instance()));
     }
 
     @Test
     void advertisesTasksExtensionWhenNegotiated() throws Exception {
-        startServer(it -> it.capabilities(CapabilitiesConfig.Builder::tasks).extension(TasksExtension.instance()));
+        startServer(it -> it.capabilities(CapabilitiesConfig.Builder::tasks).withExtensions(TasksExtension.instance()));
         try (var client = createTestClient()) {
             var initBody = buildInitializeJson(Map.of(TASKS_EXTENSION_ID, JsonNodeFactory.instance.objectNode()));
             var response = client.post(null, initBody);
@@ -162,7 +162,7 @@ class TasksExtensionTest extends AbstractStatefulMcpE2eTest {
         // through POST-SSE (ThreadLocal not inherited by ForkJoin threads).
         // This test uses a synchronous tool to verify notification delivery.
         startServer(
-                b -> b.extension(TasksExtension.instance()),
+                b -> b.withExtensions(TasksExtension.instance()),
                 s -> s.tools().register(tool -> tool.name("create-sync"), (ctx, req) -> {
                     ((DispatchContext) ctx).engine().tasks().create();
                     return ToolResult.text("ok");
@@ -188,7 +188,7 @@ class TasksExtensionTest extends AbstractStatefulMcpE2eTest {
     @Test
     void shouldNotifyTaskStatusWithCallerSuppliedMessage() throws Exception {
         startServer(
-                b -> b.extension(TasksExtension.instance()),
+                b -> b.withExtensions(TasksExtension.instance()),
                 s -> s.tools().register(tool -> tool.name("update-status-sync"), (ctx, req) -> {
                     var task = ((DispatchContext) ctx).engine().tasks().create();
                     ((DefaultTaskRegistry) ((DispatchContext) ctx).engine().tasks())
@@ -208,15 +208,13 @@ class TasksExtensionTest extends AbstractStatefulMcpE2eTest {
     }
 
     @Test
-    void shouldNotifyOnEveryFacadeDrivenMutation() throws Exception {
-        // Regression test: a caller holding only the public `Task` reference (never
-        // touching DefaultTaskRegistry's taskId-keyed methods) must still get a
-        // notification for every mutation, not just the initial creation push.
+    void shouldNotifyOnEveryTaskMutation() throws Exception {
         startServer(
-                b -> b.extension(TasksExtension.instance()),
+                b -> b.withExtensions(TasksExtension.instance()),
                 s -> s.tools().register(tool -> tool.name("drive-task-sync"), (ctx, req) -> {
-                    var task = ((DispatchContext) ctx).engine().tasks().create();
-                    task.resume("step 1");
+                    final var engine = ((DispatchContext) ctx).engine();
+                    var task = engine.tasks().create();
+                    engine.tasksRegistry().updateStatus(task.id(), TaskState.WORKING, "step 1");
                     task.updateMessage("step 2");
                     task.complete(TaskResult.completed(JsonUtils.parse("{\"output\":\"done\"}")));
                     return ToolResult.text("ok");
@@ -234,19 +232,19 @@ class TasksExtensionTest extends AbstractStatefulMcpE2eTest {
             assertThat(response.body()).contains("\"status\":\"completed\"");
             var notificationCount = response.body().split("notifications/tasks/status", -1).length - 1;
             assertThat(notificationCount)
-                    .as("one notification each for create, resume, updateMessage, complete")
+                    .as("one notification each for create, start, updateMessage, complete")
                     .isEqualTo(4);
         }
     }
 
     @Test
-    void shouldCancelAndNotifyBeforeRemovingActiveTask() throws Exception {
+    void shouldCancelAndNotifyBeforeRemovingNonTerminalTask() throws Exception {
         startServer(
-                b -> b.extension(TasksExtension.instance()),
+                b -> b.withExtensions(TasksExtension.instance()),
                 s -> s.tools().register(tool -> tool.name("remove-active-sync"), (ctx, req) -> {
-                    var task = ((DispatchContext) ctx).engine().tasks().create();
-                    task.resume(null);
-                    ((DispatchContext) ctx).engine().tasks().remove(task.id());
+                    final var engine = ((DispatchContext) ctx).engine();
+                    var task = engine.tasks().create();
+                    engine.tasks().remove(task.id());
                     return ToolResult.text(task.id());
                 }));
 
@@ -269,11 +267,12 @@ class TasksExtensionTest extends AbstractStatefulMcpE2eTest {
     @Test
     void shouldRemoveTerminalTaskSilently() throws Exception {
         startServer(
-                b -> b.extension(TasksExtension.instance()),
+                b -> b.withExtensions(TasksExtension.instance()),
                 s -> s.tools().register(tool -> tool.name("remove-terminal-sync"), (ctx, req) -> {
-                    var task = ((DispatchContext) ctx).engine().tasks().create();
+                    final var engine = ((DispatchContext) ctx).engine();
+                    var task = engine.tasks().create();
                     task.complete(TaskResult.completed(JsonUtils.parse("{\"output\":\"done\"}")));
-                    ((DispatchContext) ctx).engine().tasks().remove(task.id());
+                    engine.tasks().remove(task.id());
                     return ToolResult.text(task.id());
                 }));
 

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp20260728/TasksExtensionTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp20260728/TasksExtensionTest.java
@@ -4,18 +4,24 @@ package dev.tachyonmcp.e2e.mcp20260728;
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import dev.tachyonmcp.api.json.JsonSchema;
+import dev.tachyonmcp.api.server.domain.FormInputRequest;
 import dev.tachyonmcp.api.server.domain.ServerError;
 import dev.tachyonmcp.api.server.domain.TaskResult;
 import dev.tachyonmcp.api.server.domain.TextContent;
 import dev.tachyonmcp.api.server.features.tasks.TaskSupport;
+import dev.tachyonmcp.api.server.features.tools.ToolFn;
 import dev.tachyonmcp.api.server.features.tools.ToolResult;
 import dev.tachyonmcp.core.server.features.tasks.TasksExtension;
 import dev.tachyonmcp.core.server.json.JsonUtils;
 import dev.tachyonmcp.e2e.AbstractStatelessMcpE2eTest;
 import java.util.List;
+import java.util.Map;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import tools.jackson.databind.node.JsonNodeFactory;
 
 /**
  * MCP 2026-07-28 tasks (<a href="https://modelcontextprotocol.io/seps/2663-tasks-extension">SEP-2663</a>):
@@ -378,6 +384,307 @@ class TasksExtensionTest extends AbstractStatelessMcpE2eTest {
 
             assertThat(response.statusCode()).as(response.body()).isEqualTo(200);
             assertThatJson(response.body()).inPath("$.result.content[0].text").isString();
+        }
+    }
+
+    /**
+     * A task-augmented tool that asks for {@code user_name} the first time it's called, then
+     * completes once a {@code tasks/update} carries an answer back through a resumed dispatch.
+     */
+    private static ToolFn greetHandler() {
+        return (context, request) -> {
+            var inputResponses = request.inputResponses();
+            if (inputResponses == null || !inputResponses.containsKey("user_name")) {
+                return ToolResult.inputRequired(
+                        Map.of("user_name", FormInputRequest.of("What is your name?", JsonSchema.objectSchema())),
+                        "greet-state");
+            }
+            var name = stringField(inputResponses.get("user_name"), "name", "World");
+            return ToolResult.text("Hello, " + name + "!");
+        };
+    }
+
+    private static String stringField(@Nullable Object value, String name, String defaultValue) {
+        if (value instanceof Map<?, ?> map && map.get(name) instanceof String text) {
+            return text;
+        }
+        return defaultValue;
+    }
+
+    private static String extractTaskId(String responseJson) {
+        return JsonUtils.parse(responseJson).get("result").get("taskId").asString();
+    }
+
+    @Test
+    void tasksGetInlinesInputRequestsWhenTaskAwaitsInput() throws Exception {
+        startServer(
+                builder -> builder.withExtensions(TasksExtension.instance()),
+                registrar -> registrar
+                        .tools()
+                        .register(b -> b.name("greet").taskSupport(TaskSupport.REQUIRED), greetHandler()));
+
+        try (var client = createModernTestClient()) {
+            client.withExtensions(Map.of(TasksExtension.ID, JsonNodeFactory.instance.objectNode()));
+
+            var callResponse = client.post("""
+                    {"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"greet","arguments":{}}}
+                    """);
+            assertThat(callResponse.statusCode()).as(callResponse.body()).isEqualTo(200);
+            var taskId = extractTaskId(callResponse.body());
+
+            var getResponse = client.awaitTaskStatus(taskId, "input_required");
+
+            assertThatJson(getResponse)
+                    .whenIgnoringPaths("$.result._meta", "$.result.createdAt", "$.result.lastUpdatedAt")
+                    .isEqualTo("""
+                            {
+                              "jsonrpc":"2.0",
+                              "id":"tasks-get",
+                              "result":{
+                                "taskId":"%s",
+                                "status":"input_required",
+                                "statusMessage":"Input required",
+                                "ttlMs":null,
+                                "resultType":"complete",
+                                "inputRequests":{
+                                  "user_name":{
+                                    "method":"elicitation/create",
+                                    "params":{"message":"What is your name?","requestedSchema":{"type":"object"}}
+                                  }
+                                }
+                              }
+                            }
+                            """.formatted(taskId));
+        }
+    }
+
+    @Test
+    void tasksUpdateResumesTaskAndItCompletes() throws Exception {
+        startServer(
+                builder -> builder.extension(TasksExtension.instance()),
+                registrar -> registrar
+                        .tools()
+                        .register(b -> b.name("greet").taskSupport(TaskSupport.REQUIRED), greetHandler()));
+
+        try (var client = createModernTestClient()) {
+            client.withExtensions(Map.of(TasksExtension.ID, JsonNodeFactory.instance.objectNode()));
+
+            var callResponse = client.post("""
+                    {"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"greet","arguments":{}}}
+                    """);
+            var taskId = extractTaskId(callResponse.body());
+            client.awaitTaskStatus(taskId, "input_required");
+
+            var updateResponse = client.post("""
+                    {"jsonrpc":"2.0","id":2,"method":"tasks/update","params":{\
+                    "taskId":"%s","inputResponses":{"user_name":{"name":"Alice"}}}}
+                    """.formatted(taskId));
+
+            assertThat(updateResponse.statusCode()).as(updateResponse.body()).isEqualTo(200);
+            assertThatJson(updateResponse.body()).isEqualTo("""
+                    {"jsonrpc":"2.0","id":2,"result":{"resultType":"complete"}}
+                    """);
+
+            var completedTask = client.awaitTaskStatus(taskId, "completed");
+            assertThatJson(completedTask)
+                    .inPath("$.result.result.content[0].text")
+                    .isEqualTo("Hello, Alice!");
+        }
+    }
+
+    @Test
+    void tasksUpdateSupportsMultipleRoundsOfInputRequired() throws Exception {
+        startServer(
+                builder -> builder.extension(TasksExtension.instance()),
+                registrar -> registrar
+                        .tools()
+                        .register(b -> b.name("multi-round").taskSupport(TaskSupport.REQUIRED), (context, request) -> {
+                            var inputResponses = request.inputResponses();
+                            var requestState = request.requestState();
+                            if (inputResponses == null || requestState == null) {
+                                return ToolResult.inputRequired(
+                                        Map.of("step1", FormInputRequest.of("Step 1?", JsonSchema.objectSchema())),
+                                        "round-1");
+                            }
+                            if ("round-1".equals(requestState)) {
+                                return ToolResult.inputRequired(
+                                        Map.of("step2", FormInputRequest.of("Step 2?", JsonSchema.objectSchema())),
+                                        "round-2");
+                            }
+                            if ("round-2".equals(requestState)) {
+                                return ToolResult.inputRequired(
+                                        Map.of("step3", FormInputRequest.of("Step 3?", JsonSchema.objectSchema())),
+                                        "round-3");
+                            }
+                            return ToolResult.text("all steps done");
+                        }));
+
+        try (var client = createModernTestClient()) {
+            client.withExtensions(Map.of(TasksExtension.ID, JsonNodeFactory.instance.objectNode()));
+
+            var callResponse = client.post("""
+                    {"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"multi-round","arguments":{}}}
+                    """);
+            var taskId = extractTaskId(callResponse.body());
+            client.awaitTaskStatus(taskId, "input_required");
+
+            for (var step : List.of("step1", "step2", "step3")) {
+                var updateResponse = client.post("""
+                        {"jsonrpc":"2.0","id":2,"method":"tasks/update","params":{\
+                        "taskId":"%s","inputResponses":{"%s":"answer"}}}
+                        """.formatted(taskId, step));
+                assertThat(updateResponse.statusCode())
+                        .as(updateResponse.body())
+                        .isEqualTo(200);
+                if (!"step3".equals(step)) {
+                    client.awaitTaskStatus(taskId, "input_required");
+                }
+            }
+
+            var completedTask = client.awaitTaskStatus(taskId, "completed");
+            assertThatJson(completedTask)
+                    .inPath("$.result.result.content[0].text")
+                    .isEqualTo("all steps done");
+        }
+    }
+
+    @Test
+    void tasksUpdateIgnoresUnknownAndAlreadySatisfiedKeys() throws Exception {
+        startServer(
+                builder -> builder.extension(TasksExtension.instance()),
+                registrar -> registrar
+                        .tools()
+                        .register(b -> b.name("greet").taskSupport(TaskSupport.REQUIRED), greetHandler()));
+
+        try (var client = createModernTestClient()) {
+            client.withExtensions(Map.of(TasksExtension.ID, JsonNodeFactory.instance.objectNode()));
+
+            var callResponse = client.post("""
+                    {"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"greet","arguments":{}}}
+                    """);
+            var taskId = extractTaskId(callResponse.body());
+            client.awaitTaskStatus(taskId, "input_required");
+
+            var updateResponse = client.post("""
+                    {"jsonrpc":"2.0","id":2,"method":"tasks/update","params":{\
+                    "taskId":"%s","inputResponses":{\
+                    "user_name":{"name":"Alice"},"unknown_key":"ignored","user_name":{"name":"Alice"}}}}
+                    """.formatted(taskId));
+
+            assertThat(updateResponse.statusCode()).as(updateResponse.body()).isEqualTo(200);
+            var completedTask = client.awaitTaskStatus(taskId, "completed");
+            assertThatJson(completedTask)
+                    .inPath("$.result.result.content[0].text")
+                    .isEqualTo("Hello, Alice!");
+        }
+    }
+
+    @Test
+    void tasksUpdateAcceptsPartialResponsesAcrossMultipleCalls() throws Exception {
+        startServer(
+                builder -> builder.extension(TasksExtension.instance()),
+                registrar -> registrar
+                        .tools()
+                        .register(b -> b.name("two-fields").taskSupport(TaskSupport.REQUIRED), (context, request) -> {
+                            var inputResponses = request.inputResponses();
+                            if (inputResponses == null
+                                    || !inputResponses.containsKey("name")
+                                    || !inputResponses.containsKey("email")) {
+                                return ToolResult.inputRequired(
+                                        Map.of(
+                                                "name", FormInputRequest.of("Name?", JsonSchema.objectSchema()),
+                                                "email", FormInputRequest.of("Email?", JsonSchema.objectSchema())),
+                                        null);
+                            }
+                            return ToolResult.text(
+                                    "name=" + inputResponses.get("name") + " email=" + inputResponses.get("email"));
+                        }));
+
+        try (var client = createModernTestClient()) {
+            client.withExtensions(Map.of(TasksExtension.ID, JsonNodeFactory.instance.objectNode()));
+
+            var callResponse = client.post("""
+                    {"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"two-fields","arguments":{}}}
+                    """);
+            var taskId = extractTaskId(callResponse.body());
+            client.awaitTaskStatus(taskId, "input_required");
+
+            var firstUpdate = client.post("""
+                    {"jsonrpc":"2.0","id":2,"method":"tasks/update","params":{\
+                    "taskId":"%s","inputResponses":{"name":"Alice"}}}
+                    """.formatted(taskId));
+            assertThat(firstUpdate.statusCode()).as(firstUpdate.body()).isEqualTo(200);
+
+            // Still waiting on "email" -- task must remain input_required, not resume early.
+            var stillWaiting = client.getTask(null, taskId);
+            assertThatJson(stillWaiting).inPath("$.result.status").isEqualTo("input_required");
+
+            var secondUpdate = client.post("""
+                    {"jsonrpc":"2.0","id":3,"method":"tasks/update","params":{\
+                    "taskId":"%s","inputResponses":{"email":"alice@example.com"}}}
+                    """.formatted(taskId));
+            assertThat(secondUpdate.statusCode()).as(secondUpdate.body()).isEqualTo(200);
+
+            var completedTask = client.awaitTaskStatus(taskId, "completed");
+            assertThatJson(completedTask)
+                    .inPath("$.result.result.content[0].text")
+                    .isEqualTo("name=Alice email=alice@example.com");
+        }
+    }
+
+    @Test
+    void tasksUpdateOnUnknownTaskReturnsInvalidParams() throws Exception {
+        startTasksServer();
+
+        try (var client = createModernTestClient()) {
+            client.withExtensions(Map.of(TasksExtension.ID, JsonNodeFactory.instance.objectNode()));
+
+            var response = client.post("""
+                    {"jsonrpc":"2.0","id":1,"method":"tasks/update","params":{\
+                    "taskId":"does-not-exist","inputResponses":{}}}
+                    """);
+
+            assertThat(response.statusCode()).as(response.body()).isEqualTo(400);
+            assertThatJson(response.body()).inPath("$.error.code").isEqualTo(-32602);
+        }
+    }
+
+    @Test
+    void tasksUpdateOnTaskNotAwaitingInputIsNoOpAck() throws Exception {
+        startTasksServer();
+        var task = server.tasks().create();
+        task.complete(TaskResult.completed(JsonUtils.parse("{\"output\":\"done\"}")));
+
+        try (var client = createModernTestClient()) {
+            client.withExtensions(Map.of(TasksExtension.ID, JsonNodeFactory.instance.objectNode()));
+
+            var response = client.post("""
+                    {"jsonrpc":"2.0","id":1,"method":"tasks/update","params":{\
+                    "taskId":"%s","inputResponses":{"anything":"ignored"}}}
+                    """.formatted(task.id()));
+
+            assertThat(response.statusCode()).as(response.body()).isEqualTo(200);
+            assertThatJson(response.body()).isEqualTo("""
+                    {"jsonrpc":"2.0","id":1,"result":{"resultType":"complete"}}
+                    """);
+
+            var getResponse = client.getTask(null, task.id());
+            assertThatJson(getResponse).inPath("$.result.status").isEqualTo("completed");
+        }
+    }
+
+    @Test
+    void tasksUpdateRejectsWithoutDeclaredExtension() throws Exception {
+        startTasksServer();
+        var task = server.tasks().create();
+
+        try (var client = createModernTestClient()) {
+            var response = client.post("""
+                    {"jsonrpc":"2.0","id":1,"method":"tasks/update","params":{"taskId":"%s","inputResponses":{}}}
+                    """.formatted(task.id()));
+
+            assertThat(response.statusCode()).as(response.body()).isEqualTo(400);
+            assertThatJson(response.body()).inPath("$.error.code").isEqualTo(-32021);
         }
     }
 }

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp20260728/TasksExtensionTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp20260728/TasksExtensionTest.java
@@ -34,7 +34,7 @@ import tools.jackson.databind.node.JsonNodeFactory;
 class TasksExtensionTest extends AbstractStatelessMcpE2eTest {
 
     private void startTasksServer() {
-        startServer(builder -> builder.extension(TasksExtension.instance()), registrar -> {});
+        startServer(builder -> builder.withExtensions(TasksExtension.instance()), registrar -> {});
     }
 
     @Test
@@ -329,7 +329,7 @@ class TasksExtensionTest extends AbstractStatelessMcpE2eTest {
     @Test
     void acceptsTaskAugmentedRequiredToolWhenDeclaredPerRequest() throws Exception {
         startServer(
-                builder -> builder.extension(TasksExtension.instance()),
+                builder -> builder.withExtensions(TasksExtension.instance()),
                 registrar -> registrar
                         .tools()
                         .register(
@@ -461,10 +461,21 @@ class TasksExtensionTest extends AbstractStatelessMcpE2eTest {
     @Test
     void tasksUpdateResumesTaskAndItCompletes() throws Exception {
         startServer(
-                builder -> builder.extension(TasksExtension.instance()),
+                builder -> builder.withExtensions(TasksExtension.instance()),
                 registrar -> registrar
                         .tools()
-                        .register(b -> b.name("greet").taskSupport(TaskSupport.REQUIRED), greetHandler()));
+                        .register(b -> b.name("greet").taskSupport(TaskSupport.REQUIRED), (context, request) -> {
+                            var inputResponses = request.inputResponses();
+                            if (inputResponses == null || !inputResponses.containsKey("user_name")) {
+                                return ToolResult.inputRequired(
+                                        Map.of(
+                                                "user_name",
+                                                FormInputRequest.of("What is your name?", JsonSchema.objectSchema())),
+                                        "greet-state");
+                            }
+                            var name = stringField(inputResponses.get("user_name"), "name", "World");
+                            return ToolResult.text("Hello, " + name + "!");
+                        }));
 
         try (var client = createModernTestClient()) {
             client.withExtensions(Map.of(TasksExtension.ID, JsonNodeFactory.instance.objectNode()));
@@ -495,7 +506,7 @@ class TasksExtensionTest extends AbstractStatelessMcpE2eTest {
     @Test
     void tasksUpdateSupportsMultipleRoundsOfInputRequired() throws Exception {
         startServer(
-                builder -> builder.extension(TasksExtension.instance()),
+                builder -> builder.withExtensions(TasksExtension.instance()),
                 registrar -> registrar
                         .tools()
                         .register(b -> b.name("multi-round").taskSupport(TaskSupport.REQUIRED), (context, request) -> {
@@ -551,10 +562,25 @@ class TasksExtensionTest extends AbstractStatelessMcpE2eTest {
     @Test
     void tasksUpdateIgnoresUnknownAndAlreadySatisfiedKeys() throws Exception {
         startServer(
-                builder -> builder.extension(TasksExtension.instance()),
+                builder -> builder.withExtensions(TasksExtension.instance()),
                 registrar -> registrar
                         .tools()
-                        .register(b -> b.name("greet").taskSupport(TaskSupport.REQUIRED), greetHandler()));
+                        .register(b -> b.name("greet").taskSupport(TaskSupport.REQUIRED), (context, request) -> {
+                            var inputResponses = request.inputResponses();
+                            if (inputResponses == null
+                                    || !inputResponses.containsKey("user_name")
+                                    || !inputResponses.containsKey("email")) {
+                                return ToolResult.inputRequired(
+                                        Map.of(
+                                                "user_name",
+                                                FormInputRequest.of("What is your name?", JsonSchema.objectSchema()),
+                                                "email",
+                                                FormInputRequest.of("What is your email?", JsonSchema.objectSchema())),
+                                        "greet-state");
+                            }
+                            return ToolResult.text(
+                                    "Hello, " + stringField(inputResponses.get("user_name"), "name", "World") + "!");
+                        }));
 
         try (var client = createModernTestClient()) {
             client.withExtensions(Map.of(TasksExtension.ID, JsonNodeFactory.instance.objectNode()));
@@ -567,11 +593,20 @@ class TasksExtensionTest extends AbstractStatelessMcpE2eTest {
 
             var updateResponse = client.post("""
                     {"jsonrpc":"2.0","id":2,"method":"tasks/update","params":{\
-                    "taskId":"%s","inputResponses":{\
-                    "user_name":{"name":"Alice"},"unknown_key":"ignored","user_name":{"name":"Alice"}}}}
+                    "taskId":"%s","inputResponses":{"user_name":{"name":"Alice"},"unknown_key":"ignored"}}}
                     """.formatted(taskId));
 
             assertThat(updateResponse.statusCode()).as(updateResponse.body()).isEqualTo(200);
+
+            var stillWaiting = client.getTask(null, taskId);
+            assertThatJson(stillWaiting).inPath("$.result.status").isEqualTo("input_required");
+
+            var secondUpdate = client.post("""
+                    {"jsonrpc":"2.0","id":3,"method":"tasks/update","params":{\
+                    "taskId":"%s","inputResponses":{"user_name":{"name":"Bob"},"email":"alice@example.com"}}}
+                    """.formatted(taskId));
+
+            assertThat(secondUpdate.statusCode()).as(secondUpdate.body()).isEqualTo(200);
             var completedTask = client.awaitTaskStatus(taskId, "completed");
             assertThatJson(completedTask)
                     .inPath("$.result.result.content[0].text")
@@ -582,7 +617,7 @@ class TasksExtensionTest extends AbstractStatelessMcpE2eTest {
     @Test
     void tasksUpdateAcceptsPartialResponsesAcrossMultipleCalls() throws Exception {
         startServer(
-                builder -> builder.extension(TasksExtension.instance()),
+                builder -> builder.withExtensions(TasksExtension.instance()),
                 registrar -> registrar
                         .tools()
                         .register(b -> b.name("two-fields").taskSupport(TaskSupport.REQUIRED), (context, request) -> {

--- a/pom.xml
+++ b/pom.xml
@@ -511,6 +511,16 @@
                                     </exclude>
                                 </elements>
                             </revapi.filter>
+                            <revapi.filter>
+                                <elements>
+                                    <exclude>
+                                        <item>
+                                            <matcher>java</matcher>
+                                            <match>@dev.tachyonmcp.api.annotations.ExperimentalApi ^*;</match>
+                                        </item>
+                                    </exclude>
+                                </elements>
+                            </revapi.filter>
                             <revapi.differences>
                                 <ignore>true</ignore>
                                 <differences>

--- a/pom.xml
+++ b/pom.xml
@@ -501,12 +501,16 @@
                                     </include>
                                 </archives>
                             </revapi.filter>
-                            <revapi.java.filter.annotated>
-                                <regex>false</regex>
-                                <exclude>
-                                    <item>dev.tachyonmcp.api.annotations.InternalApi</item>
-                                </exclude>
-                            </revapi.java.filter.annotated>
+                            <revapi.filter>
+                                <elements>
+                                    <exclude>
+                                        <item>
+                                            <matcher>java</matcher>
+                                            <match>@dev.tachyonmcp.api.annotations.InternalApi ^*;</match>
+                                        </item>
+                                    </exclude>
+                                </elements>
+                            </revapi.filter>
                             <revapi.differences>
                                 <ignore>true</ignore>
                                 <differences>

--- a/tachyon-api/src/main/java/dev/tachyonmcp/api/server/domain/Task.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/api/server/domain/Task.java
@@ -84,14 +84,6 @@ public interface Task extends HasMeta {
     boolean requireInput(InputRequestBundle request, @Nullable String statusMessage);
 
     /**
-     * Resumes a task that was waiting for input.
-     *
-     * @param statusMessage optional status message
-     * @return {@code true} if the state transition was applied
-     */
-    boolean resume(@Nullable String statusMessage);
-
-    /**
      * Updates the status message of this task.
      *
      * @param statusMessage the new status message

--- a/tachyon-api/src/main/java/dev/tachyonmcp/api/server/features/tasks/TaskSupport.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/api/server/features/tasks/TaskSupport.java
@@ -1,8 +1,30 @@
 /* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
 package dev.tachyonmcp.api.server.features.tasks;
 
+/**
+ * Declares whether a tool may run as a background task instead of returning its result
+ * synchronously from {@code tools/call}. Set via {@code ToolDescriptor.taskSupport()}; a
+ * {@code null} descriptor value is treated as {@link #FORBIDDEN}.
+ *
+ * <p>MCP 2025-11-25 lets the client opt in per call via the legacy {@code tools/call.task} field:
+ * {@link #FORBIDDEN} rejects a task-augmented call, {@link #REQUIRED} rejects a plain (non
+ * task-augmented) call, and {@link #OPTIONAL} accepts either. MCP 2026-07-28 (SEP-2663) has no
+ * client-requested opt-in — that legacy field is ignored — so only {@link #REQUIRED} has an
+ * effect there: it always creates a task (the tool can never run synchronously), gated on the
+ * client having declared the {@code io.modelcontextprotocol/tasks} extension for that request.
+ * {@link #OPTIONAL} and {@link #FORBIDDEN} both run synchronously under 2026-07-28.
+ */
 public enum TaskSupport {
+
+    /** The tool never runs as a task; a task-augmented call is rejected. This is the default. */
     FORBIDDEN,
+
+    /** The tool may run either synchronously or as a task, at the caller's discretion. */
     OPTIONAL,
+
+    /**
+     * The tool always runs as a task. Under MCP 2025-11-25 a non task-augmented call is rejected;
+     * under MCP 2026-07-28 every call is dispatched as a task automatically.
+     */
     REQUIRED;
 }

--- a/tachyon-api/src/main/java/dev/tachyonmcp/api/server/features/tasks/TaskSupport.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/api/server/features/tasks/TaskSupport.java
@@ -19,7 +19,10 @@ public enum TaskSupport {
     /** The tool never runs as a task; a task-augmented call is rejected. This is the default. */
     FORBIDDEN,
 
-    /** The tool may run either synchronously or as a task, at the caller's discretion. */
+    /**
+     * Under MCP 2025-11-25, the caller may run the tool synchronously or as a task. MCP
+     * 2026-07-28 always runs this tool synchronously.
+     */
     OPTIONAL,
 
     /**

--- a/tachyon-core/revapi.json
+++ b/tachyon-core/revapi.json
@@ -46,16 +46,6 @@
         },
         {
           "ignore": true,
-          "code": "java.method.returnTypeChanged",
-          "old": "method java.lang.Long dev.tachyonmcp.core.server.features.tasks.TaskEntry::ttl()",
-          "new": "method java.time.Duration dev.tachyonmcp.core.server.features.tasks.TaskEntry::ttl()",
-          "justification": "Use idiomatic domain types",
-          "attachments": {
-            "since": "1.0.0-beta.19"
-          }
-        },
-        {
-          "ignore": true,
           "code": "java.method.parameterTypeChanged",
           "old": "parameter dev.tachyonmcp.core.protocol.mcp.v2025_11_25.models.CancelTaskResult.Builder dev.tachyonmcp.core.protocol.mcp.v2025_11_25.models.CancelTaskResult.Builder::createdAt(===java.lang.String===)",
           "new": "parameter dev.tachyonmcp.core.protocol.mcp.v2025_11_25.models.CancelTaskResult.Builder dev.tachyonmcp.core.protocol.mcp.v2025_11_25.models.CancelTaskResult.Builder::createdAt(===java.time.Instant===)",
@@ -601,43 +591,6 @@
         {
           "ignore": true,
           "code": "java.method.removed",
-          "old": "method java.lang.String dev.tachyonmcp.core.server.features.tasks.TaskEntry::createdAtIso()",
-          "justification": "Superseded by createdAt() returning Instant; ISO-8601 formatting moved to the wire codec, not TaskEntry",
-          "attachments": {
-            "since": "1.0.0-beta.19"
-          }
-        },
-        {
-          "ignore": true,
-          "code": "java.method.returnTypeChanged",
-          "old": "method long dev.tachyonmcp.core.server.features.tasks.TaskEntry::lastUpdatedAt()",
-          "new": "method java.time.Instant dev.tachyonmcp.core.server.features.tasks.TaskEntry::lastUpdatedAt()",
-          "justification": "Use idiomatic domain types",
-          "attachments": {
-            "since": "1.0.0-beta.19"
-          }
-        },
-        {
-          "ignore": true,
-          "code": "java.method.removed",
-          "old": "method java.lang.String dev.tachyonmcp.core.server.features.tasks.TaskEntry::lastUpdatedAtIso()",
-          "justification": "Superseded by lastUpdatedAt() returning Instant; ISO-8601 formatting moved to the wire codec, not TaskEntry",
-          "attachments": {
-            "since": "1.0.0-beta.19"
-          }
-        },
-        {
-          "ignore": true,
-          "code": "java.method.removed",
-          "old": "method long dev.tachyonmcp.core.server.features.tasks.TaskEntry::createdAtMillis()",
-          "justification": "No longer needed internal method",
-          "attachments": {
-            "since": "1.0.0-beta.19"
-          }
-        },
-        {
-          "ignore": true,
-          "code": "java.method.removed",
           "old": "method dev.tachyonmcp.core.server.ServerBuilder dev.tachyonmcp.core.server.ServerBuilder::executor(java.util.concurrent.ExecutorService)",
           "justification": "Server always owns a virtual-thread-per-task executor; only threadFactory() remains configurable",
           "attachments": {
@@ -646,47 +599,8 @@
         },
         {
           "ignore": true,
-          "code": "java.method.numberOfParametersChanged",
-          "old": "method boolean dev.tachyonmcp.core.server.internal.ServerEngine::completePendingRequest(dev.tachyonmcp.api.server.domain.RequestId, java.lang.String)",
-          "new": "method boolean dev.tachyonmcp.core.server.internal.ServerEngine::completePendingRequest(dev.tachyonmcp.api.server.domain.RequestId, java.lang.String, java.lang.String, java.lang.String)",
-          "justification": "Session or channel ownership prevents one client from completing another client's pending request",
-          "attachments": {
-            "since": "1.0.0-beta.19"
-          }
-        },
-        {
-          "ignore": true,
-          "code": "java.method.numberOfParametersChanged",
-          "old": "method boolean dev.tachyonmcp.core.server.internal.ServerEngine::failPendingRequest(dev.tachyonmcp.api.server.domain.RequestId, java.lang.String)",
-          "new": "method boolean dev.tachyonmcp.core.server.internal.ServerEngine::failPendingRequest(dev.tachyonmcp.api.server.domain.RequestId, java.lang.String, java.lang.String, java.lang.String)",
-          "justification": "Session or channel ownership prevents one client from failing another client's pending request",
-          "attachments": {
-            "since": "1.0.0-beta.19"
-          }
-        },
-        {
-          "ignore": true,
-          "code": "java.method.numberOfParametersChanged",
-          "old": "method void dev.tachyonmcp.core.server.internal.ServerEngine::registerPendingRequest(dev.tachyonmcp.api.server.domain.RequestId, java.util.concurrent.CompletableFuture<java.lang.String>)",
-          "new": "method void dev.tachyonmcp.core.server.internal.ServerEngine::registerPendingRequest(dev.tachyonmcp.api.server.domain.RequestId, java.lang.String, dev.tachyonmcp.core.server.OutboundSseStream, java.util.concurrent.CompletableFuture<java.lang.String>)",
-          "justification": "Pending requests retain their session and transport ownership for completion checks",
-          "attachments": {
-            "since": "1.0.0-beta.19"
-          }
-        },
-        {
-          "ignore": true,
           "code": "java.method.removed",
           "old": "method java.util.Map<java.lang.String, dev.tachyonmcp.api.json.JsonObject> dev.tachyonmcp.core.server.domain.InitializeResponse::negotiatedExtensions()",
-          "justification": "Advertise all server extensions",
-          "attachments": {
-            "since": "1.0.0-beta.20"
-          }
-        },
-        {
-          "ignore": true,
-          "code": "java.method.removed",
-          "old": "method java.util.Map<java.lang.String, dev.tachyonmcp.api.json.JsonObject> dev.tachyonmcp.core.server.handlers.ExtensionNegotiator::negotiatedExtensions(dev.tachyonmcp.core.runtime.ChannelContext)",
           "justification": "Advertise all server extensions",
           "attachments": {
             "since": "1.0.0-beta.20"
@@ -708,59 +622,6 @@
           "old": "method java.lang.Object dev.tachyonmcp.core.protocol.mcp.v2026_07_28.codecs.McpResponseMapper::discoverResult(java.util.List<java.lang.String>, dev.tachyonmcp.api.server.domain.ServerCapabilities, dev.tachyonmcp.api.server.config.ServerIdentity)",
           "new": "method java.lang.Object dev.tachyonmcp.core.protocol.mcp.v2026_07_28.codecs.McpResponseMapper::discoverResult(java.util.List<java.lang.String>, dev.tachyonmcp.api.server.domain.ServerCapabilities, dev.tachyonmcp.api.server.config.ServerIdentity, java.util.Map<java.lang.String, dev.tachyonmcp.api.json.JsonObject>)",
           "justification": "server/discover must advertise registered extensions the same way initialize does",
-          "attachments": {
-            "since": "1.0.0-beta.20"
-          }
-        },
-        {
-          "ignore": true,
-          "code": "java.method.parameterTypeChanged",
-          "old": "parameter void dev.tachyonmcp.core.protocol.mcp.v2026_07_28.transport.ExtensionNegotiationHandler::<init>(===dev.tachyonmcp.core.server.handlers.ExtensionNegotiator===)",
-          "new": "parameter void dev.tachyonmcp.core.protocol.mcp.v2026_07_28.transport.ExtensionNegotiationHandler::<init>(===java.util.List<dev.tachyonmcp.api.server.extensions.ServerExtension>===)",
-          "parameterIndex": "0",
-          "justification": "ExtensionNegotiator became a stateless static utility; the handler now carries the extension list directly instead of holding an instance",
-          "attachments": {
-            "since": "1.0.0-beta.20"
-          }
-        },
-        {
-          "ignore": true,
-          "code": "java.method.visibilityReduced",
-          "old": "method void dev.tachyonmcp.core.server.handlers.ExtensionNegotiator::<init>(java.util.List<dev.tachyonmcp.api.server.extensions.ServerExtension>)",
-          "new": "method void dev.tachyonmcp.core.server.handlers.ExtensionNegotiator::<init>()",
-          "oldVisibility": "public",
-          "newVisibility": "private",
-          "justification": "ExtensionNegotiator holds no state; it is now a non-instantiable static utility class",
-          "attachments": {
-            "since": "1.0.0-beta.20"
-          }
-        },
-        {
-          "ignore": true,
-          "code": "java.method.numberOfParametersChanged",
-          "old": "method void dev.tachyonmcp.core.server.handlers.ExtensionNegotiator::negotiate(dev.tachyonmcp.core.runtime.ChannelContext, java.util.Map<java.lang.String, dev.tachyonmcp.api.json.JsonObject>)",
-          "new": "method void dev.tachyonmcp.core.server.handlers.ExtensionNegotiator::negotiate(java.util.List<dev.tachyonmcp.api.server.extensions.ServerExtension>, dev.tachyonmcp.core.runtime.ChannelContext, java.util.Map<java.lang.String, dev.tachyonmcp.api.json.JsonObject>)",
-          "justification": "ExtensionNegotiator became a stateless static utility; negotiate() now takes the extension list as a parameter instead of reading it from instance state",
-          "attachments": {
-            "since": "1.0.0-beta.20"
-          }
-        },
-        {
-          "ignore": true,
-          "code": "java.method.nowStatic",
-          "old": "method void dev.tachyonmcp.core.server.handlers.ExtensionNegotiator::negotiate(dev.tachyonmcp.core.runtime.ChannelContext, java.util.Map<java.lang.String, dev.tachyonmcp.api.json.JsonObject>)",
-          "new": "method void dev.tachyonmcp.core.server.handlers.ExtensionNegotiator::negotiate(java.util.List<dev.tachyonmcp.api.server.extensions.ServerExtension>, dev.tachyonmcp.core.runtime.ChannelContext, java.util.Map<java.lang.String, dev.tachyonmcp.api.json.JsonObject>)",
-          "justification": "ExtensionNegotiator became a stateless static utility; negotiate() is now a static method",
-          "attachments": {
-            "since": "1.0.0-beta.20"
-          }
-        },
-        {
-          "ignore": true,
-          "code": "java.method.numberOfParametersChanged",
-          "old": "method void dev.tachyonmcp.core.server.handlers.InitializeHandler::<init>(dev.tachyonmcp.core.server.internal.ServerEngine, dev.tachyonmcp.core.server.handlers.ExtensionNegotiator)",
-          "new": "method void dev.tachyonmcp.core.server.handlers.InitializeHandler::<init>(dev.tachyonmcp.core.server.internal.ServerEngine)",
-          "justification": "ExtensionNegotiator became a stateless static utility; InitializeHandler no longer needs an injected instance",
           "attachments": {
             "since": "1.0.0-beta.20"
           }

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/ProtocolRequestMapper.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/ProtocolRequestMapper.java
@@ -60,6 +60,9 @@ public interface ProtocolRequestMapper {
     /** Extracts the {@code taskId} from params. */
     String taskId(@Nullable Object params);
 
+    /** Maps {@code tasks/update} params into the target task id and its input responses. */
+    TaskUpdateRequest taskUpdate(@Nullable Object params);
+
     /** Extracts the requested {@link LoggingLevel} from {@code logging/setLevel} params. */
     LoggingLevel loggingLevel(@Nullable Object params);
 
@@ -182,6 +185,15 @@ public interface ProtocolRequestMapper {
      */
     record TaskStatusRequest(
             String taskId, TaskState state, @Nullable String message) {}
+
+    /**
+     * A {@code tasks/update} request.
+     *
+     * @param taskId the task's ID
+     * @param inputResponses the submitted responses, keyed to the task's outstanding {@code
+     *     inputRequests}; empty if none were submitted
+     */
+    record TaskUpdateRequest(String taskId, Map<String, Object> inputResponses) {}
 
     /**
      * The notification filter requested on a {@code subscriptions/listen} call.

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/mcp/v2025_11_25/codecs/McpRequestMapper.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/mcp/v2025_11_25/codecs/McpRequestMapper.java
@@ -159,6 +159,14 @@ public class McpRequestMapper implements ProtocolRequestMapper {
     }
 
     @Override
+    public TaskUpdateRequest taskUpdate(@Nullable Object params) {
+        var map = asMap(params);
+        var responses = optionalMap(map, "inputResponses", "Invalid inputResponses");
+        return new TaskUpdateRequest(
+                requiredString(map, "taskId", "Missing taskId"), responses != null ? responses : Map.of());
+    }
+
+    @Override
     public LoggingLevel loggingLevel(@Nullable Object params) {
         var value = requiredString(asMap(params), "level", "Missing level parameter");
         try {

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/mcp/v2026_07_28/codecs/McpResponseMapper.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/mcp/v2026_07_28/codecs/McpResponseMapper.java
@@ -288,7 +288,8 @@ public final class McpResponseMapper extends dev.tachyonmcp.core.protocol.mcp.v2
     @Override
     public Object getTaskResult(dev.tachyonmcp.api.server.domain.Task entry) {
         var taskEntry = (TaskEntry) entry;
-        return McpTaskMapper.toGetTaskResult(taskEntry, taskResultNode(taskEntry), taskErrorNode(taskEntry));
+        return McpTaskMapper.toGetTaskResult(
+                taskEntry, taskResultNode(taskEntry), taskErrorNode(taskEntry), inputRequestsNode(taskEntry));
     }
 
     @Override
@@ -377,6 +378,16 @@ public final class McpResponseMapper extends dev.tachyonmcp.core.protocol.mcp.v2
                                 f.content(), f.structuredContent(), true, JsonUtils.toJsonNodeMap(f.meta())));
             case null, default -> null;
         };
+    }
+
+    /**
+     * Inlines a paused task's outstanding {@code inputRequests} into {@code tasks/get} while it's
+     * {@code input_required}; {@code null} in every other state.
+     */
+    private @Nullable JsonNode inputRequestsNode(TaskEntry entry) {
+        var pending = entry.pendingInput();
+        var encoded = pending != null ? encodedInputRequests(pending.inputRequests()) : null;
+        return encoded != null ? encodeToTree(InputRequests.class, encoded) : null;
     }
 
     /** Inlines a genuine JSON-RPC protocol failure into {@code tasks/get}'s {@code error} field. */

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/mcp/v2026_07_28/codecs/McpTaskMapper.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/mcp/v2026_07_28/codecs/McpTaskMapper.java
@@ -49,10 +49,15 @@ final class McpTaskMapper {
         return JsonUtils.toObjectNode(fields);
     }
 
-    static JsonNode toGetTaskResult(TaskEntry entry, @Nullable JsonNode inlineResult, @Nullable JsonNode inlineError) {
+    static JsonNode toGetTaskResult(
+            TaskEntry entry,
+            @Nullable JsonNode inlineResult,
+            @Nullable JsonNode inlineError,
+            @Nullable JsonNode inputRequests) {
         var fields = taskFields(entry, effectiveWireStatus(entry));
         putIfPresent(fields, "result", inlineResult);
         putIfPresent(fields, "error", inlineError);
+        putIfPresent(fields, "inputRequests", inputRequests);
         fields.put("resultType", RESULT_TYPE_COMPLETE);
         return JsonUtils.toObjectNode(fields);
     }

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/features/tasks/DefaultTaskRegistry.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/features/tasks/DefaultTaskRegistry.java
@@ -232,13 +232,7 @@ public class DefaultTaskRegistry extends AbstractRegistry<TaskDescriptor, TaskEn
             logger.debug("Task not found for client notification: {}", taskId);
             return false;
         }
-        if (statusMessage != null) {
-            if (newStatus == TaskState.WORKING && entry.resume(statusMessage)) {
-                return true;
-            }
-            return entry.transitionTo(newStatus, null, statusMessage);
-        }
-        if (!entry.transitionTo(newStatus)) {
+        if (!entry.transitionTo(newStatus, null, statusMessage)) {
             logger.debug("Invalid status transition from {} to {} for task {}", entry.status(), newStatus, taskId);
             return false;
         }

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/features/tasks/DefaultTaskRegistry.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/features/tasks/DefaultTaskRegistry.java
@@ -33,6 +33,7 @@ public class DefaultTaskRegistry extends AbstractRegistry<TaskDescriptor, TaskEn
     private static final long TTL_JANITOR_INTERVAL_SECONDS = 30;
 
     private final ConcurrentHashMap<String, Future<?>> running = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, TaskResumer> resumers = new ConcurrentHashMap<>();
     private final ServerEngine server;
     private final Clock clock;
     private final TaskIdGenerator taskIdGenerator;
@@ -81,6 +82,7 @@ public class DefaultTaskRegistry extends AbstractRegistry<TaskDescriptor, TaskEn
         if (!entry.status().isTerminal()) {
             getAndCancelTask(taskId);
         }
+        resumers.remove(taskId);
         return removeItem(taskId);
     }
 
@@ -114,19 +116,17 @@ public class DefaultTaskRegistry extends AbstractRegistry<TaskDescriptor, TaskEn
             Duration keepAlive,
             @Nullable Duration pollInterval) {
         var id = requestedId != null ? requestedId : taskIdGenerator.generateTaskId(meta, sessionId);
-        var descriptor = TaskDescriptor.builder().id(id).build();
-        var entry = new TaskEntry(
-                descriptor,
-                id,
-                TaskState.SUBMITTED,
-                ttl,
-                sessionId,
-                progressToken,
-                meta,
-                keepAlive,
-                pollInterval,
-                this::fireStatusNotification,
-                clock);
+        var entry = TaskEntry.builder(id)
+                .status(TaskState.SUBMITTED)
+                .ttl(ttl)
+                .sessionId(sessionId)
+                .progressToken(progressToken)
+                .meta(meta)
+                .keepAlive(keepAlive)
+                .pollInterval(pollInterval)
+                .statusListener(this::fireStatusNotification)
+                .clock(clock)
+                .build();
         if (!addItemIfAbsent(entry)) {
             throw new IllegalArgumentException("Task '" + id + "' already exists");
         }
@@ -142,6 +142,21 @@ public class DefaultTaskRegistry extends AbstractRegistry<TaskDescriptor, TaskEn
     @Override
     public void unregisterRunning(String taskId) {
         running.remove(taskId);
+    }
+
+    @Override
+    public void registerResumer(String taskId, TaskResumer resumer) {
+        resumers.put(taskId, resumer);
+    }
+
+    @Override
+    public void unregisterResumer(String taskId) {
+        resumers.remove(taskId);
+    }
+
+    @Override
+    public @Nullable TaskResumer getResumer(String taskId) {
+        return resumers.get(taskId);
     }
 
     public boolean completeTask(String taskId, @Nullable String resultJson) {
@@ -203,6 +218,7 @@ public class DefaultTaskRegistry extends AbstractRegistry<TaskDescriptor, TaskEn
         if (future != null) {
             future.cancel(true);
         }
+        resumers.remove(taskId);
         fireOnChange();
         return entry;
     }
@@ -257,6 +273,7 @@ public class DefaultTaskRegistry extends AbstractRegistry<TaskDescriptor, TaskEn
                 logger.info("Task expired: id={}", entry.id());
                 var failed = new TaskResult.Failed(List.of(TextContent.of("Task expired")), null, null);
                 if (entry.fail(failed)) {
+                    resumers.remove(entry.id());
                     fireOnChange();
                 }
             }

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/features/tasks/DefaultTaskRegistry.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/features/tasks/DefaultTaskRegistry.java
@@ -155,7 +155,7 @@ public class DefaultTaskRegistry extends AbstractRegistry<TaskDescriptor, TaskEn
     }
 
     @Override
-    public @Nullable TaskResumer getResumer(String taskId) {
+    public @Nullable TaskResumer findResumer(String taskId) {
         return resumers.get(taskId);
     }
 

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/features/tasks/TaskEntry.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/features/tasks/TaskEntry.java
@@ -331,20 +331,15 @@ public class TaskEntry implements ServerFeature<TaskDescriptor>, Task {
             }
             // Not Map.copyOf: JSON null is a legal response value and Map.copyOf rejects nulls.
             var merged = Collections.unmodifiableMap(new LinkedHashMap<>(next));
-            // Resume while still holding the lock: transitionTo's pause bookkeeping is guarded by
+            // Transition while still holding the lock: transitionTo's pause bookkeeping is guarded by
             // the same (reentrant) lock, so a new INPUT_REQUIRED round can't be installed between
             // validating this round's answers and resuming it -- otherwise a late resume could
             // clobber a fresher pause with a stale round's answers.
-            if (!resume("Input received")) return null;
+            if (!transitionTo(TaskState.WORKING, null, "Input received")) return null;
             return new ResumeInputs(merged, pending.requestState());
         } finally {
             inputResponsesLock.unlock();
         }
-    }
-
-    @Override
-    public boolean resume(@Nullable String statusMessage) {
-        return transitionTo(TaskState.WORKING, null, statusMessage);
     }
 
     @Override

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/features/tasks/TaskEntry.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/features/tasks/TaskEntry.java
@@ -15,12 +15,15 @@ import dev.tachyonmcp.core.server.config.TasksConfig;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Consumer;
 import org.jspecify.annotations.Nullable;
 
@@ -42,130 +45,106 @@ public class TaskEntry implements ServerFeature<TaskDescriptor>, Task {
     private volatile long expiredAt;
     private volatile @Nullable String statusMessage;
     private volatile @Nullable InputRequestBundle pendingInput;
+    private final ReentrantLock inputResponsesLock = new ReentrantLock();
+    /**
+     * @implNote guarded by {@link #inputResponsesLock}
+     */
+    private @Nullable Map<String, Object> pendingInputResponses;
+
     private final CompletableFuture<TaskResult> completionFuture = new CompletableFuture<>();
     private final @Nullable ProgressToken progressToken;
     private final Consumer<TaskEntry> statusListener;
     private final Clock clock;
 
-    TaskEntry(String id) {
-        this(
-                TaskDescriptor.builder().id(id).build(),
-                id,
-                TaskState.WORKING,
-                null,
-                null,
-                null,
-                null,
-                TasksConfig.DEFAULT_TASK_KEEP_ALIVE);
-    }
-
-    public TaskEntry(TaskDescriptor descriptor, String id, TaskState status, double ttl) {
-        this(
-                descriptor,
-                id,
-                status,
-                ttl > 0 ? Duration.ofSeconds((long) ttl) : null,
-                null,
-                null,
-                null,
-                TasksConfig.DEFAULT_TASK_KEEP_ALIVE);
-    }
-
-    public TaskEntry(TaskDescriptor descriptor, String id, TaskState status, double ttl, @Nullable String sessionId) {
-        this(
-                descriptor,
-                id,
-                status,
-                ttl > 0 ? Duration.ofSeconds((long) ttl) : null,
-                sessionId,
-                null,
-                null,
-                TasksConfig.DEFAULT_TASK_KEEP_ALIVE);
-    }
-
-    public TaskEntry(
-            TaskDescriptor descriptor,
-            String id,
-            TaskState status,
-            @Nullable Duration ttl,
-            @Nullable String sessionId,
-            @Nullable ProgressToken progressToken) {
-        this(descriptor, id, status, ttl, sessionId, progressToken, null, TasksConfig.DEFAULT_TASK_KEEP_ALIVE);
-    }
-
-    public TaskEntry(
-            TaskDescriptor descriptor,
-            String id,
-            TaskState status,
-            @Nullable Duration ttl,
-            @Nullable String sessionId,
-            @Nullable ProgressToken progressToken,
-            @Nullable Map<String, Object> meta) {
-        this(descriptor, id, status, ttl, sessionId, progressToken, meta, TasksConfig.DEFAULT_TASK_KEEP_ALIVE);
-    }
-
-    public TaskEntry(
-            TaskDescriptor descriptor,
-            String id,
-            TaskState status,
-            @Nullable Duration ttl,
-            @Nullable String sessionId,
-            @Nullable ProgressToken progressToken,
-            @Nullable Map<String, Object> meta,
-            Duration keepAlive) {
-        this(descriptor, id, status, ttl, sessionId, progressToken, meta, keepAlive, null);
-    }
-
-    public TaskEntry(
-            TaskDescriptor descriptor,
-            String id,
-            TaskState status,
-            @Nullable Duration ttl,
-            @Nullable String sessionId,
-            @Nullable ProgressToken progressToken,
-            @Nullable Map<String, Object> meta,
-            Duration keepAlive,
-            @Nullable Duration pollInterval) {
-        this(descriptor, id, status, ttl, sessionId, progressToken, meta, keepAlive, pollInterval, entry -> {});
+    /**
+     * Starts building a {@link TaskEntry}. {@code status} defaults to {@link TaskState#WORKING}
+     * and {@code keepAlive} to {@link TasksConfig#DEFAULT_TASK_KEEP_ALIVE}; every other field
+     * defaults to {@code null}/absent.
+     */
+    public static Builder builder(String id) {
+        return new Builder(id);
     }
 
     /**
-     * Full constructor; {@code statusListener} is invoked with {@code this} after every
-     * successful status/message mutation, regardless of which method the caller used to reach
-     * it. Package-private: only {@link DefaultTaskRegistry} wires a non-default listener.
+     * Builds a {@link TaskEntry}. See {@link #builder(String)}.
      */
-    TaskEntry(
-            TaskDescriptor descriptor,
-            String id,
-            TaskState status,
-            @Nullable Duration ttl,
-            @Nullable String sessionId,
-            @Nullable ProgressToken progressToken,
-            @Nullable Map<String, Object> meta,
-            Duration keepAlive,
-            @Nullable Duration pollInterval,
-            Consumer<TaskEntry> statusListener) {
-        this(
-                descriptor,
-                id,
-                status,
-                ttl,
-                sessionId,
-                progressToken,
-                meta,
-                keepAlive,
-                pollInterval,
-                statusListener,
-                Clock.systemUTC());
+    public static final class Builder {
+        private final String id;
+        private TaskState status = TaskState.WORKING;
+        private @Nullable Duration ttl;
+        private @Nullable String sessionId;
+        private @Nullable ProgressToken progressToken;
+        private @Nullable Map<String, Object> meta;
+        private Duration keepAlive = TasksConfig.DEFAULT_TASK_KEEP_ALIVE;
+        private @Nullable Duration pollInterval;
+        private Consumer<TaskEntry> statusListener = entry -> {};
+        private Clock clock = Clock.systemUTC();
+
+        private Builder(String id) {
+            this.id = Objects.requireNonNull(id, "id");
+        }
+
+        public Builder status(TaskState status) {
+            this.status = Objects.requireNonNull(status, "status");
+            return this;
+        }
+
+        public Builder ttl(@Nullable Duration ttl) {
+            this.ttl = ttl;
+            return this;
+        }
+
+        public Builder sessionId(@Nullable String sessionId) {
+            this.sessionId = sessionId;
+            return this;
+        }
+
+        public Builder progressToken(@Nullable ProgressToken progressToken) {
+            this.progressToken = progressToken;
+            return this;
+        }
+
+        public Builder meta(@Nullable Map<String, Object> meta) {
+            this.meta = meta;
+            return this;
+        }
+
+        public Builder keepAlive(Duration keepAlive) {
+            this.keepAlive = Objects.requireNonNull(keepAlive, "keepAlive");
+            return this;
+        }
+
+        public Builder pollInterval(@Nullable Duration pollInterval) {
+            this.pollInterval = pollInterval;
+            return this;
+        }
+
+        /**
+         * Invoked with the entry after every successful status/message mutation. Package-private:
+         * only {@link DefaultTaskRegistry} wires a non-default listener.
+         */
+        Builder statusListener(Consumer<TaskEntry> statusListener) {
+            this.statusListener = Objects.requireNonNull(statusListener, "statusListener");
+            return this;
+        }
+
+        /**
+         * Overrides the {@link Clock} used for {@code createdAt}/{@code lastUpdatedAt} and
+         * TTL/expiry checks. Package-private: only {@link DefaultTaskRegistry} wires a clock
+         * other than the system default.
+         */
+        Builder clock(Clock clock) {
+            this.clock = Objects.requireNonNull(clock, "clock");
+            return this;
+        }
+
+        public TaskEntry build() {
+            return new TaskEntry(
+                    id, status, ttl, sessionId, progressToken, meta, keepAlive, pollInterval, statusListener, clock);
+        }
     }
 
-    /**
-     * Full constructor with an injectable {@link Clock} for {@code createdAt}/{@code
-     * lastUpdatedAt} and TTL/expiry checks. Package-private: only {@link DefaultTaskRegistry}
-     * wires a clock other than the system default.
-     */
-    TaskEntry(
-            TaskDescriptor descriptor,
+    private TaskEntry(
             String id,
             TaskState status,
             @Nullable Duration ttl,
@@ -176,7 +155,7 @@ public class TaskEntry implements ServerFeature<TaskDescriptor>, Task {
             @Nullable Duration pollInterval,
             Consumer<TaskEntry> statusListener,
             Clock clock) {
-        this.descriptor = descriptor;
+        this.descriptor = TaskDescriptor.builder().id(id).build();
         this.id = id;
         this.sessionId = sessionId;
         this.meta = meta;
@@ -315,6 +294,54 @@ public class TaskEntry implements ServerFeature<TaskDescriptor>, Task {
         return status() == TaskState.INPUT_REQUIRED ? pendingInput : null;
     }
 
+    /**
+     * The merged, filtered input responses and opaque request state for a resumed round.
+     */
+    public record ResumeInputs(
+            Map<String, Object> inputResponses, @Nullable String requestState) {}
+
+    /**
+     * Merges {@code responses} into this {@link TaskState#INPUT_REQUIRED} pause's accumulated
+     * answers, filtered to keys present in {@link #pendingInput()}'s inputRequests and not already
+     * answered — unknown or already-satisfied keys are silently dropped (per the {@code
+     * tasks/update} spec). Per-round only: the accumulator is reset whenever a new {@code
+     * INPUT_REQUIRED} round begins (see {@link #transitionTo(TaskState, TaskResult, String,
+     * InputRequestBundle)}), so a later round's resumer never sees an earlier round's answers.
+     *
+     * <p>Returns the full merged set once every currently-outstanding key has an answer — this
+     * call has also atomically resumed the task to {@link TaskState#WORKING} at that point — or
+     * {@code null} when the task isn't awaiting input, or when outstanding keys remain.
+     */
+    public @Nullable ResumeInputs submitInput(Map<String, Object> responses) {
+        inputResponsesLock.lock();
+        try {
+            var pending = pendingInput();
+            if (pending == null) return null;
+            var next = pendingInputResponses == null
+                    ? new LinkedHashMap<String, Object>()
+                    : new LinkedHashMap<>(pendingInputResponses);
+            responses.forEach((key, value) -> {
+                if (pending.inputRequests().containsKey(key) && !next.containsKey(key)) {
+                    next.put(key, value);
+                }
+            });
+            pendingInputResponses = next;
+            if (!next.keySet().containsAll(pending.inputRequests().keySet())) {
+                return null; // still waiting on more
+            }
+            // Not Map.copyOf: JSON null is a legal response value and Map.copyOf rejects nulls.
+            var merged = Collections.unmodifiableMap(new LinkedHashMap<>(next));
+            // Resume while still holding the lock: transitionTo's pause bookkeeping is guarded by
+            // the same (reentrant) lock, so a new INPUT_REQUIRED round can't be installed between
+            // validating this round's answers and resuming it -- otherwise a late resume could
+            // clobber a fresher pause with a stale round's answers.
+            if (!resume("Input received")) return null;
+            return new ResumeInputs(merged, pending.requestState());
+        } finally {
+            inputResponsesLock.unlock();
+        }
+    }
+
     @Override
     public boolean resume(@Nullable String statusMessage) {
         return transitionTo(TaskState.WORKING, null, statusMessage);
@@ -412,7 +439,14 @@ public class TaskEntry implements ServerFeature<TaskDescriptor>, Task {
             if (statusMessage != null) {
                 this.statusMessage = statusMessage;
             }
-            this.pendingInput = newStatus == TaskState.INPUT_REQUIRED ? pendingInput : null;
+            inputResponsesLock.lock();
+            try {
+                this.pendingInput = newStatus == TaskState.INPUT_REQUIRED ? pendingInput : null;
+                // Every transition starts a clean accumulator -- per-round, never cumulative.
+                this.pendingInputResponses = null;
+            } finally {
+                inputResponsesLock.unlock();
+            }
             if (newStatus.isTerminal()) {
                 this.expiredAt = computeExpiredAt(this.lastUpdatedAt);
                 if (result != null) {

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/features/tasks/TaskMethodHandlers.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/features/tasks/TaskMethodHandlers.java
@@ -199,8 +199,7 @@ public final class TaskMethodHandlers {
                 }
                 // else: a hand-created task (server.tasks().create() + task.requireInput(...)
                 // called directly by user code, no tool-augmented dispatch) has no resumer -- it's
-                // already resumed to WORKING by submitInput(); whoever owns the Task drives it
-                // forward themselves, same as if they'd called task.resume(...) directly.
+                // already transitioned to WORKING by submitInput(); its owner drives it forward.
             }
             return context.responseMapper().emptyResult();
         }

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/features/tasks/TaskMethodHandlers.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/features/tasks/TaskMethodHandlers.java
@@ -2,6 +2,7 @@
 package dev.tachyonmcp.core.server.features.tasks;
 
 import dev.tachyonmcp.api.server.domain.ServerError;
+import dev.tachyonmcp.api.server.domain.TaskResult;
 import dev.tachyonmcp.api.server.features.tasks.TaskState;
 import dev.tachyonmcp.core.protocol.ProtocolRequestMapper;
 import dev.tachyonmcp.core.protocol.RequestMappingException;
@@ -189,12 +190,14 @@ public final class TaskMethodHandlers {
 
             var resumeInputs = entry.submitInput(request.inputResponses());
             if (resumeInputs != null) {
-                var resumer = registry.getResumer(entry.id());
+                var resumer = registry.findResumer(entry.id());
                 if (resumer != null) {
                     try {
-                        resumer.resume(resumeInputs.inputResponses(), resumeInputs.requestState());
+                        resumer.resume(context, resumeInputs.inputResponses(), resumeInputs.requestState());
                     } catch (RuntimeException e) {
                         logger.error("Task resumer failed for taskId={}", entry.id(), e);
+                        entry.fail(TaskResult.failed("Task resumer failed"));
+                        registry.unregisterResumer(entry.id());
                     }
                 }
                 // else: a hand-created task (server.tasks().create() + task.requireInput(...)

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/features/tasks/TaskMethodHandlers.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/features/tasks/TaskMethodHandlers.java
@@ -3,12 +3,15 @@ package dev.tachyonmcp.core.server.features.tasks;
 
 import dev.tachyonmcp.api.server.domain.ServerError;
 import dev.tachyonmcp.api.server.features.tasks.TaskState;
+import dev.tachyonmcp.core.protocol.ProtocolRequestMapper;
 import dev.tachyonmcp.core.protocol.RequestMappingException;
 import dev.tachyonmcp.core.server.RpcMethodHandler;
 import dev.tachyonmcp.core.server.domain.ServerErrors;
 import dev.tachyonmcp.core.server.session.DispatchContext;
 import java.util.Map;
 import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** JSON-RPC adapters for task operations. */
 public final class TaskMethodHandlers {
@@ -20,6 +23,7 @@ public final class TaskMethodHandlers {
         handlers.put("tasks/get", new TasksGetHandler(registry));
         handlers.put("tasks/cancel", new TasksCancelHandler(registry));
         handlers.put("tasks/result", new TasksResultHandler(registry));
+        handlers.put("tasks/update", new TasksUpdateHandler(registry));
     }
 
     /**
@@ -32,6 +36,18 @@ public final class TaskMethodHandlers {
         return context.requestMapper().supportsLegacyTaskAugmentation()
                 ? null
                 : ServerErrors.methodNotFound("Method not found");
+    }
+
+    /**
+     * Inverse of {@link #legacyTasksUnavailable}: {@code tasks/update} is SEP-2663's ext-tasks
+     * method for submitting a paused task's input responses -- it has no wire shape under
+     * 2025-11-25's earlier, unrelated task model (no such field on that version's generated
+     * {@code Task}/{@code GetTaskResult} models), so it doesn't exist there at all.
+     */
+    private static @Nullable ServerError modernTasksOnly(DispatchContext context) {
+        return context.requestMapper().supportsLegacyTaskAugmentation()
+                ? ServerErrors.methodNotFound("Method not found")
+                : null;
     }
 
     private record TasksListHandler(DefaultTaskRegistry registry) implements RpcMethodHandler {
@@ -142,6 +158,51 @@ public final class TaskMethodHandlers {
             return result != null
                     ? context.responseMapper().getTaskPayloadResult(result, entry.id())
                     : ServerErrors.invalidParams("Task result not available");
+        }
+    }
+
+    private record TasksUpdateHandler(DefaultTaskRegistry registry) implements RpcMethodHandler {
+        private static final Logger logger = LoggerFactory.getLogger(TasksUpdateHandler.class);
+
+        @Override
+        public String method() {
+            return "tasks/update";
+        }
+
+        @Override
+        public Object handle(DispatchContext context, Object params) {
+            var versionGate = modernTasksOnly(context);
+            if (versionGate != null) return versionGate;
+            var missingCapability = TasksExtension.requireDeclared(context);
+            if (missingCapability != null) return missingCapability;
+
+            final ProtocolRequestMapper.TaskUpdateRequest request;
+            try {
+                request = context.requestMapper().taskUpdate(params);
+            } catch (RequestMappingException e) {
+                return e.error();
+            }
+            var entry = registry.getById(request.taskId());
+            if (entry == null) {
+                return ServerErrors.invalidParams("Failed to retrieve task: Task not found");
+            }
+
+            var resumeInputs = entry.submitInput(request.inputResponses());
+            if (resumeInputs != null) {
+                var resumer = registry.getResumer(entry.id());
+                if (resumer != null) {
+                    try {
+                        resumer.resume(resumeInputs.inputResponses(), resumeInputs.requestState());
+                    } catch (RuntimeException e) {
+                        logger.error("Task resumer failed for taskId={}", entry.id(), e);
+                    }
+                }
+                // else: a hand-created task (server.tasks().create() + task.requireInput(...)
+                // called directly by user code, no tool-augmented dispatch) has no resumer -- it's
+                // already resumed to WORKING by submitInput(); whoever owns the Task drives it
+                // forward themselves, same as if they'd called task.resume(...) directly.
+            }
+            return context.responseMapper().emptyResult();
         }
     }
 }

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/features/tasks/TaskRegistry.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/features/tasks/TaskRegistry.java
@@ -28,7 +28,7 @@ public interface TaskRegistry extends Tasks {
     void unregisterResumer(String taskId);
 
     @Nullable
-    TaskResumer getResumer(String taskId);
+    TaskResumer findResumer(String taskId);
 
     void add(TaskEntry entry);
 

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/features/tasks/TaskRegistry.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/features/tasks/TaskRegistry.java
@@ -23,6 +23,13 @@ public interface TaskRegistry extends Tasks {
 
     void unregisterRunning(String taskId);
 
+    void registerResumer(String taskId, TaskResumer resumer);
+
+    void unregisterResumer(String taskId);
+
+    @Nullable
+    TaskResumer getResumer(String taskId);
+
     void add(TaskEntry entry);
 
     @Nullable

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/features/tasks/TaskResumer.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/features/tasks/TaskResumer.java
@@ -1,6 +1,7 @@
 /* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
 package dev.tachyonmcp.core.server.features.tasks;
 
+import dev.tachyonmcp.core.server.session.DispatchContext;
 import java.util.Map;
 import org.jspecify.annotations.Nullable;
 
@@ -13,5 +14,12 @@ import org.jspecify.annotations.Nullable;
 @FunctionalInterface
 public interface TaskResumer {
 
-    void resume(Map<String, Object> inputResponses, @Nullable String requestState);
+    /**
+     * Resumes a task from the {@code tasks/update} request that supplied its input.
+     *
+     * @param context the current update request context
+     * @param inputResponses merged, filtered responses
+     * @param requestState the opaque state from the pending input request
+     */
+    void resume(DispatchContext context, Map<String, Object> inputResponses, @Nullable String requestState);
 }

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/features/tasks/TaskResumer.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/features/tasks/TaskResumer.java
@@ -1,0 +1,17 @@
+/* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
+package dev.tachyonmcp.core.server.features.tasks;
+
+import java.util.Map;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Re-invokes whatever produced a task's {@link dev.tachyonmcp.api.server.features.tasks.TaskState#INPUT_REQUIRED}
+ * pause with this round's merged, filtered input responses and the pause's opaque request state.
+ * Fire-and-forget — the implementation drives the task to its next outcome (completed, failed, or
+ * parked again) itself; nothing composes on a return value, so there isn't one.
+ */
+@FunctionalInterface
+public interface TaskResumer {
+
+    void resume(Map<String, Object> inputResponses, @Nullable String requestState);
+}

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/features/tools/ToolMethodHandlers.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/features/tools/ToolMethodHandlers.java
@@ -183,7 +183,7 @@ public final class ToolMethodHandlers {
         private @Nullable Object dispatchTaskAugmented(
                 DispatchContext context, ToolHandler handler, ToolRequest request, @Nullable Duration taskTtl) {
             sendLogging(context, request.name(), "started");
-            final var engine = context.engine();
+            var engine = context.engine();
             var taskRegistry = engine.tasksRegistry();
             var task = taskRegistry.createSessionTask(
                     taskTtl,
@@ -191,8 +191,8 @@ public final class ToolMethodHandlers {
                     OutboundSseStreamMessageRouter.currentSessionId(),
                     request.progressToken());
             task.transitionTo(TaskState.WORKING);
-            final var taskResult = context.responseMapper().createTaskResult(task);
-            final var taskRequest = ToolRequest.builder()
+            var taskResult = context.responseMapper().createTaskResult(task);
+            var taskRequest = ToolRequest.builder()
                     .name(request.name())
                     .arguments(request.arguments())
                     .meta(request.meta())
@@ -203,6 +203,31 @@ public final class ToolMethodHandlers {
                     .task(task)
                     .build();
 
+            taskRegistry.registerResumer(task.id(), (responses, state) -> {
+                var resumedRequest = ToolRequest.builder()
+                        .from(taskRequest)
+                        .inputResponses(responses)
+                        .requestState(state)
+                        .build();
+                dispatchAndWire(context, handler, resumedRequest, taskRegistry, task);
+            });
+            dispatchAndWire(context, handler, taskRequest, taskRegistry, task);
+            return taskResult;
+        }
+
+        /**
+         * Runs {@code taskRequest} on the executor and wires its result through {@link
+         * #completeTask} -- shared by the first dispatch and every {@code tasks/update}-triggered
+         * resume, so a second/third/Nth {@code InputRequired} round reuses the same
+         * future/cancellation/completion plumbing as the initial call.
+         */
+        private void dispatchAndWire(
+                DispatchContext context,
+                ToolHandler handler,
+                ToolRequest taskRequest,
+                TaskRegistry taskRegistry,
+                TaskEntry task) {
+            var engine = context.engine();
             var future = new CompletableFuture<ToolResult>();
             var handlerFuture = new AtomicReference<@Nullable CompletableFuture<? extends ToolResult>>();
             var dispatchFuture = engine.executor().submit(() -> {
@@ -210,7 +235,7 @@ public final class ToolMethodHandlers {
                 try {
                     var stage = Objects.requireNonNull(
                             handler.handleAsync(context, taskRequest),
-                            "Tool '" + request.name() + "' returned a null CompletionStage");
+                            "Tool '" + taskRequest.name() + "' returned a null CompletionStage");
                     var actualFuture = stage.toCompletableFuture();
                     handlerFuture.set(actualFuture);
                     if (future.isCancelled()) {
@@ -247,7 +272,6 @@ public final class ToolMethodHandlers {
                 handleFutureFailure(taskRegistry, task, throwable);
                 return null;
             });
-            return taskResult;
         }
 
         private void completeTask(
@@ -261,9 +285,14 @@ public final class ToolMethodHandlers {
             result = prepareResult(outputSchema, result);
             var meta = result.meta();
             switch (result) {
-                case ToolResult.Error error -> task.fail(new TaskResult.Failed(error.content(), null, meta));
-                case ToolResult.Success success ->
+                case ToolResult.Error error -> {
+                    task.fail(new TaskResult.Failed(error.content(), null, meta));
+                    taskRegistry.unregisterResumer(task.id());
+                }
+                case ToolResult.Success success -> {
                     task.complete(new TaskResult.Completed(success.content(), success.structuredValue(), meta));
+                    taskRegistry.unregisterResumer(task.id());
+                }
                 case ToolResult.InputRequired inputRequired ->
                     task.requireInput(inputRequired.request(), "Input required");
             }
@@ -317,6 +346,7 @@ public final class ToolMethodHandlers {
                 handleTaskError(task, cause);
             }
             taskRegistry.unregisterRunning(task.id());
+            taskRegistry.unregisterResumer(task.id());
         }
 
         private void handleTaskError(TaskEntry task, Throwable exception) {

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/features/tools/ToolMethodHandlers.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/features/tools/ToolMethodHandlers.java
@@ -203,13 +203,13 @@ public final class ToolMethodHandlers {
                     .task(task)
                     .build();
 
-            taskRegistry.registerResumer(task.id(), (responses, state) -> {
+            taskRegistry.registerResumer(task.id(), (resumeContext, responses, state) -> {
                 var resumedRequest = ToolRequest.builder()
                         .from(taskRequest)
                         .inputResponses(responses)
                         .requestState(state)
                         .build();
-                dispatchAndWire(context, handler, resumedRequest, taskRegistry, task);
+                dispatchAndWire(resumeContext, handler, resumedRequest, taskRegistry, task);
             });
             dispatchAndWire(context, handler, taskRequest, taskRegistry, task);
             return taskResult;

--- a/tachyon-core/src/test/java/dev/tachyonmcp/core/protocol/mcp/v2025_11_25/codecs/McpTaskMapperTest.java
+++ b/tachyon-core/src/test/java/dev/tachyonmcp/core/protocol/mcp/v2025_11_25/codecs/McpTaskMapperTest.java
@@ -4,7 +4,6 @@ package dev.tachyonmcp.core.protocol.mcp.v2025_11_25.codecs;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import dev.tachyonmcp.api.server.features.tasks.TaskDescriptor;
 import dev.tachyonmcp.api.server.features.tasks.TaskState;
 import dev.tachyonmcp.core.protocol.mcp.v2025_11_25.models.TaskStatus;
 import dev.tachyonmcp.core.server.features.tasks.TaskEntry;
@@ -16,14 +15,12 @@ import tools.jackson.databind.node.JsonNodeFactory;
 class McpTaskMapperTest {
 
     private static TaskEntry entry(TaskState status) {
-        return new TaskEntry(
-                TaskDescriptor.builder().id("task-1").build(),
-                "task-1",
-                status,
-                Duration.ofMinutes(1),
-                "session-1",
-                null,
-                Map.of("trace", "abc"));
+        return TaskEntry.builder("task-1")
+                .status(status)
+                .ttl(Duration.ofMinutes(1))
+                .sessionId("session-1")
+                .meta(Map.of("trace", "abc"))
+                .build();
     }
 
     @Test
@@ -51,14 +48,10 @@ class McpTaskMapperTest {
 
     @Test
     void ttlIsPreservedAcrossAllResponseShapes() {
-        var withTtl = new TaskEntry(
-                TaskDescriptor.builder().id("task-1").build(),
-                "task-1",
-                TaskState.WORKING,
-                Duration.ofSeconds(90),
-                null,
-                null,
-                null);
+        var withTtl = TaskEntry.builder("task-1")
+                .status(TaskState.WORKING)
+                .ttl(Duration.ofSeconds(90))
+                .build();
 
         assertThat(McpTaskMapper.toTaskProto(withTtl).ttl()).isEqualTo(Duration.ofSeconds(90));
         assertThat(McpTaskMapper.toGetTaskResult(withTtl).ttl()).isEqualTo(Duration.ofSeconds(90));
@@ -68,8 +61,7 @@ class McpTaskMapperTest {
 
     @Test
     void nullTtlIsPreservedAcrossAllResponseShapes() {
-        var withoutTtl = new TaskEntry(
-                TaskDescriptor.builder().id("task-1").build(), "task-1", TaskState.WORKING, null, null, null, null);
+        var withoutTtl = TaskEntry.builder("task-1").status(TaskState.WORKING).build();
 
         assertThat(McpTaskMapper.toTaskProto(withoutTtl).ttl()).isNull();
         assertThat(McpTaskMapper.toGetTaskResult(withoutTtl).ttl()).isNull();

--- a/tachyon-core/src/test/java/dev/tachyonmcp/core/protocol/mcp/v2026_07_28/codecs/McpTaskMapperTest.java
+++ b/tachyon-core/src/test/java/dev/tachyonmcp/core/protocol/mcp/v2026_07_28/codecs/McpTaskMapperTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import dev.tachyonmcp.api.server.domain.ServerError;
 import dev.tachyonmcp.api.server.domain.TaskResult;
-import dev.tachyonmcp.api.server.features.tasks.TaskDescriptor;
 import dev.tachyonmcp.api.server.features.tasks.TaskState;
 import dev.tachyonmcp.core.server.features.tasks.TaskEntry;
 import java.time.Duration;
@@ -22,19 +21,17 @@ import tools.jackson.databind.node.JsonNodeFactory;
 class McpTaskMapperTest {
 
     private static TaskEntry entry(TaskState status) {
-        return new TaskEntry(
-                TaskDescriptor.builder().id("task-1").build(),
-                "task-1",
-                status,
-                Duration.ofMinutes(1),
-                "session-1",
-                null,
-                Map.of("trace", "abc"));
+        return TaskEntry.builder("task-1")
+                .status(status)
+                .ttl(Duration.ofMinutes(1))
+                .sessionId("session-1")
+                .meta(Map.of("trace", "abc"))
+                .build();
     }
 
     @Test
     void submittedMapsToSubmittedWireString() {
-        var node = McpTaskMapper.toGetTaskResult(entry(TaskState.SUBMITTED), null, null);
+        var node = McpTaskMapper.toGetTaskResult(entry(TaskState.SUBMITTED), null, null, null);
         assertThat(node.get("status").asString()).isEqualTo("submitted");
         assertThat(node.get("taskId").asString()).isEqualTo("task-1");
         assertThat(node.get("createdAt").asString()).isNotEmpty();
@@ -44,7 +41,7 @@ class McpTaskMapperTest {
 
     @Test
     void unknownMapsToUnknownWireStringInsteadOfThrowing() {
-        var node = McpTaskMapper.toGetTaskResult(entry(TaskState.UNKNOWN), null, null);
+        var node = McpTaskMapper.toGetTaskResult(entry(TaskState.UNKNOWN), null, null, null);
         assertThat(node.get("status").asString()).isEqualTo("unknown");
     }
 
@@ -61,7 +58,7 @@ class McpTaskMapperTest {
 
     @Test
     void wireShapeOmitsNullFieldsButAlwaysWritesTtlMsAndMeta() {
-        var node = McpTaskMapper.toGetTaskResult(entry(TaskState.SUBMITTED), null, null);
+        var node = McpTaskMapper.toGetTaskResult(entry(TaskState.SUBMITTED), null, null, null);
         assertThat(node.has("ttlMs")).isTrue();
         assertThat(node.get("ttlMs").asLong()).isEqualTo(Duration.ofMinutes(1).toMillis());
         assertThat(node.has("statusMessage")).isFalse();
@@ -73,10 +70,9 @@ class McpTaskMapperTest {
     void ttlMsIsWrittenAsNullRatherThanOmittedWhenUnlimited() {
         // SEP-2663 types Task.ttlMs as `number | null` (required) unlike the optional
         // pollIntervalMs -- an unlimited task must still report the key, just with a null value.
-        var unlimited = new TaskEntry(
-                TaskDescriptor.builder().id("task-2").build(), "task-2", TaskState.SUBMITTED, null, null, null, null);
+        var unlimited = TaskEntry.builder("task-2").status(TaskState.SUBMITTED).build();
 
-        var node = McpTaskMapper.toGetTaskResult(unlimited, null, null);
+        var node = McpTaskMapper.toGetTaskResult(unlimited, null, null, null);
 
         assertThat(node.has("ttlMs")).isTrue();
         assertThat(node.get("ttlMs").isNull()).isTrue();
@@ -86,7 +82,7 @@ class McpTaskMapperTest {
     void getTaskResultInlinesTheGivenResultNode() {
         var resultNode = JsonNodeFactory.instance.objectNode().put("text", "done");
 
-        var node = McpTaskMapper.toGetTaskResult(entry(TaskState.COMPLETED), resultNode, null);
+        var node = McpTaskMapper.toGetTaskResult(entry(TaskState.COMPLETED), resultNode, null, null);
 
         assertThat(node.get("result").get("text").asString()).isEqualTo("done");
         assertThat(node.has("error")).isFalse();
@@ -96,10 +92,21 @@ class McpTaskMapperTest {
     void getTaskResultInlinesTheGivenErrorNode() {
         var errorNode = JsonNodeFactory.instance.objectNode().put("code", -32603);
 
-        var node = McpTaskMapper.toGetTaskResult(entry(TaskState.FAILED), null, errorNode);
+        var node = McpTaskMapper.toGetTaskResult(entry(TaskState.FAILED), null, errorNode, null);
 
         assertThat(node.get("error").get("code").asInt()).isEqualTo(-32603);
         assertThat(node.has("result")).isFalse();
+    }
+
+    @Test
+    void getTaskResultInlinesTheGivenInputRequestsNode() {
+        var inputRequestsNode = JsonNodeFactory.instance.objectNode();
+
+        var node = McpTaskMapper.toGetTaskResult(entry(TaskState.INPUT_REQUIRED), null, null, inputRequestsNode);
+
+        assertThat(node.get("inputRequests")).isEqualTo(inputRequestsNode);
+        assertThat(node.has("result")).isFalse();
+        assertThat(node.has("error")).isFalse();
     }
 
     @Test
@@ -107,7 +114,7 @@ class McpTaskMapperTest {
         var task = entry(TaskState.WORKING);
         task.fail(new TaskResult.Failed(List.of(), null, null));
 
-        var node = McpTaskMapper.toGetTaskResult(task, null, null);
+        var node = McpTaskMapper.toGetTaskResult(task, null, null, null);
 
         assertThat(node.get("status").asString()).isEqualTo("completed");
     }
@@ -117,7 +124,7 @@ class McpTaskMapperTest {
         var task = entry(TaskState.WORKING);
         task.fail(TaskResult.failed(new ServerError(ServerError.Kind.INTERNAL_ERROR, "boom")));
 
-        var node = McpTaskMapper.toGetTaskResult(task, null, null);
+        var node = McpTaskMapper.toGetTaskResult(task, null, null, null);
 
         assertThat(node.get("status").asString()).isEqualTo("failed");
     }

--- a/tachyon-core/src/test/java/dev/tachyonmcp/core/protocol/mcp/v2026_07_28/codecs/McpTaskMapperTest.java
+++ b/tachyon-core/src/test/java/dev/tachyonmcp/core/protocol/mcp/v2026_07_28/codecs/McpTaskMapperTest.java
@@ -100,7 +100,7 @@ class McpTaskMapperTest {
 
     @Test
     void getTaskResultInlinesTheGivenInputRequestsNode() {
-        var inputRequestsNode = JsonNodeFactory.instance.objectNode();
+        var inputRequestsNode = JsonNodeFactory.instance.objectNode().put("field", "value");
 
         var node = McpTaskMapper.toGetTaskResult(entry(TaskState.INPUT_REQUIRED), null, null, inputRequestsNode);
 

--- a/tachyon-core/src/test/java/dev/tachyonmcp/core/server/features/tasks/DefaultTaskRegistryTest.java
+++ b/tachyon-core/src/test/java/dev/tachyonmcp/core/server/features/tasks/DefaultTaskRegistryTest.java
@@ -10,7 +10,6 @@ import dev.tachyonmcp.api.server.domain.FormInputRequest;
 import dev.tachyonmcp.api.server.domain.InputRequestBundle;
 import dev.tachyonmcp.api.server.domain.ServerError;
 import dev.tachyonmcp.api.server.domain.TaskResult;
-import dev.tachyonmcp.api.server.features.tasks.TaskDescriptor;
 import dev.tachyonmcp.api.server.features.tasks.TaskOptions;
 import dev.tachyonmcp.api.server.features.tasks.TaskState;
 import dev.tachyonmcp.core.protocol.mcp.v2025_11_25.models.CallToolResult;
@@ -58,17 +57,17 @@ class DefaultTaskRegistryTest {
 
     @Test
     void listWithZeroLimitUsesDefaultPageSize() {
-        registry.add(new TaskEntry("id-a"));
-        registry.add(new TaskEntry("id-b"));
+        registry.add(TaskEntry.builder("id-a").build());
+        registry.add(TaskEntry.builder("id-b").build());
         var result = registry.list(0, null);
         assertThat(result.items()).hasSize(2);
     }
 
     @Test
     void listWithCursorSkipsPastCursor() {
-        registry.add(new TaskEntry("id-alpha"));
-        registry.add(new TaskEntry("id-beta"));
-        registry.add(new TaskEntry("id-gamma"));
+        registry.add(TaskEntry.builder("id-alpha").build());
+        registry.add(TaskEntry.builder("id-beta").build());
+        registry.add(TaskEntry.builder("id-gamma").build());
         var result = registry.list(1, "id-alpha");
         assertThat(result.items()).hasSize(1);
         assertThat(result.items().getFirst().id()).isEqualTo("id-beta");
@@ -76,15 +75,15 @@ class DefaultTaskRegistryTest {
 
     @Test
     void listReturnsCursorWhenMoreItemsAvailable() {
-        registry.add(new TaskEntry("id-a"));
-        registry.add(new TaskEntry("id-b"));
+        registry.add(TaskEntry.builder("id-a").build());
+        registry.add(TaskEntry.builder("id-b").build());
         var result = registry.list(1, null);
         assertThat(result.nextCursor()).isEqualTo("id-a");
     }
 
     @Test
     void listReturnsNullCursorWhenAllItemsReturned() {
-        registry.add(new TaskEntry("id-a"));
+        registry.add(TaskEntry.builder("id-a").build());
         var result = registry.list(10, null);
         assertThat(result.nextCursor()).isNull();
     }
@@ -94,8 +93,8 @@ class DefaultTaskRegistryTest {
         try (var engine = newEngine(b -> {})) {
             var reg = new DefaultTaskRegistry(
                     engine, TasksConfig.builder().pageSize(1).build());
-            reg.add(new TaskEntry("id-a"));
-            reg.add(new TaskEntry("id-b"));
+            reg.add(TaskEntry.builder("id-a").build());
+            reg.add(TaskEntry.builder("id-b").build());
             var result = reg.list(0, null);
             assertThat(result.items()).hasSize(1);
             assertThat(result.nextCursor()).isEqualTo("id-a");
@@ -104,8 +103,8 @@ class DefaultTaskRegistryTest {
 
     @Test
     void listTasksReturnsRegisteredTasks() throws Exception {
-        registry.add(new TaskEntry("1"));
-        registry.add(new TaskEntry("2"));
+        registry.add(TaskEntry.builder("1").build());
+        registry.add(TaskEntry.builder("2").build());
 
         var listHandler = handlers.get("tasks/list");
         var result = (ListTasksResult) listHandler.handle(DefaultDispatchContext.noop(), null);
@@ -123,7 +122,7 @@ class DefaultTaskRegistryTest {
 
     @Test
     void getTaskReturnsResult() throws Exception {
-        registry.add(new TaskEntry("task-1"));
+        registry.add(TaskEntry.builder("task-1").build());
 
         var getHandler = handlers.get("tasks/get");
         var result = getHandler.handle(DefaultDispatchContext.noop(), Map.of("taskId", "task-1"));
@@ -142,7 +141,7 @@ class DefaultTaskRegistryTest {
 
     @Test
     void cancelTaskReturnsCancelTaskResult() throws Exception {
-        registry.add(new TaskEntry("task-1"));
+        registry.add(TaskEntry.builder("task-1").build());
 
         var cancelHandler = handlers.get("tasks/cancel");
         var result = cancelHandler.handle(DefaultDispatchContext.noop(), Map.of("taskId", "task-1"));
@@ -170,7 +169,7 @@ class DefaultTaskRegistryTest {
     @Test
     @Timeout(5)
     void taskResultBlocksUntilTaskReachesTerminalState() throws Exception {
-        registry.add(new TaskEntry("task-1"));
+        registry.add(TaskEntry.builder("task-1").build());
         var resultHandler = handlers.get("tasks/result");
 
         // SEP-1686: tasks/result MUST block a working task until it is terminal. Complete it from
@@ -195,7 +194,7 @@ class DefaultTaskRegistryTest {
 
     @Test
     void taskResultCompletedTaskReturnsPayload() throws Exception {
-        registry.add(new TaskEntry("task-1"));
+        registry.add(TaskEntry.builder("task-1").build());
         registry.completeTask("task-1", "{\"result\":\"ok\"}");
 
         var resultHandler = handlers.get("tasks/result");
@@ -314,20 +313,16 @@ class DefaultTaskRegistryTest {
 
     @Test
     void taskNotExpiredWithoutTtl() {
-        var entry = new TaskEntry("exp-1");
+        var entry = TaskEntry.builder("exp-1").build();
         assertThat(entry.isExpired()).isFalse();
     }
 
     @Test
     void taskExpiresAfterTtl() throws Exception {
-        var entry = new TaskEntry(
-                TaskDescriptor.builder().id("exp-1").build(),
-                "exp-1",
-                TaskState.WORKING,
-                Duration.ofMillis(10),
-                null,
-                null,
-                null);
+        var entry = TaskEntry.builder("exp-1")
+                .status(TaskState.WORKING)
+                .ttl(Duration.ofMillis(10))
+                .build();
         var deadline = System.currentTimeMillis() + 500;
         while (!entry.isExpired() && System.currentTimeMillis() < deadline) {
             Thread.sleep(1);
@@ -337,30 +332,20 @@ class DefaultTaskRegistryTest {
 
     @Test
     void taskResultNotExpiredBeforeKeepAliveElapses() {
-        var entry = new TaskEntry(
-                TaskDescriptor.builder().id("res-1").build(),
-                "res-1",
-                TaskState.WORKING,
-                null,
-                null,
-                null,
-                null,
-                Duration.ofMillis(200));
+        var entry = TaskEntry.builder("res-1")
+                .status(TaskState.WORKING)
+                .keepAlive(Duration.ofMillis(200))
+                .build();
         entry.complete(new TaskResult.Completed(null));
         assertThat(entry.isResultExpired()).isFalse();
     }
 
     @Test
     void taskResultExpiresAfterKeepAlive() throws Exception {
-        var entry = new TaskEntry(
-                TaskDescriptor.builder().id("res-2").build(),
-                "res-2",
-                TaskState.WORKING,
-                null,
-                null,
-                null,
-                null,
-                Duration.ofMillis(10));
+        var entry = TaskEntry.builder("res-2")
+                .status(TaskState.WORKING)
+                .keepAlive(Duration.ofMillis(10))
+                .build();
         entry.complete(new TaskResult.Completed(null));
 
         var deadline = System.currentTimeMillis() + 500;
@@ -372,15 +357,10 @@ class DefaultTaskRegistryTest {
 
     @Test
     void taskResultNeverExpiresWithZeroKeepAlive() {
-        var entry = new TaskEntry(
-                TaskDescriptor.builder().id("res-3").build(),
-                "res-3",
-                TaskState.WORKING,
-                null,
-                null,
-                null,
-                null,
-                Duration.ZERO);
+        var entry = TaskEntry.builder("res-3")
+                .status(TaskState.WORKING)
+                .keepAlive(Duration.ZERO)
+                .build();
         entry.complete(new TaskResult.Completed(null));
         assertThat(entry.isResultExpired()).isFalse();
     }
@@ -437,7 +417,7 @@ class DefaultTaskRegistryTest {
 
     @Test
     void updateStatusFromClientNotification() {
-        registry.add(new TaskEntry("task-1"));
+        registry.add(TaskEntry.builder("task-1").build());
 
         var result = registry.updateStatus("task-1", TaskState.INPUT_REQUIRED, "Need more info");
 
@@ -455,7 +435,7 @@ class DefaultTaskRegistryTest {
 
     @Test
     void updateStatusFromClientNotificationInvalidTransition() {
-        registry.add(new TaskEntry("task-1"));
+        registry.add(TaskEntry.builder("task-1").build());
         registry.completeTask("task-1", "{\"ok\":true}");
 
         var result = registry.updateStatus("task-1", TaskState.WORKING, null);
@@ -480,7 +460,7 @@ class DefaultTaskRegistryTest {
         var callCount = new AtomicInteger(0);
         registry.onChange(callCount::incrementAndGet);
 
-        registry.add(new TaskEntry("id-x"));
+        registry.add(TaskEntry.builder("id-x").build());
 
         assertThat(callCount).hasValue(1);
     }
@@ -489,7 +469,7 @@ class DefaultTaskRegistryTest {
     void shouldFireOnChangeWhenExistingTaskRemoved() {
         // Default single-arg constructor starts WORKING (non-terminal), so remove() cancels
         // it first (1 onChange) before removing it from the index (2nd onChange).
-        registry.add(new TaskEntry("id-x"));
+        registry.add(TaskEntry.builder("id-x").build());
 
         var callCount = new AtomicInteger(0);
         registry.onChange(callCount::incrementAndGet);

--- a/tachyon-core/src/test/java/dev/tachyonmcp/core/server/features/tasks/DefaultTaskRegistryTest.java
+++ b/tachyon-core/src/test/java/dev/tachyonmcp/core/server/features/tasks/DefaultTaskRegistryTest.java
@@ -272,9 +272,7 @@ class DefaultTaskRegistryTest {
     @Test
     void requireInputTransitionsToInputRequiredAndStoresPendingRequest() {
         var task = registry.create();
-        // Task has no public "start" method; resume() also legally moves SUBMITTED -> WORKING
-        // per the FSM, so it's the server-facing way to leave SUBMITTED before requireInput().
-        task.resume(null);
+        assertThat(registry.updateStatus(task.id(), TaskState.WORKING, null)).isTrue();
         var bundle = new InputRequestBundle(
                 Map.of("user_name", FormInputRequest.of("What is your name?", JsonSchema.objectSchema())),
                 "state-token");
@@ -289,12 +287,12 @@ class DefaultTaskRegistryTest {
     @Test
     void pendingInputClearsOnceTaskLeavesInputRequired() {
         var task = registry.create();
-        task.resume(null);
+        assertThat(registry.updateStatus(task.id(), TaskState.WORKING, null)).isTrue();
         var bundle = new InputRequestBundle(
                 Map.of("user_name", FormInputRequest.of("What is your name?", JsonSchema.objectSchema())), null);
         task.requireInput(bundle, null);
 
-        assertThat(task.resume(null)).isTrue();
+        assertThat(registry.updateStatus(task.id(), TaskState.WORKING, null)).isTrue();
 
         assertThat(registry.getById(task.id()).pendingInput()).isNull();
     }

--- a/tachyon-core/src/test/java/dev/tachyonmcp/core/server/features/tasks/DefaultTaskRegistryTest.java
+++ b/tachyon-core/src/test/java/dev/tachyonmcp/core/server/features/tasks/DefaultTaskRegistryTest.java
@@ -12,6 +12,7 @@ import dev.tachyonmcp.api.server.domain.ServerError;
 import dev.tachyonmcp.api.server.domain.TaskResult;
 import dev.tachyonmcp.api.server.features.tasks.TaskOptions;
 import dev.tachyonmcp.api.server.features.tasks.TaskState;
+import dev.tachyonmcp.core.protocol.Protocols;
 import dev.tachyonmcp.core.protocol.mcp.v2025_11_25.models.CallToolResult;
 import dev.tachyonmcp.core.protocol.mcp.v2025_11_25.models.CancelTaskResult;
 import dev.tachyonmcp.core.protocol.mcp.v2025_11_25.models.GetTaskResult;
@@ -282,6 +283,34 @@ class DefaultTaskRegistryTest {
         assertThat(task.status()).isEqualTo(TaskState.INPUT_REQUIRED);
         assertThat(task.statusMessage()).isEqualTo("need more info");
         assertThat(registry.getById(task.id()).pendingInput()).isEqualTo(bundle);
+    }
+
+    @Test
+    void taskUpdateFailureMarksTaskFailedAndUnregistersResumer() throws Exception {
+        var task = (TaskEntry) registry.create();
+        assertThat(registry.updateStatus(task.id(), TaskState.WORKING, null)).isTrue();
+        task.requireInput(
+                new InputRequestBundle(
+                        Map.of("user_name", FormInputRequest.of("What is your name?", JsonSchema.objectSchema())),
+                        null),
+                null);
+        registry.registerResumer(task.id(), (context, responses, state) -> {
+            throw new IllegalStateException("boom");
+        });
+        var context = DefaultDispatchContext.create(
+                Protocols.list().stream()
+                        .filter(protocol -> protocol.versionString().equals("2026-07-28"))
+                        .findFirst()
+                        .orElseThrow(),
+                engine);
+        context.enableExtension(TasksExtension.ID);
+
+        var result = handlers.get("tasks/update")
+                .handle(context, Map.of("taskId", task.id(), "inputResponses", Map.of("user_name", "Alice")));
+
+        assertThat(result).isNotInstanceOf(ServerError.class);
+        assertThat(task.status()).isEqualTo(TaskState.FAILED);
+        assertThat(registry.findResumer(task.id())).isNull();
     }
 
     @Test

--- a/tachyon-core/src/test/java/dev/tachyonmcp/core/server/features/tasks/TaskEntryTest.java
+++ b/tachyon-core/src/test/java/dev/tachyonmcp/core/server/features/tasks/TaskEntryTest.java
@@ -3,21 +3,36 @@ package dev.tachyonmcp.core.server.features.tasks;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import dev.tachyonmcp.api.server.features.tasks.TaskDescriptor;
+import dev.tachyonmcp.api.json.JsonSchema;
+import dev.tachyonmcp.api.server.domain.FormInputRequest;
+import dev.tachyonmcp.api.server.domain.InputRequestBundle;
 import dev.tachyonmcp.api.server.features.tasks.TaskState;
-import dev.tachyonmcp.core.server.config.TasksConfig;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
 import org.junit.jupiter.api.Test;
 
 class TaskEntryTest {
 
     private static TaskEntry entry(Duration ttl) {
-        return new TaskEntry(
-                TaskDescriptor.builder().id("task-1").build(), "task-1", TaskState.WORKING, ttl, null, null);
+        return TaskEntry.builder("task-1").status(TaskState.WORKING).ttl(ttl).build();
+    }
+
+    private static TaskEntry workingEntry() {
+        return entry(null);
+    }
+
+    private static InputRequestBundle bundleOf(Map<String, String> requestedKeysToPrompts, String requestState) {
+        Map<String, dev.tachyonmcp.api.server.domain.InputRequest> requests = new HashMap<>();
+        requestedKeysToPrompts.forEach(
+                (key, prompt) -> requests.put(key, FormInputRequest.of(prompt, JsonSchema.objectSchema())));
+        return new InputRequestBundle(requests, requestState);
     }
 
     @Test
@@ -49,18 +64,11 @@ class TaskEntryTest {
     @Test
     void controllableClockFlipsExpiryAndMovesLastUpdatedAt() {
         var clock = new MutableClock(Instant.parse("2025-01-01T00:00:00Z"));
-        var entry = new TaskEntry(
-                TaskDescriptor.builder().id("clock-1").build(),
-                "clock-1",
-                TaskState.WORKING,
-                Duration.ofMinutes(10),
-                null,
-                null,
-                null,
-                TasksConfig.DEFAULT_TASK_KEEP_ALIVE,
-                null,
-                ignored -> {},
-                clock);
+        var entry = TaskEntry.builder("clock-1")
+                .status(TaskState.WORKING)
+                .ttl(Duration.ofMinutes(10))
+                .clock(clock)
+                .build();
         var lastUpdated = entry.lastUpdatedAt();
         assertThat(entry.createdAt()).isEqualTo(clock.instant());
         assertThat(entry.isExpired()).isFalse();
@@ -73,6 +81,124 @@ class TaskEntryTest {
 
         clock.advance(Duration.ofMinutes(11));
         assertThat(entry.isExpired()).isTrue();
+    }
+
+    @Test
+    void submitInputFiltersUnknownAndAlreadySatisfiedKeys() {
+        var entry = workingEntry();
+        entry.requireInput(bundleOf(Map.of("user_name", "What is your name?"), "state-1"), null);
+
+        var responses = new HashMap<String, Object>();
+        responses.put("user_name", "Alice");
+        responses.put("unknown_key", "ignored");
+        var result = entry.submitInput(responses);
+
+        assertThat(result).isNotNull();
+        assertThat(result.inputResponses()).isEqualTo(Map.of("user_name", "Alice"));
+        assertThat(result.requestState()).isEqualTo("state-1");
+        assertThat(entry.status()).isEqualTo(TaskState.WORKING);
+    }
+
+    @Test
+    void submitInputIsNoOpWhenNotAwaitingInput() {
+        var entry = workingEntry();
+
+        var result = entry.submitInput(Map.of("user_name", "Alice"));
+
+        assertThat(result).isNull();
+        assertThat(entry.status()).isEqualTo(TaskState.WORKING);
+    }
+
+    @Test
+    void submitInputAcceptsPartialResponsesAcrossMultipleCalls() {
+        var entry = workingEntry();
+        entry.requireInput(bundleOf(Map.of("name", "Your name?", "email", "Your email?"), null), null);
+
+        var first = entry.submitInput(Map.of("name", "Alice"));
+        assertThat(first).isNull();
+        assertThat(entry.status()).isEqualTo(TaskState.INPUT_REQUIRED);
+
+        var second = entry.submitInput(Map.of("email", "alice@example.com"));
+
+        assertThat(second).isNotNull();
+        assertThat(second.inputResponses()).isEqualTo(Map.of("name", "Alice", "email", "alice@example.com"));
+        assertThat(entry.status()).isEqualTo(TaskState.WORKING);
+    }
+
+    @Test
+    void submitInputAccumulatorResetsOnNewInputRequiredRound() {
+        var entry = workingEntry();
+        entry.requireInput(bundleOf(Map.of("key1", "Q1"), "round-1"), null);
+        entry.submitInput(Map.of("key1", "answer-1")); // resumes -> WORKING, clears the accumulator
+
+        entry.requireInput(bundleOf(Map.of("key2", "Q2"), "round-2"), null);
+        var result = entry.submitInput(Map.of("key2", "answer-2"));
+
+        assertThat(result).isNotNull();
+        assertThat(result.inputResponses()).isEqualTo(Map.of("key2", "answer-2"));
+        assertThat(result.requestState()).isEqualTo("round-2");
+    }
+
+    @Test
+    void submitInputForStaleRoundKeysCannotResumeANewerRound() {
+        var entry = workingEntry();
+        entry.requireInput(bundleOf(Map.of("key1", "Q1"), "round-1"), null);
+        entry.submitInput(Map.of("key1", "answer-1")); // resumes -> WORKING
+
+        entry.requireInput(bundleOf(Map.of("key2", "Q2"), "round-2"), null); // now parked on round 2
+
+        // A stale submission carrying round 1's key arrives after round 2 has already begun.
+        var result = entry.submitInput(Map.of("key1", "late-answer"));
+
+        assertThat(result).isNull();
+        assertThat(entry.status()).isEqualTo(TaskState.INPUT_REQUIRED);
+    }
+
+    @Test
+    void submitInputAcceptsNullResponseValue() {
+        var entry = workingEntry();
+        entry.requireInput(bundleOf(Map.of("optional", "Optional?"), null), null);
+
+        var responses = new HashMap<String, Object>();
+        responses.put("optional", null);
+        var result = entry.submitInput(responses);
+
+        assertThat(result).isNotNull();
+        assertThat(result.inputResponses()).containsKey("optional");
+        assertThat(result.inputResponses().get("optional")).isNull();
+    }
+
+    @Test
+    void concurrentSubmitInputResumesExactlyOnce() throws InterruptedException {
+        var entry = workingEntry();
+        entry.requireInput(bundleOf(Map.of("key1", "Q1", "key2", "Q2"), null), null);
+        entry.submitInput(Map.of("key1", "answer-1")); // one key satisfied, one outstanding
+
+        var ready = new CountDownLatch(2);
+        var go = new CountDownLatch(1);
+        var results = new CopyOnWriteArrayList<TaskEntry.ResumeInputs>();
+        Runnable submitLastKey = () -> {
+            ready.countDown();
+            try {
+                go.await();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            var result = entry.submitInput(Map.of("key2", "answer-2"));
+            if (result != null) results.add(result);
+        };
+        var t1 = new Thread(submitLastKey);
+        var t2 = new Thread(submitLastKey);
+        t1.start();
+        t2.start();
+        ready.await();
+        go.countDown();
+        t1.join();
+        t2.join();
+
+        assertThat(results).hasSize(1);
+        assertThat(results.get(0).inputResponses()).isEqualTo(Map.of("key1", "answer-1", "key2", "answer-2"));
+        assertThat(entry.status()).isEqualTo(TaskState.WORKING);
     }
 
     /** A tiny mutable {@link Clock} so TTL/expiry can be driven deterministically. */

--- a/tachyon-kotlin/pom.xml
+++ b/tachyon-kotlin/pom.xml
@@ -233,11 +233,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>me.kpavlov.kbcv.maven.plugin</groupId>
-                <artifactId>kbcv-maven-plugin</artifactId>
-                <version>0.1.0-SNAPSHOT</version>
-            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION

The change adds tasks/update support for MCP 2026-07-28. Tasks expose pending input through tasks/get, accumulate submitted responses, and resume registered task producers when all required input is present. Legacy MCP 2025-11-25 behavior remains unchanged. The public Task.resume method is removed. TaskEntry now uses a builder and synchronized input state. Tests cover protocol gating, partial input, multiple rounds, invalid tasks, and no-op updates.

### New Features

- Added support for resuming paused tasks by submitting requested input.
- Task results can now display pending input requests.
- Added support for multiple input rounds, partial responses, ignored unknown fields, and nullable values.
- Task updates are available only when supported by the negotiated protocol and capabilities.

### Documentation

- Documented task resumption behavior, protocol requirements, and limitations.

### Bug Fixes

- Improved task lifecycle handling, including cleanup after completion, cancellation, or expiration.
- Prevented unsupported task updates from being accepted by legacy protocols.