### PR TITLE
fix(deps): Move BOMs up to enforce (#266)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,6 +116,38 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
+                <groupId>tools.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>${jackson.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-bom</artifactId>
+                <version>${netty.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-bom</artifactId>
+                <version>${slf4j.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.immutables</groupId>
+                <artifactId>bom</artifactId>
+                <version>${immutables.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+
+            <dependency>
                 <groupId>dev.tachyonmcp</groupId>
                 <artifactId>tachyon-api</artifactId>
                 <version>${project.version}</version>
@@ -158,37 +190,7 @@
                 <version>${snakeyaml.version}</version>
             </dependency>
 
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-bom</artifactId>
-                <version>${netty.version}</version>
-                <scope>import</scope>
-                <type>pom</type>
-            </dependency>
 
-            <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-bom</artifactId>
-                <version>${slf4j.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-
-            <dependency>
-                <groupId>org.immutables</groupId>
-                <artifactId>bom</artifactId>
-                <version>${immutables.version}</version>
-                <scope>import</scope>
-                <type>pom</type>
-            </dependency>
-
-            <dependency>
-                <groupId>tools.jackson</groupId>
-                <artifactId>jackson-bom</artifactId>
-                <version>${jackson.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
             <dependency>
                 <groupId>com.networknt</groupId>
                 <artifactId>json-schema-validator</artifactId>


### PR DESCRIPTION
Move BOM dependencies to the top of dependency management, so they win

Fixes #266

```console
$ mvn dependency:tree | grep jackson
[INFO] +- tools.jackson.core:jackson-databind:jar:3.2.2:compile
[INFO] |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.22:compile
[INFO] |  \- tools.jackson.core:jackson-core:jar:3.2.2:compile
[INFO] |  \- tools.jackson.dataformat:jackson-dataformat-yaml:jar:3.2.2:compile
[INFO] |  +- tools.jackson.core:jackson-databind:jar:3.2.2:compile
[INFO] |  |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.22:compile
[INFO] |  |  \- tools.jackson.core:jackson-core:jar:3.2.2:compile
[INFO] |     \- tools.jackson.dataformat:jackson-dataformat-yaml:jar:3.2.2:compile
[INFO] |  |  +- tools.jackson.core:jackson-databind:jar:3.2.2:compile
[INFO] |  |  |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.22:compile
[INFO] |  |  |  \- tools.jackson.core:jackson-core:jar:3.2.2:compile
[INFO] |  |     \- tools.jackson.dataformat:jackson-dataformat-yaml:jar:3.2.2:compile
[INFO] |     \- tools.jackson.dataformat:jackson-dataformat-yaml:jar:3.2.2:compile
[INFO] +- tools.jackson.core:jackson-databind:jar:3.2.2:compile
[INFO] |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.22:compile
[INFO] |  \- tools.jackson.core:jackson-core:jar:3.2.2:compile
[INFO] |  +- tools.jackson.core:jackson-databind:jar:3.2.2:compile
[INFO] |  |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.22:compile
[INFO] |  |  \- tools.jackson.core:jackson-core:jar:3.2.2:compile
[INFO] |     \- tools.jackson.dataformat:jackson-dataformat-yaml:jar:3.2.2:compile
[INFO] |  +- tools.jackson.core:jackson-databind:jar:3.2.2:compile
[INFO] |  |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.22:compile
[INFO] |  |  \- tools.jackson.core:jackson-core:jar:3.2.2:compile
[INFO] |     \- tools.jackson.dataformat:jackson-dataformat-yaml:jar:3.2.2:compile
[INFO] +- io.modelcontextprotocol.sdk:mcp-json-jackson3:jar:2.0.1:test
[INFO] |  +- tools.jackson.core:jackson-databind:jar:3.2.2:compile
[INFO] |  |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.22:compile
[INFO] |  |  \- tools.jackson.core:jackson-core:jar:3.2.2:compile
[INFO] |     \- tools.jackson.dataformat:jackson-dataformat-yaml:jar:3.2.2:compile
[INFO] |  +- tools.jackson.core:jackson-databind:jar:3.2.2:compile
[INFO] |  |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.22:compile
[INFO] |  |  \- tools.jackson.core:jackson-core:jar:3.2.2:compile
[INFO] |     \- tools.jackson.dataformat:jackson-dataformat-yaml:jar:3.2.2:compile
```