### PR TITLE
feat: migrate weather examples to FormInputRequest

### DIFF
--- a/examples/weather-mcp-kotlin/pom.xml
+++ b/examples/weather-mcp-kotlin/pom.xml
@@ -25,8 +25,6 @@
         <jackson.version>3.2.0</jackson.version>
         <slf4j.version>2.0.18</slf4j.version>
         <netty.version>4.2.15.Final</netty.version>
-        <mcp-sdk.version>2.0.0</mcp-sdk.version>
-        <awaitility.version>4.3.0</awaitility.version>
         <kotlinx-serialization-json.version>1.11.0</kotlinx-serialization-json.version>
         <kt-schema.version>0.7.0</kt-schema.version>
     </properties>
@@ -90,9 +88,9 @@
 
         <!-- Test -->
         <dependency>
-            <groupId>io.modelcontextprotocol.sdk</groupId>
-            <artifactId>mcp-json-jackson3</artifactId>
-            <version>${mcp-sdk.version}</version>
+            <groupId>dev.tachyonmcp</groupId>
+            <artifactId>tachyon-testkit</artifactId>
+            <version>${tachyon.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -118,9 +116,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.awaitility</groupId>
-            <artifactId>awaitility-kotlin</artifactId>
-            <version>4.3.0</version>
+            <groupId>io.kotest</groupId>
+            <artifactId>kotest-assertions-json-jvm</artifactId>
+            <version>${kotest.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/examples/weather-mcp-kotlin/src/main/kotlin/com/example/weather/GetWeatherTool.kt
+++ b/examples/weather-mcp-kotlin/src/main/kotlin/com/example/weather/GetWeatherTool.kt
@@ -12,13 +12,11 @@ import com.example.weather.model.TemperatureUnit.Fahrenheit
 import com.example.weather.service.WeatherService
 import com.example.weather.spi.CityNotFoundException
 import com.example.weather.spi.WeatherObservation
-import dev.tachyonmcp.api.json.JsonSchema
-import dev.tachyonmcp.api.runtime.ElicitationRequest
-import dev.tachyonmcp.api.runtime.ElicitationResult
 import dev.tachyonmcp.api.runtime.InteractionContext
 import dev.tachyonmcp.api.server.domain.ProgressToken
 import dev.tachyonmcp.api.server.features.tools.ToolResult
 import dev.tachyonmcp.kotlin.server.config.ToolScope
+import dev.tachyonmcp.kotlin.server.domain.FormInputRequest
 import dev.tachyonmcp.kotlin.server.domain.Icon
 import dev.tachyonmcp.kotlin.server.domain.ToolAnnotations
 import dev.tachyonmcp.kotlin.server.domain.stringOrNull
@@ -27,11 +25,9 @@ import me.kpavlov.kt.schema.generator.json.JsonSchemaConfig
 import me.kpavlov.kt.schema.generator.json.ReflectionClassJsonSchemaGenerator
 import org.slf4j.LoggerFactory
 import java.util.Locale
-import java.util.concurrent.TimeUnit
-import java.util.concurrent.TimeoutException
 
 private val log = LoggerFactory.getLogger("com.example.weather.GetWeatherTool")
-private const val ELICITATION_TIMEOUT_SECONDS = 600L
+private const val CITY_INPUT_KEY = "city"
 
 private val schemaGenerator =
     ReflectionClassJsonSchemaGenerator(
@@ -39,14 +35,12 @@ private val schemaGenerator =
         config = JsonSchemaConfig.Default,
     )
 
-private val CITY_SCHEMA =
-    JsonSchema.parse(
-        schemaGenerator.generateSchemaString(CityElicitationInput::class),
+private val CITY_SCHEMA_MAP: Map<String, Any> =
+    mapOf(
+        "type" to "object",
+        "properties" to mapOf("city" to mapOf("type" to "string")),
+        "required" to listOf("city"),
     )
-
-private data class CityElicitationInput(
-    val city: String,
-)
 
 val getWeatherToolDescriptor =
     ToolDescriptor {
@@ -66,7 +60,6 @@ val getWeatherToolDescriptor =
     }
 
 fun ToolScope.getWeather(weatherService: WeatherService): ToolResult {
-    val city = arguments.stringValue("city")
     val units = arguments.stringOrNull("units")
     val progressToken = request.progressToken()
     val temperatureUnit =
@@ -83,6 +76,8 @@ fun ToolScope.getWeather(weatherService: WeatherService): ToolResult {
                 Celsius
             }
         }
+    val inputResponses: Map<String, Any>? = request.inputResponses()
+    val city = elicitedCity(inputResponses) ?: arguments.stringValue("city")
 
     fun attempt(city: String): ToolResult =
         try {
@@ -106,13 +101,21 @@ fun ToolScope.getWeather(weatherService: WeatherService): ToolResult {
     return try {
         attempt(city)
     } catch (_: CityNotFoundException) {
-        val elicitedCity = elicitCity(ctx, city) ?: return fail("City not found")
-        try {
-            attempt(elicitedCity)
-        } catch (_: CityNotFoundException) {
-            fail("City not found")
-        }
+        if (inputResponses != null) return fail("City not found")
+        inputRequired(
+            CITY_INPUT_KEY to
+                FormInputRequest(
+                    "City '$city' was not found. Enter another city.",
+                    CITY_SCHEMA_MAP,
+                ),
+        )
     }
+}
+
+private fun elicitedCity(inputResponses: Map<String, Any>?): String? {
+    val response = inputResponses?.get(CITY_INPUT_KEY) as? Map<*, *> ?: return null
+    val city = response["city"] as? String ?: return null
+    return city.takeIf(String::isNotBlank)
 }
 
 private fun fetchWithProgress(
@@ -153,25 +156,4 @@ private fun internalError(e: Exception): ToolResult {
     restoreInterruptStatus(e)
     log.warn("get-weather failed", e)
     return ToolResult.error("Could not get weather")
-}
-
-private fun elicitCity(
-    ctx: InteractionContext,
-    city: String,
-): String? {
-    val future =
-        ctx.client().elicitation().create(
-            ElicitationRequest("City '$city' was not found. Enter another city.", CITY_SCHEMA),
-        )
-    val result =
-        try {
-            future.get(ELICITATION_TIMEOUT_SECONDS, TimeUnit.SECONDS)
-        } catch (e: InterruptedException) {
-            restoreInterruptStatus(e)
-            throw e
-        } catch (_: TimeoutException) {
-            return null
-        }
-    if (result.action() != ElicitationResult.Action.ACCEPT) return null
-    return result.content()?.stringOr("city", "")?.takeIf(String::isNotBlank)
 }

--- a/examples/weather-mcp-kotlin/src/main/kotlin/com/example/weather/WeatherServer.kt
+++ b/examples/weather-mcp-kotlin/src/main/kotlin/com/example/weather/WeatherServer.kt
@@ -51,7 +51,11 @@ private data class NarrationStyleInput(
 )
 
 fun main() {
-    val server = assembleServer(8080)
+    val server =
+        createServer(
+            host = System.getenv("HOST") ?: "127.0.0.1",
+            port = System.getenv("PORT")?.toIntOrNull() ?: 8080,
+        )
     server.start()
     log.info("Connect your MCP client to http://localhost:{}/mcp", server.port())
 }
@@ -67,7 +71,8 @@ fun createWeatherService(): WeatherService {
     return WeatherService(openMeteoProvider, openMeteoProvider)
 }
 
-fun assembleServer(
+fun createServer(
+    host: String,
     port: Int,
     weatherService: WeatherService = createWeatherService(),
 ): TachyonServer {
@@ -86,7 +91,10 @@ fun assembleServer(
             theme = "light"
         }
     return buildServer {
-        network { this.port = port }
+        network {
+            this.host = host
+            this.port = port
+        }
         json { serde = KxSerializationSerde.Default }
         info {
             name = "weather-server-kotlin"

--- a/examples/weather-mcp-kotlin/src/test/kotlin/com/example/weather/GetWeatherEdgeCasesTest.kt
+++ b/examples/weather-mcp-kotlin/src/test/kotlin/com/example/weather/GetWeatherEdgeCasesTest.kt
@@ -6,84 +6,120 @@ package com.example.weather
 
 import com.example.weather.service.WeatherService
 import com.example.weather.spi.WeatherProvider
-import io.kotest.matchers.shouldBe
-import io.kotest.matchers.types.shouldBeInstanceOf
-import io.modelcontextprotocol.client.McpClient
-import io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport
-import io.modelcontextprotocol.spec.McpSchema
-import io.modelcontextprotocol.spec.McpSchema.ElicitResult.Action
+import dev.tachyonmcp.testkit.McpTestClients
+import io.kotest.assertions.json.shouldEqualJson
 import org.junit.jupiter.api.Test
 import java.io.IOException
 
 class GetWeatherEdgeCasesTest {
     private fun callGetWeather(
         weatherService: WeatherService,
-        elicitationResponse: (McpSchema.ElicitRequest) -> McpSchema.ElicitResult,
-    ): McpSchema.CallToolResult {
-        val server = assembleServer(0, weatherService)
+        secondRoundInputResponses: String,
+    ): String {
+        val server = createServer(0, weatherService)
         server.start()
-        val transport =
-            HttpClientStreamableHttpTransport.builder("http://localhost:${server.port()}").build()
-        val client = McpClient.sync(transport).elicitation(elicitationResponse).build()
+        val client = McpTestClients.latest(server.port())
         try {
-            client.initialize()
-            return client.callTool(
-                McpSchema.CallToolRequest
-                    .builder("get-weather")
-                    .arguments(mapOf("city" to "Unknown"))
-                    .build(),
-            )
+            val round1 =
+                client.post(
+                    """
+                    {"jsonrpc":"2.0","id":1,"method":"tools/call",
+                     "params":{"name":"get-weather","arguments":{"city":"Unknown"}}}
+                    """,
+                )
+            val body = round1.body()
+            if (!body.contains("\"resultType\":\"input_required\"")) {
+                return body
+            }
+            val round2 =
+                client.post(
+                    """
+                    {"jsonrpc":"2.0","id":2,"method":"tools/call",
+                     "params":{"name":"get-weather","arguments":{"city":"Unknown"},
+                               "inputResponses":$secondRoundInputResponses}}
+                    """,
+                )
+            return round2.body()
         } finally {
             client.close()
-            transport.close()
             server.close()
         }
     }
 
     @Test
     fun `returns city not found when elicitation is cancelled`() {
-        val result =
-            callGetWeather(WeatherService(TestWeatherProvider(), TestCityProvider())) {
-                McpSchema.ElicitResult(Action.CANCEL, null)
-            }
+        val body =
+            callGetWeather(
+                WeatherService(
+                    weatherProvider = TestWeatherProvider(),
+                    cityProvider = TestCityProvider(),
+                ),
+                """{"city":{}}""",
+            )
 
-        val content = result.content().first()
-        content.shouldBeInstanceOf<McpSchema.TextContent>()
-        content.text() shouldBe "City not found"
-        result.isError shouldBe true
+        body shouldEqualJson
+            """
+            {
+              "jsonrpc": "2.0",
+              "id": 2,
+              "result": {
+                "content": [{"type": "text", "text": "City not found"}],
+                "isError": true,
+                "resultType": "complete"
+              }
+            }
+            """
     }
 
     @Test
     fun `returns city not found when the elicited city is unknown`() {
-        val result =
-            callGetWeather(WeatherService(TestWeatherProvider(), TestCityProvider())) {
-                McpSchema.ElicitResult(Action.ACCEPT, mapOf("city" to "Unknown"))
-            }
+        val body =
+            callGetWeather(
+                WeatherService(TestWeatherProvider(), TestCityProvider()),
+                """{"city":{"city":"Unknown"}}""",
+            )
 
-        val content = result.content().first()
-        content.shouldBeInstanceOf<McpSchema.TextContent>()
-        content.text() shouldBe "City not found"
-        result.isError shouldBe true
+        body shouldEqualJson
+            """
+            {
+              "jsonrpc": "2.0",
+              "id": 2,
+              "result": {
+                "content": [{"type": "text", "text": "City not found"}],
+                "isError": true,
+                "resultType": "complete"
+              }
+            }
+            """
     }
 
     @Test
     fun `returns fixed error when provider fails without leaking details`() {
         val failingProvider =
-            WeatherProvider {
-                _,
-                _,
-                ->
+            WeatherProvider { _, _ ->
                 throw IOException("connection refused to internal-host:6443")
             }
 
-        val result =
-            callGetWeather(WeatherService(failingProvider, TestCityProvider())) {
-                McpSchema.ElicitResult(Action.CANCEL, null)
-            }
+        val body =
+            callGetWeather(
+                WeatherService(
+                    weatherProvider = failingProvider,
+                    cityProvider = TestCityProvider(),
+                ),
+                """{"city":{}}""",
+            )
 
-        val content = result.content().first()
-        content.shouldBeInstanceOf<McpSchema.TextContent>()
-        content.text() shouldBe "Could not get weather"
-        result.isError shouldBe true
+        body shouldEqualJson
+            """
+            {
+              "jsonrpc": "2.0",
+              "id": 1,
+              "result": {
+                "content": [{"type": "text", "text": "Could not get weather"}],
+                "isError": true,
+                "resultType": "complete"
+              }
+            }
+            """
     }
 }

--- a/examples/weather-mcp-kotlin/src/test/kotlin/com/example/weather/WeatherServerTest.kt
+++ b/examples/weather-mcp-kotlin/src/test/kotlin/com/example/weather/WeatherServerTest.kt
@@ -6,384 +6,559 @@ package com.example.weather
 
 import com.example.weather.service.WeatherService
 import dev.tachyonmcp.core.server.TachyonServer
-import io.kotest.assertions.throwables.shouldThrow
-import io.kotest.matchers.collections.shouldContainExactly
-import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import dev.tachyonmcp.testkit.Mcp20260728Client
+import dev.tachyonmcp.testkit.McpTestClients
+import io.kotest.assertions.json.shouldEqualJson
 import io.kotest.matchers.collections.shouldHaveSize
-import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
-import io.kotest.matchers.shouldNotBe
-import io.kotest.matchers.string.shouldContain
-import io.kotest.matchers.string.shouldStartWith
-import io.kotest.matchers.types.shouldBeInstanceOf
-import io.modelcontextprotocol.client.McpClient
-import io.modelcontextprotocol.client.McpSyncClient
-import io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport
-import io.modelcontextprotocol.spec.McpError
-import io.modelcontextprotocol.spec.McpSchema.CallToolRequest
-import io.modelcontextprotocol.spec.McpSchema.CompleteRequest
-import io.modelcontextprotocol.spec.McpSchema.ElicitResult
-import io.modelcontextprotocol.spec.McpSchema.GetPromptRequest
-import io.modelcontextprotocol.spec.McpSchema.InitializeResult
-import io.modelcontextprotocol.spec.McpSchema.ProgressNotification
-import io.modelcontextprotocol.spec.McpSchema.PromptReference
-import io.modelcontextprotocol.spec.McpSchema.ReadResourceRequest
-import io.modelcontextprotocol.spec.McpSchema.ResourceReference
-import io.modelcontextprotocol.spec.McpSchema.Role
-import io.modelcontextprotocol.spec.McpSchema.TextContent
-import io.modelcontextprotocol.spec.McpSchema.TextResourceContents
-import org.awaitility.Awaitility.await
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
-import java.time.Duration
-import java.util.concurrent.CopyOnWriteArrayList
+
+// Redaction marker for fields kotest-assertions-json has no jsonunit-style
+// "${json-unit.ignore-element}"/"${json-unit.regex}" placeholder for.
+private const val IGNORED = "IGNORED"
+private val IGNORED_KEYS = setOf("inputSchema", "outputSchema", "requestedSchema")
+private val ICON_SRC_FIELD = Regex(""""src"\s*:\s*"data:image/png;base64,[^"]+"""")
+
+private fun JsonElement.redactIgnoredKeys(): JsonElement =
+    when (this) {
+        is JsonObject -> {
+            JsonObject(
+                entries.associate { (key, value) ->
+                    key to
+                        if (key in
+                            IGNORED_KEYS
+                        ) {
+                            JsonPrimitive(IGNORED)
+                        } else {
+                            value.redactIgnoredKeys()
+                        }
+                },
+            )
+        }
+
+        is JsonArray -> {
+            JsonArray(map { it.redactIgnoredKeys() })
+        }
+
+        else -> {
+            this
+        }
+    }
+
+// Redacts inputSchema/outputSchema/requestedSchema (structure not under test here) and
+// icon `src` data URIs (fails the comparison if they don't look like base64 PNGs).
+private fun String.redacted(): String =
+    ICON_SRC_FIELD.replace(
+        Json.parseToJsonElement(this).redactIgnoredKeys().toString(),
+    ) { """"src":"$IGNORED"""" }
+
+private const val CAPABILITIES = """{"tools":{},"resources":{},"prompts":{},"completions":{}}"""
+private const val SERVER_INFO =
+    """
+    {
+      "version": "1.0",
+      "description": "Weather MCP server built with Tachyon Kotlin DSL",
+      "websiteUrl": "https://github.com/kpavlov/tachyon/tree/main/examples/weather-mcp-kotlin",
+      "name": "weather-server-kotlin",
+      "title": "Weather Server (Kotlin)",
+      "icons": [{"src": "$IGNORED", "mimeType": "image/png", "sizes": ["256x256"]}]
+    }
+    """
+private const val RESOURCE_ANNOTATIONS =
+    """{"audience": ["user", "assistant"], "priority": 0.8, "lastModified": "2026-07-23T00:00:00Z"}"""
+private const val RESOURCE_ICON =
+    """{"src": "$IGNORED", "mimeType": "image/png", "sizes": ["256x256"], "theme": "light"}"""
 
 class WeatherServerTest {
     companion object {
+        private val json = Json { prettyPrint = true }
         private val weatherProvider = TestWeatherProvider()
         private val cityProvider = TestCityProvider()
         private val weatherService = WeatherService(weatherProvider, cityProvider)
-        private lateinit var server: TachyonServer
-        private lateinit var clientTransport: HttpClientStreamableHttpTransport
-        private lateinit var client: McpSyncClient
-        private lateinit var initResult: InitializeResult
-        private val progressNotifications = CopyOnWriteArrayList<ProgressNotification>()
+        private lateinit var handle: TachyonServer
+        private lateinit var client: Mcp20260728Client
 
         @JvmStatic
         @BeforeAll
         fun beforeAll() {
-            server = assembleServer(0, weatherService)
-            server.start()
-            val port = server.port()
-
-            clientTransport =
-                HttpClientStreamableHttpTransport.builder("http://localhost:$port").build()
-            client =
-                McpClient
-                    .sync(clientTransport)
-                    .elicitation { _ ->
-                        ElicitResult(
-                            ElicitResult.Action.ACCEPT,
-                            mapOf("city" to "Tallinn"),
-                        )
-                    }.progressConsumer { progressNotifications.add(it) }
-                    .build()
-
-            initResult = client.initialize()
+            handle = createServer(0, weatherService)
+            handle.start()
+            client = McpTestClients.latest(handle.port())
         }
 
         @JvmStatic
         @AfterAll
         fun afterAll() {
             client.close()
-            clientTransport.close()
-            server.close()
+            handle.close()
+        }
+
+        private fun weatherCallResultBody(
+            id: Int,
+            city: String,
+        ): String {
+            val structured =
+                """{"city":"$city","condition":"Clear sky","temperature":18.5,"temperatureUnit":"Celsius","humidity":52,"windSpeed":12.0}"""
+            val textJson = json.encodeToString(structured)
+            return """
+                {
+                  "jsonrpc": "2.0",
+                  "id": $id,
+                  "result": {
+                    "content": [{"type": "text", "text": $textJson}],
+                    "structuredContent": $structured,
+                    "resultType": "complete"
+                  }
+                }
+                """
+        }
+
+        private fun weatherResourceResultBody(
+            id: Int,
+            requestUri: String,
+        ): String {
+            val observation =
+                """{"condition":"Clear sky","temperature":18.5,"temperatureUnit":"Celsius","humidity":52,"windSpeed":12.0}"""
+            val textJson = json.encodeToString(observation)
+            return """
+                {
+                  "jsonrpc": "2.0",
+                  "id": $id,
+                  "result": {
+                    "contents": [{"text": $textJson, "uri": "$requestUri", "mimeType": "application/json"}],
+                    "resultType": "complete",
+                    "ttlMs": 0,
+                    "cacheScope": "public"
+                  }
+                }
+                """
         }
     }
 
     @Test
     fun verifyInitResult() {
-        with(initResult.serverInfo()) {
-            name() shouldBe "weather-server-kotlin"
-            title() shouldBe "Weather Server (Kotlin)"
-            description() shouldBe "Weather MCP server built with Tachyon Kotlin DSL"
-            websiteUrl() shouldBe
-                "https://github.com/kpavlov/tachyon/tree/main/examples/weather-mcp-kotlin"
-            icons() shouldHaveSize 1
-            icons().first().src() shouldStartWith "data:image/png;base64,"
-        }
-        initResult.protocolVersion() shouldBe "2025-11-25"
-        initResult.instructions() shouldBe "Test instructions"
+        val response = client.post("""{"jsonrpc":"2.0","id":1,"method":"server/discover"}""")
+
+        response.statusCode() shouldBe 200
+        response.body().redacted() shouldEqualJson
+            """
+            {
+              "jsonrpc": "2.0",
+              "id": 1,
+              "result": {
+                "supportedVersions": ["2026-07-28", "2025-11-25"],
+                "capabilities": $CAPABILITIES,
+                "instructions": "Test instructions",
+                "serverInfo": $SERVER_INFO,
+                "_meta": {"io.modelcontextprotocol/serverInfo": $SERVER_INFO},
+                "resultType": "complete",
+                "ttlMs": 0,
+                "cacheScope": "public"
+              }
+            }
+            """
     }
 
     @Test
     fun `should list tools`() {
-        val result = client.listTools()
+        val response = client.post("""{"jsonrpc":"2.0","id":2,"method":"tools/list"}""")
 
-        result.tools() shouldHaveSize 1
-        result.tools().first() shouldNotBeNull {
-            name() shouldBe "get-weather"
-            title() shouldBe "Current Weather"
-            description() shouldBe "Get current weather for a city"
-            outputSchema() shouldNotBe null
-        }
+        response.statusCode() shouldBe 200
+        response.body().redacted() shouldEqualJson
+            """
+            {
+              "jsonrpc": "2.0",
+              "id": 2,
+              "result": {
+                "tools": [{
+                  "description": "Get current weather for a city",
+                  "inputSchema": "$IGNORED",
+                  "outputSchema": "$IGNORED",
+                  "annotations": {
+                    "readOnlyHint": true, "destructiveHint": false, "idempotentHint": true, "openWorldHint": true
+                  },
+                  "name": "get-weather",
+                  "title": "Current Weather",
+                  "icons": [{"src": "$IGNORED", "mimeType": "image/png", "sizes": ["128x128"]}]
+                }],
+                "resultType": "complete",
+                "ttlMs": 0,
+                "cacheScope": "public"
+              }
+            }
+            """
     }
 
     @Test
     fun `should call weather tool`() {
-        val result =
-            client.callTool(
-                CallToolRequest
-                    .builder("get-weather")
-                    .arguments(mapOf("city" to "London", "units" to "Celsius"))
-                    .build(),
+        val response =
+            client.post(
+                """
+                {"jsonrpc":"2.0","id":3,"method":"tools/call",
+                 "params":{"name":"get-weather","arguments":{"city":"London","units":"Celsius"}}}
+                """,
             )
 
-        result.isError shouldNotBe true
-        result.structuredContent() shouldBe
-            mapOf(
-                "city" to "London",
-                "condition" to "Clear sky",
-                "temperature" to 18.5,
-                "temperatureUnit" to "Celsius",
-                "humidity" to 52,
-                "windSpeed" to 12.0,
-            )
-        result
-            .content()
-            .single()
-            .shouldBeInstanceOf<TextContent>()
-            .text() shouldBe
-            """{"city":"London","condition":"Clear sky","temperature":18.5,"temperatureUnit":"Celsius","humidity":52,"windSpeed":12.0}"""
+        response.statusCode() shouldBe 200
+        response.body() shouldEqualJson weatherCallResultBody(3, "London")
     }
 
     @Test
     fun `should emit progress while fetching weather`() {
-        val result =
-            client.callTool(
-                CallToolRequest
-                    .builder("get-weather")
-                    .arguments(mapOf("city" to "London"))
-                    .progressToken("weather-progress")
-                    .build(),
+        client.clearNotifications()
+
+        val responseBody =
+            client.sendRpc(
+                """
+                {"jsonrpc":"2.0","id":4,"method":"tools/call",
+                 "params":{"name":"get-weather","arguments":{"city":"London"},
+                           "_meta":{"progressToken":"weather-progress"}}}
+                """,
             )
 
-        result.isError shouldNotBe true
-        await().atMost(Duration.ofSeconds(5)).untilAsserted {
-            progressNotifications shouldHaveSize 2
-        }
-        progressNotifications.map { it.progressToken() to it.message() } shouldContainExactly
-            listOf(
-                "weather-progress" to "Fetching weather for London",
-                "weather-progress" to "Weather retrieved for London",
-            )
+        responseBody shouldEqualJson weatherCallResultBody(4, "London")
+
+        val progressNotifications =
+            client
+                .notifications()
+                .filter { it.method() == "notifications/progress" }
+                .map { it.params() }
+        progressNotifications shouldHaveSize 2
+        progressNotifications[0].toString() shouldEqualJson
+            """{"progressToken": "weather-progress", "progress": 0.1, "total": 1.0, "message": "Fetching weather for London"}"""
+        progressNotifications[1].toString() shouldEqualJson
+            """{"progressToken": "weather-progress", "progress": 1.0, "total": 1.0, "message": "Weather retrieved for London"}"""
     }
 
     @Test
     fun `should call weather tool after eliciting another city`() {
-        val result =
-            client.callTool(
-                CallToolRequest
-                    .builder("get-weather")
-                    .arguments(mapOf("city" to "Unknown"))
-                    .build(),
+        val round1 =
+            client.post(
+                """
+                {"jsonrpc":"2.0","id":5,"method":"tools/call",
+                 "params":{"name":"get-weather","arguments":{"city":"Unknown"}}}
+                """,
             )
 
-        result.isError shouldNotBe true
-        result.structuredContent() shouldBe
-            mapOf(
-                "city" to "Tallinn",
-                "condition" to "Clear sky",
-                "temperature" to 18.5,
-                "temperatureUnit" to "Celsius",
-                "humidity" to 52,
-                "windSpeed" to 12.0,
+        round1.statusCode() shouldBe 200
+        round1.body().redacted() shouldEqualJson
+            """
+            {
+              "jsonrpc": "2.0",
+              "id": 5,
+              "result": {
+                "inputRequests": {
+                  "city": {
+                    "method": "elicitation/create",
+                    "params": {
+                      "message": "City 'Unknown' was not found. Enter another city.",
+                      "requestedSchema": "$IGNORED"
+                    }
+                  }
+                },
+                "resultType": "input_required"
+              }
+            }
+            """
+
+        val round2 =
+            client.post(
+                """
+                {"jsonrpc":"2.0","id":6,"method":"tools/call",
+                 "params":{"name":"get-weather","arguments":{"city":"Unknown"},
+                           "inputResponses":{"city":{"city":"Tallinn"}}}}
+                """,
             )
-        result
-            .content()
-            .single()
-            .shouldBeInstanceOf<TextContent>()
-            .text() shouldBe
-            """{"city":"Tallinn","condition":"Clear sky","temperature":18.5,"temperatureUnit":"Celsius","humidity":52,"windSpeed":12.0}"""
+
+        round2.statusCode() shouldBe 200
+        round2.body() shouldEqualJson weatherCallResultBody(6, "Tallinn")
     }
 
     @Test
     fun `should list resources`() {
-        val result = client.listResources()
+        val response = client.post("""{"jsonrpc":"2.0","id":7,"method":"resources/list"}""")
 
-        result.resources() shouldHaveSize 2
-        val article = result.resources().first { it.uri() == "weather://prediction/article" }
-        with(article) {
-            name() shouldBe "prediction-article"
-            title() shouldBe "Weather Prediction"
-            description() shouldBe "Weather prediction article"
-            mimeType() shouldBe "text/markdown"
-            size() shouldBe
-                weatherService.predictionArticle
-                    .toByteArray()
-                    .size
-                    .toLong()
-            with(annotations()) {
-                audience() shouldContainExactly
-                    listOf(Role.USER, Role.ASSISTANT)
-                priority() shouldBe 0.8
-                lastModified() shouldBe "2026-07-23T00:00:00Z"
+        response.statusCode() shouldBe 200
+        val size = weatherService.predictionArticle.toByteArray(Charsets.UTF_8).size
+        response.body().redacted() shouldEqualJson
+            """
+            {
+              "jsonrpc": "2.0",
+              "id": 7,
+              "result": {
+                "resources": [
+                  {
+                    "uri": "weather://featured/current",
+                    "description": "Current weather in Tallinn",
+                    "mimeType": "application/json",
+                    "annotations": $RESOURCE_ANNOTATIONS,
+                    "name": "featured-current-weather",
+                    "title": "Featured Current Weather",
+                    "icons": [$RESOURCE_ICON]
+                  },
+                  {
+                    "uri": "weather://prediction/article",
+                    "description": "Weather prediction article",
+                    "mimeType": "text/markdown",
+                    "annotations": $RESOURCE_ANNOTATIONS,
+                    "size": $size,
+                    "name": "prediction-article",
+                    "title": "Weather Prediction",
+                    "icons": [$RESOURCE_ICON]
+                  }
+                ],
+                "resultType": "complete",
+                "ttlMs": 0,
+                "cacheScope": "public"
+              }
             }
-            with(icons().single()) {
-                src() shouldStartWith "data:image/png;base64,"
-                mimeType() shouldBe "image/png"
-                sizes() shouldContainExactly listOf("256x256")
-                theme() shouldBe "light"
-            }
-        }
-
-        val weather =
-            result.resources().first {
-                it.uri() == "weather://featured/current"
-            }
-        with(weather) {
-            name() shouldBe "featured-current-weather"
-            title() shouldBe "Featured Current Weather"
-            description() shouldBe "Current weather in Tallinn"
-            mimeType() shouldBe "application/json"
-            annotations() shouldBe article.annotations()
-            icons() shouldBe article.icons()
-        }
+            """
     }
 
     @Test
     fun `should read text resource`() {
-        val article =
-            client.listResources().resources().first { it.uri() == "weather://prediction/article" }
+        val response =
+            client.post(
+                """{"jsonrpc":"2.0","id":8,"method":"resources/read","params":{"uri":"weather://prediction/article"}}""",
+            )
 
-        val result = client.readResource(article)
-
-        val contents = result.contents().first()
-        with(contents) {
-            shouldBeInstanceOf<TextResourceContents>()
-            uri() shouldBe "weather://prediction/article"
-            mimeType() shouldBe "text/markdown"
-            text().trim() shouldStartWith "# Weather Prediction"
-        }
+        response.statusCode() shouldBe 200
+        val articleJson = json.encodeToString(weatherService.predictionArticle)
+        response.body() shouldEqualJson
+            """
+            {
+              "jsonrpc": "2.0",
+              "id": 8,
+              "result": {
+                "contents": [{"text": $articleJson, "uri": "weather://prediction/article", "mimeType": "text/markdown"}],
+                "resultType": "complete",
+                "ttlMs": 0,
+                "cacheScope": "public"
+              }
+            }
+            """
     }
 
     @Test
     fun `should read current weather resource`() {
-        val weather =
-            client.listResources().resources().first { it.uri() == "weather://featured/current" }
+        val response =
+            client.post(
+                """{"jsonrpc":"2.0","id":9,"method":"resources/read","params":{"uri":"weather://featured/current"}}""",
+            )
 
-        val result = client.readResource(weather)
-
-        val contents = result.contents().first()
-        with(contents) {
-            shouldBeInstanceOf<TextResourceContents>()
-            uri() shouldBe "weather://featured/current"
-            mimeType() shouldBe "application/json"
-            text() shouldContain "Clear sky"
-        }
+        response.statusCode() shouldBe 200
+        response.body() shouldEqualJson weatherResourceResultBody(9, "weather://featured/current")
     }
 
     @Test
     fun `should list resource templates`() {
-        val result = client.listResourceTemplates()
+        val response =
+            client.post(
+                """
+                {"jsonrpc":"2.0","id":10,"method":"resources/templates/list"}
+                """.trimMargin(),
+            )
 
-        result.resourceTemplates() shouldHaveSize 1
-        result.resourceTemplates().first() shouldNotBeNull {
-            uriTemplate() shouldBe "weather://current/{city}"
-            name() shouldBe "current-weather"
-            mimeType() shouldBe "application/json"
-        }
+        response.statusCode() shouldBe 200
+        response.body() shouldEqualJson
+            """
+            {
+              "jsonrpc": "2.0",
+              "id": 10,
+              "result": {
+                "resourceTemplates": [{
+                  "uriTemplate": "weather://current/{city}",
+                  "description": "Weather forecast for a city",
+                  "mimeType": "application/json",
+                  "name": "current-weather",
+                  "title": "Weather in the city"
+                }],
+                "resultType": "complete",
+                "ttlMs": 0,
+                "cacheScope": "public"
+              }
+            }
+            """
     }
 
     @Test
     fun `should read current weather from template`() {
-        val result =
-            client.readResource(
-                ReadResourceRequest.builder("weather://current/London").build(),
+        val response =
+            client.post(
+                """{"jsonrpc":"2.0","id":11,"method":"resources/read","params":{"uri":"weather://current/London"}}""",
             )
 
-        val contents = result.contents().first()
-        contents.shouldBeInstanceOf<TextResourceContents>()
-        contents.uri() shouldBe "weather://current/London"
-        contents.mimeType() shouldBe "application/json"
-        contents.text() shouldContain "Clear sky"
+        response.statusCode() shouldBe 200
+        response.body() shouldEqualJson weatherResourceResultBody(11, "weather://current/London")
     }
 
     @Test
     fun `should return invalid params when template city is unknown`() {
-        val error =
-            shouldThrow<McpError> {
-                client.readResource(
-                    ReadResourceRequest.builder("weather://current/Unknown").build(),
-                )
+        val response =
+            client.post(
+                """{"jsonrpc":"2.0","id":12,"method":"resources/read","params":{"uri":"weather://current/Unknown"}}""",
+            )
+
+        response.statusCode() shouldBe 400
+        response.body() shouldEqualJson
+            """
+            {
+              "jsonrpc": "2.0",
+              "id": 12,
+              "error": {"code": -32602, "message": "invalid argument 'city': City not found: Unknown"}
             }
-        error.jsonRpcError.code() shouldBe -32602
+            """
     }
 
     @Test
     fun `should complete city name for current weather template`() {
-        val result =
-            client.completeCompletion(
-                CompleteRequest
-                    .builder(
-                        ResourceReference("weather://current/{city}"),
-                        CompleteRequest.CompleteArgument("city", "Lo"),
-                    ).build(),
+        val response =
+            client.post(
+                """
+                {"jsonrpc":"2.0","id":13,"method":"completion/complete",
+                 "params":{"ref":{"type":"ref/resource","uri":"weather://current/{city}"},
+                           "argument":{"name":"city","value":"Lo"}}}
+                """,
             )
 
-        result.completion().values() shouldContainExactlyInAnyOrder listOf("London", "Los Angeles")
-        result.completion().hasMore() shouldNotBe true
+        response.statusCode() shouldBe 200
+        response.body() shouldEqualJson
+            """
+            {
+              "jsonrpc": "2.0",
+              "id": 13,
+              "result": {"completion": {"values": ["London", "Los Angeles"]}, "resultType": "complete"}
+            }
+            """
     }
 
     @Test
     fun `should return empty completion for blank query`() {
-        val result =
-            client.completeCompletion(
-                CompleteRequest
-                    .builder(
-                        ResourceReference("weather://current/{city}"),
-                        CompleteRequest.CompleteArgument("city", ""),
-                    ).build(),
+        val response =
+            client.post(
+                """
+                {"jsonrpc":"2.0","id":14,"method":"completion/complete",
+                 "params":{"ref":{"type":"ref/resource","uri":"weather://current/{city}"},
+                           "argument":{"name":"city","value":""}}}
+                """,
             )
 
-        result.completion().values() shouldHaveSize 0
+        response.statusCode() shouldBe 200
+        response.body() shouldEqualJson
+            """
+            {
+              "jsonrpc": "2.0",
+              "id": 14,
+              "result": {"completion": {"values": []}, "resultType": "complete"}
+            }
+            """
     }
 
     @Test
     fun `should complete style name for rewrite-forecast prompt`() {
-        val result =
-            client.completeCompletion(
-                CompleteRequest
-                    .builder(
-                        PromptReference("rewrite-forecast"),
-                        CompleteRequest.CompleteArgument("style", "pi"),
-                    ).build(),
+        val response =
+            client.post(
+                """
+                {"jsonrpc":"2.0","id":15,"method":"completion/complete",
+                 "params":{"ref":{"type":"ref/prompt","name":"rewrite-forecast"},
+                           "argument":{"name":"style","value":"pi"}}}
+                """,
             )
 
-        result.completion().values() shouldContainExactly listOf("pirate")
+        response.statusCode() shouldBe 200
+        response.body() shouldEqualJson
+            """
+            {
+              "jsonrpc": "2.0",
+              "id": 15,
+              "result": {"completion": {"values": ["pirate"]}, "resultType": "complete"}
+            }
+            """
     }
 
     @Test
     fun `should return empty completion for non-style argument of rewrite-forecast prompt`() {
-        val result =
-            client.completeCompletion(
-                CompleteRequest
-                    .builder(
-                        PromptReference("rewrite-forecast"),
-                        CompleteRequest.CompleteArgument("forecast", "Rain"),
-                    ).build(),
+        val response =
+            client.post(
+                """
+                {"jsonrpc":"2.0","id":16,"method":"completion/complete",
+                 "params":{"ref":{"type":"ref/prompt","name":"rewrite-forecast"},
+                           "argument":{"name":"forecast","value":"Rain"}}}
+                """,
             )
 
-        result.completion().values() shouldHaveSize 0
+        response.statusCode() shouldBe 200
+        response.body() shouldEqualJson
+            """
+            {
+              "jsonrpc": "2.0",
+              "id": 16,
+              "result": {"completion": {"values": []}, "resultType": "complete"}
+            }
+            """
     }
 
     @Test
     fun `should list prompts`() {
-        val result = client.listPrompts()
+        val response = client.post("""{"jsonrpc":"2.0","id":17,"method":"prompts/list"}""")
 
-        result.prompts() shouldHaveSize 1
-        val prompt = result.prompts().first()
-        prompt.name() shouldBe "rewrite-forecast"
-        prompt.description() shouldBe "Rewrites a weather forecast in a chosen style"
-        prompt.arguments() shouldHaveSize 2
+        response.statusCode() shouldBe 200
+        response.body() shouldEqualJson
+            """
+            {
+              "jsonrpc": "2.0",
+              "id": 17,
+              "result": {
+                "prompts": [{
+                  "description": "Rewrites a weather forecast in a chosen style",
+                  "arguments": [
+                    {"description": "Weather forecast to rewrite", "required": true, "name": "forecast", "title": "Forecast"},
+                    {"description": "plain, concise, or pirate", "required": true, "name": "style", "title": "Style"}
+                  ],
+                  "name": "rewrite-forecast"
+                }],
+                "resultType": "complete",
+                "ttlMs": 0,
+                "cacheScope": "public"
+              }
+            }
+            """
     }
 
     @Test
     fun `should get prompt`() {
-        val result =
-            client.getPrompt(
-                GetPromptRequest
-                    .builder("rewrite-forecast")
-                    .arguments(mapOf("forecast" to "Rain in London", "style" to "pirate"))
-                    .build(),
+        val response =
+            client.post(
+                """
+                {"jsonrpc":"2.0","id":18,"method":"prompts/get",
+                 "params":{"name":"rewrite-forecast",
+                           "arguments":{"forecast":"Rain in London","style":"pirate"}}}
+                """,
             )
 
-        result.messages() shouldHaveSize 1
-        val message = result.messages().first()
-        message.role() shouldBe Role.USER
-        message.content().shouldBeInstanceOf<TextContent>()
-        (message.content() as TextContent).text() shouldBe
-            "Rewrite the following weather forecast in pirate style. Preserve factual details:\n\n```Rain in London\n```"
+        response.statusCode() shouldBe 200
+        val text =
+            "Rewrite the following weather forecast in pirate style. " +
+                "Preserve factual details:\n\n```Rain in London\n```"
+        val textJson = json.encodeToString(text)
+        response.body() shouldEqualJson
+            """
+            {
+              "jsonrpc": "2.0",
+              "id": 18,
+              "result": {
+                "description": "Rewrites a weather forecast in a chosen style",
+                "messages": [{"role": "user", "content": {"type": "text", "text": $textJson}}],
+                "resultType": "complete"
+              }
+            }
+            """
     }
 }

--- a/examples/weather-mcp/pom.xml
+++ b/examples/weather-mcp/pom.xml
@@ -55,12 +55,6 @@
             <version>${tachyon.version}</version>
         </dependency>
 
-        <dependency>
-            <groupId>io.modelcontextprotocol.sdk</groupId>
-            <artifactId>mcp-json-jackson3</artifactId>
-            <version>2.0.0</version>
-        </dependency>
-
         <!-- Recognized by kt-schema-apt out of the box to describe generated JSON schemas -->
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
@@ -81,6 +75,12 @@
         </dependency>
 
         <!-- Test -->
+        <dependency>
+            <groupId>dev.tachyonmcp</groupId>
+            <artifactId>tachyon-testkit</artifactId>
+            <version>${tachyon.version}</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>

--- a/examples/weather-mcp/src/main/java/com/example/weather/GetWeatherTool.java
+++ b/examples/weather-mcp/src/main/java/com/example/weather/GetWeatherTool.java
@@ -11,9 +11,8 @@ import com.example.weather.service.WeatherService;
 import com.example.weather.spi.CityNotFoundException;
 import com.example.weather.spi.WeatherObservation;
 import dev.tachyonmcp.api.json.JsonSchema;
-import dev.tachyonmcp.api.runtime.ElicitationRequest;
-import dev.tachyonmcp.api.runtime.ElicitationResult;
 import dev.tachyonmcp.api.runtime.InteractionContext;
+import dev.tachyonmcp.api.server.domain.FormInputRequest;
 import dev.tachyonmcp.api.server.domain.Icon;
 import dev.tachyonmcp.api.server.domain.ProgressToken;
 import dev.tachyonmcp.api.server.domain.ToolAnnotations;
@@ -23,15 +22,19 @@ import dev.tachyonmcp.api.server.features.tools.ToolResult;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import tools.jackson.databind.ObjectMapper;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 class GetWeatherTool {
     private static final Logger log = LoggerFactory.getLogger(GetWeatherTool.class);
+    private static final ObjectMapper MAPPER = new ObjectMapper();
     private static final JsonSchema CITY_SCHEMA = JsonSchema.generate(CityInput.class);
     private static final JsonSchema INPUT_SCHEMA = JsonSchema.generate(GetWeatherRequest.class);
     private static final JsonSchema OUTPUT_SCHEMA = JsonSchema.generate(GetWeatherResponse.class);
+    private static final String CITY_INPUT_KEY = "city";
 
     static final ToolDescriptor DESCRIPTOR = ToolDescriptor.builder()
         .name("get-weather")
@@ -46,26 +49,23 @@ class GetWeatherTool {
     static ToolFn fn(WeatherService weatherService) {
         return (ctx, request) -> {
             var args = request.arguments().decode(GetWeatherRequest.class);
-            var city = args.city();
             var units = args.units();
             var progressToken = request.progressToken();
+            var inputResponses = request.inputResponses();
+            var city = elicitedCity(inputResponses).orElseGet(args::city);
             try {
                 return ToolResult.structured(
                     toResponse(city, fetchWithProgress(ctx, progressToken, weatherService, city), units)
                 );
             } catch (CityNotFoundException e) {
-                var elicitedCity = elicitCity(ctx, city);
-                if (elicitedCity.isEmpty()) {
+                if (inputResponses != null) {
                     return ToolResult.error("City not found");
                 }
-                try {
-                    final var fetched = fetchWithProgress(ctx, progressToken, weatherService, elicitedCity.get());
-                    return ToolResult.structured(
-                        toResponse(elicitedCity.get(), fetched, units)
-                    );
-                } catch (CityNotFoundException ignored) {
-                    return ToolResult.error("City not found");
-                }
+                var inputRequests = Map.of(
+                    CITY_INPUT_KEY,
+                    FormInputRequest.of(
+                        "City '%s' was not found. Enter another city.".formatted(city), citySchemaMap()));
+                return ToolResult.inputRequired(inputRequests, null);
             } catch (Exception e) {
                 return internalError(e);
             }
@@ -89,21 +89,21 @@ class GetWeatherTool {
         return ToolResult.error("Could not get weather");
     }
 
-    private static Optional<String> elicitCity(InteractionContext ctx, String city) throws Exception {
-        var request = new ElicitationRequest(
-            "City '%s' was not found. Enter another city.".formatted(city), CITY_SCHEMA);
-        ElicitationResult result;
-        try {
-            result = ctx.client().elicitation().create(request).get();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw e;
-        }
-        if (result.action() != ElicitationResult.Action.ACCEPT || result.content() == null) {
+    private static Optional<String> elicitedCity(@Nullable Map<String, Object> inputResponses) {
+        if (inputResponses == null) {
             return Optional.empty();
         }
-        var correctedCity = result.content().stringOr("city", "");
-        return correctedCity.isBlank() ? Optional.empty() : Optional.of(correctedCity);
+        if (inputResponses.get(CITY_INPUT_KEY) instanceof Map<?, ?> response
+            && response.get("city") instanceof String correctedCity
+            && !correctedCity.isBlank()) {
+            return Optional.of(correctedCity);
+        }
+        return Optional.empty();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> citySchemaMap() {
+        return (Map<String, Object>) MAPPER.readValue(CITY_SCHEMA.json(), Map.class);
     }
 
     private static GetWeatherResponse toResponse(String city, WeatherObservation weather, @Nullable TemperatureUnit units) {

--- a/examples/weather-mcp/src/test/java/com/example/weather/WeatherServerTest.java
+++ b/examples/weather-mcp/src/test/java/com/example/weather/WeatherServerTest.java
@@ -4,56 +4,55 @@
 
 package com.example.weather;
 
+import com.example.weather.model.GetWeatherResponse;
+import com.example.weather.model.TemperatureUnit;
 import com.example.weather.service.WeatherService;
+import com.example.weather.spi.WeatherObservation;
 import dev.tachyonmcp.core.server.TachyonServer;
-import io.modelcontextprotocol.client.McpClient;
-import io.modelcontextprotocol.client.McpSyncClient;
-import io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport;
-import io.modelcontextprotocol.spec.McpError;
-import io.modelcontextprotocol.spec.McpSchema;
+import dev.tachyonmcp.testkit.Mcp20260728Client;
+import dev.tachyonmcp.testkit.McpTestClients;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
 
-import java.time.Duration;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.CopyOnWriteArrayList;
-import reactor.core.publisher.Mono;
-import reactor.core.scheduler.Schedulers;
+import java.nio.charset.StandardCharsets;
+import java.util.Locale;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.Assertions.tuple;
-import static org.awaitility.Awaitility.await;
 
 class WeatherServerTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final String ICON_SRC_PATTERN = "${json-unit.regex}^data:image/png;base64,.+$";
+    private static final String CAPABILITIES = """
+        {"tools":{},"resources":{},"prompts":{},"logging":{},"completions":{}}""";
+    private static final String SERVER_INFO = """
+        {
+          "version": "1.0",
+          "description": "Weather MCP server",
+          "websiteUrl": "https://github.com/kpavlov/tachyon/tree/main/examples/weather-mcp",
+          "name": "weather-server",
+          "title": "Weather Server",
+          "icons": [{"src": "%s", "mimeType": "image/png", "sizes": ["256x256"]}]
+        }""".formatted(ICON_SRC_PATTERN);
+    private static final String RESOURCE_ANNOTATIONS = """
+        {"audience": ["user", "assistant"], "priority": 0.8, "lastModified": "2026-07-23T00:00:00Z"}""";
+    private static final String RESOURCE_ICON = """
+        {"src": "%s", "mimeType": "image/png", "sizes": ["256x256"], "theme": "light"}""".formatted(ICON_SRC_PATTERN);
 
     private static final TestWeatherProvider weatherProvider = new TestWeatherProvider();
     private static final TestCityProvider cityProvider = new TestCityProvider();
     private static final WeatherService weatherService = new WeatherService(weatherProvider, cityProvider);
     private static TachyonServer handle;
-    private static HttpClientStreamableHttpTransport clientTransport;
-    private static McpSyncClient client;
-    private static McpSchema.InitializeResult initResult;
+    private static Mcp20260728Client client;
 
     @BeforeAll
     static void beforeAll() {
         handle = WeatherServer.buildServer("localhost", 0, weatherService);
         handle.start();
-        int port = handle.port();
-
-        clientTransport = HttpClientStreamableHttpTransport
-            .builder("http://localhost:" + port)
-            .build();
-        client = McpClient.sync(clientTransport)
-            .elicitation(request -> new McpSchema.ElicitResult(
-                McpSchema.ElicitResult.Action.ACCEPT, Map.of("city", "Tallinn")))
-            .build();
-
-        initResult = client.initialize();
+        client = McpTestClients.latest(handle.port());
     }
 
     @AfterAll
@@ -61,335 +60,486 @@ class WeatherServerTest {
         if (client != null) {
             client.close();
         }
-        if (clientTransport != null) {
-            clientTransport.close();
-        }
         if (handle != null) {
             handle.close();
         }
     }
 
-    @Test
-    void shouldGetServerInfo() {
-        assertThat(initResult.serverInfo()).usingRecursiveComparison().ignoringFields("icons").isEqualTo(
-            McpSchema.Implementation.builder("weather-server", "1.0")
-                .title("Weather Server")
-                .websiteUrl("https://github.com/kpavlov/tachyon/tree/main/examples/weather-mcp")
-                .description("Weather MCP server")
-                .build());
-        assertThat(initResult.serverInfo().icons()).singleElement().satisfies(icon -> {
-            assertThat(icon.src()).startsWith("data:image/png;base64,");
-            assertThat(icon.mimeType()).isEqualTo("image/png");
-            assertThat(icon.sizes()).containsExactly("256x256");
-        });
-        assertThat(initResult.protocolVersion()).isEqualTo("2025-11-25");
-        assertThat(initResult.instructions()).isEqualTo("Test instructions");
-        assertThat(initResult.capabilities()).isEqualTo(McpSchema.ServerCapabilities.builder()
-            .tools(null)
-            .resources(null, null)
-            .prompts(null)
-            .logging()
-            .completions()
-            .build());
+    private static String weatherCallResultBody(int id, String city, String unit) throws Exception {
+        var response = new GetWeatherResponse(
+            city, "Clear sky", 18.5, TemperatureUnit.valueOf(unit.toUpperCase(Locale.ROOT)), 52, 12.0);
+        var structuredJson = MAPPER.writeValueAsString(response);
+        var textJson = MAPPER.writeValueAsString(structuredJson);
+        return """
+            {
+              "jsonrpc": "2.0",
+              "id": %d,
+              "result": {
+                "content": [{"type": "text", "text": %s}],
+                "structuredContent": %s,
+                "resultType": "complete"
+              }
+            }
+            """.formatted(id, textJson, structuredJson);
     }
 
     @Test
-    void shouldListTools() {
-        final var result = client.listTools();
-        assertThat(result).isNotNull();
-        assertThat(result.tools()).hasSize(1);
-        McpSchema.Tool tool = result.tools().getFirst();
-        assertThat(tool.name()).isEqualTo("get-weather");
-        assertThat(tool.title()).isEqualTo("Current Weather");
-        assertThat(tool.description()).isEqualTo("Get current weather for a city");
-        assertThat(tool.inputSchema()).isEqualTo(Map.of(
-            "$schema", "https://json-schema.org/draft/2020-12/schema",
-            "$id", "GetWeatherRequest",
-            "description", "Input for looking up the current weather in a city.",
-            "type", "object",
-            "required", List.of("city", "units"),
-            "additionalProperties", false,
-            "properties", Map.of(
-                "city", Map.of(
-                    "description", "City name (e.g., London, Tokyo, New York)",
-                    "type", "string"),
-                "units", Map.of(
-                    "description", "Temperature unit (default: celsius)",
-                    "oneOf", List.of(
-                        Map.of("type", "null"),
-                        Map.of("$ref", "#/$defs/TemperatureUnit")))),
-            "$defs", Map.of(
-                "TemperatureUnit", Map.of(
-                    "type", "string",
-                    "description", "Unit used to represent temperature.",
-                    "enum", List.of("celsius", "fahrenheit")))));
-        assertThat(tool.outputSchema()).isEqualTo(Map.of(
-            "$schema", "https://json-schema.org/draft/2020-12/schema",
-            "$id", "GetWeatherResponse",
-            "description", "Current weather observation for a city.",
-            "type", "object",
-            "required", List.of("city", "condition", "temperature", "unit", "humidity", "windSpeed"),
-            "additionalProperties", false,
-            "properties", Map.of(
-                "city", Map.of("description", "City name", "type", "string"),
-                "condition", Map.of("description", "Weather condition", "type", "string"),
-                "temperature", Map.of("description", "Temperature in the response unit", "type", "number"),
-                "unit", Map.of("description", "Temperature unit", "$ref", "#/$defs/TemperatureUnit"),
-                "humidity", Map.of("description", "Relative humidity percentage", "type", "integer"),
-                "windSpeed", Map.of("description", "Wind speed in km/h", "type", "number")),
-            "$defs", Map.of(
-                "TemperatureUnit", Map.of(
-                    "type", "string",
-                    "description", "Unit used to represent temperature.",
-                    "enum", List.of("celsius", "fahrenheit")))));
-        assertThat(tool.meta()).isNull();
+    void shouldGetServerInfo() throws Exception {
+        var response = client.post("""
+            {"jsonrpc":"2.0","id":1,"method":"server/discover"}
+            """);
+
+        assertThat(response.statusCode()).isEqualTo(200);
+        assertThatJson(response.body())
+            .isEqualTo("""
+                {
+                  "jsonrpc": "2.0",
+                  "id": 1,
+                  "result": {
+                    "supportedVersions": ["2026-07-28", "2025-11-25"],
+                    "capabilities": %s,
+                    "instructions": "Test instructions",
+                    "serverInfo": %s,
+                    "_meta": {"io.modelcontextprotocol/serverInfo": %s},
+                    "resultType": "complete",
+                    "ttlMs": 0,
+                    "cacheScope": "public"
+                  }
+                }
+                """.formatted(CAPABILITIES, SERVER_INFO, SERVER_INFO));
     }
 
     @Test
-    void shouldCallWeatherTool() {
-        final var result = client.callTool(McpSchema.CallToolRequest.builder("get-weather")
-            .arguments(Map.of("city", "London", "units", "celsius"))
-            .build());
+    void shouldListTools() throws Exception {
+        var response = client.post("""
+            {"jsonrpc":"2.0","id":2,"method":"tools/list"}
+            """);
 
-        assertThat(result).isNotNull();
-        assertThat(result.structuredContent()).isEqualTo(Map.of(
-            "city", "London",
-            "condition", "Clear sky",
-            "temperature", 18.5,
-            "unit", "celsius",
-            "humidity", 52,
-            "windSpeed", 12.0));
+        assertThat(response.statusCode()).isEqualTo(200);
+        assertThatJson(response.body())
+            .isEqualTo("""
+                {
+                  "jsonrpc": "2.0",
+                  "id": 2,
+                  "result": {
+                    "tools": [{
+                      "description": "Get current weather for a city",
+                      "inputSchema": {
+                        "$schema": "https://json-schema.org/draft/2020-12/schema",
+                        "$id": "GetWeatherRequest",
+                        "description": "Input for looking up the current weather in a city.",
+                        "type": "object",
+                        "required": ["city", "units"],
+                        "additionalProperties": false,
+                        "properties": {
+                          "city": {"description": "City name (e.g., London, Tokyo, New York)", "type": "string"},
+                          "units": {
+                            "description": "Temperature unit (default: celsius)",
+                            "oneOf": [{"type": "null"}, {"$ref": "#/$defs/TemperatureUnit"}]
+                          }
+                        },
+                        "$defs": {
+                          "TemperatureUnit": {
+                            "type": "string",
+                            "description": "Unit used to represent temperature.",
+                            "enum": ["celsius", "fahrenheit"]
+                          }
+                        }
+                      },
+                      "outputSchema": {
+                        "$schema": "https://json-schema.org/draft/2020-12/schema",
+                        "$id": "GetWeatherResponse",
+                        "description": "Current weather observation for a city.",
+                        "type": "object",
+                        "required": ["city", "condition", "temperature", "unit", "humidity", "windSpeed"],
+                        "additionalProperties": false,
+                        "properties": {
+                          "city": {"description": "City name", "type": "string"},
+                          "condition": {"description": "Weather condition", "type": "string"},
+                          "temperature": {"description": "Temperature in the response unit", "type": "number"},
+                          "unit": {"description": "Temperature unit", "$ref": "#/$defs/TemperatureUnit"},
+                          "humidity": {"description": "Relative humidity percentage", "type": "integer"},
+                          "windSpeed": {"description": "Wind speed in km/h", "type": "number"}
+                        },
+                        "$defs": {
+                          "TemperatureUnit": {
+                            "type": "string",
+                            "description": "Unit used to represent temperature.",
+                            "enum": ["celsius", "fahrenheit"]
+                          }
+                        }
+                      },
+                      "annotations": {
+                        "readOnlyHint": true, "destructiveHint": false, "idempotentHint": true, "openWorldHint": true
+                      },
+                      "name": "get-weather",
+                      "title": "Current Weather",
+                      "icons": [{"src": "%s", "mimeType": "image/png", "sizes": ["128x128"]}]
+                    }],
+                    "resultType": "complete",
+                    "ttlMs": 0,
+                    "cacheScope": "public"
+                  }
+                }
+                """.formatted(ICON_SRC_PATTERN));
     }
 
     @Test
-    void shouldEmitProgressWhileFetchingWeather() {
-        var progressNotifications = new CopyOnWriteArrayList<McpSchema.ProgressNotification>();
-        var progressScheduler = Schedulers.newSingle("weather-progress");
-        var progressClient = McpClient.async(HttpClientStreamableHttpTransport
-            .builder("http://localhost:" + handle.port())
-            .build())
-            .progressConsumer(notification -> Mono.<Void>fromRunnable(() -> progressNotifications.add(notification))
-                .subscribeOn(progressScheduler))
-            .build();
-        try {
-            progressClient.initialize().block();
-            var arguments = new HashMap<String, Object>();
-            arguments.put("city", "London");
-            arguments.put("units", null);
-            final var result = progressClient.callTool(McpSchema.CallToolRequest.builder("get-weather")
-                .arguments(arguments)
-                .progressToken("weather-progress")
-                .build())
-                .block();
+    void shouldCallWeatherTool() throws Exception {
+        var response = client.post("""
+            {"jsonrpc":"2.0","id":3,"method":"tools/call",
+             "params":{"name":"get-weather","arguments":{"city":"London","units":"celsius"}}}
+            """);
 
-            assertThat(result.isError()).isNotEqualTo(true);
-            await().atMost(Duration.ofSeconds(5)).untilAsserted(() ->
-                assertThat(progressNotifications)
-                    .extracting(
-                        McpSchema.ProgressNotification::progressToken,
-                        McpSchema.ProgressNotification::progress,
-                        McpSchema.ProgressNotification::total,
-                        McpSchema.ProgressNotification::message)
-                    .containsExactly(
-                        tuple("weather-progress", 0.1, 1.0, "Fetching weather for London"),
-                        tuple("weather-progress", 1.0, 1.0, "Weather retrieved for London")));
-        } finally {
-            progressClient.close();
-            progressScheduler.dispose();
-        }
+        assertThat(response.statusCode()).isEqualTo(200);
+        assertThatJson(response.body()).isEqualTo(weatherCallResultBody(3, "London", "celsius"));
     }
 
     @Test
-    void shouldCallWeatherToolAfterElicitingAnotherCity() {
-        var arguments = new HashMap<String, Object>();
-        arguments.put("city", "Unknown");
-        arguments.put("units", null);
-        final var result = client.callTool(McpSchema.CallToolRequest.builder("get-weather")
-            .arguments(arguments)
-            .build());
+    void shouldEmitProgressWhileFetchingWeather() throws Exception {
+        client.clearNotifications();
 
-        assertThat(result.structuredContent()).isEqualTo(Map.of(
-            "city", "Tallinn",
-            "condition", "Clear sky",
-            "temperature", 18.5,
-            "unit", "celsius",
-            "humidity", 52,
-            "windSpeed", 12.0));
+        var response = client.post("""
+            {"jsonrpc":"2.0","id":4,"method":"tools/call",
+             "params":{"name":"get-weather","arguments":{"city":"London","units":null},
+                       "_meta":{"progressToken":"weather-progress"}}}
+            """);
+
+        assertThat(response.statusCode()).isEqualTo(200);
+        assertThatJson(response.body()).isEqualTo(weatherCallResultBody(4, "London", "celsius"));
+
+        var progressNotifications = client.notifications().stream()
+            .filter(n -> n.method().equals("notifications/progress"))
+            .map(n -> n.params())
+            .toList();
+        assertThat(progressNotifications).hasSize(2);
+        assertThatJson(progressNotifications.get(0).toString())
+            .isEqualTo("""
+                {"progressToken": "weather-progress", "progress": 0.1, "total": 1.0, "message": "Fetching weather for London"}
+                """);
+        assertThatJson(progressNotifications.get(1).toString())
+            .isEqualTo("""
+                {"progressToken": "weather-progress", "progress": 1.0, "total": 1.0, "message": "Weather retrieved for London"}
+                """);
     }
 
     @Test
-    void shouldListResources() {
-        final var result = client.listResources();
+    void shouldCallWeatherToolAfterElicitingAnotherCity() throws Exception {
+        var round1 = client.post("""
+            {"jsonrpc":"2.0","id":5,"method":"tools/call",
+             "params":{"name":"get-weather","arguments":{"city":"Unknown","units":null}}}
+            """);
 
-        assertThat(result.resources()).hasSize(2);
+        assertThat(round1.statusCode()).isEqualTo(200);
+        assertThatJson(round1.body())
+            .isEqualTo("""
+                {
+                  "jsonrpc": "2.0",
+                  "id": 5,
+                  "result": {
+                    "inputRequests": {
+                      "city": {
+                        "method": "elicitation/create",
+                        "params": {
+                          "message": "City 'Unknown' was not found. Enter another city.",
+                          "requestedSchema": "${json-unit.ignore-element}"
+                        }
+                      }
+                    },
+                    "resultType": "input_required"
+                  }
+                }
+                """);
 
-        var article = result.resources().stream()
-            .filter(resource -> resource.uri().equals("weather://prediction/article"))
-            .findFirst().orElseThrow();
-        assertThat(article.uri()).isEqualTo("weather://prediction/article");
-        assertThat(article.name()).isEqualTo("prediction-article");
-        assertThat(article.title()).isEqualTo("Weather Prediction");
-        assertThat(article.description()).isEqualTo("Weather prediction article");
-        assertThat(article.mimeType()).isEqualTo("text/markdown");
-        assertThat(article.size()).isEqualTo(weatherService.predictionArticle().getBytes(UTF_8).length);
-        assertThat(article.annotations().audience())
-            .containsExactly(McpSchema.Role.USER, McpSchema.Role.ASSISTANT);
-        assertThat(article.annotations().priority()).isEqualTo(0.8);
-        assertThat(article.annotations().lastModified()).isEqualTo("2026-07-23T00:00:00Z");
-        assertThat(article.icons()).singleElement().satisfies(icon -> {
-            assertThat(icon.src()).startsWith("data:image/png;base64,");
-            assertThat(icon.mimeType()).isEqualTo("image/png");
-            assertThat(icon.sizes()).containsExactly("256x256");
-            assertThat(icon.theme()).isEqualTo("light");
-        });
+        var round2 = client.post("""
+            {"jsonrpc":"2.0","id":6,"method":"tools/call",
+             "params":{"name":"get-weather","arguments":{"city":"Unknown","units":null},
+                       "inputResponses":{"city":{"city":"Tallinn"}}}}
+            """);
 
-        var weather = result.resources().stream()
-            .filter(resource -> resource.uri().equals("weather://featured/current"))
-            .findFirst().orElseThrow();
-        assertThat(weather.uri()).isEqualTo("weather://featured/current");
-        assertThat(weather.name()).isEqualTo("featured-current-weather");
-        assertThat(weather.title()).isEqualTo("Featured Current Weather");
-        assertThat(weather.description()).isEqualTo("Current weather in Tallinn");
-        assertThat(weather.mimeType()).isEqualTo("application/json");
-        assertThat(weather.annotations()).isEqualTo(article.annotations());
-        assertThat(weather.icons()).isEqualTo(article.icons());
+        assertThat(round2.statusCode()).isEqualTo(200);
+        assertThatJson(round2.body()).isEqualTo(weatherCallResultBody(6, "Tallinn", "celsius"));
     }
 
     @Test
-    void shouldReadTextResource() {
-        final var listResult = client.listResources();
-        var article = listResult.resources().stream()
-            .filter(r -> r.uri().equals("weather://prediction/article"))
-            .findFirst().orElseThrow();
+    void shouldListResources() throws Exception {
+        var response = client.post("""
+            {"jsonrpc":"2.0","id":7,"method":"resources/list"}
+            """);
 
-        final var result = client.readResource(article);
-
-        var contents = result.contents().getFirst();
-        assertThat(contents).isInstanceOf(McpSchema.TextResourceContents.class);
-        var textContents = ((McpSchema.TextResourceContents) contents);
-        assertThat(textContents.uri()).isEqualTo("weather://prediction/article");
-        assertThat(textContents.mimeType()).isEqualTo("text/markdown");
-        assertThat(textContents.text().trim())
-            .startsWith("# Weather Prediction")
-            .endsWith("reports, ocean buoys, and over 30 polar-orbiting and geostationary satellites.");
+        assertThat(response.statusCode()).isEqualTo(200);
+        var size = weatherService.predictionArticle().getBytes(StandardCharsets.UTF_8).length;
+        assertThatJson(response.body())
+            .isEqualTo("""
+                {
+                  "jsonrpc": "2.0",
+                  "id": 7,
+                  "result": {
+                    "resources": [
+                      {
+                        "uri": "weather://prediction/article",
+                        "description": "Weather prediction article",
+                        "mimeType": "text/markdown",
+                        "annotations": %s,
+                        "size": %d,
+                        "name": "prediction-article",
+                        "title": "Weather Prediction",
+                        "icons": [%s]
+                      },
+                      {
+                        "uri": "weather://featured/current",
+                        "description": "Current weather in Tallinn",
+                        "mimeType": "application/json",
+                        "annotations": %s,
+                        "name": "featured-current-weather",
+                        "title": "Featured Current Weather",
+                        "icons": [%s]
+                      }
+                    ],
+                    "resultType": "complete",
+                    "ttlMs": 0,
+                    "cacheScope": "public"
+                  }
+                }
+                """.formatted(RESOURCE_ANNOTATIONS, size, RESOURCE_ICON, RESOURCE_ANNOTATIONS, RESOURCE_ICON));
     }
 
     @Test
-    void shouldReadCurrentWeatherResource() {
-        final var listResult = client.listResources();
-        var weather = listResult.resources().stream()
-            .filter(r -> r.uri().equals("weather://featured/current"))
-            .findFirst().orElseThrow();
+    void shouldReadTextResource() throws Exception {
+        var response = client.post("""
+            {"jsonrpc":"2.0","id":8,"method":"resources/read",
+             "params":{"uri":"weather://prediction/article"}}
+            """);
 
-        final var result = client.readResource(weather);
+        assertThat(response.statusCode()).isEqualTo(200);
+        var articleJson = MAPPER.writeValueAsString(weatherService.predictionArticle());
+        assertThatJson(response.body())
+            .isEqualTo("""
+                {
+                  "jsonrpc": "2.0",
+                  "id": 8,
+                  "result": {
+                    "contents": [{"text": %s, "uri": "weather://prediction/article", "mimeType": "text/markdown"}],
+                    "resultType": "complete",
+                    "ttlMs": 0,
+                    "cacheScope": "public"
+                  }
+                }
+                """.formatted(articleJson));
+    }
 
-        var contents = result.contents().getFirst();
-        assertThat(contents).isInstanceOf(McpSchema.TextResourceContents.class);
-        var textContents = ((McpSchema.TextResourceContents) contents);
-        assertThat(textContents.uri()).isEqualTo("weather://featured/current");
-        assertThat(textContents.mimeType()).isEqualTo("application/json");
-        assertThat(textContents.text()).contains("Clear sky");
+    private static String weatherResourceResultBody(int id, String requestUri) throws Exception {
+        var weather = new WeatherObservation("Clear sky", 18.5, 52, 12.0);
+        var textJson = MAPPER.writeValueAsString(MAPPER.writeValueAsString(weather));
+        return """
+            {
+              "jsonrpc": "2.0",
+              "id": %d,
+              "result": {
+                "contents": [{"text": %s, "uri": "%s", "mimeType": "application/json"}],
+                "resultType": "complete",
+                "ttlMs": 0,
+                "cacheScope": "public"
+              }
+            }
+            """.formatted(id, textJson, requestUri);
     }
 
     @Test
-    void shouldListResourceTemplates() {
-        final var result = client.listResourceTemplates();
+    void shouldReadCurrentWeatherResource() throws Exception {
+        var response = client.post("""
+            {"jsonrpc":"2.0","id":9,"method":"resources/read",
+             "params":{"uri":"weather://featured/current"}}
+            """);
 
-        assertThat(result.resourceTemplates()).hasSize(1);
-        var template = result.resourceTemplates().getFirst();
-        assertThat(template.uriTemplate()).isEqualTo("weather://current/{city}");
-        assertThat(template.name()).isEqualTo("current-weather");
-        assertThat(template.mimeType()).isEqualTo("application/json");
+        assertThat(response.statusCode()).isEqualTo(200);
+        assertThatJson(response.body()).isEqualTo(weatherResourceResultBody(9, "weather://featured/current"));
     }
 
     @Test
-    void shouldReadCurrentWeatherFromTemplate() {
-        final var result = client.readResource(
-            McpSchema.ReadResourceRequest.builder("weather://current/London").build());
+    void shouldListResourceTemplates() throws Exception {
+        var response = client.post("""
+            {"jsonrpc":"2.0","id":10,"method":"resources/templates/list"}
+            """);
 
-        var contents = result.contents().getFirst();
-        assertThat(contents).isInstanceOf(McpSchema.TextResourceContents.class);
-        var textContents = ((McpSchema.TextResourceContents) contents);
-        assertThat(textContents.uri()).isEqualTo("weather://current/London");
-        assertThat(textContents.mimeType()).isEqualTo("application/json");
-        assertThat(textContents.text()).contains("Clear sky");
+        assertThat(response.statusCode()).isEqualTo(200);
+        assertThatJson(response.body())
+            .isEqualTo("""
+                {
+                  "jsonrpc": "2.0",
+                  "id": 10,
+                  "result": {
+                    "resourceTemplates": [{
+                      "uriTemplate": "weather://current/{city}",
+                      "description": "Weather forecast for a city",
+                      "mimeType": "application/json",
+                      "name": "current-weather",
+                      "title": "Weather in the city"
+                    }],
+                    "resultType": "complete",
+                    "ttlMs": 0,
+                    "cacheScope": "public"
+                  }
+                }
+                """);
     }
 
     @Test
-    void shouldReturnInvalidParamsWhenTemplateCityIsUnknown() {
-        assertThatThrownBy(() -> client.readResource(
-                McpSchema.ReadResourceRequest.builder("weather://current/Unknown").build()))
-            .isInstanceOf(McpError.class)
-            .extracting(e -> ((McpError) e).getJsonRpcError().code())
-            .isEqualTo(-32602);
+    void shouldReadCurrentWeatherFromTemplate() throws Exception {
+        var response = client.post("""
+            {"jsonrpc":"2.0","id":11,"method":"resources/read",
+             "params":{"uri":"weather://current/London"}}
+            """);
+
+        assertThat(response.statusCode()).isEqualTo(200);
+        assertThatJson(response.body()).isEqualTo(weatherResourceResultBody(11, "weather://current/London"));
     }
 
     @Test
-    void shouldCompleteCityNameForCurrentWeatherTemplate() {
-        final var result = client.completeCompletion(McpSchema.CompleteRequest.builder(
-                new McpSchema.ResourceReference("weather://current/{city}"),
-                new McpSchema.CompleteRequest.CompleteArgument("city", "Lo"))
-            .build());
+    void shouldReturnInvalidParamsWhenTemplateCityIsUnknown() throws Exception {
+        var response = client.post("""
+            {"jsonrpc":"2.0","id":12,"method":"resources/read",
+             "params":{"uri":"weather://current/Unknown"}}
+            """);
 
-        assertThat(result.completion().values()).containsExactlyInAnyOrder("London", "Los Angeles");
-        assertThat(result.completion().hasMore()).isNotEqualTo(true);
+        assertThat(response.statusCode()).isEqualTo(400);
+        assertThatJson(response.body())
+            .isEqualTo("""
+                {
+                  "jsonrpc": "2.0",
+                  "id": 12,
+                  "error": {"code": -32602, "message": "invalid argument 'city': City not found: Unknown"}
+                }
+                """);
     }
 
     @Test
-    void shouldReturnEmptyCompletionForBlankQuery() {
-        final var result = client.completeCompletion(McpSchema.CompleteRequest.builder(
-                new McpSchema.ResourceReference("weather://current/{city}"),
-                new McpSchema.CompleteRequest.CompleteArgument("city", ""))
-            .build());
+    void shouldCompleteCityNameForCurrentWeatherTemplate() throws Exception {
+        var response = client.post("""
+            {"jsonrpc":"2.0","id":13,"method":"completion/complete",
+             "params":{"ref":{"type":"ref/resource","uri":"weather://current/{city}"},
+                       "argument":{"name":"city","value":"Lo"}}}
+            """);
 
-        assertThat(result.completion().values()).isEmpty();
+        assertThat(response.statusCode()).isEqualTo(200);
+        assertThatJson(response.body())
+            .isEqualTo("""
+                {
+                  "jsonrpc": "2.0",
+                  "id": 13,
+                  "result": {"completion": {"values": ["London", "Los Angeles"]}, "resultType": "complete"}
+                }
+                """);
     }
 
     @Test
-    void shouldCompleteStyleNameForRewriteForecastPrompt() {
-        final var result = client.completeCompletion(McpSchema.CompleteRequest.builder(
-                new McpSchema.PromptReference("rewrite-forecast"),
-                new McpSchema.CompleteRequest.CompleteArgument("style", "pi"))
-            .build());
+    void shouldReturnEmptyCompletionForBlankQuery() throws Exception {
+        var response = client.post("""
+            {"jsonrpc":"2.0","id":14,"method":"completion/complete",
+             "params":{"ref":{"type":"ref/resource","uri":"weather://current/{city}"},
+                       "argument":{"name":"city","value":""}}}
+            """);
 
-        assertThat(result.completion().values()).containsExactly("pirate");
+        assertThat(response.statusCode()).isEqualTo(200);
+        assertThatJson(response.body())
+            .isEqualTo("""
+                {
+                  "jsonrpc": "2.0",
+                  "id": 14,
+                  "result": {"completion": {"values": []}, "resultType": "complete"}
+                }
+                """);
     }
 
     @Test
-    void shouldReturnEmptyCompletionForNonStyleArgumentOfRewriteForecastPrompt() {
-        final var result = client.completeCompletion(McpSchema.CompleteRequest.builder(
-                new McpSchema.PromptReference("rewrite-forecast"),
-                new McpSchema.CompleteRequest.CompleteArgument("forecast", "Rain"))
-            .build());
+    void shouldCompleteStyleNameForRewriteForecastPrompt() throws Exception {
+        var response = client.post("""
+            {"jsonrpc":"2.0","id":15,"method":"completion/complete",
+             "params":{"ref":{"type":"ref/prompt","name":"rewrite-forecast"},
+                       "argument":{"name":"style","value":"pi"}}}
+            """);
 
-        assertThat(result.completion().values()).isEmpty();
+        assertThat(response.statusCode()).isEqualTo(200);
+        assertThatJson(response.body())
+            .isEqualTo("""
+                {
+                  "jsonrpc": "2.0",
+                  "id": 15,
+                  "result": {"completion": {"values": ["pirate"]}, "resultType": "complete"}
+                }
+                """);
     }
 
     @Test
-    void shouldListPrompts() {
-        final var result = client.listPrompts();
+    void shouldReturnEmptyCompletionForNonStyleArgumentOfRewriteForecastPrompt() throws Exception {
+        var response = client.post("""
+            {"jsonrpc":"2.0","id":16,"method":"completion/complete",
+             "params":{"ref":{"type":"ref/prompt","name":"rewrite-forecast"},
+                       "argument":{"name":"forecast","value":"Rain"}}}
+            """);
 
-        assertThat(result.prompts()).hasSize(1);
-        var prompt = result.prompts().getFirst();
-        assertThat(prompt.name()).isEqualTo("rewrite-forecast");
-        assertThat(prompt.description()).isEqualTo("Rewrites a weather forecast in a chosen style");
-        assertThat(prompt.arguments()).hasSize(2);
+        assertThat(response.statusCode()).isEqualTo(200);
+        assertThatJson(response.body())
+            .isEqualTo("""
+                {
+                  "jsonrpc": "2.0",
+                  "id": 16,
+                  "result": {"completion": {"values": []}, "resultType": "complete"}
+                }
+                """);
     }
 
     @Test
-    void shouldGetPrompt() {
-        final var result = client.getPrompt(
-            McpSchema.GetPromptRequest.builder("rewrite-forecast")
-                .arguments(Map.of("forecast", "Rain in London", "style", "pirate"))
-                .build());
+    void shouldListPrompts() throws Exception {
+        var response = client.post("""
+            {"jsonrpc":"2.0","id":17,"method":"prompts/list"}
+            """);
 
-        assertThat(result).isNotNull();
-        assertThat(result.messages()).hasSize(1);
-        var message = result.messages().getFirst();
-        assertThat(message.role()).isEqualTo(McpSchema.Role.USER);
-        assertThat(message.content()).isInstanceOf(McpSchema.TextContent.class);
-        var textContent = ((McpSchema.TextContent) message.content());
-        assertThat(textContent.text())
-            .isEqualTo("Rewrite the following weather forecast in pirate style. Preserve factual details:\n\n```Rain in London\n```");
+        assertThat(response.statusCode()).isEqualTo(200);
+        assertThatJson(response.body())
+            .isEqualTo("""
+                {
+                  "jsonrpc": "2.0",
+                  "id": 17,
+                  "result": {
+                    "prompts": [{
+                      "description": "Rewrites a weather forecast in a chosen style",
+                      "arguments": [
+                        {"description": "Weather forecast to rewrite", "required": true, "name": "forecast", "title": "Forecast"},
+                        {"description": "plain, concise, or pirate", "required": true, "name": "style", "title": "Style"}
+                      ],
+                      "name": "rewrite-forecast"
+                    }],
+                    "resultType": "complete",
+                    "ttlMs": 0,
+                    "cacheScope": "public"
+                  }
+                }
+                """);
+    }
+
+    @Test
+    void shouldGetPrompt() throws Exception {
+        var response = client.post("""
+            {"jsonrpc":"2.0","id":18,"method":"prompts/get",
+             "params":{"name":"rewrite-forecast",
+                       "arguments":{"forecast":"Rain in London","style":"pirate"}}}
+            """);
+
+        assertThat(response.statusCode()).isEqualTo(200);
+        var text = "Rewrite the following weather forecast in pirate style. "
+            + "Preserve factual details:\n\n```Rain in London\n```";
+        var textJson = MAPPER.writeValueAsString(text);
+        assertThatJson(response.body())
+            .isEqualTo("""
+                {
+                  "jsonrpc": "2.0",
+                  "id": 18,
+                  "result": {
+                    "messages": [{"role": "user", "content": {"type": "text", "text": %s}}],
+                    "resultType": "complete"
+                  }
+                }
+                """.formatted(textJson));
     }
 }

--- a/tachyon-api/pom.xml
+++ b/tachyon-api/pom.xml
@@ -56,6 +56,11 @@
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>tools.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/tachyon-api/src/test/java/dev/tachyonmcp/api/server/domain/FormInputRequestTest.java
+++ b/tachyon-api/src/test/java/dev/tachyonmcp/api/server/domain/FormInputRequestTest.java
@@ -1,14 +1,10 @@
 /* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
 package dev.tachyonmcp.api.server.domain;
 
-import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import dev.tachyonmcp.api.json.JsonSchema;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 class FormInputRequestTest {
@@ -24,25 +20,6 @@ class FormInputRequestTest {
     }
 
     @Test
-    @SuppressWarnings("deprecation")
-    void ofFromMapBuildsEquivalentSchemaViaMapJsonFactory() {
-        Map<String, Object> schemaMap = new LinkedHashMap<>();
-        schemaMap.put("type", "object");
-        schemaMap.put("properties", Map.of("name", Map.of("type", "string")));
-        schemaMap.put("required", List.of("name"));
-
-        var request = FormInputRequest.of("Enter details", schemaMap);
-
-        assertThatJson(request.requestedSchema().json()).isEqualTo("""
-                        {
-                          "type": "object",
-                          "properties": {"name": {"type": "string"}},
-                          "required": ["name"]
-                        }
-                        """);
-    }
-
-    @Test
     void builderAcceptsJsonSchemaDirectly() {
         var schema = JsonSchema.objectSchema();
 
@@ -52,17 +29,6 @@ class FormInputRequestTest {
                 .build();
 
         assertThat(request.requestedSchema()).isSameAs(schema);
-    }
-
-    @Test
-    @SuppressWarnings("deprecation")
-    void builderAcceptsMapAndRoutesThroughJsonSchemaFrom() {
-        var request = FormInputRequest.builder()
-                .message("Enter details")
-                .requestedSchema(Map.of("type", "object"))
-                .build();
-
-        assertThatJson(request.requestedSchema().json()).isEqualTo("{\"type\":\"object\"}");
     }
 
     @Test

--- a/tachyon-api/src/test/java/dev/tachyonmcp/api/server/domain/FormInputRequestTest.java
+++ b/tachyon-api/src/test/java/dev/tachyonmcp/api/server/domain/FormInputRequestTest.java
@@ -1,0 +1,84 @@
+/* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
+package dev.tachyonmcp.api.server.domain;
+
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import dev.tachyonmcp.api.json.JsonSchema;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class FormInputRequestTest {
+
+    @Test
+    void ofAcceptsJsonSchemaDirectly() {
+        var schema = JsonSchema.unchecked("{\"type\":\"object\"}");
+
+        var request = FormInputRequest.of("Enter details", schema);
+
+        assertThat(request.message()).isEqualTo("Enter details");
+        assertThat(request.requestedSchema()).isSameAs(schema);
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    void ofFromMapBuildsEquivalentSchemaViaMapJsonFactory() {
+        Map<String, Object> schemaMap = new LinkedHashMap<>();
+        schemaMap.put("type", "object");
+        schemaMap.put("properties", Map.of("name", Map.of("type", "string")));
+        schemaMap.put("required", List.of("name"));
+
+        var request = FormInputRequest.of("Enter details", schemaMap);
+
+        assertThatJson(request.requestedSchema().json()).isEqualTo("""
+                        {
+                          "type": "object",
+                          "properties": {"name": {"type": "string"}},
+                          "required": ["name"]
+                        }
+                        """);
+    }
+
+    @Test
+    void builderAcceptsJsonSchemaDirectly() {
+        var schema = JsonSchema.objectSchema();
+
+        var request = FormInputRequest.builder()
+                .message("Enter details")
+                .requestedSchema(schema)
+                .build();
+
+        assertThat(request.requestedSchema()).isSameAs(schema);
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    void builderAcceptsMapAndRoutesThroughJsonSchemaFrom() {
+        var request = FormInputRequest.builder()
+                .message("Enter details")
+                .requestedSchema(Map.of("type", "object"))
+                .build();
+
+        assertThatJson(request.requestedSchema().json()).isEqualTo("{\"type\":\"object\"}");
+    }
+
+    @Test
+    void checkRejectsBlankMessage() {
+        assertThatThrownBy(() -> FormInputRequest.of("   ", JsonSchema.objectSchema()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("message");
+    }
+
+    @Test
+    void builderFromCopiesMessageAndSchema() {
+        var original = FormInputRequest.of("Enter details", JsonSchema.objectSchema());
+
+        var copy = FormInputRequest.builder().from(original).build();
+
+        assertThat(copy.message()).isEqualTo(original.message());
+        assertThat(copy.requestedSchema()).isEqualTo(original.requestedSchema());
+    }
+}


### PR DESCRIPTION
Replace ElicitationRequest/Result-based city correction flow with ToolResult.inputRequired + FormInputRequest, matching the JsonSchema-based FormInputRequest API introduced in 26ebdcd4. Drop the now-unused mcp-json-jackson3/awaitility-kotlin deps from the examples in favor of tachyon-testkit and json-unit-assertj.