### PR TITLE
feat: #177 annotation example

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -26,6 +26,7 @@ jobs:
         example:
           - echo-kotlin
           - langchain4j-mcp
+          - mcp-java
           - mcp-skills
           - weather-mcp
           - weather-mcp-kotlin

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Opt into sessions for SSE resumability, `Last-Event-ID` replay, and TTL cleanup.
     <dependency>
         <groupId>dev.tachyonmcp</groupId>
         <artifactId>tachyon-core</artifactId>
-        <version>1.0.0-beta.20</version>
+        <version>1.0.0-beta.22</version>
     </dependency>
     ```
 

--- a/docs/migrate-from-kotlin-mcp-to-tachyon.md
+++ b/docs/migrate-from-kotlin-mcp-to-tachyon.md
@@ -146,7 +146,7 @@ ToolResult.structured(pojo)                                     // Jackson: POJO
 
 `inputSchema`/`outputSchema` accept a raw **String**, a Jackson **`JsonNode`**, or a kotlinx
 **`JsonObject`** on every overload. The `outputSchema` string overload arrived in
-**1.0.0-beta.20** — if you wrote a project-side shim for it against an earlier beta, delete the
+**1.0.0-beta.22** — if you wrote a project-side shim for it against an earlier beta, delete the
 shim now.
 
 - **Jackson 3**: `tools.jackson.databind.JsonNode`, *not* `com.fasterxml.jackson…`. Convert a

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -15,7 +15,7 @@ Maven:
 <dependency>
     <groupId>dev.tachyonmcp</groupId>
     <artifactId>tachyon-core</artifactId>
-    <version>1.0.0-beta.20</version> <!-- get latest version from Maven Central -->
+    <version>1.0.0-beta.22</version> <!-- get latest version from Maven Central -->
 </dependency>
 ```
 
@@ -23,7 +23,7 @@ Gradle (Kotlin DSL):
 
 ```kotlin
 dependencies {
-    implementation("dev.tachyonmcp:tachyon-core:1.0.0-beta.20")
+    implementation("dev.tachyonmcp:tachyon-core:1.0.0-beta.22")
 }
 ```
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -11,6 +11,8 @@ the Maven wrapper build in, so you can run it without installing anything else �
   Tachyon imports, scanned by `LangChain4jAnnotationProvider` into a running server. Depends on
   `tachyon-annotations-langchain4j`, unreleased — build the Tachyon SNAPSHOT locally first (see
   its own README).
+- [**mcp-java**](mcp-java) — Java. A plain service using mcp-java `@Tool`, `@Resource`,
+  `@ResourceTemplate`, and `@Prompt` annotations, scanned by `McpJavaAnnotationProvider`.
 - [**mcp-skills**](mcp-skills) — Java. Serves a bundled Elvish-magic Agent Skill through the MCP
   skills extension.
 

--- a/examples/echo-kotlin/pom.xml
+++ b/examples/echo-kotlin/pom.xml
@@ -18,7 +18,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>21</java.version>
         <kotlin.version>2.2.21</kotlin.version>
-        <tachyon.version>1.0.0-beta.21</tachyon.version>
+        <tachyon.version>1.0.0-beta.22</tachyon.version>
 <!--        <tachyon.version>1.0.0-SNAPSHOT</tachyon.version>-->
         <junit.version>6.1.1</junit.version>
         <kotest.version>6.2.1</kotest.version>

--- a/examples/langchain4j-mcp/pom.xml
+++ b/examples/langchain4j-mcp/pom.xml
@@ -20,7 +20,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.release>21</maven.compiler.release>
-        <tachyon.version>1.0.0-beta.21</tachyon.version>
+        <tachyon.version>1.0.0-beta.22</tachyon.version>
         <!--        <tachyon.version>1.0.0-SNAPSHOT</tachyon.version>-->
         <langchain4j.version>1.19.0</langchain4j.version>
         <junit.version>6.1.3</junit.version>

--- a/examples/mcp-java/.mvn/wrapper/maven-wrapper.properties
+++ b/examples/mcp-java/.mvn/wrapper/maven-wrapper.properties
@@ -1,0 +1,3 @@
+wrapperVersion=3.3.4
+distributionType=only-script
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.16/apache-maven-3.9.16-bin.zip

--- a/examples/mcp-java/README.md
+++ b/examples/mcp-java/README.md
@@ -1,0 +1,29 @@
+# mcp-java MCP Example
+
+Demonstrates Tachyon's `McpJavaAnnotationProvider`: a plain Java service using mcp-java
+annotations, with no Tachyon imports in the service itself.
+
+## Features
+
+- **Tool**: `add` — accepts scalar arguments and returns their sum.
+- **Resource**: `app://config` — serves static JSON configuration.
+- **Resource template**: `app://greeting/{name}` — creates a greeting for a URI parameter.
+- **Prompt**: `welcome` — creates a user message from a prompt argument.
+
+## Quickstart
+
+The annotation integration is not published in a release yet. Install the Tachyon SNAPSHOT
+locally first from the repository root:
+
+```shell
+./mvnw install -pl tachyon-api,tachyon-core,integrations/tachyon-annotations-mcp-java -am -DskipTests
+```
+
+Then build and run the example:
+
+```shell
+mvn package
+java -jar target/mcp-java-example.jar
+```
+
+The server listens on `http://localhost:8080/mcp` by default. Set `HOST` and `PORT` to change it.

--- a/examples/mcp-java/mvnw
+++ b/examples/mcp-java/mvnw
@@ -1,0 +1,295 @@
+#!/bin/sh
+# ----------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# ----------------------------------------------------------------------------
+
+# ----------------------------------------------------------------------------
+# Apache Maven Wrapper startup batch script, version 3.3.4
+#
+# Optional ENV vars
+# -----------------
+#   JAVA_HOME - location of a JDK home dir, required when download maven via java source
+#   MVNW_REPOURL - repo url base for downloading maven distribution
+#   MVNW_USERNAME/MVNW_PASSWORD - user and password for downloading maven
+#   MVNW_VERBOSE - true: enable verbose log; debug: trace the mvnw script; others: silence the output
+# ----------------------------------------------------------------------------
+
+set -euf
+[ "${MVNW_VERBOSE-}" != debug ] || set -x
+
+# OS specific support.
+native_path() { printf %s\\n "$1"; }
+case "$(uname)" in
+CYGWIN* | MINGW*)
+  [ -z "${JAVA_HOME-}" ] || JAVA_HOME="$(cygpath --unix "$JAVA_HOME")"
+  native_path() { cygpath --path --windows "$1"; }
+  ;;
+esac
+
+# set JAVACMD and JAVACCMD
+set_java_home() {
+  # For Cygwin and MinGW, ensure paths are in Unix format before anything is touched
+  if [ -n "${JAVA_HOME-}" ]; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ]; then
+      # IBM's JDK on AIX uses strange locations for the executables
+      JAVACMD="$JAVA_HOME/jre/sh/java"
+      JAVACCMD="$JAVA_HOME/jre/sh/javac"
+    else
+      JAVACMD="$JAVA_HOME/bin/java"
+      JAVACCMD="$JAVA_HOME/bin/javac"
+
+      if [ ! -x "$JAVACMD" ] || [ ! -x "$JAVACCMD" ]; then
+        echo "The JAVA_HOME environment variable is not defined correctly, so mvnw cannot run." >&2
+        echo "JAVA_HOME is set to \"$JAVA_HOME\", but \"\$JAVA_HOME/bin/java\" or \"\$JAVA_HOME/bin/javac\" does not exist." >&2
+        return 1
+      fi
+    fi
+  else
+    JAVACMD="$(
+      'set' +e
+      'unset' -f command 2>/dev/null
+      'command' -v java
+    )" || :
+    JAVACCMD="$(
+      'set' +e
+      'unset' -f command 2>/dev/null
+      'command' -v javac
+    )" || :
+
+    if [ ! -x "${JAVACMD-}" ] || [ ! -x "${JAVACCMD-}" ]; then
+      echo "The java/javac command does not exist in PATH nor is JAVA_HOME set, so mvnw cannot run." >&2
+      return 1
+    fi
+  fi
+}
+
+# hash string like Java String::hashCode
+hash_string() {
+  str="${1:-}" h=0
+  while [ -n "$str" ]; do
+    char="${str%"${str#?}"}"
+    h=$(((h * 31 + $(LC_CTYPE=C printf %d "'$char")) % 4294967296))
+    str="${str#?}"
+  done
+  printf %x\\n $h
+}
+
+verbose() { :; }
+[ "${MVNW_VERBOSE-}" != true ] || verbose() { printf %s\\n "${1-}"; }
+
+die() {
+  printf %s\\n "$1" >&2
+  exit 1
+}
+
+trim() {
+  # MWRAPPER-139:
+  #   Trims trailing and leading whitespace, carriage returns, tabs, and linefeeds.
+  #   Needed for removing poorly interpreted newline sequences when running in more
+  #   exotic environments such as mingw bash on Windows.
+  printf "%s" "${1}" | tr -d '[:space:]'
+}
+
+scriptDir="$(dirname "$0")"
+scriptName="$(basename "$0")"
+
+# parse distributionUrl and optional distributionSha256Sum, requires .mvn/wrapper/maven-wrapper.properties
+while IFS="=" read -r key value; do
+  case "${key-}" in
+  distributionUrl) distributionUrl=$(trim "${value-}") ;;
+  distributionSha256Sum) distributionSha256Sum=$(trim "${value-}") ;;
+  esac
+done <"$scriptDir/.mvn/wrapper/maven-wrapper.properties"
+[ -n "${distributionUrl-}" ] || die "cannot read distributionUrl property in $scriptDir/.mvn/wrapper/maven-wrapper.properties"
+
+case "${distributionUrl##*/}" in
+maven-mvnd-*bin.*)
+  MVN_CMD=mvnd.sh _MVNW_REPO_PATTERN=/maven/mvnd/
+  case "${PROCESSOR_ARCHITECTURE-}${PROCESSOR_ARCHITEW6432-}:$(uname -a)" in
+  *AMD64:CYGWIN* | *AMD64:MINGW*) distributionPlatform=windows-amd64 ;;
+  :Darwin*x86_64) distributionPlatform=darwin-amd64 ;;
+  :Darwin*arm64) distributionPlatform=darwin-aarch64 ;;
+  :Linux*x86_64*) distributionPlatform=linux-amd64 ;;
+  *)
+    echo "Cannot detect native platform for mvnd on $(uname)-$(uname -m), use pure java version" >&2
+    distributionPlatform=linux-amd64
+    ;;
+  esac
+  distributionUrl="${distributionUrl%-bin.*}-$distributionPlatform.zip"
+  ;;
+maven-mvnd-*) MVN_CMD=mvnd.sh _MVNW_REPO_PATTERN=/maven/mvnd/ ;;
+*) MVN_CMD="mvn${scriptName#mvnw}" _MVNW_REPO_PATTERN=/org/apache/maven/ ;;
+esac
+
+# apply MVNW_REPOURL and calculate MAVEN_HOME
+# maven home pattern: ~/.m2/wrapper/dists/{apache-maven-<version>,maven-mvnd-<version>-<platform>}/<hash>
+[ -z "${MVNW_REPOURL-}" ] || distributionUrl="$MVNW_REPOURL$_MVNW_REPO_PATTERN${distributionUrl#*"$_MVNW_REPO_PATTERN"}"
+distributionUrlName="${distributionUrl##*/}"
+distributionUrlNameMain="${distributionUrlName%.*}"
+distributionUrlNameMain="${distributionUrlNameMain%-bin}"
+MAVEN_USER_HOME="${MAVEN_USER_HOME:-${HOME}/.m2}"
+MAVEN_HOME="${MAVEN_USER_HOME}/wrapper/dists/${distributionUrlNameMain-}/$(hash_string "$distributionUrl")"
+
+exec_maven() {
+  unset MVNW_VERBOSE MVNW_USERNAME MVNW_PASSWORD MVNW_REPOURL || :
+  exec "$MAVEN_HOME/bin/$MVN_CMD" "$@" || die "cannot exec $MAVEN_HOME/bin/$MVN_CMD"
+}
+
+if [ -d "$MAVEN_HOME" ]; then
+  verbose "found existing MAVEN_HOME at $MAVEN_HOME"
+  exec_maven "$@"
+fi
+
+case "${distributionUrl-}" in
+*?-bin.zip | *?maven-mvnd-?*-?*.zip) ;;
+*) die "distributionUrl is not valid, must match *-bin.zip or maven-mvnd-*.zip, but found '${distributionUrl-}'" ;;
+esac
+
+# prepare tmp dir
+if TMP_DOWNLOAD_DIR="$(mktemp -d)" && [ -d "$TMP_DOWNLOAD_DIR" ]; then
+  clean() { rm -rf -- "$TMP_DOWNLOAD_DIR"; }
+  trap clean HUP INT TERM EXIT
+else
+  die "cannot create temp dir"
+fi
+
+mkdir -p -- "${MAVEN_HOME%/*}"
+
+# Download and Install Apache Maven
+verbose "Couldn't find MAVEN_HOME, downloading and installing it ..."
+verbose "Downloading from: $distributionUrl"
+verbose "Downloading to: $TMP_DOWNLOAD_DIR/$distributionUrlName"
+
+# select .zip or .tar.gz
+if ! command -v unzip >/dev/null; then
+  distributionUrl="${distributionUrl%.zip}.tar.gz"
+  distributionUrlName="${distributionUrl##*/}"
+fi
+
+# verbose opt
+__MVNW_QUIET_WGET=--quiet __MVNW_QUIET_CURL=--silent __MVNW_QUIET_UNZIP=-q __MVNW_QUIET_TAR=''
+[ "${MVNW_VERBOSE-}" != true ] || __MVNW_QUIET_WGET='' __MVNW_QUIET_CURL='' __MVNW_QUIET_UNZIP='' __MVNW_QUIET_TAR=v
+
+# normalize http auth
+case "${MVNW_PASSWORD:+has-password}" in
+'') MVNW_USERNAME='' MVNW_PASSWORD='' ;;
+has-password) [ -n "${MVNW_USERNAME-}" ] || MVNW_USERNAME='' MVNW_PASSWORD='' ;;
+esac
+
+if [ -z "${MVNW_USERNAME-}" ] && command -v wget >/dev/null; then
+  verbose "Found wget ... using wget"
+  wget ${__MVNW_QUIET_WGET:+"$__MVNW_QUIET_WGET"} "$distributionUrl" -O "$TMP_DOWNLOAD_DIR/$distributionUrlName" || die "wget: Failed to fetch $distributionUrl"
+elif [ -z "${MVNW_USERNAME-}" ] && command -v curl >/dev/null; then
+  verbose "Found curl ... using curl"
+  curl ${__MVNW_QUIET_CURL:+"$__MVNW_QUIET_CURL"} -f -L -o "$TMP_DOWNLOAD_DIR/$distributionUrlName" "$distributionUrl" || die "curl: Failed to fetch $distributionUrl"
+elif set_java_home; then
+  verbose "Falling back to use Java to download"
+  javaSource="$TMP_DOWNLOAD_DIR/Downloader.java"
+  targetZip="$TMP_DOWNLOAD_DIR/$distributionUrlName"
+  cat >"$javaSource" <<-END
+	public class Downloader extends java.net.Authenticator
+	{
+	  protected java.net.PasswordAuthentication getPasswordAuthentication()
+	  {
+	    return new java.net.PasswordAuthentication( System.getenv( "MVNW_USERNAME" ), System.getenv( "MVNW_PASSWORD" ).toCharArray() );
+	  }
+	  public static void main( String[] args ) throws Exception
+	  {
+	    setDefault( new Downloader() );
+	    java.nio.file.Files.copy( java.net.URI.create( args[0] ).toURL().openStream(), java.nio.file.Paths.get( args[1] ).toAbsolutePath().normalize() );
+	  }
+	}
+	END
+  # For Cygwin/MinGW, switch paths to Windows format before running javac and java
+  verbose " - Compiling Downloader.java ..."
+  "$(native_path "$JAVACCMD")" "$(native_path "$javaSource")" || die "Failed to compile Downloader.java"
+  verbose " - Running Downloader.java ..."
+  "$(native_path "$JAVACMD")" -cp "$(native_path "$TMP_DOWNLOAD_DIR")" Downloader "$distributionUrl" "$(native_path "$targetZip")"
+fi
+
+# If specified, validate the SHA-256 sum of the Maven distribution zip file
+if [ -n "${distributionSha256Sum-}" ]; then
+  distributionSha256Result=false
+  if [ "$MVN_CMD" = mvnd.sh ]; then
+    echo "Checksum validation is not supported for maven-mvnd." >&2
+    echo "Please disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties." >&2
+    exit 1
+  elif command -v sha256sum >/dev/null; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | sha256sum -c - >/dev/null 2>&1; then
+      distributionSha256Result=true
+    fi
+  elif command -v shasum >/dev/null; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | shasum -a 256 -c >/dev/null 2>&1; then
+      distributionSha256Result=true
+    fi
+  else
+    echo "Checksum validation was requested but neither 'sha256sum' or 'shasum' are available." >&2
+    echo "Please install either command, or disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties." >&2
+    exit 1
+  fi
+  if [ $distributionSha256Result = false ]; then
+    echo "Error: Failed to validate Maven distribution SHA-256, your Maven distribution might be compromised." >&2
+    echo "If you updated your Maven version, you need to update the specified distributionSha256Sum property." >&2
+    exit 1
+  fi
+fi
+
+# unzip and move
+if command -v unzip >/dev/null; then
+  unzip ${__MVNW_QUIET_UNZIP:+"$__MVNW_QUIET_UNZIP"} "$TMP_DOWNLOAD_DIR/$distributionUrlName" -d "$TMP_DOWNLOAD_DIR" || die "failed to unzip"
+else
+  tar xzf${__MVNW_QUIET_TAR:+"$__MVNW_QUIET_TAR"} "$TMP_DOWNLOAD_DIR/$distributionUrlName" -C "$TMP_DOWNLOAD_DIR" || die "failed to untar"
+fi
+
+# Find the actual extracted directory name (handles snapshots where filename != directory name)
+actualDistributionDir=""
+
+# First try the expected directory name (for regular distributions)
+if [ -d "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain" ]; then
+  if [ -f "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain/bin/$MVN_CMD" ]; then
+    actualDistributionDir="$distributionUrlNameMain"
+  fi
+fi
+
+# If not found, search for any directory with the Maven executable (for snapshots)
+if [ -z "$actualDistributionDir" ]; then
+  # enable globbing to iterate over items
+  set +f
+  for dir in "$TMP_DOWNLOAD_DIR"/*; do
+    if [ -d "$dir" ]; then
+      if [ -f "$dir/bin/$MVN_CMD" ]; then
+        actualDistributionDir="$(basename "$dir")"
+        break
+      fi
+    fi
+  done
+  set -f
+fi
+
+if [ -z "$actualDistributionDir" ]; then
+  verbose "Contents of $TMP_DOWNLOAD_DIR:"
+  verbose "$(ls -la "$TMP_DOWNLOAD_DIR")"
+  die "Could not find Maven distribution directory in extracted archive"
+fi
+
+verbose "Found extracted Maven distribution directory: $actualDistributionDir"
+printf %s\\n "$distributionUrl" >"$TMP_DOWNLOAD_DIR/$actualDistributionDir/mvnw.url"
+mv -- "$TMP_DOWNLOAD_DIR/$actualDistributionDir" "$MAVEN_HOME" || [ -d "$MAVEN_HOME" ] || die "fail to move MAVEN_HOME"
+
+clean || :
+exec_maven "$@"

--- a/examples/mcp-java/mvnw.cmd
+++ b/examples/mcp-java/mvnw.cmd
@@ -1,0 +1,189 @@
+<# : batch portion
+@REM ----------------------------------------------------------------------------
+@REM Licensed to the Apache Software Foundation (ASF) under one
+@REM or more contributor license agreements.  See the NOTICE file
+@REM distributed with this work for additional information
+@REM regarding copyright ownership.  The ASF licenses this file
+@REM to you under the Apache License, Version 2.0 (the
+@REM "License"); you may not use this file except in compliance
+@REM with the License.  You may obtain a copy of the License at
+@REM
+@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM
+@REM Unless required by applicable law or agreed to in writing,
+@REM software distributed under the License is distributed on an
+@REM "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+@REM KIND, either express or implied.  See the License for the
+@REM specific language governing permissions and limitations
+@REM under the License.
+@REM ----------------------------------------------------------------------------
+
+@REM ----------------------------------------------------------------------------
+@REM Apache Maven Wrapper startup batch script, version 3.3.4
+@REM
+@REM Optional ENV vars
+@REM   MVNW_REPOURL - repo url base for downloading maven distribution
+@REM   MVNW_USERNAME/MVNW_PASSWORD - user and password for downloading maven
+@REM   MVNW_VERBOSE - true: enable verbose log; others: silence the output
+@REM ----------------------------------------------------------------------------
+
+@IF "%__MVNW_ARG0_NAME__%"=="" (SET __MVNW_ARG0_NAME__=%~nx0)
+@SET __MVNW_CMD__=
+@SET __MVNW_ERROR__=
+@SET __MVNW_PSMODULEP_SAVE=%PSModulePath%
+@SET PSModulePath=
+@FOR /F "usebackq tokens=1* delims==" %%A IN (`powershell -noprofile "& {$scriptDir='%~dp0'; $script='%__MVNW_ARG0_NAME__%'; icm -ScriptBlock ([Scriptblock]::Create((Get-Content -Raw '%~f0'))) -NoNewScope}"`) DO @(
+  IF "%%A"=="MVN_CMD" (set __MVNW_CMD__=%%B) ELSE IF "%%B"=="" (echo %%A) ELSE (echo %%A=%%B)
+)
+@SET PSModulePath=%__MVNW_PSMODULEP_SAVE%
+@SET __MVNW_PSMODULEP_SAVE=
+@SET __MVNW_ARG0_NAME__=
+@SET MVNW_USERNAME=
+@SET MVNW_PASSWORD=
+@IF NOT "%__MVNW_CMD__%"=="" ("%__MVNW_CMD__%" %*)
+@echo Cannot start maven from wrapper >&2 && exit /b 1
+@GOTO :EOF
+: end batch / begin powershell #>
+
+$ErrorActionPreference = "Stop"
+if ($env:MVNW_VERBOSE -eq "true") {
+  $VerbosePreference = "Continue"
+}
+
+# calculate distributionUrl, requires .mvn/wrapper/maven-wrapper.properties
+$distributionUrl = (Get-Content -Raw "$scriptDir/.mvn/wrapper/maven-wrapper.properties" | ConvertFrom-StringData).distributionUrl
+if (!$distributionUrl) {
+  Write-Error "cannot read distributionUrl property in $scriptDir/.mvn/wrapper/maven-wrapper.properties"
+}
+
+switch -wildcard -casesensitive ( $($distributionUrl -replace '^.*/','') ) {
+  "maven-mvnd-*" {
+    $USE_MVND = $true
+    $distributionUrl = $distributionUrl -replace '-bin\.[^.]*$',"-windows-amd64.zip"
+    $MVN_CMD = "mvnd.cmd"
+    break
+  }
+  default {
+    $USE_MVND = $false
+    $MVN_CMD = $script -replace '^mvnw','mvn'
+    break
+  }
+}
+
+# apply MVNW_REPOURL and calculate MAVEN_HOME
+# maven home pattern: ~/.m2/wrapper/dists/{apache-maven-<version>,maven-mvnd-<version>-<platform>}/<hash>
+if ($env:MVNW_REPOURL) {
+  $MVNW_REPO_PATTERN = if ($USE_MVND -eq $False) { "/org/apache/maven/" } else { "/maven/mvnd/" }
+  $distributionUrl = "$env:MVNW_REPOURL$MVNW_REPO_PATTERN$($distributionUrl -replace "^.*$MVNW_REPO_PATTERN",'')"
+}
+$distributionUrlName = $distributionUrl -replace '^.*/',''
+$distributionUrlNameMain = $distributionUrlName -replace '\.[^.]*$','' -replace '-bin$',''
+
+$MAVEN_M2_PATH = "$HOME/.m2"
+if ($env:MAVEN_USER_HOME) {
+  $MAVEN_M2_PATH = "$env:MAVEN_USER_HOME"
+}
+
+if (-not (Test-Path -Path $MAVEN_M2_PATH)) {
+    New-Item -Path $MAVEN_M2_PATH -ItemType Directory | Out-Null
+}
+
+$MAVEN_WRAPPER_DISTS = $null
+if ((Get-Item $MAVEN_M2_PATH).Target[0] -eq $null) {
+  $MAVEN_WRAPPER_DISTS = "$MAVEN_M2_PATH/wrapper/dists"
+} else {
+  $MAVEN_WRAPPER_DISTS = (Get-Item $MAVEN_M2_PATH).Target[0] + "/wrapper/dists"
+}
+
+$MAVEN_HOME_PARENT = "$MAVEN_WRAPPER_DISTS/$distributionUrlNameMain"
+$MAVEN_HOME_NAME = ([System.Security.Cryptography.SHA256]::Create().ComputeHash([byte[]][char[]]$distributionUrl) | ForEach-Object {$_.ToString("x2")}) -join ''
+$MAVEN_HOME = "$MAVEN_HOME_PARENT/$MAVEN_HOME_NAME"
+
+if (Test-Path -Path "$MAVEN_HOME" -PathType Container) {
+  Write-Verbose "found existing MAVEN_HOME at $MAVEN_HOME"
+  Write-Output "MVN_CMD=$MAVEN_HOME/bin/$MVN_CMD"
+  exit $?
+}
+
+if (! $distributionUrlNameMain -or ($distributionUrlName -eq $distributionUrlNameMain)) {
+  Write-Error "distributionUrl is not valid, must end with *-bin.zip, but found $distributionUrl"
+}
+
+# prepare tmp dir
+$TMP_DOWNLOAD_DIR_HOLDER = New-TemporaryFile
+$TMP_DOWNLOAD_DIR = New-Item -Itemtype Directory -Path "$TMP_DOWNLOAD_DIR_HOLDER.dir"
+$TMP_DOWNLOAD_DIR_HOLDER.Delete() | Out-Null
+trap {
+  if ($TMP_DOWNLOAD_DIR.Exists) {
+    try { Remove-Item $TMP_DOWNLOAD_DIR -Recurse -Force | Out-Null }
+    catch { Write-Warning "Cannot remove $TMP_DOWNLOAD_DIR" }
+  }
+}
+
+New-Item -Itemtype Directory -Path "$MAVEN_HOME_PARENT" -Force | Out-Null
+
+# Download and Install Apache Maven
+Write-Verbose "Couldn't find MAVEN_HOME, downloading and installing it ..."
+Write-Verbose "Downloading from: $distributionUrl"
+Write-Verbose "Downloading to: $TMP_DOWNLOAD_DIR/$distributionUrlName"
+
+$webclient = New-Object System.Net.WebClient
+if ($env:MVNW_USERNAME -and $env:MVNW_PASSWORD) {
+  $webclient.Credentials = New-Object System.Net.NetworkCredential($env:MVNW_USERNAME, $env:MVNW_PASSWORD)
+}
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+$webclient.DownloadFile($distributionUrl, "$TMP_DOWNLOAD_DIR/$distributionUrlName") | Out-Null
+
+# If specified, validate the SHA-256 sum of the Maven distribution zip file
+$distributionSha256Sum = (Get-Content -Raw "$scriptDir/.mvn/wrapper/maven-wrapper.properties" | ConvertFrom-StringData).distributionSha256Sum
+if ($distributionSha256Sum) {
+  if ($USE_MVND) {
+    Write-Error "Checksum validation is not supported for maven-mvnd. `nPlease disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties."
+  }
+  Import-Module $PSHOME\Modules\Microsoft.PowerShell.Utility -Function Get-FileHash
+  if ((Get-FileHash "$TMP_DOWNLOAD_DIR/$distributionUrlName" -Algorithm SHA256).Hash.ToLower() -ne $distributionSha256Sum) {
+    Write-Error "Error: Failed to validate Maven distribution SHA-256, your Maven distribution might be compromised. If you updated your Maven version, you need to update the specified distributionSha256Sum property."
+  }
+}
+
+# unzip and move
+Expand-Archive "$TMP_DOWNLOAD_DIR/$distributionUrlName" -DestinationPath "$TMP_DOWNLOAD_DIR" | Out-Null
+
+# Find the actual extracted directory name (handles snapshots where filename != directory name)
+$actualDistributionDir = ""
+
+# First try the expected directory name (for regular distributions)
+$expectedPath = Join-Path "$TMP_DOWNLOAD_DIR" "$distributionUrlNameMain"
+$expectedMvnPath = Join-Path "$expectedPath" "bin/$MVN_CMD"
+if ((Test-Path -Path $expectedPath -PathType Container) -and (Test-Path -Path $expectedMvnPath -PathType Leaf)) {
+  $actualDistributionDir = $distributionUrlNameMain
+}
+
+# If not found, search for any directory with the Maven executable (for snapshots)
+if (!$actualDistributionDir) {
+  Get-ChildItem -Path "$TMP_DOWNLOAD_DIR" -Directory | ForEach-Object {
+    $testPath = Join-Path $_.FullName "bin/$MVN_CMD"
+    if (Test-Path -Path $testPath -PathType Leaf) {
+      $actualDistributionDir = $_.Name
+    }
+  }
+}
+
+if (!$actualDistributionDir) {
+  Write-Error "Could not find Maven distribution directory in extracted archive"
+}
+
+Write-Verbose "Found extracted Maven distribution directory: $actualDistributionDir"
+Rename-Item -Path "$TMP_DOWNLOAD_DIR/$actualDistributionDir" -NewName $MAVEN_HOME_NAME | Out-Null
+try {
+  Move-Item -Path "$TMP_DOWNLOAD_DIR/$MAVEN_HOME_NAME" -Destination $MAVEN_HOME_PARENT | Out-Null
+} catch {
+  if (! (Test-Path -Path "$MAVEN_HOME" -PathType Container)) {
+    Write-Error "fail to move MAVEN_HOME"
+  }
+} finally {
+  try { Remove-Item $TMP_DOWNLOAD_DIR -Recurse -Force | Out-Null }
+  catch { Write-Warning "Cannot remove $TMP_DOWNLOAD_DIR" }
+}
+
+Write-Output "MVN_CMD=$MAVEN_HOME/bin/$MVN_CMD"

--- a/examples/mcp-java/pom.xml
+++ b/examples/mcp-java/pom.xml
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>dev.tachyonmcp.example</groupId>
+    <artifactId>mcp-java-example</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <name>mcp-java MCP Example</name>
+    <description>MCP server using mcp-java annotations with Tachyon</description>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.release>21</maven.compiler.release>
+        <tachyon.version>1.0.0-beta.22</tachyon.version>
+        <!--        <tachyon.version>1.0.0-SNAPSHOT</tachyon.version>-->
+        <mcp-java.version>1.0.0</mcp-java.version>
+        <junit.version>6.1.3</junit.version>
+        <assertj.version>3.27.7</assertj.version>
+        <json-unit.version>6.2.0</json-unit.version>
+        <slf4j.version>2.0.18</slf4j.version>
+        <netty.version>4.2.17.Final</netty.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>${junit.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>dev.tachyonmcp</groupId>
+            <artifactId>tachyon-core</artifactId>
+            <version>${tachyon.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>dev.tachyonmcp</groupId>
+            <artifactId>tachyon-annotations-mcp-java</artifactId>
+            <version>${tachyon.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.mcpjava</groupId>
+            <artifactId>mcp-server-api</artifactId>
+            <version>${mcp-java.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${slf4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>${slf4j.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.modelcontextprotocol.sdk</groupId>
+            <artifactId>mcp-json-jackson3</artifactId>
+            <version>2.0.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>${assertj.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.javacrumbs.json-unit</groupId>
+            <artifactId>json-unit-assertj</artifactId>
+            <version>${json-unit.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>${project.artifactId}</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.15.0</version>
+                <configuration>
+                    <release>${maven.compiler.release}</release>
+                    <parameters>true</parameters>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>4.1.0</version>
+                <executions><execution><goals><goal>repackage</goal></goals></execution></executions>
+                <configuration>
+                    <mainClass>com.example.mcpjava.McpJavaServer</mainClass>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/examples/mcp-java/src/main/java/com/example/mcpjava/AnnotatedService.java
+++ b/examples/mcp-java/src/main/java/com/example/mcpjava/AnnotatedService.java
@@ -1,0 +1,60 @@
+/* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
+package com.example.mcpjava;
+
+import org.mcpjava.server.prompts.Prompt;
+import org.mcpjava.server.prompts.PromptArg;
+import org.mcpjava.server.resources.Resource;
+import org.mcpjava.server.resources.ResourceTemplate;
+import org.mcpjava.server.resources.ResourceTemplateArg;
+import org.mcpjava.server.tools.Tool;
+import org.mcpjava.server.tools.ToolArg;
+
+/**
+ * Plain mcp-java annotated service. It has no Tachyon dependency in its source code.
+ */
+public class AnnotatedService {
+
+    /**
+     * Adds two numbers.
+     */
+    @Tool(
+        name = "add",
+        description = "Adds two integers",
+        annotations = @Tool.Annotations(readOnlyHint = true)
+    )
+    public int add(@ToolArg(name = "left", description = "First number") int left,
+                   @ToolArg(name = "right", description = "Second number") int right) {
+        return left + right;
+    }
+
+    /**
+     * Returns static application configuration.
+     */
+    @Resource(uri = "app://config",
+        name = "config",
+        description = "Application configuration",
+        mimeType = "application/json")
+    public String config() {
+        return "{\"name\":\"mcp-java-example\",\"version\":\"1.0\"}";
+    }
+
+    /**
+     * Returns a greeting for a URI-template parameter.
+     */
+    @ResourceTemplate(uriTemplate = "app://greeting/{name}",
+        name = "greeting",
+        description = "A greeting for a name")
+    public String greeting(@ResourceTemplateArg(name = "name") String name) {
+        return "Hello, " + name + "!";
+    }
+
+    /**
+     * Creates a welcome prompt.
+     */
+    @Prompt(
+        name = "welcome",
+        description = "Creates a welcome message")
+    public String welcome(@PromptArg(name = "name", description = "Name to welcome") String name) {
+        return "Welcome to MCP, " + name + "!";
+    }
+}

--- a/examples/mcp-java/src/main/java/com/example/mcpjava/McpJavaServer.java
+++ b/examples/mcp-java/src/main/java/com/example/mcpjava/McpJavaServer.java
@@ -1,0 +1,46 @@
+/* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
+package com.example.mcpjava;
+
+import dev.tachyonmcp.annotations.mcpjava.McpJavaAnnotationProvider;
+import dev.tachyonmcp.core.server.TachyonServer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Starts an MCP server exposing {@link AnnotatedService}'s mcp-java annotations.
+ */
+public final class McpJavaServer {
+
+    private static final Logger log = LoggerFactory.getLogger(McpJavaServer.class);
+
+    private McpJavaServer() {
+    }
+
+    /**
+     * Starts the server on the port from {@code PORT}, defaulting to 8080.
+     */
+    public static void main(String... args) {
+        final var server = buildServer(
+            System.getenv().getOrDefault("HOST", "localhost"),
+            Integer.parseInt(System.getenv().getOrDefault("PORT", "8080"))
+        );
+        server.start();
+        log.info("Connect your MCP client to http://{}:{}/mcp", server.host(), server.port());
+    }
+
+    static TachyonServer buildServer(
+        String host,
+        int port) {
+        return TachyonServer.builder()
+            .host(host)
+            .port(port)
+            .info(it -> it.name("mcp-java-example")
+                .title("mcp-java Example")
+                .description("MCP server scanning mcp-java annotations")
+                .version("1.0"))
+            .annotations(a -> a
+                .withProvider(McpJavaAnnotationProvider.instance())
+                .register(new AnnotatedService()))
+            .build();
+    }
+}

--- a/examples/mcp-java/src/main/java/com/example/mcpjava/package-info.java
+++ b/examples/mcp-java/src/main/java/com/example/mcpjava/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package com.example.mcpjava;
+
+import org.jspecify.annotations.NullMarked;

--- a/examples/mcp-java/src/test/java/com/example/mcpjava/McpJavaServerTest.java
+++ b/examples/mcp-java/src/test/java/com/example/mcpjava/McpJavaServerTest.java
@@ -1,0 +1,80 @@
+/* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
+package com.example.mcpjava;
+
+import dev.tachyonmcp.core.server.TachyonServer;
+import io.modelcontextprotocol.client.McpClient;
+import io.modelcontextprotocol.client.McpSyncClient;
+import io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport;
+import io.modelcontextprotocol.spec.McpSchema;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class McpJavaServerTest {
+
+    private static TachyonServer server;
+    private static McpSyncClient client;
+
+    @BeforeAll
+    static void beforeAll() {
+        server = McpJavaServer.buildServer("localhost", 0);
+        server.start();
+        var transport = HttpClientStreamableHttpTransport.builder("http://localhost:" + server.port()).build();
+        client = McpClient.sync(transport).build();
+        client.initialize();
+    }
+
+    @AfterAll
+    static void afterAll() {
+        client.close();
+        server.close();
+    }
+
+    @Test
+    void registersAllMcpJavaAnnotations() {
+        assertThat(client.listTools().tools()).extracting(McpSchema.Tool::name).contains("add");
+        assertThat(client.listResources().resources()).extracting(McpSchema.Resource::name).contains("config");
+        assertThat(client.listResourceTemplates().resourceTemplates())
+            .extracting(McpSchema.ResourceTemplate::name)
+            .contains("greeting");
+        assertThat(client.listPrompts().prompts()).extracting(McpSchema.Prompt::name).contains("welcome");
+    }
+
+    @Test
+    void invokesAnnotatedTool() {
+        var result = client.callTool(McpSchema.CallToolRequest.builder("add")
+            .arguments(Map.of("left", 2, "right", 3))
+            .build());
+
+        assertThat(result.isError()).isNotEqualTo(true);
+        assertThat(result.content()).singleElement().isInstanceOf(McpSchema.TextContent.class);
+        assertThat(((McpSchema.TextContent) result.content().getFirst()).text()).isEqualTo("5");
+    }
+
+    @Test
+    void readsAnnotatedResourceAndPrompt() {
+        var resource = client.readResource(
+            McpSchema.ReadResourceRequest
+                .builder("app://greeting/Ada")
+                .build()
+        );
+        assertThat(resource.contents()).singleElement().isInstanceOf(McpSchema.TextResourceContents.class);
+        assertThat(((McpSchema.TextResourceContents) resource.contents().getFirst()).text())
+            .isEqualTo("Hello, Ada!");
+
+        var prompt = client.getPrompt(
+            McpSchema.GetPromptRequest
+                .builder("welcome")
+                .arguments(Map.of("name", "Ada"))
+                .build()
+        );
+        assertThat(prompt.messages()).singleElement().extracting(McpSchema.PromptMessage::content)
+            .isInstanceOf(McpSchema.TextContent.class);
+        assertThat(((McpSchema.TextContent) prompt.messages().getFirst().content()).text())
+            .isEqualTo("Welcome to MCP, Ada!");
+    }
+}

--- a/examples/mcp-skills/pom.xml
+++ b/examples/mcp-skills/pom.xml
@@ -16,7 +16,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.release>21</maven.compiler.release>
-        <tachyon.version>1.0.0-beta.21</tachyon.version>
+        <tachyon.version>1.0.0-beta.22</tachyon.version>
 <!--        <tachyon.version>1.0.0-SNAPSHOT</tachyon.version>-->
         <junit.version>6.1.3</junit.version>
         <json-unit.version>6.2.0</json-unit.version>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -19,6 +19,7 @@
         <module>weather-mcp</module>
         <module>weather-mcp-kotlin</module>
         <module>langchain4j-mcp</module>
+        <module>mcp-java</module>
         <module>mcp-skills</module>
     </modules>
 </project>

--- a/examples/weather-mcp-kotlin/pom.xml
+++ b/examples/weather-mcp-kotlin/pom.xml
@@ -18,7 +18,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>21</java.version>
         <kotlin.version>2.2.21</kotlin.version>
-        <tachyon.version>1.0.0-beta.21</tachyon.version>
+        <tachyon.version>1.0.0-beta.22</tachyon.version>
 <!--        <tachyon.version>1.0.0-SNAPSHOT</tachyon.version>-->
         <junit.version>6.1.2</junit.version>
         <kotest.version>6.2.1</kotest.version>

--- a/examples/weather-mcp/pom.xml
+++ b/examples/weather-mcp/pom.xml
@@ -22,7 +22,7 @@
         <jackson.version>3.2.0</jackson.version>
         <junit.version>6.1.2</junit.version>
         <kt-schema.version>0.8.3</kt-schema.version>
-        <tachyon.version>1.0.0-beta.21</tachyon.version>
+        <tachyon.version>1.0.0-beta.22</tachyon.version>
 <!--        <tachyon.version>1.0.0-SNAPSHOT</tachyon.version>-->
         <assertj.version>3.27.7</assertj.version>
         <netty.version>4.2.15.Final</netty.version>

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         <java.version>21</java.version>
         <kotlin.version>2.2.21</kotlin.version>
         <kotlin-language.version>2.2</kotlin-language.version>
-        <api.oldVersion>1.0.0-beta.21</api.oldVersion>
+        <api.oldVersion>1.0.0-beta.22</api.oldVersion>
 
         <!-- Dependencies -->
         <assertj.version>3.27.7</assertj.version>


### PR DESCRIPTION
## Summary

The change adds the mcp-java example to the Maven reactor and workflow. The example includes Java 21 Maven configuration, Maven wrapper scripts, an annotated MCP service, and a configurable Tachyon server. Integration tests verify tools, resources, resource templates, and prompts. Documentation describes setup and execution. Existing Tachyon references and examples now use 1.0.0-beta.22.

### New Features

- Added a Java MCP example demonstrating annotated tools, resources, resource templates, and prompts.
- Added setup, build, and run documentation for the example.

### Documentation

- Updated quickstarts and migration guidance for release 1.0.0-beta.22.
- Added the Java example to the examples documentation and workflow.

### Chores

- Updated example projects and project configuration to release 1.0.0-beta.22.

Issue #177