### PR TITLE
feat(testkit): Update TestKit api

### DIFF
--- a/docs/testkit.md
+++ b/docs/testkit.md
@@ -50,8 +50,8 @@ to drive a remote server instead of a local one.
 
 ## Assertions
 
-`JsonRpcResponseAssert` gives AssertJ-style assertions over a JSON-RPC response envelope —
-success/error branch, tool content, and JSON-RPC error code/message:
+`JsonRpcResponseAssert` first selects the JSON-RPC branch, then exposes only assertions valid for
+that branch:
 
 ```java
 import static dev.tachyonmcp.testkit.JsonRpcResponseAssert.assertThat;
@@ -60,18 +60,23 @@ var response = client.post("""
     {"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"echo","arguments":{"message":"hi"}}}
     """);
 
-assertThat(response).hasTextContent("echo:hi");
+assertThat(response).isSuccess().hasTextContent("echo:hi");
 ```
 
-For raw JSON-RPC error responses, use `assertThatJsonRpcResponse(String)` (avoids an ambiguous
-overload against AssertJ's own `assertThat(String)`):
+Use `hasResult(expected)` or `hasContentExactly(blocks...)` when the complete result or content
+array is stable. `hasContent()` requires at least one content block.
+
+Error assertions follow the same staged shape:
 
 ```java
 import static dev.tachyonmcp.testkit.JsonRpcResponseAssert.assertThatJsonRpcResponse;
 
 var raw = client.sendRpc("""{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"missing","arguments":{}}}""");
 
-assertThatJsonRpcResponse(raw).hasErrorCode(-32602).hasErrorMessageContaining("missing");
+assertThatJsonRpcResponse(raw)
+    .isJsonRpcError()
+    .hasErrorCode(-32602)
+    .hasErrorMessage("Invalid params");
 ```
 
 ## Notifications

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/CompletionTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/CompletionTest.java
@@ -95,7 +95,10 @@ class CompletionTest extends AbstractStatelessMcpE2eTest {
                 }}
                 """);
 
-            assertThat(response).hasErrorCode(-32602);
+            assertThat(response)
+                    .isJsonRpcError()
+                    .hasErrorCode(-32602)
+                    .hasErrorMessage("Missing or invalid ref parameter");
         }
     }
 

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/ExtensionsTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/ExtensionsTest.java
@@ -1,6 +1,7 @@
 /* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
 package dev.tachyonmcp.e2e;
 
+import static dev.tachyonmcp.testkit.JsonRpcResponseAssert.assertThat;
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -167,7 +168,7 @@ class ExtensionsTest extends AbstractStatefulMcpE2eTest {
                     {"jsonrpc":"2.0","id":2,"method":"test/ext-call","params":{}}
                     """;
             var resp1 = client.post(sessionId, callWithoutMeta);
-            assertThat(resp1.body()).contains("-32601");
+            assertThat(resp1).isJsonRpcError().hasErrorCode(-32601);
 
             // Call extension method WITH meta envelope -> should succeed
             // language=JSON

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/InputRequiredResultTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/InputRequiredResultTest.java
@@ -1,6 +1,7 @@
 /* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
 package dev.tachyonmcp.e2e;
 
+import static dev.tachyonmcp.testkit.JsonRpcResponseAssert.assertThat;
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -38,7 +39,7 @@ class InputRequiredResultTest extends AbstractStatelessMcpE2eTest {
                 {"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"test_elicitation","arguments":{}}}
                 """);
 
-            assertThatJson(round1.body()).inPath("$.result.resultType").isEqualTo("input_required");
+            assertThat(round1).isSuccess().hasResultType("input_required");
             assertThatJson(round1.body())
                     .inPath("$.result.inputRequests.user_name.method")
                     .isEqualTo("elicitation/create");
@@ -51,7 +52,7 @@ class InputRequiredResultTest extends AbstractStatelessMcpE2eTest {
                 {"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"test_elicitation","arguments":{},"inputResponses":{"user_name":{"name":"Alice"}}}}
                 """);
 
-            assertThatJson(round2.body()).inPath("$.result.content[0].text").isEqualTo("Hello, Alice!");
+            assertThat(round2).isSuccess().hasTextContent("Hello, Alice!");
         }
     }
 
@@ -68,7 +69,7 @@ class InputRequiredResultTest extends AbstractStatelessMcpE2eTest {
                 {"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"test_multi_round","arguments":{}}}
                 """);
 
-            assertThatJson(round1.body()).inPath("$.result.resultType").isEqualTo("input_required");
+            assertThat(round1).isSuccess().hasResultType("input_required");
             assertThatJson(round1.body())
                     .inPath("$.result.inputRequests.step1.params.message")
                     .isEqualTo("Step 1: What is your name?");
@@ -80,7 +81,7 @@ class InputRequiredResultTest extends AbstractStatelessMcpE2eTest {
                 {"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"test_multi_round","arguments":{},"inputResponses":{"step1":{"name":"Bob"}},"requestState":"state-round-1"}}
                 """);
 
-            assertThatJson(round2.body()).inPath("$.result.resultType").isEqualTo("input_required");
+            assertThat(round2).isSuccess().hasResultType("input_required");
             assertThatJson(round2.body())
                     .inPath("$.result.inputRequests.step2.params.message")
                     .isEqualTo("Step 2: What is your favorite color?");
@@ -110,7 +111,7 @@ class InputRequiredResultTest extends AbstractStatelessMcpE2eTest {
                 {"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"test_meta_elicitation","arguments":{}}}
                 """);
 
-            assertThatJson(response.body()).inPath("$.result.resultType").isEqualTo("input_required");
+            assertThat(response).isSuccess().hasResultType("input_required");
             assertThatJson(response.body()).inPath("$.result._meta.trace-id").isEqualTo("abc-123");
         }
     }
@@ -128,7 +129,7 @@ class InputRequiredResultTest extends AbstractStatelessMcpE2eTest {
                 {"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"test_elicitation","arguments":{},"inputResponses":{"wrong_key":{"name":"Alice"}}}}
                 """);
 
-            assertThatJson(response.body()).inPath("$.result.resultType").isEqualTo("input_required");
+            assertThat(response).isSuccess().hasResultType("input_required");
             assertThatJson(response.body())
                     .inPath("$.result.inputRequests.user_name.method")
                     .isEqualTo("elicitation/create");
@@ -151,7 +152,7 @@ class InputRequiredResultTest extends AbstractStatelessMcpE2eTest {
                 {"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"test_url_elicitation","arguments":{}}}
                 """);
 
-            assertThatJson(round1.body()).inPath("$.result.resultType").isEqualTo("input_required");
+            assertThat(round1).isSuccess().hasResultType("input_required");
             assertThatJson(round1.body())
                     .inPath("$.result.inputRequests.auth.method")
                     .isEqualTo("elicitation/create");
@@ -173,7 +174,7 @@ class InputRequiredResultTest extends AbstractStatelessMcpE2eTest {
                 {"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"test_url_elicitation","arguments":{},"inputResponses":{"auth":{"action":"accept"}}}}
                 """);
 
-            assertThatJson(round2.body()).inPath("$.result.content[0].text").isEqualTo("Authenticated successfully!");
+            assertThat(round2).isSuccess().hasTextContent("Authenticated successfully!");
         }
     }
 

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/LoggingTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/LoggingTest.java
@@ -1,12 +1,11 @@
 /* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
 package dev.tachyonmcp.e2e;
 
+import static java.time.Duration.ofSeconds;
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.net.Socket;
-import java.net.SocketTimeoutException;
-import java.nio.charset.StandardCharsets;
+import dev.tachyonmcp.testkit.SseFrame;
 import java.util.Map;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
@@ -69,48 +68,17 @@ class LoggingTest extends AbstractStatefulMcpE2eTest {
     }
 
     /**
-     * Opens a raw GET SSE listen stream and, once it is primed, triggers a server-scoped broadcast so
-     * it rides that stream. Returns each SSE event's {@code data:} payload as a stream, read until the
-     * broadcast is observed (or the read window elapses).
+     * Opens a GET SSE listen stream and, once it is primed, triggers a server-scoped broadcast so
+     * it rides that stream. Returns each SSE frame's {@code data:} payload as a stream, waiting for
+     * the broadcast to arrive.
      */
     private Stream<String> readListenStreamWhileBroadcasting(String sessionId) throws Exception {
-        try (var socket = new Socket("localhost", port)) {
-            var req = ("GET /mcp HTTP/1.1\r\n"
-                            + "Host: localhost:" + port + "\r\n"
-                            + "MCP-Session-Id: " + sessionId + "\r\n"
-                            + "MCP-Protocol-Version: 2025-11-25\r\n"
-                            + "Accept: text/event-stream\r\n"
-                            + "\r\n")
-                    .getBytes(StandardCharsets.UTF_8);
-            socket.getOutputStream().write(req);
-            socket.getOutputStream().flush();
-            socket.setSoTimeout(100);
-
-            var sb = new StringBuilder();
-            var buf = new byte[2048];
-            var broadcast = false;
-            var deadline = System.currentTimeMillis() + 15_000;
-            while (System.currentTimeMillis() < deadline) {
-                try {
-                    var n = socket.getInputStream().read(buf);
-                    if (n < 0) break;
-                    sb.append(new String(buf, 0, n, StandardCharsets.UTF_8));
-                } catch (SocketTimeoutException ignored) {
-                    // idle tick — fall through to broadcast/exit checks
-                }
-                if (!broadcast && sb.indexOf("id:") >= 0) {
-                    // stream is primed; fire a server-scoped broadcast that must ride this stream
-                    server.notifications().error("tachyon.svc", Map.of("event", "server-broadcast"));
-                    broadcast = true;
-                }
-                if (sb.indexOf("server-broadcast") >= 0) break;
-            }
-            // The stream is materialized over the accumulated text, so it outlives the closed socket.
-            return sb.toString()
-                    .lines()
-                    .filter(line -> line.startsWith("data:"))
-                    .map(line -> line.substring("data:".length()).trim())
-                    .filter(data -> !data.isEmpty());
+        try (var client = createTestClient();
+                var subscriber = client.openGetStream(sessionId, null)) {
+            subscriber.awaitFirstEventId(ofSeconds(5));
+            server.notifications().error("tachyon.svc", Map.of("event", "server-broadcast"));
+            subscriber.await(f -> f.data().contains("server-broadcast"), ofSeconds(15));
+            return subscriber.received(f -> true).stream().map(SseFrame::data);
         }
     }
 }

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/PayloadSerdeTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/PayloadSerdeTest.java
@@ -2,7 +2,6 @@
 package dev.tachyonmcp.e2e;
 
 import static dev.tachyonmcp.testkit.JsonRpcResponseAssert.assertThat;
-import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.gson.Gson;
@@ -56,10 +55,13 @@ class PayloadSerdeTest extends AbstractStatelessMcpE2eTest {
                 """);
 
             assertThat(response.statusCode()).isEqualTo(200);
-            assertThatJson(response.body())
-                    .inPath("$.result.structuredContent.message")
-                    .isEqualTo("hello from Gson");
-            assertThat(response).isSuccess().hasTextContent("text fallback");
+            assertThat(response)
+                    .isSuccess()
+                    .hasId(2)
+                    .hasTextContent("text fallback")
+                    .hasStructuredContent("""
+                            {"message":"hello from Gson"}
+                            """);
         }
     }
 
@@ -81,10 +83,13 @@ class PayloadSerdeTest extends AbstractStatelessMcpE2eTest {
                 """);
 
             assertThat(response.statusCode()).isEqualTo(200);
-            assertThatJson(response.body())
-                    .inPath("$.result.structuredContent.echo")
-                    .isEqualTo("exact");
-            assertThat(response).isSuccess().hasTextContent("raw fallback");
+            assertThat(response)
+                    .isSuccess()
+                    .hasId(2)
+                    .hasTextContent("raw fallback")
+                    .hasStructuredContent("""
+                            {"echo":"exact"}
+                            """);
         }
     }
 
@@ -122,9 +127,9 @@ class PayloadSerdeTest extends AbstractStatelessMcpE2eTest {
                 """);
 
             assertThat(response.statusCode()).isEqualTo(200);
-            assertThatJson(response.body())
-                    .inPath("$.result.structuredContent.message")
-                    .isEqualTo("valid");
+            assertThat(response).isSuccess().hasId(2).hasTextContent("ok").hasStructuredContent("""
+                            {"message":"valid","extra":42}
+                            """);
         }
     }
 

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/PayloadSerdeTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/PayloadSerdeTest.java
@@ -1,6 +1,7 @@
 /* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
 package dev.tachyonmcp.e2e;
 
+import static dev.tachyonmcp.testkit.JsonRpcResponseAssert.assertThat;
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -58,7 +59,7 @@ class PayloadSerdeTest extends AbstractStatelessMcpE2eTest {
             assertThatJson(response.body())
                     .inPath("$.result.structuredContent.message")
                     .isEqualTo("hello from Gson");
-            assertThatJson(response.body()).inPath("$.result.content[0].text").isEqualTo("text fallback");
+            assertThat(response).isSuccess().hasTextContent("text fallback");
         }
     }
 
@@ -83,7 +84,7 @@ class PayloadSerdeTest extends AbstractStatelessMcpE2eTest {
             assertThatJson(response.body())
                     .inPath("$.result.structuredContent.echo")
                     .isEqualTo("exact");
-            assertThatJson(response.body()).inPath("$.result.content[0].text").isEqualTo("raw fallback");
+            assertThat(response).isSuccess().hasTextContent("raw fallback");
         }
     }
 
@@ -161,7 +162,7 @@ class PayloadSerdeTest extends AbstractStatelessMcpE2eTest {
                 """);
 
             assertThat(response.statusCode()).isEqualTo(200);
-            assertThatJson(response.body()).inPath("$.result.content[0].text").isEqualTo("decoded: {key=value}");
+            assertThat(response).isSuccess().hasTextContent("decoded: {key=value}");
         }
     }
 

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/PromptsTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/PromptsTest.java
@@ -1,6 +1,7 @@
 /* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
 package dev.tachyonmcp.e2e;
 
+import static dev.tachyonmcp.testkit.JsonRpcResponseAssert.assertThat;
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -95,7 +96,7 @@ class PromptsTest extends AbstractStatelessMcpE2eTest {
                 {"jsonrpc":"2.0","id":2,"method":"prompts/get","params":{"name":"unknown"}}
                 """);
 
-            assertThatJson(response.body()).inPath("$.error.code").isEqualTo(-32602);
+            assertThat(response).isJsonRpcError().hasErrorCode(-32602);
         }
     }
 

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/PromptsTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/PromptsTest.java
@@ -57,10 +57,16 @@ class PromptsTest extends AbstractStatelessMcpE2eTest {
                 {"jsonrpc":"2.0","id":2,"method":"prompts/get","params":{"name":"greeting"}}
                 """);
 
-            assertThatJson(response.body())
-                    .inPath("$.result.messages[0].content.text")
-                    .isEqualTo("Hello world!");
-            assertThatJson(response.body()).inPath("$.result.messages[0].role").isEqualTo("user");
+            assertThatJson(response.body()).isEqualTo("""
+                    {
+                      "jsonrpc":"2.0",
+                      "id":2,
+                      "result":{"description":"A greeting prompt","messages":[{
+                        "role":"user",
+                        "content":{"type":"text","text":"Hello world!"}
+                      }]}
+                    }
+                    """);
         }
     }
 
@@ -162,7 +168,9 @@ class PromptsTest extends AbstractStatelessMcpE2eTest {
                 {"jsonrpc":"2.0","id":2,"method":"prompts/list"}
                 """);
 
-            assertThatJson(response.body()).inPath("$.result.prompts").isArray().isEmpty();
+            assertThatJson(response.body()).isEqualTo("""
+                    {"jsonrpc":"2.0","id":2,"result":{"prompts":[]}}
+                    """);
         }
     }
 
@@ -181,12 +189,20 @@ class PromptsTest extends AbstractStatelessMcpE2eTest {
                 {"jsonrpc":"2.0","id":2,"method":"prompts/get","params":{"name":"embedded"}}
                 """);
 
-            assertThatJson(response.body())
-                    .inPath("$.result.messages[0].content.type")
-                    .isEqualTo("resource");
-            assertThatJson(response.body())
-                    .inPath("$.result.messages[0].content.resource.text")
-                    .isEqualTo("embedded content");
+            assertThatJson(response.body()).isEqualTo("""
+                    {
+                      "jsonrpc":"2.0",
+                      "id":2,
+                      "result":{"description":"Prompt with embedded resource","messages":[{
+                        "role":"user",
+                        "content":{"type":"resource","resource":{
+                          "uri":"test://embedded",
+                          "mimeType":"text/plain",
+                          "text":"embedded content"
+                        }}
+                      }]}
+                    }
+                    """);
         }
     }
 
@@ -205,15 +221,20 @@ class PromptsTest extends AbstractStatelessMcpE2eTest {
                 {"jsonrpc":"2.0","id":2,"method":"prompts/get","params":{"name":"image-prompt"}}
                 """);
 
-            assertThatJson(response.body())
-                    .inPath("$.result.messages[0].content.type")
-                    .isEqualTo("image");
-            assertThatJson(response.body())
-                    .inPath("$.result.messages[0].content.data")
-                    .isEqualTo("iVBORw0KGgo=");
-            assertThatJson(response.body())
-                    .inPath("$.result.messages[0].content.mimeType")
-                    .isEqualTo("image/png");
+            assertThatJson(response.body()).isEqualTo("""
+                    {
+                      "jsonrpc":"2.0",
+                      "id":2,
+                      "result":{"description":"Prompt with image","messages":[{
+                        "role":"user",
+                        "content":{
+                          "type":"image",
+                          "data":"iVBORw0KGgo=",
+                          "mimeType":"image/png"
+                        }
+                      }]}
+                    }
+                    """);
         }
     }
 }

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/ResourceTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/ResourceTest.java
@@ -1,6 +1,7 @@
 /* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
 package dev.tachyonmcp.e2e;
 
+import static dev.tachyonmcp.testkit.JsonRpcResponseAssert.assertThat;
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -206,7 +207,7 @@ class ResourceTest extends AbstractStatefulMcpE2eTest {
                 {"jsonrpc":"2.0","id":2,"method":"resources/read","params":{"uri":"resource://failing"}}
                 """);
 
-            assertThatJson(response.body()).inPath("$.error.message").isEqualTo("Resource handler failed");
+            assertThat(response).isJsonRpcError().hasErrorMessage("Resource handler failed");
         }
     }
 
@@ -298,7 +299,7 @@ class ResourceTest extends AbstractStatefulMcpE2eTest {
             var readResponse = client.post(sessionId, """
                 {"jsonrpc":"2.0","id":2,"method":"resources/read","params":{"uri":"resource://alpha"}}
                 """);
-            assertThatJson(readResponse.body()).inPath("$.error.code").isEqualTo(-32002);
+            assertThat(readResponse).isJsonRpcError().hasErrorCode(-32002);
 
             var listResponse = client.post(sessionId, """
                 {"jsonrpc":"2.0","id":3,"method":"resources/list"}

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/SchemaValidationTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/SchemaValidationTest.java
@@ -163,7 +163,6 @@ class SchemaValidationTest extends AbstractStatelessMcpE2eTest {
                 }}
                 """;
             assertThatJson(response.body()).isEqualTo(expected);
-            assertThatJson(response.body()).inPath("$.result").isObject().containsKey("messages");
         }
     }
 

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/SessionJanitorOutboundActivityTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/SessionJanitorOutboundActivityTest.java
@@ -10,11 +10,7 @@ import dev.tachyonmcp.core.runtime.SessionState;
 import dev.tachyonmcp.core.server.TachyonServer;
 import dev.tachyonmcp.core.server.internal.ServerEngine;
 import dev.tachyonmcp.testkit.Mcp20251125Client;
-import java.net.Socket;
-import java.net.SocketTimeoutException;
-import java.nio.charset.StandardCharsets;
 import java.time.Duration;
-import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -56,8 +52,11 @@ class SessionJanitorOutboundActivityTest {
     @Test
     void silentListeningStreamStaysAlive() throws Exception {
         var sessionId = initializeAndActivate(port);
-        try (var sseSocket = openRawSse(port, sessionId);
-                var reader = drainInBackground(sseSocket, 6000)) {
+        try (var client = new Mcp20251125Client(port)) {
+            var subscriber = client.openGetStream(sessionId, null);
+            var opened = subscriber.awaitRawResponse(body -> body.contains("\r\n\r\n"), ofSeconds(5));
+            assertThat(opened).contains("200 OK");
+
             // Well past the 2s TTL: the session must survive on heartbeats alone.
             await().atMost(ofSeconds(6)).pollInterval(ofMillis(200)).untilAsserted(() -> {
                 var session = ((ServerEngine) serverHandle).getSession(sessionId);
@@ -65,13 +64,11 @@ class SessionJanitorOutboundActivityTest {
                 assertThat(session.get().state()).isEqualTo(SessionState.ACTIVE);
             });
 
-            try (var client = new Mcp20251125Client(port)) {
-                var ping = client.post(sessionId, """
+            var ping = client.post(sessionId, """
                     {"jsonrpc":"2.0","id":1,"method":"ping"}
                     """);
-                assertThat(ping.statusCode()).isEqualTo(200);
-                assertThat(ping.body()).contains("result");
-            }
+            assertThat(ping.statusCode()).isEqualTo(200);
+            assertThat(ping.body()).contains("result");
         }
     }
 
@@ -86,8 +83,10 @@ class SessionJanitorOutboundActivityTest {
         try (noHbServer) {
             var noHbPort = noHbServer.port();
             var sessionId = initializeAndActivate(noHbPort);
-            try (var sseSocket = openRawSse(noHbPort, sessionId);
-                    var reader = drainInBackground(sseSocket, 6000)) {
+            try (var client = new Mcp20251125Client(noHbPort)) {
+                var subscriber = client.openGetStream(sessionId, null);
+                subscriber.awaitRawResponse(body -> body.contains("\r\n\r\n"), ofSeconds(5));
+
                 await().atMost(ofSeconds(6))
                         .pollInterval(ofMillis(200))
                         .untilAsserted(() -> assertThat(((ServerEngine) noHbServer).getSession(sessionId))
@@ -98,49 +97,9 @@ class SessionJanitorOutboundActivityTest {
 
     // ---- helpers ----
 
-    /** Keeps reading the socket in a background thread until {@code durationMs} elapses. */
-    private static AutoCloseable drainInBackground(Socket socket, long durationMs) {
-        var deadline = System.currentTimeMillis() + durationMs;
-        var future = CompletableFuture.runAsync(() -> {
-            var buf = new byte[4096];
-            while (System.currentTimeMillis() < deadline) {
-                try {
-                    socket.setSoTimeout(100);
-                    if (socket.getInputStream().read(buf) < 0) break;
-                } catch (SocketTimeoutException e) {
-                    // expected — poll until deadline
-                } catch (Exception e) {
-                    break;
-                }
-            }
-        });
-        return () -> future.cancel(true);
-    }
-
     private String initializeAndActivate(int targetPort) throws Exception {
         try (var client = new Mcp20251125Client(targetPort)) {
             return client.initialize();
         }
-    }
-
-    static Socket openRawSse(int targetPort, String sessionId) throws Exception {
-        var socket = new Socket("localhost", targetPort);
-        var req = ("GET /mcp HTTP/1.1\r\n"
-                        + "Host: localhost:" + targetPort + "\r\n"
-                        + "MCP-Session-Id: " + sessionId + "\r\n"
-                        + "Accept: text/event-stream\r\n"
-                        + "\r\n")
-                .getBytes(StandardCharsets.UTF_8);
-        socket.getOutputStream().write(req);
-        socket.getOutputStream().flush();
-        var sb = new StringBuilder();
-        var buf = new byte[1];
-        socket.setSoTimeout(5000);
-        while (!sb.toString().endsWith("\r\n\r\n")) {
-            if (socket.getInputStream().read(buf) < 0) break;
-            sb.append((char) buf[0]);
-        }
-        assertThat(sb.toString()).contains("200 OK");
-        return socket;
     }
 }

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/SessionJanitorOutboundActivityTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/SessionJanitorOutboundActivityTest.java
@@ -1,6 +1,7 @@
 /* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
 package dev.tachyonmcp.e2e;
 
+import static dev.tachyonmcp.testkit.JsonRpcResponseAssert.assertThat;
 import static java.time.Duration.ofMillis;
 import static java.time.Duration.ofSeconds;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -68,7 +69,7 @@ class SessionJanitorOutboundActivityTest {
                     {"jsonrpc":"2.0","id":1,"method":"ping"}
                     """);
             assertThat(ping.statusCode()).isEqualTo(200);
-            assertThat(ping.body()).contains("result");
+            assertThat(ping).isSuccess();
         }
     }
 

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/SseHeartbeatTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/SseHeartbeatTest.java
@@ -10,9 +10,6 @@ import dev.tachyonmcp.core.transport.netty.NettyIoEngine;
 import dev.tachyonmcp.core.transport.netty.NettyServer;
 import dev.tachyonmcp.core.transport.netty.NettyServerConfig;
 import dev.tachyonmcp.testkit.Mcp20251125Client;
-import java.net.Socket;
-import java.net.SocketTimeoutException;
-import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -66,50 +63,23 @@ class SseHeartbeatTest {
     void idleSseStreamReceivesRepeatedHeartbeats() throws Exception {
         var sessionId = initializeSession();
 
-        // Read for ~5 heartbeat intervals; a 150ms interval should yield several ":\r\n" comments.
-        var raw = readRawSse(sessionId, HEARTBEAT_INTERVAL.toMillis() * 5);
+        try (var client = new Mcp20251125Client(port);
+                var subscriber = client.openGetStream(sessionId, null)) {
+            // Poll until ~2 heartbeat comments have arrived, bounded by ~10 heartbeat intervals.
+            var raw = subscriber.awaitRawResponse(
+                    body -> countOccurrences(body, ":\r\n") >= 2, HEARTBEAT_INTERVAL.multipliedBy(10));
 
-        assertThat(raw).as("stream must open as text/event-stream").contains("text/event-stream");
-        assertThat(raw).contains("X-Accel-Buffering: no");
-        assertThat(countOccurrences(raw, ":\r\n"))
-                .as("scheduler must drive repeated SSE comment heartbeats")
-                .isGreaterThanOrEqualTo(2);
+            assertThat(raw).as("stream must open as text/event-stream").contains("text/event-stream");
+            assertThat(raw).contains("X-Accel-Buffering: no");
+            assertThat(countOccurrences(raw, ":\r\n"))
+                    .as("scheduler must drive repeated SSE comment heartbeats")
+                    .isGreaterThanOrEqualTo(2);
+        }
     }
 
     private String initializeSession() throws Exception {
         try (var client = new Mcp20251125Client(port)) {
             return client.initialize();
-        }
-    }
-
-    /**
-     * Opens a raw SSE GET and accumulates everything received over {@code durationMs}.
-     */
-    private String readRawSse(String sessionId, long durationMs) throws Exception {
-        try (var socket = new Socket("localhost", port)) {
-            var req = ("GET /mcp HTTP/1.1\r\n"
-                            + "Host: localhost:" + port + "\r\n"
-                            + "MCP-Session-Id: " + sessionId + "\r\n"
-                            + "Accept: text/event-stream\r\n"
-                            + "\r\n")
-                    .getBytes(StandardCharsets.UTF_8);
-            socket.getOutputStream().write(req);
-            socket.getOutputStream().flush();
-            socket.setSoTimeout(50);
-
-            var sb = new StringBuilder();
-            var buf = new byte[4096];
-            var deadline = System.currentTimeMillis() + durationMs;
-            while (System.currentTimeMillis() < deadline) {
-                try {
-                    var n = socket.getInputStream().read(buf);
-                    if (n < 0) break;
-                    if (n > 0) sb.append(new String(buf, 0, n, StandardCharsets.UTF_8));
-                } catch (SocketTimeoutException e) {
-                    // No data this poll; keep reading until the deadline.
-                }
-            }
-            return sb.toString();
         }
     }
 

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/SsePollingTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/SsePollingTest.java
@@ -1,13 +1,9 @@
 /* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
 package dev.tachyonmcp.e2e;
 
+import static java.time.Duration.ofSeconds;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.net.Socket;
-import java.net.SocketTimeoutException;
-import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
@@ -22,37 +18,44 @@ class SsePollingTest extends AbstractStatefulMcpE2eTest {
     @Test
     void getSseStreamIncludesRetryField() throws Exception {
         var sessionId = initializeSession();
-        var raw = readRawSse(sessionId, 1024, 2000);
-        assertThat(raw).contains("retry: 3000");
-        assertThat(raw).contains("X-Accel-Buffering: no");
-        assertThat(raw)
-                .as("SSE response must signal Connection: close so the client does not pool the socket")
-                .containsIgnoringCase("connection: close");
+        try (var client = createTestClient();
+                var subscriber = client.openGetStream(sessionId, null)) {
+            var raw = subscriber.awaitRawResponse(body -> body.contains("\r\n\r\n"), ofSeconds(2));
+            assertThat(raw).contains("retry: 3000");
+            assertThat(raw).contains("X-Accel-Buffering: no");
+            assertThat(raw)
+                    .as("SSE response must signal Connection: close so the client does not pool the socket")
+                    .containsIgnoringCase("connection: close");
+        }
     }
 
     @Test
     void getSseStreamSendsPrimingEventWithEventId() throws Exception {
         var sessionId = initializeSession();
-        var events = parseSseEvents(readRawSse(sessionId, 2048, 2000));
-
-        assertThat(events).isNotEmpty();
-        var first = events.getFirst();
-        assertThat(first.id).as("Priming event should carry an event ID").isNotEmpty();
-        assertThat(first.event).as("Priming event type").isEqualTo("message");
-        assertThat(first.data).as("Priming event data should be empty").isEmpty();
+        try (var client = createTestClient();
+                var subscriber = client.openGetStream(sessionId, null)) {
+            var first = subscriber.await(f -> f.id() != null, ofSeconds(2));
+            assertThat(first.id()).as("Priming event should carry an event ID").isNotEmpty();
+            assertThat(first.eventType()).as("Priming event type").isEqualTo("message");
+            assertThat(first.data()).as("Priming event data should be empty").isEmpty();
+        }
     }
 
     @Test
     void getSseStreamPrimingHasSequentialId() throws Exception {
         var sessionId = initializeSession();
 
-        var events1 = parseSseEvents(readRawSse(sessionId, 2048, 2000));
-        assertThat(events1).isNotEmpty();
-        var firstId = Long.parseLong(events1.getFirst().id());
+        long firstId;
+        try (var client = createTestClient();
+                var subscriber = client.openGetStream(sessionId, null)) {
+            firstId = Long.parseLong(subscriber.awaitFirstEventId(ofSeconds(2)));
+        }
 
-        var events2 = parseSseEvents(readRawSse(sessionId, 2048, 2000));
-        assertThat(events2).isNotEmpty();
-        var secondId = Long.parseLong(events2.getFirst().id());
+        long secondId;
+        try (var client = createTestClient();
+                var subscriber = client.openGetStream(sessionId, null)) {
+            secondId = Long.parseLong(subscriber.awaitFirstEventId(ofSeconds(2)));
+        }
 
         assertThat(secondId).isGreaterThan(firstId);
     }
@@ -66,73 +69,4 @@ class SsePollingTest extends AbstractStatefulMcpE2eTest {
             return client.initialize();
         }
     }
-
-    /** Reads raw SSE bytes until {@code timeoutMs}. */
-    private String readRawSse(String sessionId, int bufSize, int timeoutMs) throws Exception {
-        try (var socket = new Socket("localhost", port)) {
-            var req = ("GET /mcp HTTP/1.1\r\n"
-                            + "Host: localhost:" + port + "\r\n"
-                            + "MCP-Session-Id: " + sessionId + "\r\n"
-                            + "Accept: text/event-stream\r\n"
-                            + "\r\n")
-                    .getBytes(StandardCharsets.UTF_8);
-            socket.getOutputStream().write(req);
-            socket.getOutputStream().flush();
-            socket.setSoTimeout(50);
-
-            var sb = new StringBuilder();
-            var buf = new byte[bufSize];
-            var deadline = System.currentTimeMillis() + timeoutMs;
-            while (System.currentTimeMillis() < deadline) {
-                try {
-                    var n = socket.getInputStream().read(buf);
-                    if (n < 0) break;
-                    if (n > 0) sb.append(new String(buf, 0, n, StandardCharsets.UTF_8));
-                } catch (SocketTimeoutException e) {
-                    // No data this poll; keep reading until the deadline.
-                }
-            }
-            var raw = sb.toString();
-            assertThat(raw).as("must have received data").isNotEmpty();
-            return raw;
-        }
-    }
-
-    private List<SseEvent> parseSseEvents(String raw) {
-        return parseEvents(raw.lines().toList());
-    }
-
-    private List<SseEvent> parseEvents(List<String> lines) {
-        var events = new ArrayList<SseEvent>();
-        var bufId = new StringBuilder();
-        var bufEvent = new StringBuilder();
-        var bufData = new StringBuilder();
-
-        for (var line : lines) {
-            if (line.startsWith("retry: ") || line.isBlank()) {
-                continue;
-            }
-            if (line.startsWith("id: ")) {
-                if (!bufId.isEmpty()) {
-                    events.add(new SseEvent(bufId.toString(), bufEvent.toString(), bufData.toString()));
-                }
-                bufId.setLength(0);
-                bufEvent.setLength(0);
-                bufData.setLength(0);
-                bufId.append(line.substring("id: ".length()));
-            } else if (line.startsWith("event: ")) {
-                if (!bufEvent.isEmpty()) bufEvent.append('\n');
-                bufEvent.append(line.substring("event: ".length()));
-            } else if (line.startsWith("data: ")) {
-                if (!bufData.isEmpty()) bufData.append('\n');
-                bufData.append(line.substring("data: ".length()));
-            }
-        }
-        if (!bufId.isEmpty()) {
-            events.add(new SseEvent(bufId.toString(), bufEvent.toString(), bufData.toString()));
-        }
-        return List.copyOf(events);
-    }
-
-    record SseEvent(String id, String event, String data) {}
 }

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/SsePollingTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/SsePollingTest.java
@@ -20,7 +20,7 @@ class SsePollingTest extends AbstractStatefulMcpE2eTest {
         var sessionId = initializeSession();
         try (var client = createTestClient();
                 var subscriber = client.openGetStream(sessionId, null)) {
-            var raw = subscriber.awaitRawResponse(body -> body.contains("\r\n\r\n"), ofSeconds(2));
+            var raw = subscriber.awaitRawResponse(body -> body.contains("retry: 3000"), ofSeconds(2));
             assertThat(raw).contains("retry: 3000");
             assertThat(raw).contains("X-Accel-Buffering: no");
             assertThat(raw)

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/SsePostReconnectRedeliveryTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/SsePostReconnectRedeliveryTest.java
@@ -5,10 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import dev.tachyonmcp.api.server.features.tools.ToolResult;
 import dev.tachyonmcp.core.server.OutboundSseStreamMessageRouter;
-import java.io.IOException;
-import java.net.Socket;
-import java.net.SocketTimeoutException;
-import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.regex.Pattern;
 import org.junit.jupiter.api.Test;
 
@@ -68,45 +65,14 @@ class SsePostReconnectRedeliveryTest extends AbstractStatefulMcpE2eTest {
             // Resume that exact POST stream. The tool is still sleeping, so its response has not
             // been appended yet: the one-shot replay finds nothing, and only live re-delivery on
             // resume can hand the client its result.
-            try (var socket = openGetStream(sessionId, lastEventId)) {
-                var received = readStream(socket, body -> body.contains("resumed-payload"), 5000);
+            try (var subscriber = client.openGetStream(lastEventId)) {
+                var received =
+                        subscriber.awaitRawResponse(body -> body.contains("resumed-payload"), Duration.ofSeconds(5));
                 assertThat(received)
                         .as("resumed POST stream must receive the final response delivered after reconnect")
                         .contains("\"id\":9")
                         .contains("resumed-payload");
             }
         }
-    }
-
-    private Socket openGetStream(String sessionId, String lastEventId) throws IOException {
-        var socket = new Socket("localhost", port);
-        var req = "GET /mcp HTTP/1.1\r\n"
-                + "Host: localhost:" + port + "\r\n"
-                + "MCP-Session-Id: " + sessionId + "\r\n"
-                + "MCP-Protocol-Version: 2025-11-25\r\n"
-                + "Accept: text/event-stream\r\n"
-                + "Last-Event-ID: " + lastEventId + "\r\n"
-                + "\r\n";
-        socket.getOutputStream().write(req.getBytes(StandardCharsets.UTF_8));
-        socket.getOutputStream().flush();
-        socket.setSoTimeout(50);
-        return socket;
-    }
-
-    private static String readStream(Socket socket, java.util.function.Predicate<String> until, long timeoutMs)
-            throws IOException {
-        var sb = new StringBuilder();
-        var buf = new byte[1024];
-        var deadline = System.currentTimeMillis() + timeoutMs;
-        while (System.currentTimeMillis() < deadline && !until.test(sb.toString())) {
-            try {
-                var n = socket.getInputStream().read(buf);
-                if (n < 0) break;
-                if (n > 0) sb.append(new String(buf, 0, n, StandardCharsets.UTF_8));
-            } catch (SocketTimeoutException e) {
-                // No data this poll; keep reading until the deadline.
-            }
-        }
-        return sb.toString();
     }
 }

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/SseReplayPerStreamTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/SseReplayPerStreamTest.java
@@ -5,11 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import dev.tachyonmcp.api.server.features.tools.ToolDescriptor;
 import dev.tachyonmcp.api.server.features.tools.ToolResult;
-import java.io.IOException;
-import java.net.Socket;
-import java.net.SocketTimeoutException;
-import java.nio.charset.StandardCharsets;
-import java.util.regex.Pattern;
+import java.time.Duration;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -22,8 +18,6 @@ import org.junit.jupiter.api.Test;
  * its last GET-stream event ID, the replay must not re-deliver the POST-stream messages.
  */
 class SseReplayPerStreamTest extends AbstractStatefulMcpE2eTest {
-
-    private static final Pattern EVENT_ID = Pattern.compile("^id: (\\d+)", Pattern.MULTILINE);
 
     @Override
     protected void startDefaultServer() {
@@ -46,14 +40,9 @@ class SseReplayPerStreamTest extends AbstractStatefulMcpE2eTest {
 
             // GET stream #1: capture its priming event id as the client's Last-Event-ID
             // baseline, then drop the connection.
-            long getStreamLastEventId;
-            try (var socket = openGetStream(sessionId, null)) {
-                var opening = readStream(socket, body -> EVENT_ID.matcher(body).find(), 5000);
-                var matcher = EVENT_ID.matcher(opening);
-                assertThat(matcher.find())
-                        .as("GET stream priming event id in:\n%s", opening)
-                        .isTrue();
-                getStreamLastEventId = Long.parseLong(matcher.group(1));
+            String getStreamLastEventId;
+            try (var subscriber = client.openGetStream(null)) {
+                getStreamLastEventId = subscriber.awaitFirstEventId(Duration.ofSeconds(5));
             }
 
             // While the GET stream is down: tools/call → the inline notification upgrades the
@@ -71,12 +60,14 @@ class SseReplayPerStreamTest extends AbstractStatefulMcpE2eTest {
 
             // Resume the GET stream from the pre-call baseline. Per spec the server may replay
             // only messages of the disconnected (GET) stream — never the POST stream's.
-            try (var socket = openGetStream(sessionId, getStreamLastEventId)) {
-                // Read until the new priming event arrives, then linger so an (incorrect)
-                // replay of the POST-stream messages would have time to show up.
-                var replayed = readStream(socket, body -> EVENT_ID.matcher(body).find(), 5000);
-                replayed = replayed + readStream(socket, body -> false, 1000);
+            try (var subscriber = client.openGetStream(getStreamLastEventId)) {
+                // Wait for the new priming event, then linger so an (incorrect) replay of the
+                // POST-stream messages would have time to show up — there's no faster way to
+                // confirm an absence than waiting out the window.
+                subscriber.awaitFirstEventId(Duration.ofSeconds(5));
+                Thread.sleep(1000);
 
+                var replayed = subscriber.rawResponse();
                 assertThat(replayed)
                         .as("GET resume must not replay the response delivered on the POST stream")
                         .doesNotContain("\"id\":7")
@@ -87,44 +78,5 @@ class SseReplayPerStreamTest extends AbstractStatefulMcpE2eTest {
                         .doesNotContain("post-stream-payload");
             }
         }
-    }
-
-    private Socket openGetStream(String sessionId, Long lastEventId) throws IOException {
-        var socket = new Socket("localhost", port);
-        var req = new StringBuilder("GET /mcp HTTP/1.1\r\n")
-                .append("Host: localhost:")
-                .append(port)
-                .append("\r\n")
-                .append("MCP-Session-Id: ")
-                .append(sessionId)
-                .append("\r\n")
-                .append("MCP-Protocol-Version: 2025-11-25\r\n")
-                .append("Accept: text/event-stream\r\n");
-        if (lastEventId != null) {
-            req.append("Last-Event-ID: ").append(lastEventId).append("\r\n");
-        }
-        req.append("\r\n");
-        socket.getOutputStream().write(req.toString().getBytes(StandardCharsets.UTF_8));
-        socket.getOutputStream().flush();
-        socket.setSoTimeout(50);
-        return socket;
-    }
-
-    /** Reads the stream until {@code until} is satisfied or {@code timeoutMs} elapses. */
-    private static String readStream(Socket socket, java.util.function.Predicate<String> until, long timeoutMs)
-            throws IOException {
-        var sb = new StringBuilder();
-        var buf = new byte[1024];
-        var deadline = System.currentTimeMillis() + timeoutMs;
-        while (System.currentTimeMillis() < deadline && !until.test(sb.toString())) {
-            try {
-                var n = socket.getInputStream().read(buf);
-                if (n < 0) break;
-                if (n > 0) sb.append(new String(buf, 0, n, StandardCharsets.UTF_8));
-            } catch (SocketTimeoutException e) {
-                // No data this poll; keep reading until the deadline.
-            }
-        }
-        return sb.toString();
     }
 }

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/SseRetryTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/SseRetryTest.java
@@ -1,11 +1,9 @@
 /* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
 package dev.tachyonmcp.e2e;
 
+import static java.time.Duration.ofSeconds;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.net.Socket;
-import java.net.SocketTimeoutException;
-import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
@@ -20,30 +18,9 @@ class SseRetryTest extends AbstractStatefulMcpE2eTest {
             sessionId = client.initialize();
         }
 
-        try (var socket = new Socket("localhost", port)) {
-            var req = ("GET /mcp HTTP/1.1\r\n"
-                            + "Host: localhost:" + port + "\r\n"
-                            + "MCP-Session-Id: " + sessionId + "\r\n"
-                            + "Accept: text/event-stream\r\n"
-                            + "\r\n")
-                    .getBytes(StandardCharsets.UTF_8);
-            socket.getOutputStream().write(req);
-            socket.getOutputStream().flush();
-            socket.setSoTimeout(50);
-
-            var sb = new StringBuilder();
-            var buf = new byte[512];
-            var deadline = System.currentTimeMillis() + 5000;
-            while (System.currentTimeMillis() < deadline) {
-                try {
-                    var n = socket.getInputStream().read(buf);
-                    if (n < 0) break;
-                    if (n > 0) sb.append(new String(buf, 0, n, StandardCharsets.UTF_8));
-                } catch (SocketTimeoutException e) {
-                    // No data this poll; keep reading until the deadline.
-                }
-            }
-            var raw = sb.toString();
+        try (var client = createTestClient();
+                var subscriber = client.openGetStream(sessionId, null)) {
+            var raw = subscriber.awaitRawResponse(body -> body.contains("\r\n\r\n"), ofSeconds(5));
             assertThat(raw).contains("retry: 3000");
             assertThat(raw).contains("X-Accel-Buffering: no");
         }

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/SseRetryTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/SseRetryTest.java
@@ -20,7 +20,7 @@ class SseRetryTest extends AbstractStatefulMcpE2eTest {
 
         try (var client = createTestClient();
                 var subscriber = client.openGetStream(sessionId, null)) {
-            var raw = subscriber.awaitRawResponse(body -> body.contains("\r\n\r\n"), ofSeconds(5));
+            var raw = subscriber.awaitRawResponse(body -> body.contains("retry: 3000"), ofSeconds(5));
             assertThat(raw).contains("retry: 3000");
             assertThat(raw).contains("X-Accel-Buffering: no");
         }

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/StatefulSessionLifecycleTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/StatefulSessionLifecycleTest.java
@@ -1,6 +1,7 @@
 /* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
 package dev.tachyonmcp.e2e;
 
+import static dev.tachyonmcp.testkit.JsonRpcResponseAssert.assertThat;
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -51,7 +52,7 @@ class StatefulSessionLifecycleTest extends AbstractStatefulMcpE2eTest {
 
             var response = clientB.ping(sessionB, 1);
             assertThat(response.statusCode()).isEqualTo(200);
-            assertThat(response.body()).contains("result");
+            assertThat(response).isSuccess();
         }
     }
 
@@ -113,7 +114,7 @@ class StatefulSessionLifecycleTest extends AbstractStatefulMcpE2eTest {
             // session2 should still work
             var response = client.ping(session2, 1);
             assertThat(response.statusCode()).isEqualTo(200);
-            assertThat(response.body()).contains("result");
+            assertThat(response).isSuccess();
         }
     }
 

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/StringSchemaTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/StringSchemaTest.java
@@ -37,14 +37,26 @@ class StringSchemaTest extends AbstractStatelessMcpE2eTest {
                 """);
 
             assertThat(response.statusCode()).isEqualTo(200);
-            assertThatJson(response.body())
-                    .inPath("$.result.tools[0].inputSchema")
-                    .isObject()
-                    .containsKey("properties");
-            assertThatJson(response.body())
-                    .inPath("$.result.tools[0].outputSchema")
-                    .isObject()
-                    .containsKey("properties");
+            assertThatJson(response.body()).isEqualTo("""
+                    {
+                      "jsonrpc":"2.0",
+                      "id":2,
+                      "result":{"tools":[{
+                        "name":"string-schema-tool",
+                        "description":"Tool with string schemas",
+                        "inputSchema":{
+                          "type":"object",
+                          "properties":{"x":{"type":"string"}},
+                          "required":["x"]
+                        },
+                        "outputSchema":{
+                          "type":"object",
+                          "properties":{"y":{"type":"integer"}},
+                          "required":["y"]
+                        }
+                      }]}
+                    }
+                    """);
         }
     }
 

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/StringSchemaTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/StringSchemaTest.java
@@ -118,7 +118,7 @@ class StringSchemaTest extends AbstractStatelessMcpE2eTest {
                 """);
 
             assertThat(response.statusCode()).isEqualTo(200);
-            assertThat(response).hasTextContent("called");
+            assertThat(response).isSuccess().hasTextContent("called");
         }
     }
 }

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/TaskAugmentedToolTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/TaskAugmentedToolTest.java
@@ -1,6 +1,7 @@
 /* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
 package dev.tachyonmcp.e2e;
 
+import static dev.tachyonmcp.testkit.JsonRpcResponseAssert.assertThatJsonRpcResponse;
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -448,7 +449,7 @@ class TaskAugmentedToolTest extends AbstractStatelessMcpE2eTest {
             var resultJson = client.sendRpc("""
                 {"jsonrpc":"2.0","id":4,"method":"tasks/result","params":{"taskId":"%s"}}
                 """.formatted(secondTaskId));
-            assertThatJson(resultJson).inPath("$.result.content[0].text").isEqualTo("Hello, Alice!");
+            assertThatJsonRpcResponse(resultJson).isSuccess().hasTextContent("Hello, Alice!");
 
             // The original task was never resumed -- still parked, exactly where round 1 left it.
             var firstAfter = client.sendRpc("""
@@ -468,7 +469,7 @@ class TaskAugmentedToolTest extends AbstractStatelessMcpE2eTest {
                 {"jsonrpc":"2.0","id":2,"method":"tasks/update","params":{"taskId":"task-1","inputResponses":{}}}
                 """);
 
-            assertThatJson(response).inPath("$.error.code").isEqualTo(-32601);
+            assertThatJsonRpcResponse(response).isJsonRpcError().hasErrorCode(-32601);
         }
     }
 

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/TasksCoreTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/TasksCoreTest.java
@@ -126,9 +126,9 @@ class TasksCoreTest extends AbstractStatefulMcpE2eTest {
             var resultJson = client.sendRpc("""
                     {"jsonrpc":"2.0","id":3,"method":"tasks/result","params":{"taskId":"%s"}}
                     """.formatted(task.id()));
-            assertThatJsonRpcResponse(resultJson)
-                    .hasContent()
-                    .hasStructuredContent(JsonNodeFactory.instance.objectNode().put("output", "success"));
+            assertThatJsonRpcResponse(resultJson).isSuccess().hasContent().hasStructuredContent("""
+                            {"output":"success"}
+                            """);
         }
     }
 
@@ -141,7 +141,7 @@ class TasksCoreTest extends AbstractStatefulMcpE2eTest {
             var getJson = client.sendRpc("""
                     {"jsonrpc":"2.0","id":2,"method":"tasks/get","params":{"taskId":"nonexistent-id"}}
                     """);
-            assertThatJson(getJson).inPath("$.error.code").isEqualTo(-32602);
+            assertThatJsonRpcResponse(getJson).isJsonRpcError().hasErrorCode(-32602);
         }
     }
 

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/TasksExtensionTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/TasksExtensionTest.java
@@ -1,6 +1,8 @@
 /* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
 package dev.tachyonmcp.e2e;
 
+import static dev.tachyonmcp.testkit.JsonRpcResponseAssert.assertThat;
+import static dev.tachyonmcp.testkit.JsonRpcResponseAssert.assertThatJsonRpcResponse;
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -68,7 +70,7 @@ class TasksExtensionTest extends AbstractStatefulMcpE2eTest {
             var callJson = client.sendRpc("""
                     {"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"create_task","arguments":{"name":"my-task","description":"from tool"}}}
                     """);
-            assertThatJson(callJson).inPath("$.result.content[0].text").isString();
+            assertThatJsonRpcResponse(callJson).isSuccess().hasTextContent();
             var taskId = extractText(callJson);
 
             var getJson = client.sendRpc("""
@@ -100,8 +102,7 @@ class TasksExtensionTest extends AbstractStatefulMcpE2eTest {
 
             assertThat(response.statusCode()).isEqualTo(200);
             assertThat(response.headers().firstValue("content-type").orElse("")).startsWith("application/json");
-            assertThat(response.body()).contains("not yet active");
-            assertThatJson(response.body()).inPath("$.error").isObject();
+            assertThat(response).isJsonRpcError().hasErrorMessageContaining("not yet active");
         }
     }
 
@@ -260,7 +261,7 @@ class TasksExtensionTest extends AbstractStatefulMcpE2eTest {
             var getAfterRemove = client.sendRpc("""
                     {"jsonrpc":"2.0","id":3,"method":"tasks/get","params":{"taskId":"%s"}}
                     """.formatted(taskId));
-            assertThatJson(getAfterRemove).inPath("$.error").isObject();
+            assertThatJsonRpcResponse(getAfterRemove).isJsonRpcError();
         }
     }
 
@@ -292,7 +293,7 @@ class TasksExtensionTest extends AbstractStatefulMcpE2eTest {
             var getAfterRemove = client.sendRpc("""
                     {"jsonrpc":"2.0","id":3,"method":"tasks/get","params":{"taskId":"%s"}}
                     """.formatted(taskId));
-            assertThatJson(getAfterRemove).inPath("$.error").isObject();
+            assertThatJsonRpcResponse(getAfterRemove).isJsonRpcError();
         }
     }
 

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/ToolCapabilitiesTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/ToolCapabilitiesTest.java
@@ -1,6 +1,7 @@
 /* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
 package dev.tachyonmcp.e2e;
 
+import static dev.tachyonmcp.testkit.JsonRpcResponseAssert.assertThat;
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -205,7 +206,7 @@ class ToolCapabilitiesTest extends AbstractStatelessMcpE2eTest {
                 """);
 
             assertThat(response.statusCode()).isEqualTo(200);
-            assertThatJson(response.body()).inPath("$.result.content[0].text").isEqualTo("Echo: hi");
+            assertThat(response).isSuccess().hasTextContent("Echo: hi");
             assertThatJson(response.body())
                     .inPath("$.result.structuredContent")
                     .isObject()

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp20260728/CustomHeaderValidationTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp20260728/CustomHeaderValidationTest.java
@@ -1,7 +1,7 @@
 /* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
 package dev.tachyonmcp.e2e.mcp20260728;
 
-import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static dev.tachyonmcp.testkit.JsonRpcResponseAssert.assertThat;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import dev.tachyonmcp.api.server.features.tools.ToolResult;
@@ -73,23 +73,21 @@ class CustomHeaderValidationTest extends AbstractStatelessMcpE2eTest {
     void acceptsMatchingParamHeader() throws Exception {
         var response = post(toolCallBody(1, "us-west1"), "us-west1");
         assertThat(response.statusCode()).as(response.body()).isEqualTo(200);
-        assertThatJson(response.body()).inPath("$.result.content[0].text").isEqualTo("region=us-west1 query=SELECT 1");
+        assertThat(response).isSuccess().hasTextContent("region=us-west1 query=SELECT 1");
     }
 
     @Test
     void rejectsMissingParamHeaderWhenBodyHasValue() throws Exception {
         var response = post(toolCallBody(2, "us-west1"), null);
         assertThat(response.statusCode()).as(response.body()).isEqualTo(400);
-        assertThatJson(response.body()).inPath("$.id").isEqualTo(2);
-        assertThatJson(response.body()).inPath("$.error.code").isEqualTo(-32020);
+        assertThat(response).isJsonRpcError().hasId(2).hasErrorCode(-32020);
     }
 
     @Test
     void rejectsMismatchedParamHeader() throws Exception {
         var response = post(toolCallBody(3, "us-west1"), "eu-west1");
         assertThat(response.statusCode()).as(response.body()).isEqualTo(400);
-        assertThatJson(response.body()).inPath("$.id").isEqualTo(3);
-        assertThatJson(response.body()).inPath("$.error.code").isEqualTo(-32020);
+        assertThat(response).isJsonRpcError().hasId(3).hasErrorCode(-32020);
     }
 
     @Test
@@ -98,15 +96,14 @@ class CustomHeaderValidationTest extends AbstractStatelessMcpE2eTest {
                 .encodeToString("us-west1".getBytes(java.nio.charset.StandardCharsets.UTF_8));
         var response = post(toolCallBody(4, "us-west1"), "=?base64?" + encoded + "?=");
         assertThat(response.statusCode()).as(response.body()).isEqualTo(200);
-        assertThatJson(response.body()).inPath("$.result.content[0].text").isEqualTo("region=us-west1 query=SELECT 1");
+        assertThat(response).isSuccess().hasTextContent("region=us-west1 query=SELECT 1");
     }
 
     @Test
     void rejectsInvalidBase64ParamHeader() throws Exception {
         var response = post(toolCallBody(5, "us-west1"), "=?base64?not-valid-base64!!?=");
         assertThat(response.statusCode()).as(response.body()).isEqualTo(400);
-        assertThatJson(response.body()).inPath("$.id").isEqualTo(5);
-        assertThatJson(response.body()).inPath("$.error.code").isEqualTo(-32020);
+        assertThat(response).isJsonRpcError().hasId(5).hasErrorCode(-32020);
     }
 
     @Test
@@ -115,8 +112,7 @@ class CustomHeaderValidationTest extends AbstractStatelessMcpE2eTest {
         // character; the server must not throw while extracting the (empty) encoded segment.
         var response = post(toolCallBody(7, "us-west1"), "=?base64?=");
         assertThat(response.statusCode()).as(response.body()).isEqualTo(400);
-        assertThatJson(response.body()).inPath("$.id").isEqualTo(7);
-        assertThatJson(response.body()).inPath("$.error.code").isEqualTo(-32020);
+        assertThat(response).isJsonRpcError().hasId(7).hasErrorCode(-32020);
     }
 
     @Test
@@ -128,7 +124,6 @@ class CustomHeaderValidationTest extends AbstractStatelessMcpE2eTest {
                 .replace("=", "");
         var response = post(toolCallBody(6, "Hello"), "=?base64?" + encoded + "?=");
         assertThat(response.statusCode()).as(response.body()).isEqualTo(400);
-        assertThatJson(response.body()).inPath("$.id").isEqualTo(6);
-        assertThatJson(response.body()).inPath("$.error.code").isEqualTo(-32020);
+        assertThat(response).isJsonRpcError().hasId(6).hasErrorCode(-32020);
     }
 }

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp20260728/DiscoverCapabilitiesMatchHandlersTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp20260728/DiscoverCapabilitiesMatchHandlersTest.java
@@ -20,13 +20,9 @@ class DiscoverCapabilitiesMatchHandlersTest extends AbstractStatelessMcpE2eTest 
     @Test
     void toolsCapabilityAdvertisedInDiscoverActuallyWorks() throws Exception {
         try (var client = createModernTestClient()) {
-            var discover = client.post("""
-                    {"jsonrpc": "2.0", "id": 1, "method": "server/discover"}
+            client.discover().isSuccess().hasCapabilities("""
+                    {"logging":{},"tools":{}}
                     """);
-            assertThat(discover.statusCode()).as(discover.body()).isEqualTo(200);
-            assertThatJson(discover.body())
-                    .inPath("$.result.capabilities.tools")
-                    .isPresent();
 
             var toolsList = client.post("""
                     {"jsonrpc": "2.0", "id": 2, "method": "tools/list"}

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp20260728/DiscoverExtensionsTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp20260728/DiscoverExtensionsTest.java
@@ -1,15 +1,11 @@
 /* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
 package dev.tachyonmcp.e2e.mcp20260728;
 
-import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
-import static org.assertj.core.api.Assertions.assertThat;
-
 import dev.tachyonmcp.api.server.extensions.AdvertiseMode;
 import dev.tachyonmcp.api.server.extensions.ExtensionSettings;
 import dev.tachyonmcp.api.server.extensions.ServerExtension;
 import dev.tachyonmcp.e2e.AbstractStatelessMcpE2eTest;
 import java.util.Map;
-import net.javacrumbs.jsonunit.core.Option;
 import org.junit.jupiter.api.Test;
 import tools.jackson.databind.node.JsonNodeFactory;
 
@@ -25,17 +21,9 @@ class DiscoverExtensionsTest extends AbstractStatelessMcpE2eTest {
         startServer(it -> it.withExtensions(new TestExtension(ALWAYS_EXT_ID, AdvertiseMode.ALWAYS)));
 
         try (var client = createModernTestClient()) {
-            var response = client.post("""
-                    {"jsonrpc": "2.0", "id": 1, "method": "server/discover"}
+            client.discover().isSuccess().hasCapabilities("""
+                    {"extensions":{"com.example/always":{"version":"1.0"}}}
                     """);
-
-            assertThat(response.statusCode()).as(response.body()).isEqualTo(200);
-            assertThatJson(response.body())
-                    .inPath("$.result.capabilities.extensions")
-                    // language=JSON
-                    .isEqualTo("""
-                            {"com.example/always": {"version": "1.0"}}
-                            """);
         }
     }
 
@@ -46,23 +34,9 @@ class DiscoverExtensionsTest extends AbstractStatelessMcpE2eTest {
                 new TestExtension(NEVER_EXT_ID, AdvertiseMode.NEVER)));
 
         try (var client = createModernTestClient()) {
-            var response = client.post("""
-                    {"jsonrpc": "2.0", "id": 1, "method": "server/discover"}
+            client.discover().isSuccess().hasCapabilities("""
+                    {"extensions":{"com.example/always":{"version":"1.0"}}}
                     """);
-
-            assertThat(response.statusCode()).as(response.body()).isEqualTo(200);
-            assertThatJson(response.body())
-                    .when(Option.IGNORING_EXTRA_FIELDS)
-                    // language=JSON
-                    .isEqualTo("""
-                            {
-                              "result": {
-                                "capabilities": {
-                                  "extensions": {"com.example/always": {"version": "1.0"}}
-                                }
-                              }
-                            }
-                            """);
         }
     }
 
@@ -72,17 +46,9 @@ class DiscoverExtensionsTest extends AbstractStatelessMcpE2eTest {
 
         try (var client = createModernTestClient()) {
             client.withExtensions(Map.of(NEGOTIATED_EXT_ID, JsonNodeFactory.instance.objectNode()));
-            var response = client.post("""
-                    {"jsonrpc": "2.0", "id": 1, "method": "server/discover"}
+            client.discover().isSuccess().hasCapabilities("""
+                    {"extensions":{"com.example/negotiated":{"version":"1.0"}}}
                     """);
-
-            assertThat(response.statusCode()).as(response.body()).isEqualTo(200);
-            assertThatJson(response.body())
-                    .inPath("$.result.capabilities.extensions")
-                    // language=JSON
-                    .isEqualTo("""
-                            {"com.example/negotiated": {"version": "1.0"}}
-                            """);
         }
     }
 
@@ -91,14 +57,7 @@ class DiscoverExtensionsTest extends AbstractStatelessMcpE2eTest {
         startServer(it -> it.withExtensions(new TestExtension(NEGOTIATED_EXT_ID, AdvertiseMode.NEGOTIATED)));
 
         try (var client = createModernTestClient()) {
-            var response = client.post("""
-                    {"jsonrpc": "2.0", "id": 1, "method": "server/discover"}
-                    """);
-
-            assertThat(response.statusCode()).as(response.body()).isEqualTo(200);
-            assertThatJson(response.body())
-                    .node("result.capabilities.extensions")
-                    .isAbsent();
+            client.discover().isSuccess().hasCapabilities("{}");
         }
     }
 

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp20260728/HeaderValidationTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp20260728/HeaderValidationTest.java
@@ -1,7 +1,7 @@
 /* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
 package dev.tachyonmcp.e2e.mcp20260728;
 
-import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static dev.tachyonmcp.testkit.JsonRpcResponseAssert.assertThat;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import dev.tachyonmcp.e2e.AbstractStatelessMcpE2eTest;
@@ -47,8 +47,7 @@ class HeaderValidationTest extends AbstractStatelessMcpE2eTest {
 
     private void assertHeaderMismatch(HttpResponse<String> response) {
         assertThat(response.statusCode()).as(response.body()).isEqualTo(400);
-        assertThatJson(response.body()).inPath("$.id").isEqualTo(9);
-        assertThatJson(response.body()).inPath("$.error.code").isEqualTo(-32020);
+        assertThat(response).isJsonRpcError().hasId(9).hasErrorCode(-32020);
     }
 
     @Test
@@ -70,7 +69,7 @@ class HeaderValidationTest extends AbstractStatelessMcpE2eTest {
     void acceptsWhitespacePaddedNameHeader() throws Exception {
         var response = post("tools/call", "  echo  ");
         assertThat(response.statusCode()).as(response.body()).isEqualTo(200);
-        assertThatJson(response.body()).inPath("$.result.content[0].text").isEqualTo("hi");
+        assertThat(response).isSuccess().hasTextContent("hi");
     }
 
     @Test
@@ -78,7 +77,7 @@ class HeaderValidationTest extends AbstractStatelessMcpE2eTest {
         var encoded = Base64.getEncoder().encodeToString("echo".getBytes(StandardCharsets.UTF_8));
         var response = post("tools/call", "=?base64?" + encoded + "?=");
         assertThat(response.statusCode()).as(response.body()).isEqualTo(200);
-        assertThatJson(response.body()).inPath("$.result.content[0].text").isEqualTo("hi");
+        assertThat(response).isSuccess().hasTextContent("hi");
     }
 
     @Test
@@ -103,7 +102,6 @@ class HeaderValidationTest extends AbstractStatelessMcpE2eTest {
         var response = postMcpRequest(body, Map.of("Mcp-Method", "tools/call", "Mcp-Name", "echo"));
 
         assertThat(response.statusCode()).as(response.body()).isEqualTo(400);
-        assertThatJson(response.body()).inPath("$.id").isEqualTo(11);
-        assertThatJson(response.body()).inPath("$.error.code").isEqualTo(-32020);
+        assertThat(response).isJsonRpcError().hasId(11).hasErrorCode(-32020);
     }
 }

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp20260728/InputRequiredResultTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp20260728/InputRequiredResultTest.java
@@ -1,6 +1,7 @@
 /* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
 package dev.tachyonmcp.e2e.mcp20260728;
 
+import static dev.tachyonmcp.testkit.JsonRpcResponseAssert.assertThat;
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -161,7 +162,7 @@ class InputRequiredResultTest extends AbstractStatelessMcpE2eTest {
         try (var client = createModernTestClient()) {
             var round1 = client.post(toolCallBody(1, "elicit_name", ""));
             assertThat(round1.statusCode()).as(round1.body()).isEqualTo(200);
-            assertThatJson(round1.body()).inPath("$.result.resultType").isEqualTo("input_required");
+            assertThat(round1).isSuccess().hasResultType("input_required");
             assertThatJson(round1.body())
                     .inPath("$.result.inputRequests.user_name.method")
                     .isEqualTo("elicitation/create");
@@ -172,7 +173,7 @@ class InputRequiredResultTest extends AbstractStatelessMcpE2eTest {
                             "elicit_name",
                             "\"inputResponses\": {\"user_name\": {\"action\": \"accept\", \"content\": {\"name\": \"Alice\"}}}"));
             assertThat(round2.statusCode()).as(round2.body()).isEqualTo(200);
-            assertThatJson(round2.body()).inPath("$.result.content[0].text").isEqualTo("Hello, Alice!");
+            assertThat(round2).isSuccess().hasTextContent("Hello, Alice!");
         }
     }
 
@@ -181,7 +182,7 @@ class InputRequiredResultTest extends AbstractStatelessMcpE2eTest {
         try (var client = createModernTestClient()) {
             var round1 = client.post(toolCallBody(3, "ask_sampling", ""));
             assertThat(round1.statusCode()).as(round1.body()).isEqualTo(200);
-            assertThatJson(round1.body()).inPath("$.result.resultType").isEqualTo("input_required");
+            assertThat(round1).isSuccess().hasResultType("input_required");
             assertThatJson(round1.body())
                     .inPath("$.result.inputRequests.capital_question.method")
                     .isEqualTo("sampling/createMessage");
@@ -212,7 +213,7 @@ class InputRequiredResultTest extends AbstractStatelessMcpE2eTest {
         try (var client = createModernTestClient()) {
             var round1 = client.post(toolCallBody(4, "ask_roots", ""));
             assertThat(round1.statusCode()).as(round1.body()).isEqualTo(200);
-            assertThatJson(round1.body()).inPath("$.result.resultType").isEqualTo("input_required");
+            assertThat(round1).isSuccess().hasResultType("input_required");
             assertThatJson(round1.body())
                     .inPath("$.result.inputRequests.client_roots.method")
                     .isEqualTo("roots/list");
@@ -224,7 +225,7 @@ class InputRequiredResultTest extends AbstractStatelessMcpE2eTest {
         try (var client = createModernTestClient()) {
             var round1 = client.post(toolCallBody(8, "ask_url", ""));
             assertThat(round1.statusCode()).as(round1.body()).isEqualTo(200);
-            assertThatJson(round1.body()).inPath("$.result.resultType").isEqualTo("input_required");
+            assertThat(round1).isSuccess().hasResultType("input_required");
             assertThatJson(round1.body())
                     .inPath("$.result.inputRequests.auth.method")
                     .isEqualTo("elicitation/create");
@@ -241,7 +242,7 @@ class InputRequiredResultTest extends AbstractStatelessMcpE2eTest {
             var round2 =
                     client.post(toolCallBody(9, "ask_url", "\"inputResponses\": {\"auth\": {\"action\": \"accept\"}}"));
             assertThat(round2.statusCode()).as(round2.body()).isEqualTo(200);
-            assertThatJson(round2.body()).inPath("$.result.content[0].text").isEqualTo("authenticated");
+            assertThat(round2).isSuccess().hasTextContent("authenticated");
         }
     }
 
@@ -250,7 +251,7 @@ class InputRequiredResultTest extends AbstractStatelessMcpE2eTest {
         try (var client = createModernTestClient()) {
             var round1 = client.post(toolCallBody(5, "ask_multiple", ""));
             assertThat(round1.statusCode()).as(round1.body()).isEqualTo(200);
-            assertThatJson(round1.body()).inPath("$.result.resultType").isEqualTo("input_required");
+            assertThat(round1).isSuccess().hasResultType("input_required");
             assertThatJson(round1.body())
                     .inPath("$.result.inputRequests.user_name.method")
                     .isEqualTo("elicitation/create");
@@ -296,7 +297,7 @@ class InputRequiredResultTest extends AbstractStatelessMcpE2eTest {
         var response = postMcpRequest(body, Map.of("Mcp-Method", "tools/call", "Mcp-Name", "respect_capabilities"));
 
         assertThat(response.statusCode()).as(response.body()).isEqualTo(200);
-        assertThatJson(response.body()).inPath("$.result.resultType").isEqualTo("input_required");
+        assertThat(response).isSuccess().hasResultType("input_required");
         assertThatJson(response.body())
                 .inPath("$.result.inputRequests.capital_question.method")
                 .isEqualTo("sampling/createMessage");

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp20260728/MetaValidationTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp20260728/MetaValidationTest.java
@@ -1,7 +1,7 @@
 /* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
 package dev.tachyonmcp.e2e.mcp20260728;
 
-import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static dev.tachyonmcp.testkit.JsonRpcResponseAssert.assertThat;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import dev.tachyonmcp.e2e.AbstractStatelessMcpE2eTest;
@@ -41,8 +41,7 @@ class MetaValidationTest extends AbstractStatelessMcpE2eTest {
 
     private void assertRejected(HttpResponse<String> response) {
         assertThat(response.statusCode()).as(response.body()).isEqualTo(400);
-        assertThatJson(response.body()).inPath("$.id").isEqualTo(7);
-        assertThatJson(response.body()).inPath("$.error.code").isEqualTo(-32602);
+        assertThat(response).isJsonRpcError().hasId(7).hasErrorCode(-32602);
     }
 
     @Test
@@ -65,7 +64,7 @@ class MetaValidationTest extends AbstractStatelessMcpE2eTest {
                 "io.modelcontextprotocol/clientCapabilities": {}
                 """);
         assertThat(response.statusCode()).as(response.body()).isEqualTo(200);
-        assertThatJson(response.body()).inPath("$.result.content[0].text").isEqualTo("hi");
+        assertThat(response).isSuccess().hasTextContent("hi");
     }
 
     @Test
@@ -116,6 +115,6 @@ class MetaValidationTest extends AbstractStatelessMcpE2eTest {
     void acceptsCompleteMeta() throws Exception {
         var response = postToolsCall(VALID_META);
         assertThat(response.statusCode()).as(response.body()).isEqualTo(200);
-        assertThatJson(response.body()).inPath("$.result.content[0].text").isEqualTo("hi");
+        assertThat(response).isSuccess().hasTextContent("hi");
     }
 }

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp20260728/MissingCapabilityTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp20260728/MissingCapabilityTest.java
@@ -1,6 +1,7 @@
 /* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
 package dev.tachyonmcp.e2e.mcp20260728;
 
+import static dev.tachyonmcp.testkit.JsonRpcResponseAssert.assertThat;
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -49,8 +50,7 @@ class MissingCapabilityTest extends AbstractStatelessMcpE2eTest {
                     """);
 
             assertThat(response.statusCode()).as(response.body()).isEqualTo(400);
-            assertThatJson(response.body()).inPath("$.id").isEqualTo(1);
-            assertThatJson(response.body()).inPath("$.error.code").isEqualTo(-32021);
+            assertThat(response).isJsonRpcError().hasId(1).hasErrorCode(-32021);
             assertThatJson(response.body())
                     .inPath("$.error.data.requiredCapabilities.sampling")
                     .isEqualTo(Map.of());
@@ -79,6 +79,6 @@ class MissingCapabilityTest extends AbstractStatelessMcpE2eTest {
         var response = postMcpRequest(body, Map.of("Mcp-Method", "tools/call", "Mcp-Name", "test_missing_capability"));
 
         assertThat(response.statusCode()).as(response.body()).isEqualTo(200);
-        assertThatJson(response.body()).inPath("$.result.content[0].text").isEqualTo("sampling capability present");
+        assertThat(response).isSuccess().hasTextContent("sampling capability present");
     }
 }

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp20260728/RemovedMethodsTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp20260728/RemovedMethodsTest.java
@@ -1,7 +1,7 @@
 /* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
 package dev.tachyonmcp.e2e.mcp20260728;
 
-import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static dev.tachyonmcp.testkit.JsonRpcResponseAssert.assertThat;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import dev.tachyonmcp.e2e.AbstractStatelessMcpE2eTest;
@@ -37,7 +37,6 @@ class RemovedMethodsTest extends AbstractStatelessMcpE2eTest {
         assertThat(response.statusCode())
                 .as("status for removed method '%s': %s", method, response.body())
                 .isEqualTo(404);
-        assertThatJson(response.body()).inPath("$.id").isEqualTo(42);
-        assertThatJson(response.body()).inPath("$.error.code").isEqualTo(-32601);
+        assertThat(response).isJsonRpcError().hasId(42).hasErrorCode(-32601);
     }
 }

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp20260728/ResourceNotFoundTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp20260728/ResourceNotFoundTest.java
@@ -1,6 +1,7 @@
 /* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
 package dev.tachyonmcp.e2e.mcp20260728;
 
+import static dev.tachyonmcp.testkit.JsonRpcResponseAssert.assertThat;
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -29,7 +30,7 @@ class ResourceNotFoundTest extends AbstractStatelessMcpE2eTest {
                     """);
 
             assertThat(response.statusCode()).as(response.body()).isEqualTo(200);
-            assertThatJson(response.body()).inPath("$.error.code").isEqualTo(-32602);
+            assertThat(response).isJsonRpcError().hasErrorCode(-32602);
             assertThatJson(response.body()).inPath("$.error.data.uri").isEqualTo("test://does-not-exist");
         }
     }

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp20260728/StatelessDispatchTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp20260728/StatelessDispatchTest.java
@@ -1,6 +1,7 @@
 /* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
 package dev.tachyonmcp.e2e.mcp20260728;
 
+import static dev.tachyonmcp.testkit.JsonRpcResponseAssert.assertThat;
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -29,7 +30,7 @@ class StatelessDispatchTest extends AbstractStatelessMcpE2eTest {
 
             assertThat(response.statusCode()).isEqualTo(200);
             assertThat(response.headers().firstValue("MCP-Session-Id")).isEmpty();
-            assertThatJson(response.body()).inPath("$.result.content[0].text").isEqualTo("hi");
+            assertThat(response).isSuccess().hasTextContent("hi");
         }
     }
 

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp20260728/TasksExtensionTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp20260728/TasksExtensionTest.java
@@ -1,6 +1,7 @@
 /* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
 package dev.tachyonmcp.e2e.mcp20260728;
 
+import static dev.tachyonmcp.testkit.JsonRpcResponseAssert.assertThat;
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -102,7 +103,7 @@ class TasksExtensionTest extends AbstractStatelessMcpE2eTest {
                     """.formatted(task.id()));
 
             assertThat(response.statusCode()).as(response.body()).isEqualTo(400);
-            assertThatJson(response.body()).inPath("$.error.code").isEqualTo(-32021);
+            assertThat(response).isJsonRpcError().hasErrorCode(-32021);
             assertThatJson(response.body())
                     .inPath("$.error.data.requiredCapabilities.extensions")
                     .isObject()
@@ -128,7 +129,7 @@ class TasksExtensionTest extends AbstractStatelessMcpE2eTest {
                     {"jsonrpc":"2.0","id":2,"method":"tasks/get","params":{"taskId":"%s"}}
                     """.formatted(task.id()));
             assertThat(undeclared.statusCode()).as(undeclared.body()).isEqualTo(400);
-            assertThatJson(undeclared.body()).inPath("$.error.code").isEqualTo(-32021);
+            assertThat(undeclared).isJsonRpcError().hasErrorCode(-32021);
         }
     }
 
@@ -268,7 +269,7 @@ class TasksExtensionTest extends AbstractStatelessMcpE2eTest {
                     """.formatted(task.id()));
 
             assertThat(response.statusCode()).as(response.body()).isEqualTo(400);
-            assertThatJson(response.body()).inPath("$.error.code").isEqualTo(-32021);
+            assertThat(response).isJsonRpcError().hasErrorCode(-32021);
         }
     }
 
@@ -318,7 +319,7 @@ class TasksExtensionTest extends AbstractStatelessMcpE2eTest {
                     """);
 
             assertThat(response.statusCode()).as(response.body()).isEqualTo(400);
-            assertThatJson(response.body()).inPath("$.error.code").isEqualTo(-32021);
+            assertThat(response).isJsonRpcError().hasErrorCode(-32021);
             assertThatJson(response.body())
                     .inPath("$.error.data.requiredCapabilities.extensions")
                     .isObject()
@@ -367,8 +368,7 @@ class TasksExtensionTest extends AbstractStatelessMcpE2eTest {
                     """);
 
             assertThat(response.statusCode()).as(response.body()).isEqualTo(400);
-            assertThatJson(response.body()).inPath("$.error.code").isEqualTo(-32602);
-            assertThatJson(response.body()).inPath("$.error.message").isEqualTo("Unknown tool: create_task");
+            assertThat(response).isJsonRpcError().hasErrorCode(-32602).hasErrorMessage("Unknown tool: create_task");
         }
     }
 
@@ -383,7 +383,7 @@ class TasksExtensionTest extends AbstractStatelessMcpE2eTest {
                     """.formatted(TasksExtension.ID));
 
             assertThat(response.statusCode()).as(response.body()).isEqualTo(200);
-            assertThatJson(response.body()).inPath("$.result.content[0].text").isString();
+            assertThat(response).isSuccess().hasTextContent();
         }
     }
 
@@ -680,7 +680,7 @@ class TasksExtensionTest extends AbstractStatelessMcpE2eTest {
                     """);
 
             assertThat(response.statusCode()).as(response.body()).isEqualTo(400);
-            assertThatJson(response.body()).inPath("$.error.code").isEqualTo(-32602);
+            assertThat(response).isJsonRpcError().hasErrorCode(-32602);
         }
     }
 
@@ -719,7 +719,7 @@ class TasksExtensionTest extends AbstractStatelessMcpE2eTest {
                     """.formatted(task.id()));
 
             assertThat(response.statusCode()).as(response.body()).isEqualTo(400);
-            assertThatJson(response.body()).inPath("$.error.code").isEqualTo(-32021);
+            assertThat(response).isJsonRpcError().hasErrorCode(-32021);
         }
     }
 }

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp20260728/UnsupportedProtocolVersionTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp20260728/UnsupportedProtocolVersionTest.java
@@ -1,6 +1,7 @@
 /* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
 package dev.tachyonmcp.e2e.mcp20260728;
 
+import static dev.tachyonmcp.testkit.JsonRpcResponseAssert.assertThat;
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -49,13 +50,12 @@ class UnsupportedProtocolVersionTest extends AbstractStatelessMcpE2eTest {
         var response = HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
 
         assertThat(response.statusCode()).as(response.body()).isEqualTo(400);
-        assertThatJson(response.body()).inPath("$.error.code").isEqualTo(-32022);
+        assertThat(response).isJsonRpcError().hasId(301).hasErrorCode(-32022);
         assertThatJson(response.body()).inPath("$.error.data.requested").isEqualTo("v999.0.0");
         assertThatJson(response.body())
                 .inPath("$.error.data.supported")
                 .isArray()
                 .contains("2026-07-28", "2025-11-25");
-        assertThatJson(response.body()).inPath("$.id").isEqualTo(301);
         assertThat(response.headers().firstValue("Access-Control-Allow-Origin")).contains("http://localhost:3000");
     }
 
@@ -72,6 +72,6 @@ class UnsupportedProtocolVersionTest extends AbstractStatelessMcpE2eTest {
         var response = HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
 
         assertThat(response.statusCode()).as(response.body()).isEqualTo(400);
-        assertThat(response.body()).contains("\"id\":null");
+        assertThat(response).isJsonRpcError().hasId(null);
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         <java.version>21</java.version>
         <kotlin.version>2.2.21</kotlin.version>
         <kotlin-language.version>2.2</kotlin-language.version>
-        <api.oldVersion>1.0.0-beta.20</api.oldVersion>
+        <api.oldVersion>1.0.0-beta.21</api.oldVersion>
 
         <!-- Dependencies -->
         <assertj.version>3.27.7</assertj.version>

--- a/tachyon-testkit/revapi.json
+++ b/tachyon-testkit/revapi.json
@@ -3,7 +3,80 @@
     "extension": "revapi.differences",
     "configuration": {
       "ignore": true,
-      "differences": []
+      "differences": [
+        {
+          "ignore": true,
+          "code": "java.method.removed",
+          "old": "method dev.tachyonmcp.testkit.JsonRpcResponseAssert dev.tachyonmcp.testkit.JsonRpcResponseAssert::hasContent()",
+          "justification": "Moved to JsonRpcSuccessAssert so content assertions require a verified success branch.",
+          "attachments": {"since": "1.0.0-beta.22"}
+        },
+        {
+          "ignore": true,
+          "code": "java.method.removed",
+          "old": "method dev.tachyonmcp.testkit.JsonRpcResponseAssert dev.tachyonmcp.testkit.JsonRpcResponseAssert::hasErrorCode(int)",
+          "justification": "Moved to JsonRpcErrorAssert so error assertions require a verified error branch.",
+          "attachments": {"since": "1.0.0-beta.22"}
+        },
+        {
+          "ignore": true,
+          "code": "java.method.removed",
+          "old": "method dev.tachyonmcp.testkit.JsonRpcResponseAssert dev.tachyonmcp.testkit.JsonRpcResponseAssert::hasErrorDataSatisfying(java.util.function.Consumer<tools.jackson.databind.JsonNode>)",
+          "justification": "Moved to JsonRpcErrorAssert so error assertions require a verified error branch.",
+          "attachments": {"since": "1.0.0-beta.22"}
+        },
+        {
+          "ignore": true,
+          "code": "java.method.removed",
+          "old": "method dev.tachyonmcp.testkit.JsonRpcResponseAssert dev.tachyonmcp.testkit.JsonRpcResponseAssert::hasErrorMessage(java.lang.String)",
+          "justification": "Moved to JsonRpcErrorAssert so error assertions require a verified error branch.",
+          "attachments": {"since": "1.0.0-beta.22"}
+        },
+        {
+          "ignore": true,
+          "code": "java.method.removed",
+          "old": "method dev.tachyonmcp.testkit.JsonRpcResponseAssert dev.tachyonmcp.testkit.JsonRpcResponseAssert::hasErrorMessageContaining(java.lang.String)",
+          "justification": "Moved to JsonRpcErrorAssert so error assertions require a verified error branch.",
+          "attachments": {"since": "1.0.0-beta.22"}
+        },
+        {
+          "ignore": true,
+          "code": "java.method.removed",
+          "old": "method dev.tachyonmcp.testkit.JsonRpcResponseAssert dev.tachyonmcp.testkit.JsonRpcResponseAssert::hasStructuredContent(tools.jackson.databind.JsonNode)",
+          "justification": "Moved to JsonRpcSuccessAssert so content assertions require a verified success branch.",
+          "attachments": {"since": "1.0.0-beta.22"}
+        },
+        {
+          "ignore": true,
+          "code": "java.method.removed",
+          "old": "method dev.tachyonmcp.testkit.JsonRpcResponseAssert dev.tachyonmcp.testkit.JsonRpcResponseAssert::hasTextContent(java.lang.String)",
+          "justification": "Moved to JsonRpcSuccessAssert so content assertions require a verified success branch.",
+          "attachments": {"since": "1.0.0-beta.22"}
+        },
+        {
+          "ignore": true,
+          "code": "java.method.returnTypeChanged",
+          "old": "method dev.tachyonmcp.testkit.JsonRpcResponseAssert dev.tachyonmcp.testkit.JsonRpcResponseAssert::isJsonRpcError()",
+          "new": "method dev.tachyonmcp.testkit.JsonRpcResponseAssert.JsonRpcErrorAssert dev.tachyonmcp.testkit.JsonRpcResponseAssert::isJsonRpcError()",
+          "justification": "Returns the error-stage assertion type to prevent success-only assertions after selecting the error branch.",
+          "attachments": {"since": "1.0.0-beta.22"}
+        },
+        {
+          "ignore": true,
+          "code": "java.method.returnTypeChanged",
+          "old": "method dev.tachyonmcp.testkit.JsonRpcResponseAssert dev.tachyonmcp.testkit.JsonRpcResponseAssert::isSuccess()",
+          "new": "method dev.tachyonmcp.testkit.JsonRpcResponseAssert.JsonRpcSuccessAssert dev.tachyonmcp.testkit.JsonRpcResponseAssert::isSuccess()",
+          "justification": "Returns the success-stage assertion type to prevent error-only assertions after selecting the success branch.",
+          "attachments": {"since": "1.0.0-beta.22"}
+        },
+        {
+          "ignore": true,
+          "code": "java.method.removed",
+          "old": "method dev.tachyonmcp.testkit.JsonRpcResponseAssert dev.tachyonmcp.testkit.JsonRpcResponseAssert::isToolError()",
+          "justification": "Moved to JsonRpcSuccessAssert because a tool error is an MCP result on the JSON-RPC success branch.",
+          "attachments": {"since": "1.0.0-beta.22"}
+        }
+      ]
     }
   }
 ]

--- a/tachyon-testkit/src/main/java/dev/tachyonmcp/testkit/DiscoverResponseAssert.java
+++ b/tachyon-testkit/src/main/java/dev/tachyonmcp/testkit/DiscoverResponseAssert.java
@@ -1,0 +1,49 @@
+/* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
+package dev.tachyonmcp.testkit;
+
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+
+import java.net.http.HttpResponse;
+import org.assertj.core.api.AbstractAssert;
+import org.intellij.lang.annotations.Language;
+
+/** Staged assertions for an MCP 2026-07-28 {@code server/discover} response. */
+public final class DiscoverResponseAssert extends AbstractAssert<DiscoverResponseAssert, HttpResponse<String>> {
+
+    DiscoverResponseAssert(HttpResponse<String> response) {
+        super(response, DiscoverResponseAssert.class);
+    }
+
+    /**
+     * Verifies HTTP and JSON-RPC success, then exposes discover result assertions.
+     *
+     * @return success-only assertions
+     */
+    public DiscoverSuccessAssert isSuccess() {
+        isNotNull();
+        if (actual.statusCode() != 200) {
+            failWithMessage("Expected discover HTTP status <200> but was <%s>: %s", actual.statusCode(), actual.body());
+        }
+        JsonRpcResponseAssert.assertThat(actual).isSuccess().hasId(1);
+        return new DiscoverSuccessAssert(actual.body());
+    }
+
+    /** Assertions available after the discover success branch is verified. */
+    public static final class DiscoverSuccessAssert extends AbstractAssert<DiscoverSuccessAssert, String> {
+
+        private DiscoverSuccessAssert(String body) {
+            super(body, DiscoverSuccessAssert.class);
+        }
+
+        /**
+         * Verifies the discover capabilities object.
+         *
+         * @param capabilities expected capabilities JSON
+         * @return {@code this}
+         */
+        public DiscoverSuccessAssert hasCapabilities(@Language("json") String capabilities) {
+            assertThatJson(actual).inPath("$.result.capabilities").isEqualTo(capabilities);
+            return this;
+        }
+    }
+}

--- a/tachyon-testkit/src/main/java/dev/tachyonmcp/testkit/JsonRpcResponseAssert.java
+++ b/tachyon-testkit/src/main/java/dev/tachyonmcp/testkit/JsonRpcResponseAssert.java
@@ -1,24 +1,16 @@
 /* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
 package dev.tachyonmcp.testkit;
 
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+
 import java.net.http.HttpResponse;
 import java.util.function.Consumer;
 import org.assertj.core.api.AbstractAssert;
+import org.intellij.lang.annotations.Language;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 
-/**
- * Fluent AssertJ assertions over a JSON-RPC response envelope ({@code {jsonrpc, id, result|error}}),
- * as produced by {@link McpClient#post} / {@link McpClient#sendRpc}.
- *
- * <pre>{@code
- * var response = client.post("""
- *     {"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"echo","arguments":{"message":"hi"}}}
- *     """);
- *
- * assertThat(response).hasTextContent("echo:hi");
- * }</pre>
- */
+/** Fluent, branch-safe assertions over a JSON-RPC response envelope. */
 public final class JsonRpcResponseAssert extends AbstractAssert<JsonRpcResponseAssert, JsonNode> {
 
     private static final ObjectMapper MAPPER = new ObjectMapper();
@@ -27,190 +19,219 @@ public final class JsonRpcResponseAssert extends AbstractAssert<JsonRpcResponseA
         super(envelope, JsonRpcResponseAssert.class);
     }
 
-    /**
-     * Creates assertions for an already-parsed JSON-RPC response envelope.
-     *
-     * @param envelope the JSON-RPC response envelope
-     * @return a new assertion object
-     */
+    /** Creates assertions for a parsed JSON-RPC response envelope. */
     public static JsonRpcResponseAssert assertThat(JsonNode envelope) {
         return new JsonRpcResponseAssert(envelope);
     }
 
-    /**
-     * Creates assertions for an HTTP response carrying a JSON-RPC response envelope as its body.
-     *
-     * @param httpResponse the HTTP response
-     * @return a new assertion object
-     */
-    public static JsonRpcResponseAssert assertThat(HttpResponse<String> httpResponse) {
-        return assertThatJsonRpcResponse(httpResponse.body());
+    /** Creates assertions for an HTTP response containing a JSON-RPC envelope. */
+    public static JsonRpcResponseAssert assertThat(HttpResponse<String> response) {
+        return assertThatJsonRpcResponse(response.body());
     }
 
-    /**
-     * Creates assertions for a raw JSON-RPC response body, e.g. as returned by {@link
-     * McpClient#sendRpc}. Named distinctly from {@code assertThat} to avoid an ambiguous overload
-     * against {@code org.assertj.core.api.Assertions.assertThat(String)} when both are statically
-     * imported.
-     *
-     * @param json the JSON-RPC response body
-     * @return a new assertion object
-     */
+    /** Creates assertions for a raw JSON-RPC response body. */
     public static JsonRpcResponseAssert assertThatJsonRpcResponse(String json) {
         return new JsonRpcResponseAssert(MAPPER.readTree(json));
     }
 
-    /**
-     * Asserts the envelope carries a {@code result} and no {@code error}.
-     *
-     * @return {@code this}
-     */
-    public JsonRpcResponseAssert isSuccess() {
+    /** Verifies the success branch and returns success-only assertions. */
+    public JsonRpcSuccessAssert isSuccess() {
         isNotNull();
-        if (!actual.path("error").isMissingNode()) {
-            failWithMessage("Expected a successful JSON-RPC response but found an error: %s", actual.path("error"));
+        if (actual.has("error") || !actual.has("result")) {
+            failWithMessage("Expected a successful JSON-RPC response but was: %s", actual);
         }
-        if (actual.path("result").isMissingNode()) {
-            failWithMessage(
-                    "Expected a successful JSON-RPC response with a 'result' but found neither 'result' nor"
-                            + " 'error': %s",
-                    actual);
-        }
-        return this;
+        return new JsonRpcSuccessAssert(actual);
     }
 
-    /**
-     * Asserts the envelope carries an {@code error}.
-     *
-     * @return {@code this}
-     */
-    public JsonRpcResponseAssert isJsonRpcError() {
+    /** Verifies the error branch and returns error-only assertions. */
+    public JsonRpcErrorAssert isJsonRpcError() {
         isNotNull();
-        if (actual.path("error").isMissingNode()) {
-            failWithMessage("Expected a JSON-RPC error response but 'error' is missing: %s", actual);
+        if (actual.has("result") || !actual.path("error").isObject()) {
+            failWithMessage("Expected a JSON-RPC error response but was: %s", actual);
         }
-        return this;
+        return new JsonRpcErrorAssert(actual);
     }
 
-    /**
-     * Asserts the JSON-RPC error code equals {@code expectedCode}.
-     *
-     * @param expectedCode the expected {@code error.code}
-     * @return {@code this}
-     */
-    public JsonRpcResponseAssert hasErrorCode(int expectedCode) {
-        isJsonRpcError();
-        var actualCode = actual.path("error").path("code").asInt();
-        if (actualCode != expectedCode) {
-            failWithMessage("Expected JSON-RPC error code <%s> but was <%s> in: %s", expectedCode, actualCode, actual);
+    /** Assertions available only after verifying a successful response. */
+    public static final class JsonRpcSuccessAssert extends AbstractAssert<JsonRpcSuccessAssert, JsonNode> {
+
+        private JsonRpcSuccessAssert(JsonNode envelope) {
+            super(envelope, JsonRpcSuccessAssert.class);
         }
-        return this;
-    }
 
-    /**
-     * Asserts the JSON-RPC error message equals {@code expectedMessage} exactly.
-     *
-     * @param expectedMessage the expected {@code error.message}
-     * @return {@code this}
-     */
-    public JsonRpcResponseAssert hasErrorMessage(String expectedMessage) {
-        isJsonRpcError();
-        var actualMessage = actual.path("error").path("message").asString(null);
-        if (!expectedMessage.equals(actualMessage)) {
-            failWithMessage(
-                    "Expected JSON-RPC error message <%s> but was <%s> in: %s", expectedMessage, actualMessage, actual);
-        }
-        return this;
-    }
-
-    /**
-     * Asserts the JSON-RPC error message contains {@code substring}.
-     *
-     * @param substring the expected substring of {@code error.message}
-     * @return {@code this}
-     */
-    public JsonRpcResponseAssert hasErrorMessageContaining(String substring) {
-        isJsonRpcError();
-        var actualMessage = actual.path("error").path("message").asString("");
-        if (!actualMessage.contains(substring)) {
-            failWithMessage(
-                    "Expected JSON-RPC error message containing <%s> but was <%s> in: %s",
-                    substring, actualMessage, actual);
-        }
-        return this;
-    }
-
-    /**
-     * Runs {@code assertion} against the JSON-RPC error's {@code data} field.
-     *
-     * @param assertion the assertion to run against {@code error.data}
-     * @return {@code this}
-     */
-    public JsonRpcResponseAssert hasErrorDataSatisfying(Consumer<JsonNode> assertion) {
-        isJsonRpcError();
-        assertion.accept(actual.path("error").path("data"));
-        return this;
-    }
-
-    /**
-     * Asserts a successful tool call result has {@code isError: true} — the MCP tool-execution
-     * failure channel, distinct from a JSON-RPC-level error.
-     *
-     * @return {@code this}
-     */
-    public JsonRpcResponseAssert isToolError() {
-        isSuccess();
-        var isError = actual.path("result").path("isError");
-        if (!(isError.isBoolean() && isError.asBoolean())) {
-            failWithMessage("Expected tool result 'isError' to be true in: %s", actual);
-        }
-        return this;
-    }
-
-    /**
-     * Asserts the result's content blocks include a text block equal to {@code expectedText}.
-     *
-     * @param expectedText the expected text content
-     * @return {@code this}
-     */
-    public JsonRpcResponseAssert hasTextContent(String expectedText) {
-        isSuccess();
-        var content = actual.path("result").path("content");
-        for (var block : content) {
-            if ("text".equals(block.path("type").asString())
-                    && expectedText.equals(block.path("text").asString())) {
-                return this;
+        /** Verifies the JSON-RPC response id. */
+        public JsonRpcSuccessAssert hasId(Object expected) {
+            var expectedId = MAPPER.valueToTree(expected);
+            var id = actual.path("id");
+            if (!id.equals(expectedId)) {
+                failWithMessage("Expected JSON-RPC id <%s> but was <%s> in: %s", expectedId, id, actual);
             }
+            return this;
         }
-        failWithMessage("Expected result content to contain text <%s> but was: %s", expectedText, content);
-        return this;
+
+        /** Verifies a successful tool result reports {@code isError: true}. */
+        public JsonRpcSuccessAssert isToolError() {
+            var isError = actual.path("result").path("isError");
+            if (!isError.isBoolean() || !isError.asBoolean()) {
+                failWithMessage("Expected tool result 'isError' to be true in: %s", actual);
+            }
+            return this;
+        }
+
+        /** Verifies result content contains an equal text block. */
+        public JsonRpcSuccessAssert hasTextContent(String expectedText) {
+            var content = actual.path("result").path("content");
+            for (var block : content) {
+                if ("text".equals(block.path("type").asString())
+                        && expectedText.equals(block.path("text").asString())) {
+                    return this;
+                }
+            }
+            failWithMessage("Expected result content to contain text <%s> but was: %s", expectedText, content);
+            return this;
+        }
+
+        /** Verifies result content contains a text block. */
+        public JsonRpcSuccessAssert hasTextContent() {
+            var content = actual.path("result").path("content");
+            for (var block : content) {
+                if ("text".equals(block.path("type").asString())
+                        && block.path("text").isString()) {
+                    return this;
+                }
+            }
+            failWithMessage("Expected result content to contain a text block but was: %s", content);
+            return this;
+        }
+
+        /**
+         * Verifies result content is a non-empty array.
+         */
+        public JsonRpcSuccessAssert hasContent() {
+            var content = actual.path("result").path("content");
+            if (!content.isArray() || content.isEmpty()) {
+                failWithMessage("Expected result 'content' to be a non-empty array in: %s", actual);
+            }
+            return this;
+        }
+
+        /**
+         * Verifies result content contains exactly the expected blocks, in order.
+         */
+        public JsonRpcSuccessAssert hasContentExactly(JsonNode... expected) {
+            var content = actual.path("result").path("content");
+            var expectedContent = MAPPER.valueToTree(expected);
+            if (!content.equals(expectedContent)) {
+                failWithMessage("Expected result content <%s> but was <%s> in: %s", expectedContent, content, actual);
+            }
+            return this;
+        }
+
+        /**
+         * Verifies the complete JSON-RPC result value.
+         */
+        public JsonRpcSuccessAssert hasResult(JsonNode expected) {
+            var result = actual.path("result");
+            if (!result.equals(expected)) {
+                failWithMessage("Expected result <%s> but was <%s> in: %s", expected, result, actual);
+            }
+            return this;
+        }
+
+        /**
+         * Verifies the MCP result type.
+         */
+        public JsonRpcSuccessAssert hasResultType(String expected) {
+            var resultType = actual.path("result").path("resultType").asString(null);
+            if (!expected.equals(resultType)) {
+                failWithMessage("Expected resultType <%s> but was <%s> in: %s", expected, resultType, actual);
+            }
+            return this;
+        }
+
+        /** Verifies {@code structuredContent} equals the expected JSON. */
+        public JsonRpcSuccessAssert hasStructuredContent(JsonNode expected) {
+            var structuredContent = actual.path("result").path("structuredContent");
+            if (!structuredContent.equals(expected)) {
+                failWithMessage(
+                        "Expected structuredContent <%s> but was <%s> in: %s", expected, structuredContent, actual);
+            }
+            return this;
+        }
+
+        /**
+         * Verifies {@code structuredContent} equals the expected JSON text.
+         */
+        public JsonRpcSuccessAssert hasStructuredContent(@Language("json") String expectedJson) {
+            assertThatJson(actual.path("result").path("structuredContent")).isEqualTo(expectedJson);
+            return this;
+        }
     }
 
     /**
-     * Asserts the result's {@code content} field is present and is an array.
-     *
-     * @return {@code this}
+     * Assertions available only after verifying an error response.
      */
-    public JsonRpcResponseAssert hasContent() {
-        isSuccess();
-        if (!actual.path("result").path("content").isArray()) {
-            failWithMessage("Expected result 'content' to be an array in: %s", actual);
-        }
-        return this;
-    }
+    public static final class JsonRpcErrorAssert extends AbstractAssert<JsonRpcErrorAssert, JsonNode> {
 
-    /**
-     * Asserts the result's {@code structuredContent} equals {@code expected}.
-     *
-     * @param expected the expected structured content
-     * @return {@code this}
-     */
-    public JsonRpcResponseAssert hasStructuredContent(JsonNode expected) {
-        isSuccess();
-        var actualStructured = actual.path("result").path("structuredContent");
-        if (!actualStructured.equals(expected)) {
-            failWithMessage("Expected structuredContent <%s> but was <%s> in: %s", expected, actualStructured, actual);
+        private JsonRpcErrorAssert(JsonNode envelope) {
+            super(envelope, JsonRpcErrorAssert.class);
         }
-        return this;
+
+        /** Verifies the JSON-RPC response id. */
+        public JsonRpcErrorAssert hasId(Object expected) {
+            var expectedId = MAPPER.valueToTree(expected);
+            var id = actual.path("id");
+            if (!id.equals(expectedId)) {
+                failWithMessage("Expected JSON-RPC id <%s> but was <%s> in: %s", expectedId, id, actual);
+            }
+            return this;
+        }
+
+        /** Verifies the JSON-RPC error code. */
+        public JsonRpcErrorAssert hasErrorCode(int expectedCode) {
+            var code = actual.path("error").path("code");
+            if (!code.isInt() || code.asInt() != expectedCode) {
+                failWithMessage("Expected JSON-RPC error code <%s> but was <%s> in: %s", expectedCode, code, actual);
+            }
+            return this;
+        }
+
+        /** Verifies the exact JSON-RPC error message. */
+        public JsonRpcErrorAssert hasErrorMessage(String expectedMessage) {
+            var message = actual.path("error").path("message").asString(null);
+            if (!expectedMessage.equals(message)) {
+                failWithMessage(
+                        "Expected JSON-RPC error message <%s> but was <%s> in: %s", expectedMessage, message, actual);
+            }
+            return this;
+        }
+
+        /** Verifies the JSON-RPC error message contains the expected text. */
+        public JsonRpcErrorAssert hasErrorMessageContaining(String expectedText) {
+            var message = actual.path("error").path("message").asString("");
+            if (!message.contains(expectedText)) {
+                failWithMessage(
+                        "Expected JSON-RPC error message containing <%s> but was <%s> in: %s",
+                        expectedText, message, actual);
+            }
+            return this;
+        }
+
+        /** Runs an assertion against {@code error.data}. */
+        public JsonRpcErrorAssert hasErrorDataSatisfying(Consumer<JsonNode> assertion) {
+            assertion.accept(actual.path("error").path("data"));
+            return this;
+        }
+
+        /**
+         * Verifies the complete JSON-RPC error value.
+         */
+        public JsonRpcErrorAssert hasError(JsonNode expected) {
+            var error = actual.path("error");
+            if (!error.equals(expected)) {
+                failWithMessage("Expected error <%s> but was <%s> in: %s", expected, error, actual);
+            }
+            return this;
+        }
     }
 }

--- a/tachyon-testkit/src/main/java/dev/tachyonmcp/testkit/JsonRpcResponseAssert.java
+++ b/tachyon-testkit/src/main/java/dev/tachyonmcp/testkit/JsonRpcResponseAssert.java
@@ -29,6 +29,17 @@ public final class JsonRpcResponseAssert extends AbstractAssert<JsonRpcResponseA
         return assertThatJsonRpcResponse(response.body());
     }
 
+    /**
+     * Creates assertions for one JSON-RPC envelope within an SSE HTTP response.
+     *
+     * @param response SSE HTTP response
+     * @param requestId JSON-RPC request id
+     * @return assertions for the matching JSON-RPC response
+     */
+    public static JsonRpcResponseAssert assertThat(HttpResponse<String> response, String requestId) {
+        return assertThatJsonRpcResponse(McpClient.extractJsonRpcResponse(response.body(), requestId));
+    }
+
     /** Creates assertions for a raw JSON-RPC response body. */
     public static JsonRpcResponseAssert assertThatJsonRpcResponse(String json) {
         return new JsonRpcResponseAssert(MAPPER.readTree(json));

--- a/tachyon-testkit/src/main/java/dev/tachyonmcp/testkit/Mcp20260728Client.java
+++ b/tachyon-testkit/src/main/java/dev/tachyonmcp/testkit/Mcp20260728Client.java
@@ -54,6 +54,18 @@ public final class Mcp20260728Client extends McpClient {
         return this;
     }
 
+    /**
+     * Sends {@code server/discover} and returns staged assertions for its response.
+     *
+     * @return discover response assertions
+     * @throws Exception when the request cannot be sent
+     */
+    public DiscoverResponseAssert discover() throws Exception {
+        return new DiscoverResponseAssert(post("""
+                {"jsonrpc":"2.0","id":1,"method":"server/discover"}
+                """));
+    }
+
     @Override
     public @Nullable String initialize() {
         throw new UnsupportedOperationException(

--- a/tachyon-testkit/src/main/java/dev/tachyonmcp/testkit/McpClient.java
+++ b/tachyon-testkit/src/main/java/dev/tachyonmcp/testkit/McpClient.java
@@ -12,6 +12,8 @@ import java.net.http.HttpResponse;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
@@ -38,6 +40,7 @@ public abstract class McpClient implements Closeable {
     private final URI mcpEndpoint;
     private final HttpClient httpClient;
     private final MessageAggregator<JsonNode> notifications = new MessageAggregator<>();
+    private final List<SseStream> openGetStreams = new CopyOnWriteArrayList<>();
     private volatile @Nullable String sessionId;
     private volatile boolean closed;
 
@@ -62,7 +65,27 @@ public abstract class McpClient implements Closeable {
     @Override
     public void close() {
         closed = true;
+        openGetStreams.forEach(SseStream::close);
         httpClient.close();
+    }
+
+    /**
+     * Opens a raw GET stream against this client's session, for reconnect / {@code Last-Event-ID}
+     * testing. Requires {@link #initialize()} (or {@link #sendInitialized}) to have set a session
+     * id first. Closed automatically when this client is {@link #close() closed}, in addition to
+     * whatever the caller does with it directly.
+     */
+    public SseStream openGetStream(@Nullable String lastEventId) {
+        return openGetStream(
+                Objects.requireNonNull(sessionId, "call initialize() before openGetStream()"), lastEventId);
+    }
+
+    /** {@link #openGetStream(String)} against an explicit session id rather than this client's stored one. */
+    public SseStream openGetStream(String sessionId, @Nullable String lastEventId) {
+        var subscriber = new SseStream(mcpEndpoint.getPort(), sessionId, lastEventId, protocolVersion());
+        openGetStreams.add(subscriber);
+        subscriber.start();
+        return subscriber;
     }
 
     /**

--- a/tachyon-testkit/src/main/java/dev/tachyonmcp/testkit/McpClient.java
+++ b/tachyon-testkit/src/main/java/dev/tachyonmcp/testkit/McpClient.java
@@ -82,7 +82,7 @@ public abstract class McpClient implements Closeable {
 
     /** {@link #openGetStream(String)} against an explicit session id rather than this client's stored one. */
     public SseStream openGetStream(String sessionId, @Nullable String lastEventId) {
-        var subscriber = new SseStream(mcpEndpoint.getPort(), sessionId, lastEventId, protocolVersion());
+        var subscriber = new SseStream(mcpEndpoint, sessionId, lastEventId, protocolVersion());
         openGetStreams.add(subscriber);
         subscriber.start();
         return subscriber;
@@ -417,14 +417,14 @@ public abstract class McpClient implements Closeable {
      */
     public static String extractJsonRpcResponse(String sseBody, String requestId) {
         String last = null;
-        var idMarker = "\"id\":" + requestId;
+        var expectedId = requestId.isEmpty() ? null : MAPPER.readTree(requestId);
         for (var line : sseBody.split("\n")) {
             String data = null;
             if (line.startsWith("data: ")) data = line.substring("data: ".length());
             else if (line.startsWith("data:")) data = line.substring("data:".length());
             if (data == null) continue;
             last = data;
-            if (!requestId.isEmpty() && data.contains(idMarker)) {
+            if (expectedId != null && MAPPER.readTree(data).path("id").equals(expectedId)) {
                 return data;
             }
         }

--- a/tachyon-testkit/src/main/java/dev/tachyonmcp/testkit/McpClient.java
+++ b/tachyon-testkit/src/main/java/dev/tachyonmcp/testkit/McpClient.java
@@ -231,8 +231,13 @@ public abstract class McpClient implements Closeable {
 
     /** Sends a notification with the given params. */
     public HttpResponse<String> notify(String method, @Nullable Object params) throws Exception {
-        var paramsJson = params == null ? "" : "," + MAPPER.writeValueAsString(params);
-        return post(sessionId, "{\"jsonrpc\":\"2.0\",\"method\":\"%s\"%s}".formatted(method, paramsJson));
+        return post(sessionId, notificationEnvelope(method, params));
+    }
+
+    /** Builds the JSON-RPC notification envelope sent by {@link #notify(String, Object)}. */
+    static String notificationEnvelope(String method, @Nullable Object params) {
+        var paramsJson = params == null ? "" : ",\"params\":" + MAPPER.writeValueAsString(params);
+        return "{\"jsonrpc\":\"2.0\",\"method\":\"%s\"%s}".formatted(method, paramsJson);
     }
 
     /**
@@ -253,7 +258,7 @@ public abstract class McpClient implements Closeable {
             if (closed) {
                 throw new IllegalStateException("McpClient closed while awaiting " + method);
             }
-            return method.equals(node.path("method").asString()) && predicate.test(node);
+            return method.equals(node.path("method").asString()) && predicate.test(node.path("params"));
         });
         return Notification.from(message);
     }

--- a/tachyon-testkit/src/main/java/dev/tachyonmcp/testkit/SseFrame.java
+++ b/tachyon-testkit/src/main/java/dev/tachyonmcp/testkit/SseFrame.java
@@ -1,0 +1,27 @@
+/* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
+package dev.tachyonmcp.testkit;
+
+import org.jspecify.annotations.Nullable;
+import tools.jackson.databind.JsonNode;
+
+/**
+ * One SSE eventType frame parsed off the wire by {@link SseStream}: its {@code id:} and
+ * {@code eventType:} lines, if any, and its raw {@code data:} line.
+ *
+ * @param id    the SSE eventType id, or {@code null} if the frame carried none
+ * @param eventType the SSE eventType type (e.g. {@code "message"}), or {@code null} if the frame carried none
+ * @param data  the frame's raw data payload
+ */
+public record SseFrame(@Nullable String id, @Nullable String eventType, String data) {
+
+    /**
+     * Parses {@link #data} as JSON — every {@code data:} line on a Tachyon MCP server's SSE
+     * stream is a JSON-RPC envelope, the same assumption {@link McpClient} already makes for
+     * POST-delivered notifications (see {@code McpClient#captureNotifications}). Parsed lazily,
+     * on the caller's thread, so a malformed payload fails the assertion that reads it rather
+     * than the background reader thread.
+     */
+    public JsonNode json() {
+        return McpClient.MAPPER.readTree(data);
+    }
+}

--- a/tachyon-testkit/src/main/java/dev/tachyonmcp/testkit/SseStream.java
+++ b/tachyon-testkit/src/main/java/dev/tachyonmcp/testkit/SseStream.java
@@ -5,12 +5,14 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.Socket;
 import java.net.SocketTimeoutException;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
+import javax.net.ssl.SSLSocketFactory;
 import me.kpavlov.finchly.queue.MessageAggregator;
 import me.kpavlov.finchly.queue.QueueSubscriber;
 import org.awaitility.Awaitility;
@@ -33,7 +35,7 @@ public final class SseStream extends QueueSubscriber<SseFrame> implements AutoCl
     private static final Pattern EVENT_LINE = Pattern.compile("event:\\s?(.*)");
     private static final Pattern DATA_LINE = Pattern.compile("data:\\s?(.*)");
 
-    private final int port;
+    private final URI endpoint;
     private final String sessionId;
     private final @Nullable String lastEventId;
     private final String protocolVersion;
@@ -43,20 +45,20 @@ public final class SseStream extends QueueSubscriber<SseFrame> implements AutoCl
     private volatile boolean stopped;
 
     /**
-     * Opens against {@code /mcp} on {@code localhost:port}, with its own {@link MessageAggregator}.
+     * Opens against {@code endpoint}, with its own {@link MessageAggregator}.
      */
-    SseStream(int port, String sessionId, @Nullable String lastEventId, String protocolVersion) {
-        this(port, sessionId, lastEventId, protocolVersion, new MessageAggregator<>());
+    SseStream(URI endpoint, String sessionId, @Nullable String lastEventId, String protocolVersion) {
+        this(endpoint, sessionId, lastEventId, protocolVersion, new MessageAggregator<>());
     }
 
     SseStream(
-            int port,
+            URI endpoint,
             String sessionId,
             @Nullable String lastEventId,
             String protocolVersion,
             MessageAggregator<SseFrame> aggregator) {
         super(aggregator);
-        this.port = port;
+        this.endpoint = endpoint;
         this.sessionId = sessionId;
         this.lastEventId = lastEventId;
         this.protocolVersion = protocolVersion;
@@ -68,9 +70,18 @@ public final class SseStream extends QueueSubscriber<SseFrame> implements AutoCl
     @Override
     public void start() {
         try {
-            socket = new Socket("localhost", port);
-            var req = new StringBuilder("GET /mcp HTTP/1.1\r\n")
-                    .append("Host: localhost:")
+            var host = endpoint.getHost();
+            var port = endpoint.getPort() != -1 ? endpoint.getPort() : defaultPort(endpoint);
+            socket = "https".equalsIgnoreCase(endpoint.getScheme())
+                    ? SSLSocketFactory.getDefault().createSocket(host, port)
+                    : new Socket(host, port);
+            var path = endpoint.getRawPath() == null || endpoint.getRawPath().isEmpty() ? "/" : endpoint.getRawPath();
+            var req = new StringBuilder("GET ")
+                    .append(path)
+                    .append(" HTTP/1.1\r\n")
+                    .append("Host: ")
+                    .append(host)
+                    .append(':')
                     .append(port)
                     .append("\r\n")
                     .append("MCP-Session-Id: ")
@@ -88,9 +99,13 @@ public final class SseStream extends QueueSubscriber<SseFrame> implements AutoCl
             socket.getOutputStream().flush();
             socket.setSoTimeout(50);
         } catch (IOException e) {
-            throw new UncheckedIOException("Failed to open SSE stream to localhost:" + port, e);
+            throw new UncheckedIOException("Failed to open SSE stream to " + endpoint, e);
         }
         Thread.ofVirtual().start(this::readLoop);
+    }
+
+    private static int defaultPort(URI endpoint) {
+        return "https".equalsIgnoreCase(endpoint.getScheme()) ? 443 : 80;
     }
 
     /**
@@ -108,6 +123,9 @@ public final class SseStream extends QueueSubscriber<SseFrame> implements AutoCl
         }
     }
 
+    /**
+     * Stops the background reader and closes the socket, same as {@link #stop()}.
+     */
     @Override
     public void close() {
         stop();
@@ -132,7 +150,7 @@ public final class SseStream extends QueueSubscriber<SseFrame> implements AutoCl
      * Unlike {@link #await}, absence can't be confirmed faster than waiting the full window —
      * this isn't a lazy sleep standing in for a pollable condition, it <em>is</em> the condition.
      */
-    public void assertNoneArrive(Predicate<SseFrame> predicate, Duration window) {
+    public void assertNoneArrived(Predicate<SseFrame> predicate, Duration window) {
         try {
             Thread.sleep(window);
         } catch (InterruptedException e) {
@@ -178,6 +196,7 @@ public final class SseStream extends QueueSubscriber<SseFrame> implements AutoCl
         var lineBuf = new StringBuilder();
         String pendingId = null;
         String pendingEvent = null;
+        StringBuilder pendingData = null;
         while (!stopped) {
             try {
                 var n = socket.getInputStream().read(buf);
@@ -192,6 +211,17 @@ public final class SseStream extends QueueSubscriber<SseFrame> implements AutoCl
                 while ((newline = lineBuf.indexOf("\n")) >= 0) {
                     var line = lineBuf.substring(0, newline).stripTrailing();
                     lineBuf.delete(0, newline + 1);
+                    if (line.isEmpty()) {
+                        // Blank line terminates the event per the SSE spec: dispatch once, joining
+                        // any accumulated data: lines with embedded newlines.
+                        if (pendingData != null) {
+                            deliver(new SseFrame(pendingId, pendingEvent, pendingData.toString()));
+                        }
+                        pendingId = null;
+                        pendingEvent = null;
+                        pendingData = null;
+                        continue;
+                    }
                     var idMatcher = ID_LINE.matcher(line);
                     var eventMatcher = EVENT_LINE.matcher(line);
                     var dataMatcher = DATA_LINE.matcher(line);
@@ -200,9 +230,12 @@ public final class SseStream extends QueueSubscriber<SseFrame> implements AutoCl
                     } else if (eventMatcher.matches()) {
                         pendingEvent = eventMatcher.group(1);
                     } else if (dataMatcher.matches()) {
-                        deliver(new SseFrame(pendingId, pendingEvent, dataMatcher.group(1)));
-                        pendingId = null;
-                        pendingEvent = null;
+                        if (pendingData == null) {
+                            pendingData = new StringBuilder();
+                        } else {
+                            pendingData.append('\n');
+                        }
+                        pendingData.append(dataMatcher.group(1));
                     }
                 }
             } catch (SocketTimeoutException e) {

--- a/tachyon-testkit/src/main/java/dev/tachyonmcp/testkit/SseStream.java
+++ b/tachyon-testkit/src/main/java/dev/tachyonmcp/testkit/SseStream.java
@@ -1,0 +1,215 @@
+/* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
+package dev.tachyonmcp.testkit;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.Socket;
+import java.net.SocketTimeoutException;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
+import me.kpavlov.finchly.queue.MessageAggregator;
+import me.kpavlov.finchly.queue.QueueSubscriber;
+import org.awaitility.Awaitility;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Raw socket GET against a Tachyon MCP server's Streamable HTTP endpoint — for reconnect /
+ * {@code Last-Event-ID} scenarios {@link java.net.http.HttpClient}'s higher-level, {@code Stream}-
+ * based body handling doesn't give fine enough control over: bounded polling reads, and an
+ * explicit mid-stream close to simulate a dropped connection.
+ *
+ * <p>A {@link QueueSubscriber} for this transport: {@link #start()} opens the socket and a
+ * background virtual thread parses arriving SSE frames, delivering each to the underlying {@link
+ * MessageAggregator} so callers {@link #await} a specific frame the same way {@link
+ * McpClient#awaitNotification} awaits a notification.
+ */
+public final class SseStream extends QueueSubscriber<SseFrame> implements AutoCloseable {
+
+    private static final Pattern ID_LINE = Pattern.compile("id:\\s?(.*)");
+    private static final Pattern EVENT_LINE = Pattern.compile("event:\\s?(.*)");
+    private static final Pattern DATA_LINE = Pattern.compile("data:\\s?(.*)");
+
+    private final int port;
+    private final String sessionId;
+    private final @Nullable String lastEventId;
+    private final String protocolVersion;
+
+    private @Nullable Socket socket;
+    private final StringBuilder rawResponse = new StringBuilder();
+    private volatile boolean stopped;
+
+    /**
+     * Opens against {@code /mcp} on {@code localhost:port}, with its own {@link MessageAggregator}.
+     */
+    SseStream(int port, String sessionId, @Nullable String lastEventId, String protocolVersion) {
+        this(port, sessionId, lastEventId, protocolVersion, new MessageAggregator<>());
+    }
+
+    SseStream(
+            int port,
+            String sessionId,
+            @Nullable String lastEventId,
+            String protocolVersion,
+            MessageAggregator<SseFrame> aggregator) {
+        super(aggregator);
+        this.port = port;
+        this.sessionId = sessionId;
+        this.lastEventId = lastEventId;
+        this.protocolVersion = protocolVersion;
+    }
+
+    /**
+     * Opens the socket, sends the GET request, and starts the background frame-parsing thread.
+     */
+    @Override
+    public void start() {
+        try {
+            socket = new Socket("localhost", port);
+            var req = new StringBuilder("GET /mcp HTTP/1.1\r\n")
+                    .append("Host: localhost:")
+                    .append(port)
+                    .append("\r\n")
+                    .append("MCP-Session-Id: ")
+                    .append(sessionId)
+                    .append("\r\n")
+                    .append("MCP-Protocol-Version: ")
+                    .append(protocolVersion)
+                    .append("\r\n")
+                    .append("Accept: text/event-stream\r\n");
+            if (lastEventId != null) {
+                req.append("Last-Event-ID: ").append(lastEventId).append("\r\n");
+            }
+            req.append("\r\n");
+            socket.getOutputStream().write(req.toString().getBytes(StandardCharsets.UTF_8));
+            socket.getOutputStream().flush();
+            socket.setSoTimeout(50);
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to open SSE stream to localhost:" + port, e);
+        }
+        Thread.ofVirtual().start(this::readLoop);
+    }
+
+    /**
+     * Closes the socket, simulating a dropped connection, and stops the background reader.
+     */
+    @Override
+    public void stop() {
+        stopped = true;
+        if (socket != null) {
+            try {
+                socket.close();
+            } catch (IOException ignored) {
+                // Best-effort close; nothing more to do with a socket we're discarding.
+            }
+        }
+    }
+
+    @Override
+    public void close() {
+        stop();
+    }
+
+    /**
+     * Awaits an SSE frame matching {@code predicate}, or fails after {@code timeout}.
+     */
+    public SseFrame await(Predicate<SseFrame> predicate, Duration timeout) {
+        return aggregator.awaitMessage(timeout, false, predicate);
+    }
+
+    /**
+     * Awaits the first frame carrying an eventType id — the priming eventType a fresh GET stream sends.
+     */
+    public String awaitFirstEventId(Duration timeout) {
+        return Objects.requireNonNull(await(f -> f.id() != null, timeout).id());
+    }
+
+    /**
+     * Waits out {@code window} and asserts no frame matching {@code predicate} arrived in it.
+     * Unlike {@link #await}, absence can't be confirmed faster than waiting the full window —
+     * this isn't a lazy sleep standing in for a pollable condition, it <em>is</em> the condition.
+     */
+    public void assertNoneArrive(Predicate<SseFrame> predicate, Duration window) {
+        try {
+            Thread.sleep(window);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        }
+        var unexpected = aggregator.findAll(predicate);
+        if (!unexpected.isEmpty()) {
+            throw new AssertionError("Expected no matching SSE frame within " + window + ", but got: " + unexpected);
+        }
+    }
+
+    /**
+     * All frames delivered so far matching {@code predicate}, without waiting.
+     */
+    public List<SseFrame> received(Predicate<SseFrame> predicate) {
+        return aggregator.findAll(predicate);
+    }
+
+    /**
+     * The raw response bytes accumulated so far (status line, headers, and any SSE body), as text.
+     */
+    public synchronized String rawResponse() {
+        return rawResponse.toString();
+    }
+
+    /**
+     * Polls {@link #rawResponse()} until {@code predicate} holds, or fails after {@code timeout}.
+     * For plain, non-SSE-framed responses (a 4xx status and body) that never deliver a frame, so
+     * {@link #await} has nothing to wait on.
+     */
+    public String awaitRawResponse(Predicate<String> predicate, Duration timeout) {
+        return Awaitility.await()
+                .atMost(timeout)
+                .pollDelay(Duration.ofMillis(20))
+                .pollInterval(Duration.ofMillis(50))
+                .until(this::rawResponse, predicate::test);
+    }
+
+    private void readLoop() {
+        var socket = Objects.requireNonNull(this.socket, "start() must run before the reader thread");
+        var buf = new byte[1024];
+        var lineBuf = new StringBuilder();
+        String pendingId = null;
+        String pendingEvent = null;
+        while (!stopped) {
+            try {
+                var n = socket.getInputStream().read(buf);
+                if (n < 0) break;
+                if (n == 0) continue;
+                var chunk = new String(buf, 0, n, StandardCharsets.UTF_8);
+                synchronized (this) {
+                    rawResponse.append(chunk);
+                }
+                lineBuf.append(chunk);
+                int newline;
+                while ((newline = lineBuf.indexOf("\n")) >= 0) {
+                    var line = lineBuf.substring(0, newline).stripTrailing();
+                    lineBuf.delete(0, newline + 1);
+                    var idMatcher = ID_LINE.matcher(line);
+                    var eventMatcher = EVENT_LINE.matcher(line);
+                    var dataMatcher = DATA_LINE.matcher(line);
+                    if (idMatcher.matches()) {
+                        pendingId = idMatcher.group(1);
+                    } else if (eventMatcher.matches()) {
+                        pendingEvent = eventMatcher.group(1);
+                    } else if (dataMatcher.matches()) {
+                        deliver(new SseFrame(pendingId, pendingEvent, dataMatcher.group(1)));
+                        pendingId = null;
+                        pendingEvent = null;
+                    }
+                }
+            } catch (SocketTimeoutException e) {
+                // No data this poll; keep reading until stopped, or the socket closes/errors.
+            } catch (IOException e) {
+                break;
+            }
+        }
+    }
+}

--- a/tachyon-testkit/src/test/java/dev/tachyonmcp/testkit/JsonRpcResponseAssertTest.java
+++ b/tachyon-testkit/src/test/java/dev/tachyonmcp/testkit/JsonRpcResponseAssertTest.java
@@ -1,129 +1,106 @@
 /* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
 package dev.tachyonmcp.testkit;
 
-import static dev.tachyonmcp.testkit.JsonRpcResponseAssert.assertThat;
 import static dev.tachyonmcp.testkit.JsonRpcResponseAssert.assertThatJsonRpcResponse;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import dev.tachyonmcp.api.server.features.tools.ToolResult;
-import dev.tachyonmcp.core.server.TachyonServer;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import tools.jackson.databind.ObjectMapper;
 
-/**
- * Verifies {@link JsonRpcResponseAssert} against a real port-0 server and inline JSON-RPC envelopes.
- */
+/** Verifies JSON-RPC envelope branch assertions. */
 class JsonRpcResponseAssertTest {
 
     private static final ObjectMapper JSON = new ObjectMapper();
 
-    private static TachyonServer server;
-    private static int port;
-
-    @BeforeAll
-    static void startServer() {
-        server = McpTestServers.start(b -> b.session(c -> c.enabled(true)), s -> {
-            s.tools()
-                    .register(
-                            d -> d.name("echo").description("Echo back the input"),
-                            (ctx, request) -> ToolResult.text(
-                                    "echo:" + request.arguments().stringOr("message", "")));
-            s.tools()
-                    .register(
-                            d -> d.name("boom").description("Always fails"),
-                            (ctx, request) -> ToolResult.error("boom"));
-            s.tools()
-                    .register(
-                            d -> d.name("structured").description("Returns structured content"),
-                            (ctx, request) -> ToolResult.structured(
-                                    JSON.createObjectNode().put("output", "success"), "done"));
-        });
-        port = server.port();
-    }
-
-    @AfterAll
-    static void stopServer() {
-        server.close();
+    @Test
+    void identifiesSuccessEnvelope() {
+        assertThatJsonRpcResponse("""
+                {"jsonrpc":"2.0","id":1,"result":{"content":[]}}
+                """).isSuccess();
     }
 
     @Test
-    void toolCallSuccessExposesTextContent() throws Exception {
-        try (var client =
-                McpTestClients.builder(port).protocolVersion("2025-11-25").build()) {
-            var response = client.sendRpc("""
-                {"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"echo","arguments":{"message":"hi"}}}
-                """);
-
-            assertThatJsonRpcResponse(response).isSuccess().hasContent().hasTextContent("echo:hi");
-        }
+    void identifiesErrorEnvelope() {
+        assertThatJsonRpcResponse("""
+                {"jsonrpc":"2.0","id":1,"error":{"code":-32602,"message":"Invalid params"}}
+                """).isJsonRpcError();
     }
 
     @Test
-    void toolExecutionFailureIsToolErrorNotJsonRpcError() throws Exception {
-        try (var client =
-                McpTestClients.builder(port).protocolVersion("2025-11-25").build()) {
-            var response = client.sendRpc("""
-                {"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"boom","arguments":{}}}
-                """);
+    void successBranchExposesContentAssertions() {
+        var text = JSON.readTree("{\"type\":\"text\",\"text\":\"done\"}");
 
-            assertThatJsonRpcResponse(response).isSuccess().isToolError();
-        }
+        assertThatJsonRpcResponse("""
+                {"jsonrpc":"2.0","id":1,"result":{"content":[{"type":"text","text":"done"}],"resultType":"complete",
+                "structuredContent":{"output":"success"}}}
+                """)
+                .isSuccess()
+                .hasId(1)
+                .hasContent()
+                .hasContentExactly(text)
+                .hasTextContent("done")
+                .hasResultType("complete")
+                .hasStructuredContent(JSON.readTree("{\"output\":\"success\"}"))
+                .hasResult(JSON.readTree("""
+                        {"content":[{"type":"text","text":"done"}],"resultType":"complete",
+                         "structuredContent":{"output":"success"}}
+                        """));
     }
 
     @Test
-    void jsonRpcErrorForUnknownMethodExposesCodeAndMessage() throws Exception {
-        try (var client =
-                McpTestClients.builder(port).protocolVersion("2025-11-25").build()) {
-            var raw = client.sendRpc("""
-                {"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"missing","arguments":{}}}
-                """);
-
-            assertThatJsonRpcResponse(raw).isJsonRpcError().hasErrorCode(-32602).hasErrorMessageContaining("missing");
-        }
-    }
-
-    @Test
-    void structuredContentIsExposedAsJsonNode() throws Exception {
-        try (var client =
-                McpTestClients.builder(port).protocolVersion("2025-11-25").build()) {
-            var response = client.sendRpc("""
-                {"jsonrpc":"2.0","id":5,"method":"tools/call","params":{"name":"structured","arguments":{}}}
-                """);
-
-            assertThatJsonRpcResponse(response)
-                    .hasStructuredContent(JSON.createObjectNode().put("output", "success"));
-        }
-    }
-
-    @Test
-    void isSuccessFailsOnAnErrorEnvelope() {
-        var envelope = JSON.readTree("""
-            {"jsonrpc":"2.0","id":1,"error":{"code":-32602,"message":"Invalid params"}}
-            """);
-
-        assertThatThrownBy(() -> assertThat(envelope).isSuccess()).isInstanceOf(AssertionError.class);
-    }
-
-    @Test
-    void hasErrorCodeFailsOnASuccessEnvelope() {
-        var envelope = JSON.readTree("""
-            {"jsonrpc":"2.0","id":1,"result":{"content":[]}}
-            """);
-
-        assertThatThrownBy(() -> assertThat(envelope).hasErrorCode(-32602)).isInstanceOf(AssertionError.class);
-    }
-
-    @Test
-    void hasErrorDataSatisfyingRunsTheGivenAssertionAgainstErrorData() {
-        var envelope = JSON.readTree("""
-            {"jsonrpc":"2.0","id":1,"error":{"code":-32602,"message":"Invalid params","data":{"field":"name"}}}
-            """);
-
-        assertThat(envelope)
+    void errorBranchExposesErrorAssertions() {
+        assertThatJsonRpcResponse("""
+                {"jsonrpc":"2.0","id":1,"error":{"code":-32602,"message":"Invalid params: name",
+                "data":{"field":"name"}}}
+                """)
+                .isJsonRpcError()
+                .hasId(1)
+                .hasErrorCode(-32602)
+                .hasErrorMessageContaining("Invalid params")
                 .hasErrorDataSatisfying(
-                        data -> assertThat(data.path("field").asString()).isEqualTo("name"));
+                        data -> assertThat(data.path("field").asString()).isEqualTo("name"))
+                .hasError(JSON.readTree("""
+                        {"code":-32602,"message":"Invalid params: name","data":{"field":"name"}}
+                        """));
+    }
+
+    @Test
+    void rejectsErrorEnvelopeAsSuccess() {
+        assertThatThrownBy(() -> assertThatJsonRpcResponse("""
+                            {"jsonrpc":"2.0","id":1,"error":{"code":-32602,"message":"Invalid params"}}
+                            """).isSuccess()).isInstanceOf(AssertionError.class);
+    }
+
+    @Test
+    void rejectsSuccessEnvelopeAsError() {
+        assertThatThrownBy(() -> assertThatJsonRpcResponse("""
+                            {"jsonrpc":"2.0","id":1,"result":{"content":[]}}
+                            """).isJsonRpcError())
+                .isInstanceOf(AssertionError.class);
+    }
+
+    @Test
+    void rejectsEnvelopeContainingResultAndError() {
+        assertThatThrownBy(() -> assertThatJsonRpcResponse("""
+                            {"jsonrpc":"2.0","id":1,"result":{},"error":{"code":-32603,"message":"error"}}
+                            """).isJsonRpcError())
+                .isInstanceOf(AssertionError.class);
+    }
+
+    @Test
+    void rejectsNullError() {
+        assertThatThrownBy(() -> assertThatJsonRpcResponse("""
+                            {"jsonrpc":"2.0","id":1,"error":null}
+                            """).isJsonRpcError())
+                .isInstanceOf(AssertionError.class);
+    }
+
+    @Test
+    void hasContentRejectsEmptyArray() {
+        assertThatThrownBy(() -> assertThatJsonRpcResponse("""
+                            {"jsonrpc":"2.0","id":1,"result":{"content":[]}}
+                            """).isSuccess().hasContent())
+                .isInstanceOf(AssertionError.class);
     }
 }

--- a/tachyon-testkit/src/test/java/dev/tachyonmcp/testkit/McpClientTest.java
+++ b/tachyon-testkit/src/test/java/dev/tachyonmcp/testkit/McpClientTest.java
@@ -1,0 +1,56 @@
+/* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
+package dev.tachyonmcp.testkit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+/** Verifies {@link McpClient#extractJsonRpcResponse(String, String)} matches ids structurally. */
+class McpClientTest {
+
+    @Test
+    void matchesIdDespiteWhitespaceAfterColon() {
+        var sseBody = """
+                data: {"jsonrpc":"2.0","method":"notifications/progress","params":{}}
+
+                data: {"jsonrpc":"2.0", "id": 7, "result":{"ok":true}}
+
+                """;
+
+        assertThat(McpClient.extractJsonRpcResponse(sseBody, "7")).contains("\"ok\":true");
+    }
+
+    @Test
+    void doesNotMatchIdAsSubstringOfALongerId() {
+        var sseBody = """
+                data: {"jsonrpc":"2.0","id":70,"result":{"which":"wrong"}}
+
+                data: {"jsonrpc":"2.0","id":7,"result":{"which":"right"}}
+
+                """;
+
+        assertThat(McpClient.extractJsonRpcResponse(sseBody, "7")).contains("\"which\":\"right\"");
+    }
+
+    @Test
+    void isNotFooledByALaterNotificationContainingTheIdAsAFieldValue() {
+        var sseBody = """
+                data: {"jsonrpc":"2.0","id":7,"result":{"which":"right"}}
+
+                data: {"jsonrpc":"2.0","method":"notifications/progress","params":{"id":7}}
+
+                """;
+
+        assertThat(McpClient.extractJsonRpcResponse(sseBody, "7")).contains("\"which\":\"right\"");
+    }
+
+    @Test
+    void matchesStringIds() {
+        var sseBody = """
+                data: {"jsonrpc":"2.0","id":"tasks-get","result":{"ok":true}}
+
+                """;
+
+        assertThat(McpClient.extractJsonRpcResponse(sseBody, "\"tasks-get\"")).contains("\"ok\":true");
+    }
+}

--- a/tachyon-testkit/src/test/java/dev/tachyonmcp/testkit/McpTestKitSmokeTest.java
+++ b/tachyon-testkit/src/test/java/dev/tachyonmcp/testkit/McpTestKitSmokeTest.java
@@ -1,6 +1,7 @@
 /* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
 package dev.tachyonmcp.testkit;
 
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -132,6 +133,27 @@ class McpTestKitSmokeTest {
         }
     }
 
+    @Test
+    void awaitNotificationPredicateReceivesParamsAndSkipsNonMatchingNotifications() throws Exception {
+        try (var client = McpTestClients.latest(port)) {
+            client.post("""
+                    {"jsonrpc":"2.0","id":7,"method":"tools/call",
+                     "params":{"name":"slow-progress","arguments":{},"_meta":{"progressToken":"skip"}}}
+                    """);
+            client.post("""
+                {"jsonrpc":"2.0","id":8,"method":"tools/call",
+                 "params":{"name":"slow-progress","arguments":{},"_meta":{"progressToken":"match"}}}
+                """);
+
+            var notification = client.awaitNotification(
+                    "notifications/progress",
+                    params -> params.path("progressToken").asString().equals("match"),
+                    Duration.ofMillis(100));
+
+            assertThat(notification.params().path("progressToken").asString()).isEqualTo("match");
+        }
+    }
+
     /** Notifications received so far are listed in arrival order and can be cleared. */
     @Test
     void notificationsSnapshotAndClear() throws Exception {
@@ -148,13 +170,33 @@ class McpTestKitSmokeTest {
 
     /** A client-side notification is accepted (2025 session, initialized client). */
     @Test
-    void notifySendsNotification() throws Exception {
+    void notifySerializesParams() throws Exception {
         try (var client = McpTestClients.forVersion(port, "2025-11-25")) {
             client.initialize();
-            var response = client.notify("notifications/initialized");
+            var response = client.notify("notifications/initialized", Map.of("ready", true));
             assertThat(response.statusCode()).as(response.body()).isEqualTo(202);
             assertThat(response.body()).isEmpty();
         }
+    }
+
+    /** The notification envelope carries params under a {@code params} key when given. */
+    @Test
+    void notificationEnvelopeIncludesParamsWhenPresent() {
+        var json = McpClient.notificationEnvelope("notifications/initialized", Map.of("ready", true));
+        // language=JSON
+        assertThatJson(json).isEqualTo("""
+                {"jsonrpc":"2.0","method":"notifications/initialized","params":{"ready":true}}
+                """);
+    }
+
+    /** The notification envelope omits the {@code params} key entirely when there are no params. */
+    @Test
+    void notificationEnvelopeOmitsParamsWhenAbsent() {
+        var json = McpClient.notificationEnvelope("notifications/initialized", null);
+        // language=JSON
+        assertThatJson(json).isEqualTo("""
+                {"jsonrpc":"2.0","method":"notifications/initialized"}
+                """);
     }
 
     @Test

--- a/tachyon-testkit/src/test/java/dev/tachyonmcp/testkit/SseStreamTest.java
+++ b/tachyon-testkit/src/test/java/dev/tachyonmcp/testkit/SseStreamTest.java
@@ -1,0 +1,56 @@
+/* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
+package dev.tachyonmcp.testkit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+
+/** Verifies {@link SseStream}'s wire-frame parsing against a raw loopback socket. */
+class SseStreamTest {
+
+    @Test
+    void joinsMultiLineDataIntoOneFrameDispatchedOnBlankLine() throws Exception {
+        try (var server = new ServerSocket(0)) {
+            var endpoint = URI.create("http://localhost:" + server.getLocalPort() + "/mcp");
+            try (var stream = new SseStream(endpoint, "session-1", null, "2025-11-25")) {
+                stream.start();
+                try (var accepted = server.accept()) {
+                    consumeRequestHeaders(accepted);
+                    var out = accepted.getOutputStream();
+                    out.write(("HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\n\r\n" + "id: 1\n" + "event: mess")
+                            .getBytes(StandardCharsets.UTF_8));
+                    out.flush();
+                    Thread.sleep(20); // force the "event:" line to arrive split across two socket reads
+                    out.write(("age\n" + "data: line one\n" + "data: line two\n" + "\n")
+                            .getBytes(StandardCharsets.UTF_8));
+                    out.flush();
+
+                    var frame = stream.await(f -> true, Duration.ofSeconds(2));
+                    assertThat(frame.id()).isEqualTo("1");
+                    assertThat(frame.eventType()).isEqualTo("message");
+                    assertThat(frame.data()).isEqualTo("line one\nline two");
+                    assertThat(stream.received(f -> true))
+                            .as("multi-line data must dispatch as exactly one frame")
+                            .hasSize(1);
+                }
+            }
+        }
+    }
+
+    private static void consumeRequestHeaders(Socket socket) throws Exception {
+        var in = socket.getInputStream();
+        var tail = new StringBuilder();
+        int b;
+        while ((b = in.read()) != -1) {
+            tail.append((char) b);
+            if (tail.length() > 4) tail.deleteCharAt(0);
+            if ("\r\n\r\n".contentEquals(tail)) return;
+        }
+        throw new AssertionError("connection closed before request headers completed");
+    }
+}


### PR DESCRIPTION
## Summary

The test kit now provides branch-specific JSON-RPC assertions, typed server/discover assertions, and managed SSE stream utilities. MCP client notifications now serialize params correctly and expose parameter-only predicates. End-to-end tests migrate from JSON-path and raw-socket checks to these APIs. Documentation, unit tests, Revapi configuration, and the API baseline are updated.

### New Features

- Added clearer, branch-specific assertions for successful and error JSON-RPC responses, including result, content, IDs, codes, messages, and structured data.
- Added response validation for capability discovery requests.
- Added improved SSE stream handling, reconnection support, event tracking, and frame inspection.
- Notifications now support optional parameters and more precise predicate matching.

### Documentation

- Updated TestKit guidance with staged success and error assertion examples.

### Tests

- Expanded end-to-end coverage for response validation, SSE behavior, notifications, capabilities, tasks, prompts, resources, and schemas.


