### PR TITLE
feat(kotlin): close DSL attribute gaps for resource/prompt/template

### DIFF
--- a/.agents/skills/tachyon-development/SKILL.md
+++ b/.agents/skills/tachyon-development/SKILL.md
@@ -20,19 +20,18 @@ description: Apply Tachyon MCP project rules when designing, implementing, revie
 
 # Test Rules 🧪
 
-- AssertJ fluent. Short spec ref comment in method. JUnit6+JUnit Pioneer annotations. Prefer parametrized tests.
+- Java: AssertJ fluent. Short spec ref comment in method. JUnit6+JUnit Pioneer annotations. Prefer parametrized tests.
 - Handlers that throw: test with a real checked exception thrown directly from the lambda (no try/catch) — exercises the `throws Exception` SAM contract, not just unchecked paths.
 - "Omitted/null on wire" claims: serialize through the real codec (`CodecRegistry.codecFor(X.class).encodeToBytes(value)`, or `JsonRpcCodec.writeValueAsString`) and assert on the resulting JSON. Asserting a domain/model field is `null` only proves the mapper produced `null` — it trusts, but doesn't verify, that the codec omits it.
-
-## E2E
-
-- Java MCP SDK client. Raw HTTP only for edge cases.
 - `JsonUnit` + AssertJ for JSON. Assert full JSON via `assertThatJson(actual).isEqualTo(expected)`, dynamic values (IDs etc.) via `.formatted(...)` — not `inPath(...)` fragments, which can hide a wrong response shape behind passing checks. `whenIgnoringPaths`, `IGNORING_ARRAY_ORDER`, `IGNORING_EXTRA_FIELDS`, `TREATING_NULL_AS_ABSENT` for partial tolerance.
 - `// language=json` before JSON strings.
-- Awaitility for polling.
-- Kotlin: use kotest-assertions
+- Kotlin: kotest-assertions, kotest-assertions-json for json payload testing. Assert full JSON
 
-### Shared E2E servers
+## E2E
+- Use mcp client and assertions from tachyon-testkit
+- Test for full payload(all attributes) and minimal set of attributes
+
+## Shared E2E servers
 
 - Treat shared stateful/stateless singleton servers as production-parity SUTs, not just suite optimizations.
 - Keep shared server config/registries immutable after startup. Tests that register or replace features use an isolated `startServer(...)`.
@@ -42,12 +41,13 @@ description: Apply Tachyon MCP project rules when designing, implementing, revie
 - For stateless concurrency, verify: parallel initialization returns no session ID, concurrent requests never cross responses or client data.
 - Test observable server behavior through real clients. Don't add tests for test helpers.
 
-## JSON Schemas
+# JSON/JSON Schemas
 
+- Avoid creating new helpers for parsing json/schemas, reuse `dev.tachyonmcp.api.json`
 - Static schema → parse text block. `ObjectMapper.readTree("""...""")` or shared `parseJson(String)` helper. `// language=json` for IDE.
 - Imperative `JsonNodeFactory` only for runtime-computed schemas.
 
-## Logging
+# Logging
 
 [Logging policy](https://kpavlov.me/blog/logging-policy/)
 

--- a/.agents/skills/tachyon-mcp/resources/kotlin/PromptFnExample.kt
+++ b/.agents/skills/tachyon-mcp/resources/kotlin/PromptFnExample.kt
@@ -33,6 +33,8 @@ fun argDescriptor(): PromptDescriptor =
             required = false
         }
         // inputSchema also settable
+        extensionId = "com.example/rewrite"
+        meta = mapOf("version" to 2)
     }
 
 /** Receiver factory with required and optional properties. */

--- a/.agents/skills/tachyon-mcp/resources/kotlin/ResourceFnExample.kt
+++ b/.agents/skills/tachyon-mcp/resources/kotlin/ResourceFnExample.kt
@@ -37,6 +37,8 @@ fun richDescriptor(): ResourceDescriptor =
                     theme = "dark",
                 ),
             )
+        extensionId = "com.example/profiles"
+        meta = mapOf("cacheable" to true)
     }
 
 /** URI template — {param} segments captured at runtime. */

--- a/docs/architecture/guidance.md
+++ b/docs/architecture/guidance.md
@@ -114,7 +114,7 @@ those same façade APIs; do not add feature-specific registration overloads to `
 - Do not reimplement Java builder validation, defaulting, or registration collections in Kotlin. Add missing reusable behavior to Java first, then expose it through the Kotlin DSL.
 - Expose one Kotlin server-construction surface: `TachyonServerBuilder`. Do not publish Kotlin extensions on the Java `ServerBuilder`; they bypass Kotlin defaults and duplicate autocomplete. Use an internal owned collaborator when thin adaptation would make the public builder too large.
 - Keep Kotlin files focused. Once a file exceeds 300 lines, consider splitting it by owned responsibility. Do not split member DSLs into global extensions merely to reduce line count; prefer composition with an internal class.
-- Keep required values first and flexible metadata as defaulted named parameters on the common call. Named arguments remove ambiguity; do not hide useful descriptor fields in a registration sub-DSL.
+- Keep required values first and flexible metadata as defaulted named parameters on the common call. Named arguments remove ambiguity; do not hide useful descriptor fields in a registration sub-DSL. Exception: `extensionId` — see the note below the reference shape.
 - Keep a value overload accepting the prebuilt descriptor for reuse, testing, and advanced construction.
 - Name a trailing behavioral lambda `block`. Do not add a ceremonial `handler {}` or `read {}` wrapper inside another configuration lambda.
 - Use a result DSL when it removes repeated request data. Seed contextual defaults such as the requested resource URI and registered MIME type, while allowing explicit overrides.
@@ -131,6 +131,7 @@ resourceTemplate(
     title = "User profile",
     annotations = annotations,
     icons = icons,
+    meta = mapOf("owner" to "team-x"),
 ) {
     TextResourceContents {
         text = """{"id":"${param("userId")}"}"""
@@ -148,7 +149,8 @@ fun resourceTemplate(
     mimeType: String? = null,
     title: String? = null,
     annotations: Annotations? = null,
-    icons: List<Icon>? = null,
+    icons: List<Icon> = emptyList(),
+    meta: Map<String, Any>? = null,
     block: suspend TemplateScope.() -> ResourceContents,
 )
 
@@ -157,6 +159,23 @@ fun resourceTemplate(
     block: suspend TemplateScope.() -> ResourceContents,
 )
 ```
+
+Every field here maps directly onto the corresponding `*Descriptor.Builder` field — add a new
+flat param the moment the Java builder gains one, don't let the Kotlin overload drift behind it.
+
+⚠️ **`extensionId` is the one deliberate exception** — never add it as a flat named parameter on
+`tool`/`resource`/`resourceTemplate`/`prompt`/`registerTool`. It marks extension-owned features:
+`ResourceMethodHandlers`/`PromptMethodHandlers`/`ToolMethodHandlers` filter both `*/list` results
+and direct reads to only the extensions the current session negotiated
+(`context.isExtensionEnabled`), so a feature carrying an `extensionId` with no matching negotiated
+extension becomes silently invisible — a footgun for ordinary server authors who'd never touch it
+otherwise. It never appears on the wire either way. The one real caller
+(`TasksExtension.java`) sets it via the raw Java `*Descriptor.Builder` in its own bootstrap code —
+extension implementations are the intended and only audience. Kotlin still exposes it, but only
+on the `*DescriptorScope`/`*Builder` DSL classes (`ToolDescriptorScope`, `ResourceDescriptorScope`,
+`ResourceTemplateDescriptorBuilder`, `PromptDescriptorScope`), marked `@ExperimentalApi` to signal
+it's for advanced/extension use: `resourceDescriptor(name, uri) { extensionId = MY_EXT_ID }` then
+`resource(descriptor) { }` — never `resource(name, uri, extensionId = ...) { }`.
 
 ## ⚠️ `_meta` stays out of the ergonomic surface
 

--- a/docs/kotlin.md
+++ b/docs/kotlin.md
@@ -166,12 +166,13 @@ prompt(
 }
 ```
 
-`extensionId` is deliberately not one of these named params — it marks a resource/tool/prompt as
-owned by a specific extension (gating its visibility to sessions that negotiated that extension;
-see [Extensions](extensions.md)) and is meant for extension implementations, not ordinary server
-code. Set it through the descriptor scope instead, e.g. `resourceDescriptor(name, uri) {
-extensionId = MY_EXTENSION_ID }`, then pass the built descriptor to the `resource(descriptor) { }`
-overload.
+`extensionId` is deliberately not one of these named params — it marks a
+resource/resourceTemplate/tool/prompt as owned by a specific extension (gating its visibility to
+sessions that negotiated that extension; see [Extensions](extensions.md)) and is meant for
+extension implementations, not ordinary server code. Set it through the descriptor scope instead,
+e.g. `resourceDescriptor(name, uri) { extensionId = MY_EXTENSION_ID }` or
+`ResourceTemplateDescriptor { extensionId = MY_EXTENSION_ID }`, then pass the built descriptor to
+the `resource(descriptor) { }` or `resourceTemplate(descriptor) { }` overload.
 
 Inside a resource handler, `TextResourceContents { }` and `BlobResourceContents { }` default `uri`
 to the requested URI and `mimeType` to the registered resource MIME type. You can override either

--- a/docs/kotlin.md
+++ b/docs/kotlin.md
@@ -130,6 +130,7 @@ resource(
     annotations = Annotations { priority = 0.8 },
     size = 1024,
     icons = listOf(Icon { src = "https://example.com/config.svg" }),
+    meta = mapOf("owner" to "team-x"),
 ) {
     // this: ResourceScope — ctx, uri, params, uriTemplate
     val config = fetchConfig()  // suspend call
@@ -141,6 +142,36 @@ prompt(name = "greet", description = "Greeting prompt") {
     listOf(PromptMessage.user("Hello, ${arguments ?: "world"}"))
 }
 ```
+
+`prompt(...)` accepts the full `PromptDescriptor` attribute set as named params too:
+
+```kotlin
+prompt(
+    name = "rewrite",
+    description = "Rewrites text in a style",
+    title = "Rewrite Tool",
+    arguments =
+        listOf(
+            PromptArgument {
+                name = "style"
+                required = false
+            },
+        ),
+    inputSchema = schema,
+    icons = listOf(Icon { src = "https://example.com/rewrite.svg" }),
+    meta = mapOf("owner" to "team-x"),
+) {
+    val style = arguments.stringOrNull("style") ?: "a neutral"
+    listOf(PromptMessage.user("Rewrite this in $style style"))
+}
+```
+
+`extensionId` is deliberately not one of these named params — it marks a resource/tool/prompt as
+owned by a specific extension (gating its visibility to sessions that negotiated that extension;
+see [Extensions](extensions.md)) and is meant for extension implementations, not ordinary server
+code. Set it through the descriptor scope instead, e.g. `resourceDescriptor(name, uri) {
+extensionId = MY_EXTENSION_ID }`, then pass the built descriptor to the `resource(descriptor) { }`
+overload.
 
 Inside a resource handler, `TextResourceContents { }` and `BlobResourceContents { }` default `uri`
 to the requested URI and `mimeType` to the registered resource MIME type. You can override either

--- a/e2e/src/test/kotlin/dev/tachyonmcp/e2e/ResourcePromptAttributesE2eTest.kt
+++ b/e2e/src/test/kotlin/dev/tachyonmcp/e2e/ResourcePromptAttributesE2eTest.kt
@@ -1,0 +1,201 @@
+// Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors.
+package dev.tachyonmcp.e2e
+
+import dev.tachyonmcp.api.json.JsonSchema
+import dev.tachyonmcp.kotlin.server.TachyonServer
+import dev.tachyonmcp.kotlin.server.domain.Annotations
+import dev.tachyonmcp.kotlin.server.domain.Icon
+import dev.tachyonmcp.kotlin.server.domain.PromptArgument
+import dev.tachyonmcp.kotlin.server.domain.TextResourceContents
+import dev.tachyonmcp.kotlin.server.features.prompts.PromptDescriptor
+import dev.tachyonmcp.kotlin.server.features.resources.ResourceTemplateDescriptor
+import dev.tachyonmcp.kotlin.server.features.resources.resourceDescriptor
+import io.kotest.matchers.equals.shouldEqual
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
+import org.junit.jupiter.api.Test
+
+/**
+ * Exercises the full flat-parameter attribute set of the Kotlin DSL's `resource`,
+ * `resourceTemplate`, and `prompt` registration functions end-to-end. Every optional attribute
+ * (`title`, `annotations`, `size`, `icons`, `meta`, `arguments`, `inputSchema`) is unused by every
+ * other e2e/example call site in this repo, so this is the only place proving the full flat shape
+ * actually works over the wire, not just at the unit level.
+ *
+ * `extensionId` is deliberately NOT one of the flat parameters — it's an extension-ownership
+ * marker for extension implementations, set via the `*DescriptorScope`/`*Builder` DSL (or the raw
+ * Java `*Descriptor.Builder`), never as an ordinary named argument. `ResourceMethodHandlers`/
+ * `PromptMethodHandlers` filter both the list results and direct reads to only the extensions the
+ * current session has negotiated (see `context.isExtensionEnabled`), so a resource/prompt carrying
+ * an `extensionId` with no matching negotiated extension is — by design — completely absent from
+ * the wire, not merely missing one field. That's asserted explicitly below (via the descriptor
+ * overload) rather than treated as a wire-format detail like `inputSchema` (prompt-only, also not
+ * on the wire, but not gated — just not part of the `Prompt` protocol model).
+ */
+internal class ResourcePromptAttributesE2eTest : AbstractStatelessMcpE2eTest() {
+    @Test
+    fun `resource full attribute set round-trips over the wire`() {
+        val icon = Icon { src = "https://example.com/resource-icon.png" }
+        val annotations = Annotations { priority = 0.5 }
+
+        TachyonServer(port = 0) {
+            resource(
+                name = "full-resource",
+                uri = "test://full-resource",
+                description = "Full resource",
+                mimeType = "text/plain",
+                title = "Full Resource Title",
+                annotations = annotations,
+                size = 123,
+                icons = listOf(icon),
+                meta = mapOf("owner" to "team-x"),
+            ) {
+                TextResourceContents { text = "hello" }
+            }
+            resource(
+                descriptor =
+                    resourceDescriptor("gated-resource", "test://gated-resource") {
+                        extensionId = "com.example/resource-ext"
+                    },
+            ) {
+                TextResourceContents { text = "gated" }
+            }
+        }.use { server ->
+            server
+                .resources()
+                .find("gated-resource")
+                .orElseThrow()
+                .extensionId() shouldEqual "com.example/resource-ext"
+
+            val client = createTestClient(server.port())
+            client.initialize()
+            val response =
+                client.post(
+                    """{"jsonrpc":"2.0","id":2,"method":"resources/list","params":{}}""",
+                )
+
+            response.statusCode() shouldEqual 200
+            val body = response.body()
+            body shouldContain """"uri":"test://full-resource""""
+            body shouldContain """"description":"Full resource""""
+            body shouldContain """"mimeType":"text/plain""""
+            body shouldContain """"title":"Full Resource Title""""
+            body shouldContain """"priority":0.5"""
+            body shouldContain """"size":123"""
+            body shouldContain """"src":"https://example.com/resource-icon.png""""
+            body shouldContain """"owner":"team-x""""
+            // extensionId gates visibility: no negotiated extension for "com.example/resource-ext"
+            // means this session never sees the resource, not even without the field.
+            body shouldNotContain """"uri":"test://gated-resource""""
+        }
+    }
+
+    @Test
+    fun `resourceTemplate full attribute set round-trips over the wire`() {
+        val icon = Icon { src = "https://example.com/template-icon.png" }
+        val annotations = Annotations { priority = 0.7 }
+
+        TachyonServer(port = 0) {
+            resourceTemplate(
+                descriptor =
+                    ResourceTemplateDescriptor {
+                        name = "full-template"
+                        uriTemplate = "test://full-template/{id}"
+                        description = "Full template"
+                        mimeType = "application/json"
+                        title = "Full Template Title"
+                        this.annotations = annotations
+                        icons = listOf(icon)
+                        extensionId = "com.example/template-ext"
+                        meta = mapOf("owner" to "team-y")
+                    },
+            ) {
+                TextResourceContents { text = """{"id":"${param("id")}"}""" }
+            }
+        }.use { server ->
+            server
+                .resources()
+                .findTemplate("full-template")
+                .orElseThrow()
+                .extensionId() shouldEqual "com.example/template-ext"
+
+            val client = createTestClient(server.port())
+            client.initialize()
+            val response =
+                client.post(
+                    """{"jsonrpc":"2.0","id":2,"method":"resources/templates/list","params":{}}""",
+                )
+
+            response.statusCode() shouldEqual 200
+            val body = response.body()
+            body shouldContain """"uriTemplate":"test://full-template/{id}""""
+            body shouldContain """"description":"Full template""""
+            body shouldContain """"mimeType":"application/json""""
+            body shouldContain """"title":"Full Template Title""""
+            body shouldContain """"priority":0.7"""
+            body shouldContain """"src":"https://example.com/template-icon.png""""
+            body shouldContain """"owner":"team-y""""
+        }
+    }
+
+    @Test
+    fun `prompt full attribute set round-trips over the wire`() {
+        val icon = Icon { src = "https://example.com/prompt-icon.png" }
+        val argument =
+            PromptArgument {
+                name = "topic"
+                required = true
+            }
+
+        TachyonServer(port = 0) {
+            prompt(
+                name = "full-prompt",
+                description = "Full prompt",
+                title = "Full Prompt Title",
+                arguments = listOf(argument),
+                inputSchema = JsonSchema.objectSchema(),
+                icons = listOf(icon),
+                meta = mapOf("owner" to "team-z"),
+            ) {
+                content { text("Discuss the topic") }
+            }
+            prompt(
+                descriptor =
+                    PromptDescriptor {
+                        name = "gated-prompt"
+                        extensionId = "com.example/prompt-ext"
+                    },
+            ) {
+                content { text("Gated") }
+            }
+        }.use { server ->
+            with(server.prompts().find("full-prompt").orElseThrow()) {
+                inputSchema()?.json() shouldEqual JsonSchema.objectSchema().json()
+            }
+            server
+                .prompts()
+                .find("gated-prompt")
+                .orElseThrow()
+                .extensionId() shouldEqual "com.example/prompt-ext"
+
+            val client = createTestClient(server.port())
+            client.initialize()
+            val response =
+                client.post(
+                    """{"jsonrpc":"2.0","id":2,"method":"prompts/list","params":{}}""",
+                )
+
+            response.statusCode() shouldEqual 200
+            val body = response.body()
+            body shouldContain """"name":"full-prompt""""
+            body shouldContain """"description":"Full prompt""""
+            body shouldContain """"title":"Full Prompt Title""""
+            body shouldContain """"name":"topic""""
+            body shouldContain """"required":true"""
+            body shouldContain """"src":"https://example.com/prompt-icon.png""""
+            body shouldContain """"owner":"team-z""""
+            // extensionId gates visibility, same as resources.
+            body shouldNotContain """"name":"gated-prompt""""
+        }
+    }
+}

--- a/e2e/src/test/kotlin/dev/tachyonmcp/e2e/ResourcePromptAttributesE2eTest.kt
+++ b/e2e/src/test/kotlin/dev/tachyonmcp/e2e/ResourcePromptAttributesE2eTest.kt
@@ -97,17 +97,23 @@ internal class ResourcePromptAttributesE2eTest : AbstractStatelessMcpE2eTest() {
 
         TachyonServer(port = 0) {
             resourceTemplate(
+                name = "full-template",
+                uriTemplate = "test://full-template/{id}",
+                description = "Full template",
+                mimeType = "application/json",
+                title = "Full Template Title",
+                annotations = annotations,
+                icons = listOf(icon),
+                meta = mapOf("owner" to "team-y"),
+            ) {
+                TextResourceContents { text = """{"id":"${param("id")}"}""" }
+            }
+            resourceTemplate(
                 descriptor =
                     ResourceTemplateDescriptor {
-                        name = "full-template"
-                        uriTemplate = "test://full-template/{id}"
-                        description = "Full template"
-                        mimeType = "application/json"
-                        title = "Full Template Title"
-                        this.annotations = annotations
-                        icons = listOf(icon)
+                        name = "gated-template"
+                        uriTemplate = "test://gated-template/{id}"
                         extensionId = "com.example/template-ext"
-                        meta = mapOf("owner" to "team-y")
                     },
             ) {
                 TextResourceContents { text = """{"id":"${param("id")}"}""" }
@@ -115,7 +121,7 @@ internal class ResourcePromptAttributesE2eTest : AbstractStatelessMcpE2eTest() {
         }.use { server ->
             server
                 .resources()
-                .findTemplate("full-template")
+                .findTemplate("gated-template")
                 .orElseThrow()
                 .extensionId() shouldEqual "com.example/template-ext"
 
@@ -135,6 +141,9 @@ internal class ResourcePromptAttributesE2eTest : AbstractStatelessMcpE2eTest() {
             body shouldContain """"priority":0.7"""
             body shouldContain """"src":"https://example.com/template-icon.png""""
             body shouldContain """"owner":"team-y""""
+            // extensionId gates visibility: no negotiated extension for "com.example/template-ext"
+            // means this session never sees the template, not even without the field.
+            body shouldNotContain """"uriTemplate":"test://gated-template/{id}""""
         }
     }
 

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/features/resources/ResourceMethodHandlers.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/features/resources/ResourceMethodHandlers.java
@@ -73,7 +73,13 @@ public final class ResourceMethodHandlers {
             if (page.cursor() != null) {
                 return ServerErrors.invalidParams("Invalid cursor");
             }
-            return context.responseMapper().listResourceTemplatesResult(registry.templateDescriptors(), null);
+            final var visible = registry.templateDescriptors().stream()
+                    .filter(descriptor -> {
+                        var extensionId = descriptor.extensionId();
+                        return extensionId == null || context.isExtensionEnabled(extensionId);
+                    })
+                    .toList();
+            return context.responseMapper().listResourceTemplatesResult(visible, null);
         }
     }
 

--- a/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/TachyonServer.kt
+++ b/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/TachyonServer.kt
@@ -163,7 +163,7 @@ internal class DefaultKotlinTachyonServer(
 
 /**
  * Registers a suspend tool on an already-built server, resolving its input/output schemas from
- * [In]/[Out] and adapting the handler to those types.
+ * [In]/[Out] and adapting the block to those types.
  *
  * The post-build twin of
  * [typedTool][dev.tachyonmcp.kotlin.server.config.TachyonServerBuilder.typedTool] — see its
@@ -173,11 +173,11 @@ internal class DefaultKotlinTachyonServer(
  *
  * Two behaviours go beyond the build-time overload, mirroring
  * [dev.tachyonmcp.api.server.features.tools.TypedToolFn]: the call arguments are decoded into
- * [In] by the serde configured in server config, and the handler's return value is wrapped with
- * [ToolResult.structured]. The handler runs with a [ToolScope] receiver, so `ctx` and `task`
+ * [In] by the serde configured in server config, and the block's return value is wrapped with
+ * [ToolResult.structured]. The block runs with a [ToolScope] receiver, so `ctx` and `task`
  * stay reachable.
  *
- * The handler may return **either** shape:
+ * The block may return **either** shape:
  *  - an [Out] — wrapped into a success result carrying it as `structuredContent`;
  *  - a [ToolResult] — passed through untouched, for results that also need `_meta`, a custom
  *    text block, extra content blocks, [ToolScope.fail], or [ToolScope.inputRequired].
@@ -187,7 +187,7 @@ internal class DefaultKotlinTachyonServer(
  * expected type.
  *
  * Unlike the build-time `typedTool`, this can safely share the `registerTool` name: both type
- * arguments must always be given explicitly (neither is inferable from the handler), and an
+ * arguments must always be given explicitly (neither is inferable from the block), and an
  * explicit type argument list excludes every untyped overload, which declares none. Existing
  * schema-less `registerTool(name) { }` calls therefore never resolve here, and omitting the type
  * arguments is a compile error rather than a silent fallback.
@@ -209,7 +209,7 @@ internal class DefaultKotlinTachyonServer(
  * @param name tool name
  * @param description optional tool description
  * @param taskSupport optional task-augmentation support level
- * @param handler handler receiving the decoded [In], returning an [Out] or a [ToolResult]
+ * @param block block receiving the decoded [In], returning an [Out] or a [ToolResult]
  * @return this server
  */
 @ExperimentalApi
@@ -223,7 +223,7 @@ public inline fun <reified In : Any, reified Out : Any> TachyonServer.registerTo
     annotations: ToolAnnotations? = null,
     icons: List<Icon>? = null,
     meta: Map<String, Any>? = null,
-    noinline handler: suspend ToolScope.(In) -> Any,
+    noinline block: suspend ToolScope.(In) -> Any,
 ): TachyonServer {
     val inputType = In::class.java
     val outputType = Out::class.java
@@ -240,7 +240,7 @@ public inline fun <reified In : Any, reified Out : Any> TachyonServer.registerTo
             meta = meta,
         )
     return registerTool(descriptor) {
-        when (val produced = handler(arguments.decode(inputType))) {
+        when (val produced = block(arguments.decode(inputType))) {
             is ToolResult -> produced
             else -> success(outputType.cast(produced))
         }

--- a/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/TachyonServer.kt
+++ b/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/TachyonServer.kt
@@ -40,7 +40,6 @@ public sealed interface TachyonServer : CoreTachyonServer {
         taskSupport: TaskSupport? = null,
         annotations: ToolAnnotations? = null,
         icons: List<Icon>? = null,
-        extensionId: String? = null,
         meta: Map<String, Any>? = null,
         block: suspend ToolScope.() -> ToolResult,
     ): TachyonServer =
@@ -55,7 +54,6 @@ public sealed interface TachyonServer : CoreTachyonServer {
                     taskSupport = taskSupport,
                     annotations = annotations,
                     icons = icons,
-                    extensionId = extensionId,
                     meta = meta,
                 ),
             block = block,
@@ -73,7 +71,6 @@ public sealed interface TachyonServer : CoreTachyonServer {
         taskSupport: TaskSupport? = null,
         annotations: ToolAnnotations? = null,
         icons: List<Icon>? = null,
-        extensionId: String? = null,
         meta: Map<String, Any>? = null,
         block: suspend ToolScope.() -> ToolResult,
     ): TachyonServer =
@@ -86,7 +83,6 @@ public sealed interface TachyonServer : CoreTachyonServer {
             taskSupport = taskSupport,
             annotations = annotations,
             icons = icons,
-            extensionId = extensionId,
             meta = meta,
             block = block,
         )
@@ -134,7 +130,6 @@ public sealed interface TachyonServer : CoreTachyonServer {
         taskSupport: TaskSupport? = null,
         annotations: ToolAnnotations? = null,
         icons: List<Icon>? = null,
-        extensionId: String? = null,
         meta: Map<String, Any>? = null,
         block: suspend ToolScope.() -> ToolResult,
     ): TachyonServer =
@@ -147,7 +142,6 @@ public sealed interface TachyonServer : CoreTachyonServer {
             taskSupport = taskSupport,
             annotations = annotations,
             icons = icons,
-            extensionId = extensionId,
             meta = meta,
             block = block,
         )
@@ -228,7 +222,6 @@ public inline fun <reified In : Any, reified Out : Any> TachyonServer.registerTo
     taskSupport: TaskSupport? = null,
     annotations: ToolAnnotations? = null,
     icons: List<Icon>? = null,
-    extensionId: String? = null,
     meta: Map<String, Any>? = null,
     noinline handler: suspend ToolScope.(In) -> Any,
 ): TachyonServer {
@@ -244,7 +237,6 @@ public inline fun <reified In : Any, reified Out : Any> TachyonServer.registerTo
             taskSupport = taskSupport,
             annotations = annotations,
             icons = icons,
-            extensionId = extensionId,
             meta = meta,
         )
     return registerTool(descriptor) {

--- a/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/config/KotlinFeatureRegistrar.kt
+++ b/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/config/KotlinFeatureRegistrar.kt
@@ -51,7 +51,7 @@ internal class KotlinFeatureRegistrar(
         inputSchema: JsonSchema?,
         outputSchema: JsonSchema?,
         taskSupport: TaskSupport?,
-        handler: suspend ToolScope.() -> ToolResult,
+        block: suspend ToolScope.() -> ToolResult,
     ) {
         delegate.withTools { tools ->
             tools.registerAsync(
@@ -63,7 +63,7 @@ internal class KotlinFeatureRegistrar(
                         .outputSchema(outputSchema)
                         .taskSupport(taskSupport)
                 },
-                toolFn(name, runtime, handler),
+                toolFn(name, runtime, block),
             )
         }
     }
@@ -74,7 +74,7 @@ internal class KotlinFeatureRegistrar(
         inputSchema: String?,
         outputSchema: String?,
         taskSupport: TaskSupport?,
-        handler: suspend ToolScope.() -> ToolResult,
+        block: suspend ToolScope.() -> ToolResult,
     ) {
         delegate.withTools { tools ->
             tools.registerAsync(
@@ -86,49 +86,49 @@ internal class KotlinFeatureRegistrar(
                         .outputSchema(outputSchema)
                         .taskSupport(taskSupport)
                 },
-                toolFn(name, runtime, handler),
+                toolFn(name, runtime, block),
             )
         }
     }
 
     fun tool(
         descriptor: ToolDescriptor,
-        handler: suspend ToolScope.() -> ToolResult,
+        block: suspend ToolScope.() -> ToolResult,
     ) {
         delegate.withTools {
-            it.registerAsync(descriptor, toolFn(descriptor.name(), runtime, handler))
+            it.registerAsync(descriptor, toolFn(descriptor.name(), runtime, block))
         }
     }
 
     fun prompt(
         descriptor: PromptDescriptor,
-        handler: suspend PromptScope.() -> List<PromptMessage>,
+        block: suspend PromptScope.() -> List<PromptMessage>,
     ) {
         delegate.withPrompts {
-            it.registerAsync(descriptor, promptFn(descriptor, runtime, handler))
+            it.registerAsync(descriptor, promptFn(descriptor, runtime, block))
         }
     }
 
     fun promptCompletion(
         promptName: String,
-        handler: suspend CompletionScope.() -> CompletionResult,
+        block: suspend CompletionScope.() -> CompletionResult,
     ) {
         delegate.withCompletions {
             it.registerForPromptAsync(
                 promptName,
-                promptCompletionFn(promptName, runtime, handler),
+                promptCompletionFn(promptName, runtime, block),
             )
         }
     }
 
     fun resourceCompletion(
         uriOrTemplate: String,
-        handler: suspend CompletionScope.() -> CompletionResult,
+        block: suspend CompletionScope.() -> CompletionResult,
     ) {
         delegate.withCompletions {
             it.registerForResourceAsync(
                 uriOrTemplate,
-                resourceCompletionFn(uriOrTemplate, runtime, handler),
+                resourceCompletionFn(uriOrTemplate, runtime, block),
             )
         }
     }

--- a/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/config/KotlinFeatureRegistrar.kt
+++ b/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/config/KotlinFeatureRegistrar.kt
@@ -2,8 +2,6 @@
 package dev.tachyonmcp.kotlin.server.config
 
 import dev.tachyonmcp.api.json.JsonSchema
-import dev.tachyonmcp.api.server.domain.Annotations
-import dev.tachyonmcp.api.server.domain.Icon
 import dev.tachyonmcp.api.server.domain.PromptMessage
 import dev.tachyonmcp.api.server.domain.ResourceContents
 import dev.tachyonmcp.api.server.features.completions.CompletionResult
@@ -27,67 +25,11 @@ internal class KotlinFeatureRegistrar(
     private val runtime: CoroutineRuntime,
 ) {
     fun resource(
-        name: String,
-        uri: String,
-        description: String?,
-        mimeType: String?,
-        title: String?,
-        annotations: Annotations?,
-        size: Long?,
-        icons: List<Icon>,
-        block: suspend ResourceScope.() -> ResourceContents,
-    ) {
-        delegate.withResources { resources ->
-            resources.registerAsync(
-                { descriptor ->
-                    descriptor
-                        .name(name)
-                        .uri(uri)
-                        .description(description)
-                        .mimeType(mimeType)
-                        .title(title)
-                        .annotations(annotations)
-                        .size(size)
-                        .icons(icons)
-                },
-                resourceFn(name, mimeType, runtime, block),
-            )
-        }
-    }
-
-    fun resource(
         descriptor: ResourceDescriptor,
         block: suspend ResourceScope.() -> ResourceContents,
     ) {
         delegate.withResources {
             it.registerAsync(descriptor, resourceFn(descriptor, runtime, block))
-        }
-    }
-
-    fun resourceTemplate(
-        name: String,
-        uriTemplate: String,
-        description: String?,
-        mimeType: String?,
-        title: String?,
-        annotations: Annotations?,
-        icons: List<Icon>,
-        block: suspend TemplateScope.() -> ResourceContents,
-    ) {
-        delegate.withResources { resources ->
-            resources.registerTemplateAsync(
-                { descriptor ->
-                    descriptor
-                        .name(name)
-                        .uriTemplate(uriTemplate)
-                        .description(description)
-                        .mimeType(mimeType)
-                        .title(title)
-                        .annotations(annotations)
-                        .icons(icons)
-                },
-                templateFn(name, mimeType, runtime, block),
-            )
         }
     }
 

--- a/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/config/TachyonServerBuilder.kt
+++ b/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/config/TachyonServerBuilder.kt
@@ -5,6 +5,7 @@ import dev.tachyonmcp.api.annotations.ExperimentalApi
 import dev.tachyonmcp.api.json.JsonSchema
 import dev.tachyonmcp.api.server.domain.Annotations
 import dev.tachyonmcp.api.server.domain.Icon
+import dev.tachyonmcp.api.server.domain.PromptArgument
 import dev.tachyonmcp.api.server.domain.PromptMessage
 import dev.tachyonmcp.api.server.domain.ResourceContents
 import dev.tachyonmcp.api.server.domain.ToolAnnotations
@@ -133,7 +134,6 @@ public class TachyonServerBuilder
             taskSupport: TaskSupport? = null,
             annotations: ToolAnnotations? = null,
             icons: List<Icon>? = null,
-            extensionId: String? = null,
             meta: Map<String, Any>? = null,
             handler: suspend ToolScope.() -> ToolResult,
         ): TachyonServerBuilder =
@@ -148,7 +148,6 @@ public class TachyonServerBuilder
                         taskSupport = taskSupport,
                         annotations = annotations,
                         icons = icons,
-                        extensionId = extensionId,
                         meta = meta,
                     ),
                 handler = handler,
@@ -224,7 +223,6 @@ public class TachyonServerBuilder
             noinline schemaGenerator: (Class<*>) -> JsonSchema = JsonSchema::generate,
             annotations: ToolAnnotations? = null,
             icons: List<Icon>? = null,
-            extensionId: String? = null,
             meta: Map<String, Any>? = null,
             noinline handler: suspend ToolScope.(In) -> Any,
         ): TachyonServerBuilder {
@@ -240,7 +238,6 @@ public class TachyonServerBuilder
                     taskSupport = taskSupport,
                     annotations = annotations,
                     icons = icons,
-                    extensionId = extensionId,
                     meta = meta,
                 )
             return tool(descriptor) {
@@ -275,10 +272,12 @@ public class TachyonServerBuilder
          * @param annotations optional presentation hints
          * @param size optional raw content size in bytes
          * @param icons associated icons, or an empty list
+         * @param meta optional protocol extension metadata
          * @param block handles reads of the registered resource
          * @return this builder
          */
         @JvmSynthetic
+        @Suppress("LongParameterList")
         public fun resource(
             name: String,
             uri: String,
@@ -288,21 +287,25 @@ public class TachyonServerBuilder
             annotations: Annotations? = null,
             size: Long? = null,
             icons: List<Icon> = emptyList(),
+            meta: Map<String, Any>? = null,
             block: suspend ResourceScope.() -> ResourceContents,
         ): TachyonServerBuilder =
-            this.also {
-                featureRegistrar.resource(
-                    name = name,
-                    uri = uri,
-                    description = description,
-                    mimeType = mimeType,
-                    title = title,
-                    annotations = annotations,
-                    size = size,
-                    icons = icons,
-                    block = block,
-                )
-            }
+            resource(
+                descriptor =
+                    ResourceDescriptor
+                        .builder()
+                        .name(name)
+                        .uri(uri)
+                        .description(description)
+                        .mimeType(mimeType)
+                        .title(title)
+                        .annotations(annotations)
+                        .size(size)
+                        .icons(icons)
+                        .meta(meta)
+                        .build(),
+                block = block,
+            )
 
         /**
          * Registers a prebuilt static-resource descriptor.
@@ -322,19 +325,40 @@ public class TachyonServerBuilder
          *
          * @param name The prompt name.
          * @param description An optional description of the prompt.
+         * @param title The optional human-readable title.
+         * @param arguments The arguments accepted by this prompt, or an empty list.
+         * @param inputSchema The optional JSON schema describing the prompt's arguments.
+         * @param icons The prompt icons, or an empty list.
+         * @param meta The optional protocol extension metadata.
          * @param handler The handler that generates the prompt messages.
          * @return This builder.
          */
         @JvmSynthetic
+        @Suppress("LongParameterList")
         public fun prompt(
             name: String,
             description: String? = null,
+            title: String? = null,
+            arguments: List<PromptArgument> = emptyList(),
+            inputSchema: JsonSchema? = null,
+            icons: List<Icon> = emptyList(),
+            meta: Map<String, Any>? = null,
             handler: suspend PromptScope.() -> List<PromptMessage>,
         ): TachyonServerBuilder =
-            this.also {
-                val descriptor = PromptDescriptor.of(name, description, null, emptyList(), null)
-                featureRegistrar.prompt(descriptor, handler)
-            }
+            prompt(
+                descriptor =
+                    PromptDescriptor
+                        .builder()
+                        .name(name)
+                        .description(description)
+                        .title(title)
+                        .arguments(arguments)
+                        .inputSchema(inputSchema)
+                        .icons(icons)
+                        .meta(meta)
+                        .build(),
+                handler = handler,
+            )
 
         /**
          * Registers a prebuilt prompt descriptor with a suspending handler block.
@@ -359,10 +383,12 @@ public class TachyonServerBuilder
          * @param title The optional template title.
          * @param annotations The optional template annotations.
          * @param icons The template icons, or an empty list.
+         * @param meta The optional protocol extension metadata.
          * @param block Handles requests for resources matching the template.
          * @return This builder.
          */
         @JvmSynthetic
+        @Suppress("LongParameterList")
         public fun resourceTemplate(
             name: String,
             uriTemplate: String,
@@ -371,20 +397,24 @@ public class TachyonServerBuilder
             title: String? = null,
             annotations: Annotations? = null,
             icons: List<Icon> = emptyList(),
+            meta: Map<String, Any>? = null,
             block: suspend TemplateScope.() -> ResourceContents,
         ): TachyonServerBuilder =
-            this.also {
-                featureRegistrar.resourceTemplate(
-                    name = name,
-                    uriTemplate = uriTemplate,
-                    description = description,
-                    mimeType = mimeType,
-                    title = title,
-                    annotations = annotations,
-                    icons = icons,
-                    block = block,
-                )
-            }
+            resourceTemplate(
+                descriptor =
+                    ResourceTemplateDescriptor
+                        .builder()
+                        .name(name)
+                        .uriTemplate(uriTemplate)
+                        .description(description)
+                        .mimeType(mimeType)
+                        .title(title)
+                        .annotations(annotations)
+                        .icons(icons)
+                        .meta(meta)
+                        .build(),
+                block = block,
+            )
 
         /**
          * Registers a prebuilt resource-template descriptor.
@@ -445,7 +475,6 @@ public class TachyonServerBuilder
             taskSupport: TaskSupport? = null,
             annotations: ToolAnnotations? = null,
             icons: List<Icon>? = null,
-            extensionId: String? = null,
             meta: Map<String, Any>? = null,
             handler: suspend ToolScope.() -> ToolResult,
         ): TachyonServerBuilder =
@@ -458,7 +487,6 @@ public class TachyonServerBuilder
                 taskSupport = taskSupport,
                 annotations = annotations,
                 icons = icons,
-                extensionId = extensionId,
                 meta = meta,
                 handler = handler,
             )

--- a/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/config/TachyonServerBuilder.kt
+++ b/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/config/TachyonServerBuilder.kt
@@ -135,7 +135,7 @@ public class TachyonServerBuilder
             annotations: ToolAnnotations? = null,
             icons: List<Icon>? = null,
             meta: Map<String, Any>? = null,
-            handler: suspend ToolScope.() -> ToolResult,
+            block: suspend ToolScope.() -> ToolResult,
         ): TachyonServerBuilder =
             tool(
                 descriptor =
@@ -150,7 +150,7 @@ public class TachyonServerBuilder
                         icons = icons,
                         meta = meta,
                     ),
-                handler = handler,
+                block = block,
             )
 
         @JvmSynthetic
@@ -160,7 +160,7 @@ public class TachyonServerBuilder
             message = "Use tool(...) with explicit JsonSchema object",
             replaceWith =
                 ReplaceWith(
-                    "tool(name = name, description = description, inputSchema = JsonSchema.parse(inputSchema), outputSchema = outputSchema?.let(JsonSchema::parse), taskSupport = taskSupport, handler = handler)",
+                    "tool(name = name, description = description, inputSchema = JsonSchema.parse(inputSchema), outputSchema = outputSchema?.let(JsonSchema::parse), taskSupport = taskSupport, block = block)",
                     "dev.tachyonmcp.api.json.JsonSchema",
                 ),
         )
@@ -170,7 +170,7 @@ public class TachyonServerBuilder
             inputSchema: String,
             outputSchema: String? = null,
             taskSupport: TaskSupport? = null,
-            handler: suspend ToolScope.() -> ToolResult,
+            block: suspend ToolScope.() -> ToolResult,
         ): TachyonServerBuilder =
             this.also {
                 featureRegistrar.tool(
@@ -179,7 +179,7 @@ public class TachyonServerBuilder
                     inputSchema,
                     outputSchema,
                     taskSupport,
-                    handler,
+                    block,
                 )
             }
 
@@ -196,7 +196,7 @@ public class TachyonServerBuilder
          *
          * Pass [schemaGenerator] to control generation for this call only.
          *
-         * The call arguments are decoded into [In] by the configured serde, and the handler may
+         * The call arguments are decoded into [In] by the configured serde, and the block may
          * return **either** shape:
          *  - an [Out] — wrapped into a success result carrying it as `structuredContent`;
          *  - a [ToolResult] — passed through untouched, for results that also need `_meta`, a
@@ -206,7 +206,7 @@ public class TachyonServerBuilder
          * The two never collide: [ToolResult] is a sealed interface, so no [Out] can also be
          * one. A value that is neither fails with [ClassCastException] naming the expected type.
          *
-         * Both type arguments must be given explicitly — neither is inferable from the handler.
+         * Both type arguments must be given explicitly — neither is inferable from the block.
          * The name stays `typedTool` for symmetry with the rest of the build-time DSL; the
          * original reason (a reified `tool` overload hijacking schema-less `tool(name) { }`
          * calls) no longer applies, since an explicit type argument list excludes every untyped
@@ -224,7 +224,7 @@ public class TachyonServerBuilder
             annotations: ToolAnnotations? = null,
             icons: List<Icon>? = null,
             meta: Map<String, Any>? = null,
-            noinline handler: suspend ToolScope.(In) -> Any,
+            noinline block: suspend ToolScope.(In) -> Any,
         ): TachyonServerBuilder {
             val inputType = In::class.java
             val outputType = Out::class.java
@@ -241,7 +241,7 @@ public class TachyonServerBuilder
                     meta = meta,
                 )
             return tool(descriptor) {
-                when (val produced = handler(arguments.decode(inputType))) {
+                when (val produced = block(arguments.decode(inputType))) {
                     is ToolResult -> produced
                     else -> success(outputType.cast(produced))
                 }
@@ -252,14 +252,14 @@ public class TachyonServerBuilder
          * Registers a prebuilt tool descriptor with a suspending handler block.
          *
          * @param descriptor tool descriptor
-         * @param handler handler invoked for tool calls
+         * @param block handler invoked for tool calls
          * @return this builder
          */
         @JvmSynthetic
         public fun tool(
             descriptor: ToolDescriptor,
-            handler: suspend ToolScope.() -> ToolResult,
-        ): TachyonServerBuilder = this.also { featureRegistrar.tool(descriptor, handler) }
+            block: suspend ToolScope.() -> ToolResult,
+        ): TachyonServerBuilder = this.also { featureRegistrar.tool(descriptor, block) }
 
         /**
          * Registers a static resource with a suspending handler block.
@@ -330,7 +330,7 @@ public class TachyonServerBuilder
          * @param inputSchema The optional JSON schema describing the prompt's arguments.
          * @param icons The prompt icons, or an empty list.
          * @param meta The optional protocol extension metadata.
-         * @param handler The handler that generates the prompt messages.
+         * @param block The handler that generates the prompt messages.
          * @return This builder.
          */
         @JvmSynthetic
@@ -343,7 +343,7 @@ public class TachyonServerBuilder
             inputSchema: JsonSchema? = null,
             icons: List<Icon> = emptyList(),
             meta: Map<String, Any>? = null,
-            handler: suspend PromptScope.() -> List<PromptMessage>,
+            block: suspend PromptScope.() -> List<PromptMessage>,
         ): TachyonServerBuilder =
             prompt(
                 descriptor =
@@ -357,21 +357,21 @@ public class TachyonServerBuilder
                         .icons(icons)
                         .meta(meta)
                         .build(),
-                handler = handler,
+                block = block,
             )
 
         /**
          * Registers a prebuilt prompt descriptor with a suspending handler block.
          *
          * @param descriptor prompt descriptor
-         * @param handler handler invoked for prompt requests
+         * @param block handler invoked for prompt requests
          * @return this builder
          */
         @JvmSynthetic
         public fun prompt(
             descriptor: PromptDescriptor,
-            handler: suspend PromptScope.() -> List<PromptMessage>,
-        ): TachyonServerBuilder = this.also { featureRegistrar.prompt(descriptor, handler) }
+            block: suspend PromptScope.() -> List<PromptMessage>,
+        ): TachyonServerBuilder = this.also { featureRegistrar.prompt(descriptor, block) }
 
         /**
          * Registers a resource template with the server.
@@ -433,32 +433,32 @@ public class TachyonServerBuilder
          * Registers a completion handler for a prompt's arguments.
          *
          * @param promptName the prompt name
-         * @param handler the suspend function that returns completion candidates
+         * @param block the suspend function that returns completion candidates
          * @return this builder
          */
         @JvmSynthetic
         public fun promptCompletion(
             promptName: String,
-            handler: suspend CompletionScope.() -> CompletionResult,
+            block: suspend CompletionScope.() -> CompletionResult,
         ): TachyonServerBuilder =
             this.also {
-                featureRegistrar.promptCompletion(promptName, handler)
+                featureRegistrar.promptCompletion(promptName, block)
             }
 
         /**
          * Registers a completion handler for a resource template's variables.
          *
          * @param uriOrTemplate the resource URI or template
-         * @param handler the suspend function that returns completion candidates
+         * @param block the suspend function that returns completion candidates
          * @return this builder
          */
         @JvmSynthetic
         public fun resourceCompletion(
             uriOrTemplate: String,
-            handler: suspend CompletionScope.() -> CompletionResult,
+            block: suspend CompletionScope.() -> CompletionResult,
         ): TachyonServerBuilder =
             this.also {
-                featureRegistrar.resourceCompletion(uriOrTemplate, handler)
+                featureRegistrar.resourceCompletion(uriOrTemplate, block)
             }
 
         /**
@@ -476,7 +476,7 @@ public class TachyonServerBuilder
             annotations: ToolAnnotations? = null,
             icons: List<Icon>? = null,
             meta: Map<String, Any>? = null,
-            handler: suspend ToolScope.() -> ToolResult,
+            block: suspend ToolScope.() -> ToolResult,
         ): TachyonServerBuilder =
             this.tool(
                 name = name,
@@ -488,7 +488,7 @@ public class TachyonServerBuilder
                 annotations = annotations,
                 icons = icons,
                 meta = meta,
-                handler = handler,
+                block = block,
             )
 
         public fun name(name: String): TachyonServerBuilder = this.also { delegate.name(name) }

--- a/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/features/prompts/PromptDescriptorScope.kt
+++ b/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/features/prompts/PromptDescriptorScope.kt
@@ -3,6 +3,7 @@
 
 package dev.tachyonmcp.kotlin.server.features.prompts
 
+import dev.tachyonmcp.api.annotations.ExperimentalApi
 import dev.tachyonmcp.api.json.JsonSchema
 import dev.tachyonmcp.api.server.domain.Icon
 import dev.tachyonmcp.api.server.domain.PromptArgument
@@ -26,6 +27,10 @@ public class PromptDescriptorScope
         public var arguments: List<PromptArgument>? = null
         public var inputSchema: JsonSchema? = null
         public var icons: List<Icon>? = null
+
+        /** Extension-ownership marker; set by extension implementations only, not by ordinary prompts. */
+        @ExperimentalApi
+        public var extensionId: String? = null
         public var meta: Map<String, Any>? = null
 
         /** Sets the input schema from a kotlinx-serialization [JsonObject]. */
@@ -56,6 +61,7 @@ public class PromptDescriptorScope
                 .arguments(arguments.orEmpty())
                 .inputSchema(inputSchema)
                 .icons(icons.orEmpty())
+                .extensionId(extensionId)
                 .meta(meta)
                 .build()
         }

--- a/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/features/resources/ResourceDescriptorScope.kt
+++ b/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/features/resources/ResourceDescriptorScope.kt
@@ -3,6 +3,7 @@
 
 package dev.tachyonmcp.kotlin.server.features.resources
 
+import dev.tachyonmcp.api.annotations.ExperimentalApi
 import dev.tachyonmcp.api.server.domain.Annotations
 import dev.tachyonmcp.api.server.domain.Icon
 import dev.tachyonmcp.api.server.features.resources.ResourceDescriptor
@@ -26,23 +27,29 @@ public class ResourceDescriptorScope
         public var annotations: Annotations? = null
         public var size: Long? = null
         public var icons: List<Icon> = emptyList()
+
+        /** Extension-ownership marker; set by extension implementations only, not by ordinary resources. */
+        @ExperimentalApi
+        public var extensionId: String? = null
         public var meta: Map<String, Any>? = null
 
         @PublishedApi
         internal fun build(): ResourceDescriptor {
             val n = requireNotNull(name) { "ResourceDescriptor.name is required" }
             val u = requireNotNull(uri) { "ResourceDescriptor.uri is required" }
-            return ResourceDescriptor(
-                name = n,
-                uri = u,
-                description = description,
-                mimeType = mimeType ?: MimeTypes.guess(u),
-                title = title,
-                annotations = annotations,
-                size = size,
-                icons = icons,
-                meta = meta,
-            )
+            return ResourceDescriptor
+                .builder()
+                .name(n)
+                .uri(u)
+                .description(description)
+                .mimeType(mimeType ?: MimeTypes.guess(u))
+                .title(title)
+                .annotations(annotations)
+                .size(size)
+                .icons(icons)
+                .extensionId(extensionId)
+                .meta(meta)
+                .build()
         }
     }
 

--- a/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/features/resources/ResourceTemplateDescriptorBuilder.kt
+++ b/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/features/resources/ResourceTemplateDescriptorBuilder.kt
@@ -5,6 +5,7 @@
 
 package dev.tachyonmcp.kotlin.server.features.resources
 
+import dev.tachyonmcp.api.annotations.ExperimentalApi
 import dev.tachyonmcp.api.server.domain.Annotations
 import dev.tachyonmcp.api.server.domain.Icon
 import dev.tachyonmcp.api.server.features.resources.ResourceTemplateDescriptor
@@ -33,7 +34,8 @@ public class ResourceTemplateDescriptorBuilder
         /** Human-readable title. */
         public var title: String? = null
 
-        /** Extension ID. */
+        /** Extension-ownership marker; set by extension implementations only, not by ordinary templates. */
+        @ExperimentalApi
         public var extensionId: String? = null
 
         /** Optional presentation hints. */

--- a/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/features/tools/ToolDescriptorScope.kt
+++ b/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/features/tools/ToolDescriptorScope.kt
@@ -3,6 +3,7 @@
 
 package dev.tachyonmcp.kotlin.server.features.tools
 
+import dev.tachyonmcp.api.annotations.ExperimentalApi
 import dev.tachyonmcp.api.json.JsonSchema
 import dev.tachyonmcp.api.server.domain.Icon
 import dev.tachyonmcp.api.server.domain.ToolAnnotations
@@ -28,6 +29,9 @@ public class ToolDescriptorScope
         public var taskSupport: TaskSupport? = null
         public var annotations: ToolAnnotations? = null
         public var icons: List<Icon>? = null
+
+        /** Extension-ownership marker; set by extension implementations only, not by ordinary tools. */
+        @ExperimentalApi
         public var extensionId: String? = null
         public var meta: Map<String, Any>? = null
 
@@ -118,7 +122,6 @@ internal fun toolDescriptorOf(
     taskSupport: TaskSupport?,
     annotations: ToolAnnotations?,
     icons: List<Icon>?,
-    extensionId: String?,
     meta: Map<String, Any>?,
 ): ToolDescriptor =
     toolDescriptor(name) {
@@ -129,6 +132,5 @@ internal fun toolDescriptorOf(
         this.taskSupport = taskSupport
         this.annotations = annotations
         this.icons = icons
-        this.extensionId = extensionId
         this.meta = meta
     }

--- a/tachyon-kotlin/src/test/kotlin/dev/tachyonmcp/kotlin/server/PromptDescriptorAttributesTest.kt
+++ b/tachyon-kotlin/src/test/kotlin/dev/tachyonmcp/kotlin/server/PromptDescriptorAttributesTest.kt
@@ -1,0 +1,58 @@
+// Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors.
+package dev.tachyonmcp.kotlin.server
+
+import dev.tachyonmcp.api.json.JsonSchema
+import dev.tachyonmcp.kotlin.server.domain.Icon
+import dev.tachyonmcp.kotlin.server.domain.PromptArgument
+import dev.tachyonmcp.kotlin.server.features.prompts.PromptDescriptor
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+/**
+ * The flat `prompt(...)` overload must accept the full optional attribute set of
+ * [dev.tachyonmcp.api.server.features.prompts.PromptDescriptor.Builder].
+ */
+internal class PromptDescriptorAttributesTest {
+    @Test
+    fun `every optional attribute reaches the descriptor`() {
+        val icon = Icon { src = "https://example.com/prompt.png" }
+        val argument =
+            PromptArgument {
+                name = "topic"
+                required = true
+            }
+
+        buildServer {
+            // when
+            prompt(
+                name = "summarize",
+                description = "desc",
+                title = "Title",
+                arguments = listOf(argument),
+                inputSchema = JsonSchema.objectSchema(),
+                icons = listOf(icon),
+                meta = mapOf("k" to "v"),
+            ) { content { text("Summarize this") } }
+        }.use { server ->
+            // then
+            val descriptor = server.prompts().find("summarize").orElseThrow()
+            descriptor.title() shouldBe "Title"
+            descriptor.description() shouldBe "desc"
+            descriptor.arguments() shouldBe listOf(argument)
+            descriptor.inputSchema() shouldBe JsonSchema.objectSchema()
+            descriptor.icons() shouldBe listOf(icon)
+            descriptor.meta() shouldBe mapOf("k" to "v")
+        }
+    }
+
+    @Test
+    fun `extensionId is not a flat prompt attribute, only settable via the descriptor scope`() {
+        val descriptor =
+            PromptDescriptor {
+                name = "summarize"
+                extensionId = "ext"
+            }
+
+        descriptor.extensionId() shouldBe "ext"
+    }
+}

--- a/tachyon-kotlin/src/test/kotlin/dev/tachyonmcp/kotlin/server/ResourceDescriptorAttributesTest.kt
+++ b/tachyon-kotlin/src/test/kotlin/dev/tachyonmcp/kotlin/server/ResourceDescriptorAttributesTest.kt
@@ -1,0 +1,50 @@
+// Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors.
+package dev.tachyonmcp.kotlin.server
+
+import dev.tachyonmcp.kotlin.server.domain.Icon
+import dev.tachyonmcp.kotlin.server.features.resources.resourceDescriptor
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import org.junit.jupiter.api.Test
+
+/**
+ * The flat `resource(...)` overload must accept the full optional attribute set of
+ * [dev.tachyonmcp.api.server.features.resources.ResourceDescriptor.Builder].
+ */
+internal class ResourceDescriptorAttributesTest {
+    @Test
+    fun `every optional attribute reaches the descriptor`() {
+        val icon = Icon { src = "https://example.com/resource.png" }
+
+        buildServer {
+            // when
+            resource(
+                name = "greeting",
+                uri = "res://greeting",
+                description = "desc",
+                mimeType = "text/plain",
+                title = "Title",
+                size = 42,
+                icons = listOf(icon),
+                meta = mapOf("k" to "v"),
+            ) { TextResourceContents { text = "hi" } }
+        }.use { server ->
+            // then
+            val descriptor = server.resources().find("greeting").orElseThrow()
+            descriptor.title() shouldBe "Title"
+            descriptor.description() shouldBe "desc"
+            descriptor.mimeType() shouldBe "text/plain"
+            descriptor.size() shouldBe 42L
+            descriptor.icons() shouldBe listOf(icon)
+            descriptor.meta() shouldBe mapOf("k" to "v")
+            descriptor shouldNotBe null
+        }
+    }
+
+    @Test
+    fun `extensionId is not a flat resource attribute, only settable via the descriptor scope`() {
+        val descriptor = resourceDescriptor("greeting", "res://greeting") { extensionId = "ext" }
+
+        descriptor.extensionId() shouldBe "ext"
+    }
+}

--- a/tachyon-kotlin/src/test/kotlin/dev/tachyonmcp/kotlin/server/ResourceTemplateDescriptorAttributesTest.kt
+++ b/tachyon-kotlin/src/test/kotlin/dev/tachyonmcp/kotlin/server/ResourceTemplateDescriptorAttributesTest.kt
@@ -1,0 +1,51 @@
+// Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors.
+package dev.tachyonmcp.kotlin.server
+
+import dev.tachyonmcp.kotlin.server.domain.Icon
+import dev.tachyonmcp.kotlin.server.features.resources.ResourceTemplateDescriptor
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+/**
+ * The flat `resourceTemplate(...)` overload must accept the full optional attribute set of
+ * [dev.tachyonmcp.api.server.features.resources.ResourceTemplateDescriptor.Builder].
+ */
+internal class ResourceTemplateDescriptorAttributesTest {
+    @Test
+    fun `every optional attribute reaches the descriptor`() {
+        val icon = Icon { src = "https://example.com/template.png" }
+
+        buildServer {
+            // when
+            resourceTemplate(
+                name = "file",
+                uriTemplate = "file:///{path}",
+                description = "desc",
+                mimeType = "text/plain",
+                title = "Title",
+                icons = listOf(icon),
+                meta = mapOf("k" to "v"),
+            ) { TextResourceContents { text = "contents" } }
+        }.use { server ->
+            // then
+            val descriptor = server.resources().findTemplate("file").orElseThrow()
+            descriptor.title() shouldBe "Title"
+            descriptor.description() shouldBe "desc"
+            descriptor.mimeType() shouldBe "text/plain"
+            descriptor.icons() shouldBe listOf(icon)
+            descriptor.meta() shouldBe mapOf("k" to "v")
+        }
+    }
+
+    @Test
+    fun `extensionId is not flat, only settable via the descriptor scope`() {
+        val descriptor =
+            ResourceTemplateDescriptor {
+                name = "file"
+                uriTemplate = "file:///{path}"
+                extensionId = "ext"
+            }
+
+        descriptor.extensionId() shouldBe "ext"
+    }
+}

--- a/tachyon-kotlin/src/test/kotlin/dev/tachyonmcp/kotlin/server/ToolDescriptorAttributesTest.kt
+++ b/tachyon-kotlin/src/test/kotlin/dev/tachyonmcp/kotlin/server/ToolDescriptorAttributesTest.kt
@@ -5,6 +5,7 @@ import dev.tachyonmcp.api.json.JsonSchema
 import dev.tachyonmcp.api.server.domain.ToolAnnotations
 import dev.tachyonmcp.api.server.features.tasks.TaskSupport
 import dev.tachyonmcp.kotlin.server.domain.Icon
+import dev.tachyonmcp.kotlin.server.features.tools.toolDescriptor
 import io.kotest.assertions.withClue
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
@@ -34,7 +35,6 @@ internal class ToolDescriptorAttributesTest {
                 taskSupport = TaskSupport.OPTIONAL,
                 annotations = toolAnnotations,
                 icons = listOf(icon),
-                extensionId = "ext",
                 meta = mapOf("k" to "v"),
             ) { text("ok") }
         }.use { server ->
@@ -47,7 +47,6 @@ internal class ToolDescriptorAttributesTest {
                 taskSupport = TaskSupport.OPTIONAL,
                 annotations = toolAnnotations,
                 icons = listOf(icon),
-                extensionId = "ext",
                 meta = mapOf("k" to "v"),
             ) { text("ok") }
 
@@ -58,7 +57,6 @@ internal class ToolDescriptorAttributesTest {
                 taskSupport = TaskSupport.OPTIONAL,
                 annotations = toolAnnotations,
                 icons = listOf(icon),
-                extensionId = "ext",
                 meta = mapOf("k" to "v"),
             ) { _: TypedInput -> TypedOutput() }
 
@@ -70,12 +68,18 @@ internal class ToolDescriptorAttributesTest {
                     descriptor.taskSupport() shouldBe TaskSupport.OPTIONAL
                     descriptor.annotations() shouldBe toolAnnotations
                     descriptor.icons() shouldBe listOf(icon)
-                    descriptor.extensionId() shouldBe "ext"
                     descriptor.meta() shouldBe mapOf("k" to "v")
                     descriptor.inputSchema() shouldNotBe null
                     descriptor.outputSchema() shouldNotBe null
                 }
             }
         }
+    }
+
+    @Test
+    fun `extensionId is not a flat tool attribute, only settable via the descriptor scope`() {
+        val descriptor = toolDescriptor("extension-owned") { extensionId = "ext" }
+
+        descriptor.extensionId() shouldBe "ext"
     }
 }


### PR DESCRIPTION
## Summary

### New Features

- Added support for metadata across resources, resource templates, prompts, and descriptors.
- Prompt registration now supports titles, arguments, input schemas, icons, and metadata.
- Extension ownership can be configured through descriptor-based APIs.
- Added comprehensive attribute round-tripping and extension visibility coverage.

### Changes

- Simplified registration APIs by removing direct extension identifiers from tools and descriptor-free resource registration.
- Resource and resource-template registration now uses descriptor-based configuration.
- Gate resourceTemplate visibility by `extensionId`
- Rename trailing lambdas to `block`

### Documentation

- Updated Kotlin examples and architecture guidance for metadata, descriptors, and extension handling.

