### PR TITLE
fix(transport): harden SEP-2243 header validation

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -148,6 +148,40 @@ Entries are bare authorities, not URLs, matched case-insensitively; an entry wit
 matches that host on any port. See `DnsRebindingProtectionHandler`'s class docs for exact
 matching rules (bracketed IPv6, multiple/missing `Host` headers, HTTP/1.0 exemption).
 
+### `Mcp-Param-*` character restrictions
+
+On a `2026-07-28` request, a literal (non-Base64) `Mcp-Param-*` value may contain only
+horizontal tab, space, and visible ASCII (`0x21`–`0x7E`); anything else is rejected with `400`
+and JSON-RPC `-32020` (HeaderMismatch). Per SEP-2243 clients must Base64-wrap such values as
+`=?base64?{value}?=` instead. Every `Mcp-Param-*` header on the request is checked, whether or
+not it maps to an `x-mcp-header` tool argument.
+
+Netty's decoder already rejects NUL/CR/LF, but decodes `0x80`–`0xFF` as ISO-8859-1 and passes
+it through — that non-ASCII case is what this check catches.
+
+### MCP header guard
+
+Two request shapes let the HTTP view of a request and the executed view disagree. Both are
+rejected with `400 Bad Request` before the body is read, and the connection is closed. Not
+configurable.
+
+**Duplicate singleton headers.** `MCP-Protocol-Version`, `MCP-Session-Id`, `Mcp-Method`,
+`Mcp-Name`, `Last-Event-ID`, and any `Mcp-Param-*` carry exactly one value. Repeating one lets
+the server and an intermediary read different values from the same request — the SEP-2243
+routing headers exist precisely so a gateway can decide without parsing the body, which only
+holds while both views agree. Repeating `MCP-Protocol-Version` is a downgrade: the server
+negotiates the first value while a proxy reading the last one believes a newer revision applied.
+
+Duplicates are rejected even when both values are identical, since an intermediary can still
+disagree about whether the field is singular. Repeatable headers (`Accept`, `Cookie`, …) are
+untouched.
+
+**Mirrored headers without `MCP-Protocol-Version: 2026-07-28`.** `Mcp-Method`, `Mcp-Name` and
+`Mcp-Param-*` are only compared against the body by the `2026-07-28` revision. A request naming
+an older version — or omitting the header entirely — would carry them uninspected, so
+`Mcp-Method: tools/list` could clear a gateway while the body ran `tools/call`. The mirrors were
+introduced by `2026-07-28`, so no legitimate older client sends them.
+
 ## I/O engine
 
 `NettyIoEngine` selects the Netty transport:

--- a/docs/testkit.md
+++ b/docs/testkit.md
@@ -79,6 +79,24 @@ assertThatJsonRpcResponse(raw)
     .hasErrorMessage("Invalid params");
 ```
 
+### HTTP status and transport rejections
+
+`JsonRpcResponseAssert` reads the body as a JSON-RPC envelope, so it cannot speak for the HTTP
+status, nor for a rejection the transport answers in plain text before an envelope exists —
+a duplicate MCP header, a protocol version that cannot validate mirrored headers, an oversized
+body. `McpHttpResponseAssert` covers both and chains into the JSON-RPC assertions:
+
+```java
+import static dev.tachyonmcp.testkit.McpHttpResponseAssert.assertThatResponse;
+
+assertThatResponse(response).hasStatus(200).isSuccess().hasTextContent("echo:hi");
+assertThatResponse(response).hasStatus(400).isJsonRpcError().hasId(9).hasErrorCode(-32020);
+assertThatResponse(response).isRejectedWith(400, "Duplicate MCP header");
+```
+
+Prefer `isRejectedWith` over a bare status check for transport rejections: a JSON-RPC error
+carries the same `400`, so the status alone does not prove which layer rejected the request.
+
 ## Notifications
 
 Every client captures server-to-client notifications delivered over SSE; await one by method

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -134,6 +134,42 @@ return ToolResult.text("done").withMeta("taskId", JSON.textNode("t-123"));
 
 Metadata appears in the `_meta` field of the response.
 
+## Mirror an argument into an HTTP header
+
+MCP 2026-07-28 (SEP-2243) lets a tool argument be mirrored into an `Mcp-Param-{Name}` request
+header, so load balancers, WAFs and rate limiters can route on it without parsing the JSON body.
+Annotate the property with `x-mcp-header`:
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "region": {"type": "string", "x-mcp-header": "Region"},
+    "query": {"type": "string"}
+  }
+}
+```
+
+A conforming client then sends `Mcp-Param-Region: us-west1`, and the server rejects the call with
+`400` / JSON-RPC `-32020` if that header is missing, malformed, or disagrees with the body.
+
+The annotation is validated when the tool is registered — a violation throws
+`IllegalArgumentException` rather than being ignored, because an annotation the server skips is a
+header an intermediary trusts but nothing ever checks against the body:
+
+| Rule | Detail |
+|---|---|
+| Non-empty HTTP token | RFC 9110 `1*tchar` — no spaces, colons, control characters, or non-ASCII |
+| Unique, ignoring case | Two properties mirroring to one header make it ambiguous |
+| Primitive types only | `string`, `integer`, `boolean`. `number` is excluded — its string form is not canonical |
+| Top-level properties only | An annotation on a nested property, inside `items`, or behind a `$ref` is rejected rather than silently ignored |
+
+Values must be ASCII; see [Configuration](configuration.md) for the character rules and the
+`=?base64?…?=` wrapper for anything else.
+
+> Do not annotate secrets. Mirrored values are visible to every intermediary on the path, and Base64
+> is an encoding, not encryption.
+
 ## Jackson note
 
 Tachyon uses **Jackson 3** (`tools.jackson.*`), not Jackson 2. Import `tools.jackson.databind.JsonNode`, not `com.fasterxml.jackson.databind.JsonNode`.

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/AbstractStatelessMcpE2eTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/AbstractStatelessMcpE2eTest.java
@@ -5,6 +5,8 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 public abstract class AbstractStatelessMcpE2eTest extends AbstractMcpE2eTest {
@@ -30,13 +32,28 @@ public abstract class AbstractStatelessMcpE2eTest extends AbstractMcpE2eTest {
      * (e.g. {@code Mcp-Method}/{@code Mcp-Name}/{@code Mcp-Param-*}).
      */
     protected HttpResponse<String> postMcpRequest(String body, Map<String, String> headers) throws Exception {
+        var multiValued = new LinkedHashMap<String, List<String>>();
+        headers.forEach((name, value) -> multiValued.put(name, List.of(value)));
+        return postMcpRequest(body, multiValued, true);
+    }
+
+    /**
+     * Multi-valued variant of {@link #postMcpRequest(String, Map)}: each value becomes its own field
+     * line, so a test can send a header twice. Pass {@code includeDefaultProtocolVersion = false} to
+     * take over {@code MCP-Protocol-Version} — the only way to duplicate it.
+     */
+    protected HttpResponse<String> postMcpRequest(
+            String body, Map<String, ? extends Iterable<String>> headers, boolean includeDefaultProtocolVersion)
+            throws Exception {
         var builder = HttpRequest.newBuilder()
                 .uri(URI.create("http://localhost:" + port + "/mcp"))
                 .header("Content-Type", "application/json")
                 .header("Accept", "application/json, text/event-stream")
-                .header("MCP-Protocol-Version", "2026-07-28")
                 .POST(HttpRequest.BodyPublishers.ofString(body));
-        headers.forEach(builder::header);
+        if (includeDefaultProtocolVersion) {
+            builder.header("MCP-Protocol-Version", "2026-07-28");
+        }
+        headers.forEach((name, values) -> values.forEach(value -> builder.header(name, value)));
         return HTTP_CLIENT.send(builder.build(), HttpResponse.BodyHandlers.ofString());
     }
 }

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/MaxContentLengthTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/MaxContentLengthTest.java
@@ -1,0 +1,27 @@
+/* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
+package dev.tachyonmcp.e2e;
+
+import static dev.tachyonmcp.testkit.McpHttpResponseAssert.assertThatResponse;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins that {@code NetworkConfig.maxContentLength} actually reaches the
+ * {@code HttpObjectAggregator}: a body past the 1 MiB default is refused, not parsed.
+ */
+class MaxContentLengthTest extends AbstractStatelessMcpE2eTest {
+
+    @Test
+    void rejectsBodyLargerThanMaxContentLength() throws Exception {
+        var oversized = "x".repeat(2 * 1024 * 1024);
+        // language=JSON
+        var body = """
+                {"jsonrpc":"2.0","id":1,"method":"tools/list","params":{"padding":"%s"}}
+                """.formatted(oversized);
+
+        var response = postMcpRequest(body, Map.of("Mcp-Method", "tools/list"));
+
+        assertThatResponse(response).hasStatus(413);
+    }
+}

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp20260728/CustomHeaderValidationTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp20260728/CustomHeaderValidationTest.java
@@ -227,4 +227,12 @@ class CustomHeaderValidationTest extends AbstractStatelessMcpE2eTest {
 
         assertThatResponse(response).hasStatus(400).isJsonRpcError().hasId(15).hasErrorCode(-32020);
     }
+
+    /** A body value that overflows to {@code Infinity} must reject cleanly, not throw. */
+    @Test
+    void rejectsNonFiniteNumericBody() throws Exception {
+        var response = postWithLimit(16, "1e400", "1");
+
+        assertThatResponse(response).hasStatus(400).isJsonRpcError().hasId(16).hasErrorCode(-32020);
+    }
 }

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp20260728/CustomHeaderValidationTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp20260728/CustomHeaderValidationTest.java
@@ -1,13 +1,15 @@
 /* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
 package dev.tachyonmcp.e2e.mcp20260728;
 
-import static dev.tachyonmcp.testkit.JsonRpcResponseAssert.assertThat;
-import static org.assertj.core.api.Assertions.assertThat;
+import static dev.tachyonmcp.testkit.McpHttpResponseAssert.assertThatResponse;
 
 import dev.tachyonmcp.api.server.features.tools.ToolResult;
 import dev.tachyonmcp.e2e.AbstractStatelessMcpE2eTest;
 import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.LinkedHashMap;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -26,6 +28,7 @@ class CustomHeaderValidationTest extends AbstractStatelessMcpE2eTest {
               "type": "object",
               "properties": {
                 "region": {"type": "string", "x-mcp-header": "Region"},
+                "limit": {"type": "integer", "x-mcp-header": "Limit"},
                 "query": {"type": "string"}
               },
               "required": ["region", "query"]
@@ -72,38 +75,32 @@ class CustomHeaderValidationTest extends AbstractStatelessMcpE2eTest {
     @Test
     void acceptsMatchingParamHeader() throws Exception {
         var response = post(toolCallBody(1, "us-west1"), "us-west1");
-        assertThat(response.statusCode()).as(response.body()).isEqualTo(200);
-        assertThat(response).isSuccess().hasTextContent("region=us-west1 query=SELECT 1");
+        assertThatResponse(response).hasStatus(200).isSuccess().hasTextContent("region=us-west1 query=SELECT 1");
     }
 
     @Test
     void rejectsMissingParamHeaderWhenBodyHasValue() throws Exception {
         var response = post(toolCallBody(2, "us-west1"), null);
-        assertThat(response.statusCode()).as(response.body()).isEqualTo(400);
-        assertThat(response).isJsonRpcError().hasId(2).hasErrorCode(-32020);
+        assertThatResponse(response).hasStatus(400).isJsonRpcError().hasId(2).hasErrorCode(-32020);
     }
 
     @Test
     void rejectsMismatchedParamHeader() throws Exception {
         var response = post(toolCallBody(3, "us-west1"), "eu-west1");
-        assertThat(response.statusCode()).as(response.body()).isEqualTo(400);
-        assertThat(response).isJsonRpcError().hasId(3).hasErrorCode(-32020);
+        assertThatResponse(response).hasStatus(400).isJsonRpcError().hasId(3).hasErrorCode(-32020);
     }
 
     @Test
     void acceptsBase64EncodedParamHeader() throws Exception {
-        var encoded = java.util.Base64.getEncoder()
-                .encodeToString("us-west1".getBytes(java.nio.charset.StandardCharsets.UTF_8));
+        var encoded = Base64.getEncoder().encodeToString("us-west1".getBytes(StandardCharsets.UTF_8));
         var response = post(toolCallBody(4, "us-west1"), "=?base64?" + encoded + "?=");
-        assertThat(response.statusCode()).as(response.body()).isEqualTo(200);
-        assertThat(response).isSuccess().hasTextContent("region=us-west1 query=SELECT 1");
+        assertThatResponse(response).hasStatus(200).isSuccess().hasTextContent("region=us-west1 query=SELECT 1");
     }
 
     @Test
     void rejectsInvalidBase64ParamHeader() throws Exception {
         var response = post(toolCallBody(5, "us-west1"), "=?base64?not-valid-base64!!?=");
-        assertThat(response.statusCode()).as(response.body()).isEqualTo(400);
-        assertThat(response).isJsonRpcError().hasId(5).hasErrorCode(-32020);
+        assertThatResponse(response).hasStatus(400).isJsonRpcError().hasId(5).hasErrorCode(-32020);
     }
 
     @Test
@@ -111,19 +108,123 @@ class CustomHeaderValidationTest extends AbstractStatelessMcpE2eTest {
         // "=?base64?=" is short enough that the "=?base64?" prefix and "?=" suffix overlap by one
         // character; the server must not throw while extracting the (empty) encoded segment.
         var response = post(toolCallBody(7, "us-west1"), "=?base64?=");
-        assertThat(response.statusCode()).as(response.body()).isEqualTo(400);
-        assertThat(response).isJsonRpcError().hasId(7).hasErrorCode(-32020);
+        assertThatResponse(response).hasStatus(400).isJsonRpcError().hasId(7).hasErrorCode(-32020);
     }
 
     @Test
     void rejectsBase64ParamHeaderWithMissingPadding() throws Exception {
         // "Hello" -> "SGVsbG8=" — strip the trailing '=' pad character. Base64.getDecoder() tolerates
         // this (decodes fine without it), but SEP-2243 requires the server to reject malformed padding.
-        var encoded = java.util.Base64.getEncoder()
-                .encodeToString("Hello".getBytes(java.nio.charset.StandardCharsets.UTF_8))
+        var encoded = Base64.getEncoder()
+                .encodeToString("Hello".getBytes(StandardCharsets.UTF_8))
                 .replace("=", "");
         var response = post(toolCallBody(6, "Hello"), "=?base64?" + encoded + "?=");
-        assertThat(response.statusCode()).as(response.body()).isEqualTo(400);
-        assertThat(response).isJsonRpcError().hasId(6).hasErrorCode(-32020);
+        assertThatResponse(response).hasStatus(400).isJsonRpcError().hasId(6).hasErrorCode(-32020);
+    }
+
+    @Test
+    void rejectsDuplicateParamHeaders() throws Exception {
+        var headers = new LinkedHashMap<String, List<String>>();
+        headers.put("Mcp-Method", List.of("tools/call"));
+        headers.put("Mcp-Name", List.of("execute_sql"));
+        headers.put("Mcp-Param-Region", List.of("us-west1", "eu-west1"));
+
+        var response = postMcpRequest(toolCallBody(8, "us-west1"), headers, true);
+
+        assertThatResponse(response).isRejectedWith(400, "Duplicate MCP header");
+    }
+
+    @Test
+    void rejectsDuplicateIdenticalParamHeaders() throws Exception {
+        var headers = new LinkedHashMap<String, List<String>>();
+        headers.put("Mcp-Method", List.of("tools/call"));
+        headers.put("Mcp-Name", List.of("execute_sql"));
+        headers.put("Mcp-Param-Region", List.of("us-west1", "us-west1"));
+
+        var response = postMcpRequest(toolCallBody(9, "us-west1"), headers, true);
+
+        assertThatResponse(response).isRejectedWith(400, "Duplicate MCP header");
+    }
+
+    /** Pins the trust boundary: an injected {@code Mcp-Param-Admin} must not influence execution. */
+    @Test
+    void ignoresUnknownParamHeaderForDispatch() throws Exception {
+        var headers = new LinkedHashMap<String, List<String>>();
+        headers.put("Mcp-Method", List.of("tools/call"));
+        headers.put("Mcp-Name", List.of("execute_sql"));
+        headers.put("Mcp-Param-Region", List.of("us-west1"));
+        headers.put("Mcp-Param-Admin", List.of("true"));
+
+        var response = postMcpRequest(toolCallBody(10, "us-west1"), headers, true);
+
+        assertThatResponse(response).hasStatus(200).isSuccess().hasTextContent("region=us-west1 query=SELECT 1");
+    }
+
+    /** Netty passes {@code 0x80}-{@code 0xFF} through as ISO-8859-1, so nothing else catches it. */
+    @Test
+    void rejectsParamHeaderWithNonAsciiCharacters() throws Exception {
+        var response = post(toolCallBody(11, "us-west1"), "us-west\u00e9");
+
+        assertThatResponse(response).hasStatus(400).isJsonRpcError().hasId(11).hasErrorCode(-32020);
+    }
+
+    @Test
+    void acceptsParamHeaderWithInternalSpaces() throws Exception {
+        var response = post(toolCallBody(12, "us west 1"), "us west 1");
+
+        assertThatResponse(response)
+                .as("space is a permitted field-value character; only leading/trailing needs Base64")
+                .hasStatus(200)
+                .isSuccess()
+                .hasTextContent("region=us west 1 query=SELECT 1");
+    }
+
+    private HttpResponse<String> postWithLimit(int id, String bodyLimit, String limitHeader) throws Exception {
+        var headers = new LinkedHashMap<String, String>();
+        headers.put("Mcp-Method", "tools/call");
+        headers.put("Mcp-Name", "execute_sql");
+        headers.put("Mcp-Param-Region", "us-west1");
+        headers.put("Mcp-Param-Limit", limitHeader);
+        // language=JSON
+        var body = """
+                {
+                  "jsonrpc": "2.0",
+                  "id": %d,
+                  "method": "tools/call",
+                  "params": {
+                    "name": "execute_sql",
+                    "arguments": {"region": "us-west1", "limit": %s, "query": "SELECT 1"},
+                    "_meta": {
+                      "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+                      "io.modelcontextprotocol/clientInfo": {"name": "t", "version": "1"},
+                      "io.modelcontextprotocol/clientCapabilities": {}
+                    }
+                  }
+                }
+                """.formatted(id, bodyLimit);
+        return postMcpRequest(body, headers);
+    }
+
+    /** JSON Schema accepts 42.0 as an integer, so this must not slip past the header comparison. */
+    @Test
+    void rejectsSpoofedHeaderAgainstFractionalIntegerBody() throws Exception {
+        var response = postWithLimit(13, "42.0", "1");
+
+        assertThatResponse(response).hasStatus(400).isJsonRpcError().hasId(13).hasErrorCode(-32020);
+    }
+
+    /** SEP-2243: integers compare numerically, so 42.0 and 42 are the same value. */
+    @Test
+    void acceptsNumericallyEqualIntegerHeader() throws Exception {
+        var response = postWithLimit(14, "42.0", "42");
+
+        assertThatResponse(response).hasStatus(200).isSuccess();
+    }
+
+    @Test
+    void rejectsNonNumericHeaderAgainstNumericBody() throws Exception {
+        var response = postWithLimit(15, "42", "not-a-number");
+
+        assertThatResponse(response).hasStatus(400).isJsonRpcError().hasId(15).hasErrorCode(-32020);
     }
 }

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp20260728/CustomHeaderValidationTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp20260728/CustomHeaderValidationTest.java
@@ -84,6 +84,36 @@ class CustomHeaderValidationTest extends AbstractStatelessMcpE2eTest {
         assertThatResponse(response).hasStatus(400).isJsonRpcError().hasId(2).hasErrorCode(-32020);
     }
 
+    /** A header claiming a value with nothing in the body to back it is spoofable, not just extra. */
+    @Test
+    void rejectsParamHeaderWhenBodyOmitsTheArgument() throws Exception {
+        var headers = new LinkedHashMap<String, String>();
+        headers.put("Mcp-Method", "tools/call");
+        headers.put("Mcp-Name", "execute_sql");
+        headers.put("Mcp-Param-Region", "us-west1");
+        headers.put("Mcp-Param-Limit", "999");
+        // language=JSON
+        var body = """
+                {
+                  "jsonrpc": "2.0",
+                  "id": 17,
+                  "method": "tools/call",
+                  "params": {
+                    "name": "execute_sql",
+                    "arguments": {"region": "us-west1", "query": "SELECT 1"},
+                    "_meta": {
+                      "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+                      "io.modelcontextprotocol/clientInfo": {"name": "t", "version": "1"},
+                      "io.modelcontextprotocol/clientCapabilities": {}
+                    }
+                  }
+                }
+                """;
+        var response = postMcpRequest(body, headers);
+
+        assertThatResponse(response).hasStatus(400).isJsonRpcError().hasId(17).hasErrorCode(-32020);
+    }
+
     @Test
     void rejectsMismatchedParamHeader() throws Exception {
         var response = post(toolCallBody(3, "us-west1"), "eu-west1");

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp20260728/HeaderValidationTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp20260728/HeaderValidationTest.java
@@ -1,14 +1,14 @@
 /* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
 package dev.tachyonmcp.e2e.mcp20260728;
 
-import static dev.tachyonmcp.testkit.JsonRpcResponseAssert.assertThat;
-import static org.assertj.core.api.Assertions.assertThat;
+import static dev.tachyonmcp.testkit.McpHttpResponseAssert.assertThatResponse;
 
 import dev.tachyonmcp.e2e.AbstractStatelessMcpE2eTest;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 
@@ -38,6 +38,8 @@ class HeaderValidationTest extends AbstractStatelessMcpE2eTest {
             }
             """;
 
+    private static final String VERSION_REJECTION = "SEP-2243 headers require MCP-Protocol-Version: 2026-07-28";
+
     private HttpResponse<String> post(String mcpMethodHeader, String mcpNameHeader) throws Exception {
         var headers = new LinkedHashMap<String, String>();
         if (mcpMethodHeader != null) headers.put("Mcp-Method", mcpMethodHeader);
@@ -46,8 +48,7 @@ class HeaderValidationTest extends AbstractStatelessMcpE2eTest {
     }
 
     private void assertHeaderMismatch(HttpResponse<String> response) {
-        assertThat(response.statusCode()).as(response.body()).isEqualTo(400);
-        assertThat(response).isJsonRpcError().hasId(9).hasErrorCode(-32020);
+        assertThatResponse(response).hasStatus(400).isJsonRpcError().hasId(9).hasErrorCode(-32020);
     }
 
     @Test
@@ -68,16 +69,14 @@ class HeaderValidationTest extends AbstractStatelessMcpE2eTest {
     @Test
     void acceptsWhitespacePaddedNameHeader() throws Exception {
         var response = post("tools/call", "  echo  ");
-        assertThat(response.statusCode()).as(response.body()).isEqualTo(200);
-        assertThat(response).isSuccess().hasTextContent("hi");
+        assertThatResponse(response).hasStatus(200).isSuccess().hasTextContent("hi");
     }
 
     @Test
     void acceptsBase64EncodedNameHeader() throws Exception {
         var encoded = Base64.getEncoder().encodeToString("echo".getBytes(StandardCharsets.UTF_8));
         var response = post("tools/call", "=?base64?" + encoded + "?=");
-        assertThat(response.statusCode()).as(response.body()).isEqualTo(200);
-        assertThat(response).isSuccess().hasTextContent("hi");
+        assertThatResponse(response).hasStatus(200).isSuccess().hasTextContent("hi");
     }
 
     @Test
@@ -101,7 +100,74 @@ class HeaderValidationTest extends AbstractStatelessMcpE2eTest {
                 """;
         var response = postMcpRequest(body, Map.of("Mcp-Method", "tools/call", "Mcp-Name", "echo"));
 
-        assertThat(response.statusCode()).as(response.body()).isEqualTo(400);
-        assertThat(response).isJsonRpcError().hasId(11).hasErrorCode(-32020);
+        assertThatResponse(response).hasStatus(400).isJsonRpcError().hasId(11).hasErrorCode(-32020);
+    }
+
+    /** Rejected pre-aggregation, so the response is a plain {@code 400}, not JSON-RPC {@code -32020}. */
+    private void assertDuplicateHeaderRejected(HttpResponse<String> response) {
+        assertThatResponse(response).isRejectedWith(400, "Duplicate MCP header");
+    }
+
+    @Test
+    void rejectsDuplicateMethodHeaders() throws Exception {
+        assertDuplicateHeaderRejected(postMcpRequest(
+                TOOLS_CALL_ECHO_BODY,
+                Map.of("Mcp-Method", List.of("tools/call", "tools/list"), "Mcp-Name", List.of("echo")),
+                true));
+    }
+
+    @Test
+    void rejectsDuplicateNameHeaders() throws Exception {
+        assertDuplicateHeaderRejected(postMcpRequest(
+                TOOLS_CALL_ECHO_BODY,
+                Map.of("Mcp-Method", List.of("tools/call"), "Mcp-Name", List.of("echo", "other_tool")),
+                true));
+    }
+
+    @Test
+    void rejectsDuplicateIdenticalNameHeaders() throws Exception {
+        assertDuplicateHeaderRejected(postMcpRequest(
+                TOOLS_CALL_ECHO_BODY,
+                Map.of("Mcp-Method", List.of("tools/call"), "Mcp-Name", List.of("echo", "echo")),
+                true));
+    }
+
+    /** Duplicates here are a downgrade: first value negotiates, an intermediary reads the last. */
+    @Test
+    void rejectsDuplicateProtocolVersionHeaders() throws Exception {
+        assertDuplicateHeaderRejected(postMcpRequest(
+                TOOLS_CALL_ECHO_BODY,
+                Map.of(
+                        "MCP-Protocol-Version", List.of("2025-11-25", "2026-07-28"),
+                        "Mcp-Method", List.of("tools/call"),
+                        "Mcp-Name", List.of("echo")),
+                false));
+    }
+
+    /**
+     * Header/body agreement is enforced only by this revision's {@code RequestValidationHandler}. A
+     * mirrored header on a request negotiating an older revision is therefore never compared to the
+     * body: a gateway would authorize the benign {@code Mcp-Method} while the body ran something
+     * else. Rejecting costs nothing — the mirrors did not exist before 2026-07-28.
+     */
+    @Test
+    void rejectsMirroredHeadersOnOlderProtocolVersion() throws Exception {
+        var response = postMcpRequest(
+                TOOLS_CALL_ECHO_BODY,
+                Map.of(
+                        "MCP-Protocol-Version", List.of("2025-11-25"),
+                        "Mcp-Method", List.of("tools/list"),
+                        "Mcp-Name", List.of("echo")),
+                false);
+
+        assertThatResponse(response).isRejectedWith(400, VERSION_REJECTION);
+    }
+
+    @Test
+    void rejectsMirroredHeadersWithNoProtocolVersion() throws Exception {
+        var response = postMcpRequest(
+                TOOLS_CALL_ECHO_BODY, Map.of("Mcp-Method", List.of("tools/list"), "Mcp-Name", List.of("echo")), false);
+
+        assertThatResponse(response).isRejectedWith(400, VERSION_REJECTION);
     }
 }

--- a/tachyon-api/src/main/java/dev/tachyonmcp/api/server/session/SessionIdGenerator.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/api/server/session/SessionIdGenerator.java
@@ -29,6 +29,10 @@ import org.jspecify.annotations.Nullable;
  * server.session(s -> s.enabled(true).sessionIdGenerator(byTenant));
  * }</pre>
  *
+ * <p><b>A session id is not a credential.</b> It identifies protocol state, not the caller. An
+ * application adding authentication must verify the principal even on requests attaching to an
+ * existing session, or possession of the id becomes authorization.
+ *
  * @param <T> the transport-specific request type (a Netty {@code HttpRequest} for the HTTP
  *     transport); use {@link Object} for a request-independent generator like {@link #DEFAULT}
  * @author Konstantin Pavlov

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/mcp/McpHeaderNames.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/mcp/McpHeaderNames.java
@@ -1,8 +1,10 @@
 /* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
 package dev.tachyonmcp.core.protocol.mcp;
 
+import io.netty.util.AsciiString;
+
 /**
- * Constants for MCP-related HTTP header names.
+ * Constants for MCP HTTP header names, and the schema keyword that declares the custom ones.
  */
 public final class McpHeaderNames {
 
@@ -21,6 +23,25 @@ public final class McpHeaderNames {
 
     public static final String MCP_METHOD = "Mcp-Method";
     public static final String MCP_NAME = "Mcp-Name";
+
+    /**
+     * Tool input-schema keyword naming the {@link #MCP_PARAM_PREFIX} header a property mirrors into
+     * (SEP-2243).
+     */
+    public static final String X_MCP_HEADER = "x-mcp-header";
+
+    /** Prefix of the headers mirroring {@link #X_MCP_HEADER}-annotated tool arguments (SEP-2243). */
+    public static final String MCP_PARAM_PREFIX = "Mcp-Param-";
+
+    /**
+     * Whether {@code name} is an {@code Mcp-Param-*} header, matched case-insensitively per RFC 9110.
+     *
+     * @param name the HTTP header name
+     * @return {@code true} if {@code name} starts with {@link #MCP_PARAM_PREFIX}
+     */
+    public static boolean isParamHeader(CharSequence name) {
+        return AsciiString.regionMatches(name, true, 0, MCP_PARAM_PREFIX, 0, MCP_PARAM_PREFIX.length());
+    }
 
     private McpHeaderNames() {}
 }

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/mcp/v2026_07_28/transport/RequestValidationHandler.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/mcp/v2026_07_28/transport/RequestValidationHandler.java
@@ -205,9 +205,18 @@ public final class RequestValidationHandler extends ChannelInboundHandlerAdapter
         if (bodyValue == null) {
             return null; // Not in arguments: client MUST omit the header, server MUST NOT expect it.
         }
-        if (argument instanceof Number n && new BigDecimal(n.toString()).abs().compareTo(MAX_SAFE_INTEGER) > 0) {
-            return ServerErrors.headerMismatch("Header mismatch: " + headerName + " value '" + bodyValue
-                    + "' is outside the safe integer range and cannot be mirrored");
+        if (argument instanceof Number n) {
+            BigDecimal decimal;
+            try {
+                decimal = new BigDecimal(n.toString());
+            } catch (NumberFormatException e) {
+                // NaN/Infinity: not a BigDecimal literal. Value not echoed: it is client-controlled.
+                return ServerErrors.headerMismatch("Header mismatch: " + headerName + " value is not a finite number");
+            }
+            if (decimal.abs().compareTo(MAX_SAFE_INTEGER) > 0) {
+                return ServerErrors.headerMismatch("Header mismatch: " + headerName + " value '" + bodyValue
+                        + "' is outside the safe integer range and cannot be mirrored");
+            }
         }
         var rawHeader = req.headers().get(headerName);
         if (rawHeader == null) {

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/mcp/v2026_07_28/transport/RequestValidationHandler.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/mcp/v2026_07_28/transport/RequestValidationHandler.java
@@ -19,6 +19,7 @@ import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
@@ -87,10 +88,10 @@ public final class RequestValidationHandler extends ChannelInboundHandlerAdapter
             return;
         }
         if (message instanceof JsonRpcMessage.Notification<?> notification) {
-            // Mcp-Method is required on notifications too, and this revision does define one
-            // client-to-server notification (notifications/cancelled). The other mirrors are
-            // request-scoped, and there is no id to echo, so the error carries a null one.
+            // Mcp-Method applies to notifications too; Mcp-Name/Mcp-Param-* are request-scoped, but
+            // the char-format rule isn't. No id to echo, so the error carries null.
             var rejection = validateMethodHeader(req, notification.method());
+            if (rejection == null) rejection = validateParamHeaderChars(req);
             if (rejection != null) {
                 reject(ctx, req, null, rejection);
                 return;
@@ -155,12 +156,8 @@ public final class RequestValidationHandler extends ChannelInboundHandlerAdapter
             }
         }
 
-        // Not scoped to tools/call: the rule is about the field's wire format, matched or not.
-        var invalidHeader = findInvalidCharacterParamHeader(req);
-        if (invalidHeader != null) {
-            return ServerErrors.headerMismatch(
-                    "Header mismatch: " + invalidHeader + " contains characters not permitted in an HTTP field value");
-        }
+        var charRejection = validateParamHeaderChars(req);
+        if (charRejection != null) return charRejection;
 
         if ("tools/call".equals(method)) {
             var toolCallRejection = validateCustomParamHeaders(req, paramsMap);
@@ -171,11 +168,22 @@ public final class RequestValidationHandler extends ChannelInboundHandlerAdapter
     }
 
     /**
+     * Not scoped to tools/call: the rule is about the field's wire format, matched or not.
+     */
+    private static @Nullable ServerError validateParamHeaderChars(HttpRequest req) {
+        var invalidHeader = findInvalidCharacterParamHeader(req);
+        return invalidHeader == null
+                ? null
+                : ServerErrors.headerMismatch("Header mismatch: " + invalidHeader
+                        + " contains characters not permitted in an HTTP field value");
+    }
+
+    /**
      * Validates {@code Mcp-Param-{Name}} headers against the tool's {@code x-mcp-header}-annotated
      * properties (SEP-2243). Registration rejects annotations below the top level, so every one the
      * schema carries is checked here.
      */
-    private @Nullable ServerError validateCustomParamHeaders(FullHttpRequest req, Map<?, ?> paramsMap) {
+    private @Nullable ServerError validateCustomParamHeaders(HttpRequest req, Map<?, ?> paramsMap) {
         var toolName = asString(paramsMap.get("name"));
         if (toolName == null) return null;
         var descriptor = server.tools().find(toolName).orElse(null);
@@ -200,10 +208,15 @@ public final class RequestValidationHandler extends ChannelInboundHandlerAdapter
     }
 
     private static @Nullable ServerError validateMirroredValue(
-            FullHttpRequest req, String headerName, String propertyName, @Nullable Object argument) {
+            HttpRequest req, String headerName, String propertyName, @Nullable Object argument) {
         var bodyValue = argumentAsHeaderString(argument);
         if (bodyValue == null) {
-            return null; // Not in arguments: client MUST omit the header, server MUST NOT expect it.
+            // Client MUST omit the header when the argument is absent/null/non-primitive; a header
+            // present anyway has nothing in the body backing the value a gateway would route on.
+            return req.headers().get(headerName) == null
+                    ? null
+                    : ServerErrors.headerMismatch(
+                            "Header mismatch: " + headerName + " is present but body has no matching value");
         }
         if (argument instanceof Number n) {
             BigDecimal decimal;
@@ -256,7 +269,7 @@ public final class RequestValidationHandler extends ChannelInboundHandlerAdapter
      * Name of the first {@code Mcp-Param-*} header violating SEP-2243's character restrictions, or
      * {@code null}. Read before Base64 decoding: the rule applies to what travelled on the wire.
      */
-    private static @Nullable CharSequence findInvalidCharacterParamHeader(FullHttpRequest req) {
+    private static @Nullable CharSequence findInvalidCharacterParamHeader(HttpRequest req) {
         var it = req.headers().iteratorCharSequence();
         while (it.hasNext()) {
             var entry = it.next();
@@ -299,7 +312,7 @@ public final class RequestValidationHandler extends ChannelInboundHandlerAdapter
         };
     }
 
-    private static @Nullable ServerError validateMethodHeader(FullHttpRequest req, String method) {
+    private static @Nullable ServerError validateMethodHeader(HttpRequest req, String method) {
         var headerMethod = strip(req.headers().get(McpHeaderNames.MCP_METHOD));
         if (method.equals(headerMethod)) return null;
         return ServerErrors.headerMismatch("Header mismatch: " + McpHeaderNames.MCP_METHOD + " header value '"

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/mcp/v2026_07_28/transport/RequestValidationHandler.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/mcp/v2026_07_28/transport/RequestValidationHandler.java
@@ -1,6 +1,8 @@
 /* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
 package dev.tachyonmcp.core.protocol.mcp.v2026_07_28.transport;
 
+import static dev.tachyonmcp.core.protocol.mcp.McpHeaderNames.X_MCP_HEADER;
+
 import dev.tachyonmcp.api.server.domain.RequestId;
 import dev.tachyonmcp.api.server.domain.ServerError;
 import dev.tachyonmcp.core.protocol.mcp.McpHeaderNames;
@@ -18,6 +20,7 @@ import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpResponseStatus;
+import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Map;
@@ -49,10 +52,11 @@ public final class RequestValidationHandler extends ChannelInboundHandlerAdapter
     private static final String CLIENT_INFO_KEY = "io.modelcontextprotocol/clientInfo";
     private static final String CLIENT_CAPABILITIES_KEY = "io.modelcontextprotocol/clientCapabilities";
 
+    /** 2^53-1. Past it a JSON number cannot round-trip through a JavaScript intermediary intact. */
+    private static final BigDecimal MAX_SAFE_INTEGER = BigDecimal.valueOf(9007199254740991L);
+
     private static final String BASE64_PREFIX = "=?base64?";
     private static final String BASE64_SUFFIX = "?=";
-    private static final String X_MCP_HEADER = "x-mcp-header";
-    private static final String PARAM_HEADER_PREFIX = "Mcp-Param-";
 
     private final ServerEngine server;
 
@@ -82,9 +86,19 @@ public final class RequestValidationHandler extends ChannelInboundHandlerAdapter
             ctx.fireChannelRead(msg);
             return;
         }
+        if (message instanceof JsonRpcMessage.Notification<?> notification) {
+            // Mcp-Method is required on notifications too, and this revision does define one
+            // client-to-server notification (notifications/cancelled). The other mirrors are
+            // request-scoped, and there is no id to echo, so the error carries a null one.
+            var rejection = validateMethodHeader(req, notification.method());
+            if (rejection != null) {
+                reject(ctx, req, null, rejection);
+                return;
+            }
+            ctx.fireChannelRead(msg);
+            return;
+        }
         if (!(message instanceof JsonRpcMessage.Request<?> request)) {
-            // Notifications/responses/errors: this revision defines no client-to-client-side
-            // notifications over Streamable HTTP; nothing to validate here.
             ctx.fireChannelRead(msg);
             return;
         }
@@ -128,20 +142,24 @@ public final class RequestValidationHandler extends ChannelInboundHandlerAdapter
                     + PROTOCOL_VERSION_KEY + " value '" + metaProtocolVersion + "'");
         }
 
-        var headerMethod = strip(req.headers().get(McpHeaderNames.MCP_METHOD));
-        if (!method.equals(headerMethod)) {
-            return ServerErrors.headerMismatch("Header mismatch: " + McpHeaderNames.MCP_METHOD + " header value '"
-                    + headerMethod + "' does not match body method '" + method + "'");
-        }
+        var methodRejection = validateMethodHeader(req, method);
+        if (methodRejection != null) return methodRejection;
 
         if (NAME_REQUIRED_METHODS.contains(method)) {
             var bodyName =
                     "resources/read".equals(method) ? asString(paramsMap.get("uri")) : asString(paramsMap.get("name"));
             var headerName = decodeName(req.headers().get(McpHeaderNames.MCP_NAME));
-            if (bodyName == null || headerName == null || !headerName.equals(bodyName)) {
+            if (headerName == null || !headerName.equals(bodyName)) {
                 return ServerErrors.headerMismatch("Header mismatch: " + McpHeaderNames.MCP_NAME + " header value '"
                         + headerName + "' does not match body value '" + bodyName + "'");
             }
+        }
+
+        // Not scoped to tools/call: the rule is about the field's wire format, matched or not.
+        var invalidHeader = findInvalidCharacterParamHeader(req);
+        if (invalidHeader != null) {
+            return ServerErrors.headerMismatch(
+                    "Header mismatch: " + invalidHeader + " contains characters not permitted in an HTTP field value");
         }
 
         if ("tools/call".equals(method)) {
@@ -154,8 +172,8 @@ public final class RequestValidationHandler extends ChannelInboundHandlerAdapter
 
     /**
      * Validates {@code Mcp-Param-{Name}} headers against the tool's {@code x-mcp-header}-annotated
-     * input-schema properties (SEP-2243). Only scans top-level {@code properties} — nested reachable
-     * chains are a schema-authoring detail this server's tools don't currently need.
+     * properties (SEP-2243). Registration rejects annotations below the top level, so every one the
+     * schema carries is checked here.
      */
     private @Nullable ServerError validateCustomParamHeaders(FullHttpRequest req, Map<?, ?> paramsMap) {
         var toolName = asString(paramsMap.get("name"));
@@ -165,35 +183,94 @@ public final class RequestValidationHandler extends ChannelInboundHandlerAdapter
         if (inputSchema == null) return null;
         var properties = JsonUtils.parse(inputSchema).path("properties");
         if (!properties.isObject()) return null;
+        var arguments = paramsMap.get("arguments") instanceof Map<?, ?> m ? m : Map.of();
 
-        var arguments = paramsMap.get("arguments") instanceof Map<?, ?> a ? a : Map.of();
         for (var entry : properties.properties()) {
             var headerAnnotation = entry.getValue().path(X_MCP_HEADER);
             if (!headerAnnotation.isString()) continue;
             var propertyName = entry.getKey();
-            var headerName = PARAM_HEADER_PREFIX + headerAnnotation.asString();
-            var bodyValue = argumentAsHeaderString(arguments.get(propertyName));
-            var rawHeader = req.headers().get(headerName);
+            var rejection = validateMirroredValue(
+                    req,
+                    McpHeaderNames.MCP_PARAM_PREFIX + headerAnnotation.asString(),
+                    propertyName,
+                    arguments.get(propertyName));
+            if (rejection != null) return rejection;
+        }
+        return null;
+    }
 
-            if (bodyValue == null) {
-                continue; // Parameter not in arguments: client MUST omit the header, server MUST NOT expect it.
-            }
-            if (rawHeader == null) {
-                return ServerErrors.headerMismatch("Header mismatch: " + headerName
-                        + " is required because body arguments contains '" + propertyName + "'");
-            }
-            String decodedHeader;
-            try {
-                decodedHeader = decodeParamValue(rawHeader);
-            } catch (IllegalArgumentException e) {
-                return ServerErrors.headerMismatch("Header mismatch: " + headerName + " has invalid Base64 encoding");
-            }
-            if (!decodedHeader.equals(bodyValue)) {
-                return ServerErrors.headerMismatch("Header mismatch: " + headerName + " header value '" + decodedHeader
-                        + "' does not match body value '" + bodyValue + "'");
+    private static @Nullable ServerError validateMirroredValue(
+            FullHttpRequest req, String headerName, String propertyName, @Nullable Object argument) {
+        var bodyValue = argumentAsHeaderString(argument);
+        if (bodyValue == null) {
+            return null; // Not in arguments: client MUST omit the header, server MUST NOT expect it.
+        }
+        if (argument instanceof Number n && new BigDecimal(n.toString()).abs().compareTo(MAX_SAFE_INTEGER) > 0) {
+            return ServerErrors.headerMismatch("Header mismatch: " + headerName + " value '" + bodyValue
+                    + "' is outside the safe integer range and cannot be mirrored");
+        }
+        var rawHeader = req.headers().get(headerName);
+        if (rawHeader == null) {
+            return ServerErrors.headerMismatch("Header mismatch: " + headerName
+                    + " is required because body arguments contains '" + propertyName + "'");
+        }
+        String decodedHeader;
+        try {
+            decodedHeader = decodeParamValue(rawHeader);
+        } catch (IllegalArgumentException e) {
+            return ServerErrors.headerMismatch("Header mismatch: " + headerName + " has invalid Base64 encoding");
+        }
+        if (!matches(argument, bodyValue, decodedHeader)) {
+            return ServerErrors.headerMismatch("Header mismatch: " + headerName + " header value '" + decodedHeader
+                    + "' does not match body value '" + bodyValue + "'");
+        }
+        return null;
+    }
+
+    /**
+     * SEP-2243: numbers compare numerically, so {@code 42} and {@code 42.0} are the same value. That
+     * also stops a spoof — JSON Schema accepts {@code 42.0} as an {@code integer}, so a string-only
+     * comparison would have to skip it, leaving the header unchecked.
+     */
+    private static boolean matches(@Nullable Object argument, String bodyValue, String decodedHeader) {
+        if (!(argument instanceof Number)) {
+            return decodedHeader.equals(bodyValue);
+        }
+        try {
+            return new BigDecimal(decodedHeader).compareTo(new BigDecimal(bodyValue)) == 0;
+        } catch (NumberFormatException e) {
+            return false;
+        }
+    }
+
+    /**
+     * Name of the first {@code Mcp-Param-*} header violating SEP-2243's character restrictions, or
+     * {@code null}. Read before Base64 decoding: the rule applies to what travelled on the wire.
+     */
+    private static @Nullable CharSequence findInvalidCharacterParamHeader(FullHttpRequest req) {
+        var it = req.headers().iteratorCharSequence();
+        while (it.hasNext()) {
+            var entry = it.next();
+            if (McpHeaderNames.isParamHeader(entry.getKey()) && hasInvalidHeaderCharacter(entry.getValue())) {
+                return entry.getKey();
             }
         }
         return null;
+    }
+
+    /**
+     * SEP-2243 permits only HTAB, space and visible ASCII; anything else must travel Base64-wrapped.
+     * Netty rejects NUL/CR/LF already, but passes {@code 0x80}-{@code 0xFF} through as ISO-8859-1 —
+     * that non-ASCII case is what this catches.
+     */
+    private static boolean hasInvalidHeaderCharacter(CharSequence value) {
+        for (var i = 0; i < value.length(); i++) {
+            var c = value.charAt(i);
+            if (c != '\t' && (c < 0x20 || c > 0x7E)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**
@@ -205,14 +282,22 @@ public final class RequestValidationHandler extends ChannelInboundHandlerAdapter
         return switch (value) {
             case null -> null;
             case String s -> s;
-            case Long l -> String.valueOf(l);
-            case Integer i -> String.valueOf(i);
             case Boolean b -> String.valueOf(b);
+            // Every Number, not just the integral ones: a value the schema calls an integer can still
+            // decode to Double (42.0), and returning null there would skip the header check.
+            case Number n -> n.toString();
             default -> null;
         };
     }
 
-    private void reject(ChannelHandlerContext ctx, FullHttpRequest req, RequestId id, ServerError error) {
+    private static @Nullable ServerError validateMethodHeader(FullHttpRequest req, String method) {
+        var headerMethod = strip(req.headers().get(McpHeaderNames.MCP_METHOD));
+        if (method.equals(headerMethod)) return null;
+        return ServerErrors.headerMismatch("Header mismatch: " + McpHeaderNames.MCP_METHOD + " header value '"
+                + headerMethod + "' does not match body method '" + method + "'");
+    }
+
+    private void reject(ChannelHandlerContext ctx, FullHttpRequest req, @Nullable RequestId id, ServerError error) {
         var interaction = ChannelHandlerUtils.requireInteractionContext(ctx);
         var wireError = interaction.protocol().responseMapper().error(error);
         var body = JsonRpcCodec.serializeError(id, wireError.code(), wireError.message(), wireError.data());

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/features/tools/DefaultToolRegistry.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/features/tools/DefaultToolRegistry.java
@@ -86,6 +86,7 @@ public class DefaultToolRegistry extends AbstractRegistry<ToolDescriptor, ToolHa
         var name = descriptor.name();
         validateName(name);
         JsonSchemaUtils.validateInputSchemaRoot(schemaFactory, name, descriptor.inputSchema());
+        JsonSchemaUtils.validateHeaderAnnotations(schemaFactory, name, descriptor.inputSchema());
         JsonSchemaUtils.validateOutputSchemaRoot(schemaFactory, name, descriptor.outputSchema());
         var desc = descriptor.description();
         if (desc != null && desc.length() > MAX_DESCRIPTION_LENGTH) {

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/json/JsonSchemaUtils.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/json/JsonSchemaUtils.java
@@ -83,10 +83,10 @@ public class JsonSchemaUtils {
      * definition on violation — an annotation the server silently skips is a header intermediaries
      * route on but nothing compares to the body.
      *
-     * <p>Only top-level properties may be mirrored. The SEP's constraints allow any nesting depth,
-     * but its conformance suite requires servers to reject a nested annotation, and the stricter
-     * reading is the safe one: a nested annotation a server accepted but never validated would leave
-     * the header spoofable.
+     * <p>Only top-level properties may be mirrored. The SEP allows any nesting depth; this is a
+     * Tachyon-only restriction, not a conformance requirement — {@code RequestValidationHandler} only
+     * checks top-level {@code tools/call} arguments, so a nested annotation would go unvalidated and
+     * leave the header spoofable.
      *
      * @param factory  parses and validates the schema's raw JSON; must handle {@link String} sources
      * @param toolName the name of the tool owning the schema

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/json/JsonSchemaUtils.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/json/JsonSchemaUtils.java
@@ -1,18 +1,27 @@
 /* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
 package dev.tachyonmcp.core.server.json;
 
+import static dev.tachyonmcp.core.protocol.mcp.McpHeaderNames.X_MCP_HEADER;
+
 import dev.tachyonmcp.api.annotations.InternalApi;
 import dev.tachyonmcp.api.json.JsonDocument;
 import dev.tachyonmcp.api.json.JsonSchema;
 import dev.tachyonmcp.api.json.JsonSchemaValidator;
 import dev.tachyonmcp.api.json.SchemaValidationError;
 import dev.tachyonmcp.api.json.spi.JsonSchemaFactory;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import org.jspecify.annotations.Nullable;
 import tools.jackson.databind.JsonNode;
 
 @InternalApi
 public class JsonSchemaUtils {
+
+    /** {@code number} is excluded: its string form is not canonical, so header and body could differ. */
+    private static final List<String> MIRRORABLE_TYPES = List.of("string", "integer", "boolean");
+
     private JsonSchemaUtils() {
         // noop
     }
@@ -67,6 +76,110 @@ public class JsonSchemaUtils {
         if (node.isObject()) return;
         throw new IllegalArgumentException(
                 "Tool '" + toolName + "' outputSchema must be a JSON Schema object, got: " + node.getNodeType());
+    }
+
+    /**
+     * Validates a tool's {@code x-mcp-header} annotations against SEP-2243, rejecting the tool
+     * definition on violation — an annotation the server silently skips is a header intermediaries
+     * route on but nothing compares to the body.
+     *
+     * <p>Only top-level properties may be mirrored. The SEP's constraints allow any nesting depth,
+     * but its conformance suite requires servers to reject a nested annotation, and the stricter
+     * reading is the safe one: a nested annotation a server accepted but never validated would leave
+     * the header spoofable.
+     *
+     * @param factory  parses and validates the schema's raw JSON; must handle {@link String} sources
+     * @param toolName the name of the tool owning the schema
+     * @param schema   the schema to validate, or {@code null}
+     * @throws IllegalArgumentException if any {@code x-mcp-header} annotation is invalid
+     */
+    public static void validateHeaderAnnotations(
+            JsonSchemaFactory<?> factory, String toolName, @Nullable JsonSchema schema) {
+        if (schema == null) return;
+        var root = parseSchemaRoot(factory, "inputSchema", toolName, schema);
+        var topLevel = validateTopLevelAnnotations(root, toolName, new HashMap<>());
+        if (countAnnotations(root) > topLevel) {
+            throw new IllegalArgumentException("Tool '" + toolName + "' declares an " + X_MCP_HEADER
+                    + " on a nested property; only top-level properties can be mirrored");
+        }
+    }
+
+    /**
+     * Validates the top-level annotations and returns how many there were, for comparison against
+     * {@link #countAnnotations} — a higher total means one sits deeper in the schema.
+     *
+     * @param claimed header name, lowercased, to the property that claimed it
+     */
+    private static int validateTopLevelAnnotations(JsonNode root, String toolName, Map<String, String> claimed) {
+        var properties = root.path("properties");
+        if (!properties.isObject()) return 0;
+        var count = 0;
+        for (var entry : properties.properties()) {
+            var propertySchema = entry.getValue();
+            var annotation = propertySchema.path(X_MCP_HEADER);
+            if (annotation.isString()) {
+                validateAnnotation(toolName, entry.getKey(), annotation.asString(), propertySchema, claimed);
+                count++;
+            }
+        }
+        return count;
+    }
+
+    private static void validateAnnotation(
+            String toolName, String property, String headerName, JsonNode propertySchema, Map<String, String> claimed) {
+        if (!isToken(headerName)) {
+            throw new IllegalArgumentException("Tool '" + toolName + "' property '" + property + "' has an "
+                    + X_MCP_HEADER + " that is not a non-empty HTTP token: '" + headerName + "'");
+        }
+        var declaredType = propertySchema.path("type");
+        var type = declaredType.isString() ? declaredType.asString() : null;
+        if (!MIRRORABLE_TYPES.contains(type)) {
+            throw new IllegalArgumentException("Tool '" + toolName + "' property '" + property + "' declares "
+                    + X_MCP_HEADER + " on type '" + type + "'; only " + MIRRORABLE_TYPES + " can be mirrored");
+        }
+        var previous = claimed.put(headerName.toLowerCase(Locale.ROOT), property);
+        if (previous != null) {
+            throw new IllegalArgumentException("Tool '" + toolName + "' maps both '" + previous + "' and '" + property
+                    + "' to " + X_MCP_HEADER + " '" + headerName + "'; names must be unique ignoring case");
+        }
+    }
+
+    /** Occurrences anywhere in the tree, to catch those off the {@code properties} chain. */
+    private static int countAnnotations(JsonNode node) {
+        return countAnnotations(node, false);
+    }
+
+    /**
+     * @param propertyNames {@code true} when {@code node} is a {@code properties} map, whose keys are
+     *     author-chosen property names rather than schema keywords — a property may legitimately be
+     *     called {@code x-mcp-header} without being one
+     */
+    private static int countAnnotations(JsonNode node, boolean propertyNames) {
+        if (!node.isObject()) {
+            var elements = 0;
+            for (var child : node) {
+                elements += countAnnotations(child, false);
+            }
+            return elements;
+        }
+        var count = !propertyNames && node.path(X_MCP_HEADER).isString() ? 1 : 0;
+        for (var child : node.properties()) {
+            count += countAnnotations(child.getValue(), "properties".equals(child.getKey()));
+        }
+        return count;
+    }
+
+    /** RFC 9110 section 5.6.2 {@code 1*tchar} — note the {@code 1*}: empty is not a token. */
+    private static boolean isToken(String value) {
+        if (value.isEmpty()) return false;
+        for (var i = 0; i < value.length(); i++) {
+            var c = value.charAt(i);
+            var alphanumeric = (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9');
+            if (!alphanumeric && "!#$%&'*+-.^_`|~".indexOf(c) < 0) {
+                return false;
+            }
+        }
+        return true;
     }
 
     private static JsonNode parseSchemaRoot(

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/json/JsonSchemaUtils.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/json/JsonSchemaUtils.java
@@ -117,10 +117,13 @@ public class JsonSchemaUtils {
         for (var entry : properties.properties()) {
             var propertySchema = entry.getValue();
             var annotation = propertySchema.path(X_MCP_HEADER);
-            if (annotation.isString()) {
-                validateAnnotation(toolName, entry.getKey(), annotation.asString(), propertySchema, claimed);
-                count++;
+            if (annotation.isMissingNode()) continue;
+            if (!annotation.isString()) {
+                throw new IllegalArgumentException("Tool '" + toolName + "' property '" + entry.getKey() + "' has an "
+                        + X_MCP_HEADER + " that is not a string");
             }
+            validateAnnotation(toolName, entry.getKey(), annotation.asString(), propertySchema, claimed);
+            count++;
         }
         return count;
     }
@@ -162,7 +165,7 @@ public class JsonSchemaUtils {
             }
             return elements;
         }
-        var count = !propertyNames && node.path(X_MCP_HEADER).isString() ? 1 : 0;
+        var count = !propertyNames && !node.path(X_MCP_HEADER).isMissingNode() ? 1 : 0;
         for (var child : node.properties()) {
             count += countAnnotations(child.getValue(), "properties".equals(child.getKey()));
         }

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/transport/netty/ChannelHandlerUtils.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/transport/netty/ChannelHandlerUtils.java
@@ -23,6 +23,7 @@ import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpUtil;
 import io.netty.handler.codec.http.HttpVersion;
 import io.netty.util.AttributeKey;
+import io.netty.util.ReferenceCountUtil;
 import java.util.Objects;
 import org.jspecify.annotations.Nullable;
 
@@ -31,6 +32,60 @@ public final class ChannelHandlerUtils {
     private static final AttributeKey<Session> SESSION_KEY = AttributeKey.valueOf("tachyonSession");
 
     private ChannelHandlerUtils() {}
+
+    private static final AttributeKey<Boolean> REJECTED = AttributeKey.valueOf("tachyonRequestRejected");
+
+    /**
+     * Rejects the request with {@code status} and closes the connection, marking the channel so
+     * {@link #dropIfRejected} discards what the decoder already produced from the same read. Releases
+     * {@code msg}: it is not forwarded on, so nothing else would free it.
+     *
+     * @param ctx     the channel handler context
+     * @param msg     the inbound message being rejected
+     * @param status  the HTTP status to respond with
+     * @param message the plain-text response body; must not echo client-controlled input
+     */
+    public static void rejectAndClose(
+            ChannelHandlerContext ctx, Object msg, HttpResponseStatus status, String message) {
+        markRejected(ctx, msg);
+        sendPlainTextAndClose(ctx, status, message);
+    }
+
+    /**
+     * {@link #rejectAndClose} bookkeeping without the response, for handlers writing their own. Call
+     * after reading anything still needed from {@code msg} — it releases the message.
+     *
+     * @param ctx the channel handler context
+     * @param msg the inbound message being rejected
+     */
+    public static void markRejected(ChannelHandlerContext ctx, Object msg) {
+        ctx.channel().attr(REJECTED).set(Boolean.TRUE);
+        ReferenceCountUtil.release(msg);
+    }
+
+    /**
+     * Releases {@code msg} and returns {@code true} when this channel already rejected a request via
+     * {@link #rejectAndClose}. The decoder can emit the body's {@code HttpContent} chunks from the
+     * same read batch as the {@link HttpRequest} that was rejected, and forwarding headerless content
+     * downstream while the close is in flight leaks it into the next handler.
+     *
+     * <p>Called from exactly one place — {@code DnsRebindingProtectionHandler}, the first inbound
+     * handler after the codec — so every later handler is covered no matter which one rejected.
+     * Repeating the check in those handlers is unreachable: nothing forwards content past the head
+     * once the flag is set. A pipeline customizer that removes {@code dns-rebinding} removes this
+     * too.
+     *
+     * @param ctx the channel handler context
+     * @param msg the inbound message
+     * @return {@code true} if the message was dropped and the caller must return
+     */
+    public static boolean dropIfRejected(ChannelHandlerContext ctx, Object msg) {
+        if (!Boolean.TRUE.equals(ctx.channel().attr(REJECTED).get())) {
+            return false;
+        }
+        ReferenceCountUtil.release(msg);
+        return true;
+    }
 
     /**
      * Binds a session to the channel and installs the {@link SessionTouchHandler} if not already

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/transport/netty/McpChannelInitializer.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/transport/netty/McpChannelInitializer.java
@@ -7,6 +7,7 @@ import dev.tachyonmcp.core.server.internal.ServerEngine;
 import dev.tachyonmcp.core.transport.netty.http.AcceptValidationHandler;
 import dev.tachyonmcp.core.transport.netty.http.DnsRebindingProtectionHandler;
 import dev.tachyonmcp.core.transport.netty.http.EndpointValidatorHandler;
+import dev.tachyonmcp.core.transport.netty.http.McpHeaderGuardHandler;
 import dev.tachyonmcp.core.transport.netty.http.StatelessValidatorHandler;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelInitializer;
@@ -149,6 +150,10 @@ public class McpChannelInitializer extends ChannelInitializer<SocketChannel> {
             p.addLast("cors", new CorsHandler(corsConfig));
         }
         p.addLast("mcp-endpoint", endpointValidatorHandler);
+
+        // Must precede "protocol-version": a repeated version header would otherwise negotiate on its
+        // first value while an intermediary routes on the last.
+        p.addLast("mcp-header-guard", McpHeaderGuardHandler.INSTANCE);
         p.addLast("protocol-version", protocolVersionHandler);
         p.addLast("accept-header", acceptHeaderValidator);
         if (stateless) {

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/transport/netty/ProtocolVersionHandler.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/transport/netty/ProtocolVersionHandler.java
@@ -55,10 +55,17 @@ public class ProtocolVersionHandler extends ChannelInboundHandlerAdapter {
                 ctx.channel().attr(UNSUPPORTED_VERSION_KEY).set(protoVersion != null ? protoVersion : "");
             } else {
                 var interaction = ctx.channel().attr(InteractionHandler.INTERACTION_CONTEXT_KEY);
-                if (McpProtocol.VERSION.equals(protocol.get().versionString())) {
+                var current = interaction.get();
+                // 2026-07-28 is sessionless and negotiates extensions per request, so it always starts
+                // a fresh context. Older versions keep theirs across the keep-alive connection, since
+                // the session lives on the channel — but only while the version still matches: a
+                // proxy pooling upstream connections across unrelated clients can put a 2026-07-28
+                // request ahead of a 2025-11-25 one, and validating the latter against the context the
+                // former left behind rejects a perfectly legal request.
+                if (McpProtocol.VERSION.equals(protocol.get().versionString())
+                        || current == null
+                        || !protocol.get().versionString().equals(current.protocolVersion())) {
                     interaction.set(protocol.get().createInteractionContext());
-                } else {
-                    interaction.setIfAbsent(protocol.get().createInteractionContext());
                 }
             }
         }

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/transport/netty/http/AcceptValidationHandler.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/transport/netty/http/AcceptValidationHandler.java
@@ -1,6 +1,7 @@
 /* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
 package dev.tachyonmcp.core.transport.netty.http;
 
+import static dev.tachyonmcp.core.transport.netty.ChannelHandlerUtils.markRejected;
 import static dev.tachyonmcp.core.transport.netty.ChannelHandlerUtils.sendResponseAndClose;
 
 import io.netty.buffer.Unpooled;
@@ -112,9 +113,11 @@ public final class AcceptValidationHandler extends ChannelInboundHandlerAdapter 
                 req.headers().get(HttpHeaderNames.ACCEPT) == null ? "missing" : "incompatible",
                 method,
                 String.join(", ", requiredTypes));
-        var msg = "Accept header must include " + String.join(" or ", requiredTypes) + " on " + method;
-        var body = Unpooled.copiedBuffer(msg, StandardCharsets.UTF_8);
+        var text = "Accept header must include " + String.join(" or ", requiredTypes) + " on " + method;
+        var body = Unpooled.copiedBuffer(text, StandardCharsets.UTF_8);
+        // Read the origin before marking rejected: markRejected releases the request.
         var origin = req.headers().get(HttpHeaderNames.ORIGIN);
+        markRejected(ctx, req);
         sendResponseAndClose(ctx, HttpResponseStatus.NOT_ACCEPTABLE, TEXT_PLAIN, body, origin);
     }
 }

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/transport/netty/http/DnsRebindingProtectionHandler.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/transport/netty/http/DnsRebindingProtectionHandler.java
@@ -1,7 +1,8 @@
 /* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
 package dev.tachyonmcp.core.transport.netty.http;
 
-import static dev.tachyonmcp.core.transport.netty.ChannelHandlerUtils.sendPlainTextAndClose;
+import static dev.tachyonmcp.core.transport.netty.ChannelHandlerUtils.dropIfRejected;
+import static dev.tachyonmcp.core.transport.netty.ChannelHandlerUtils.rejectAndClose;
 
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
@@ -10,8 +11,6 @@ import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
-import io.netty.util.AttributeKey;
-import io.netty.util.ReferenceCountUtil;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
@@ -74,14 +73,9 @@ public class DnsRebindingProtectionHandler extends ChannelInboundHandlerAdapter 
                 .collect(Collectors.toUnmodifiableSet());
     }
 
-    private static final AttributeKey<Boolean> REJECTED = AttributeKey.valueOf("tachyonDnsRebindingRejected");
-
     @Override
     public void channelRead(ChannelHandlerContext ctx, Object msg) {
-        if (Boolean.TRUE.equals(ctx.channel().attr(REJECTED).get())) {
-            // The request was rejected; drop its trailing content chunks instead of forwarding
-            // headerless content downstream while the close is in flight.
-            ReferenceCountUtil.release(msg);
+        if (dropIfRejected(ctx, msg)) {
             return;
         }
         if (msg instanceof HttpRequest req) {
@@ -123,9 +117,7 @@ public class DnsRebindingProtectionHandler extends ChannelInboundHandlerAdapter 
      * message first: it is not forwarded down the pipeline, so nothing else will free its buffers.
      */
     private static void reject(ChannelHandlerContext ctx, Object msg) {
-        ctx.channel().attr(REJECTED).set(Boolean.TRUE);
-        ReferenceCountUtil.release(msg);
-        sendPlainTextAndClose(ctx, HttpResponseStatus.FORBIDDEN, "Forbidden");
+        rejectAndClose(ctx, msg, HttpResponseStatus.FORBIDDEN, "Forbidden");
     }
 
     /** Returns {@code true} when {@code authority} matches a configured allowed host. */

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/transport/netty/http/EndpointValidatorHandler.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/transport/netty/http/EndpointValidatorHandler.java
@@ -1,14 +1,13 @@
 /* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
 package dev.tachyonmcp.core.transport.netty.http;
 
-import static dev.tachyonmcp.core.transport.netty.ChannelHandlerUtils.sendPlainTextAndClose;
+import static dev.tachyonmcp.core.transport.netty.ChannelHandlerUtils.rejectAndClose;
 
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponseStatus;
-import io.netty.util.ReferenceCountUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,8 +33,7 @@ public class EndpointValidatorHandler extends ChannelInboundHandlerAdapter {
 
             if (!normalizedPath(uri).equals(mcpEndpoint)) {
                 LOGGER.warn("Unknown endpoint: {}", uri);
-                ReferenceCountUtil.release(msg);
-                sendPlainTextAndClose(ctx, HttpResponseStatus.NOT_FOUND, "Not Found");
+                rejectAndClose(ctx, msg, HttpResponseStatus.NOT_FOUND, "Not Found");
                 return;
             }
         }

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/transport/netty/http/McpHeaderGuardHandler.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/transport/netty/http/McpHeaderGuardHandler.java
@@ -1,0 +1,131 @@
+/* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
+package dev.tachyonmcp.core.transport.netty.http;
+
+import static dev.tachyonmcp.core.transport.netty.ChannelHandlerUtils.rejectAndClose;
+import static io.netty.util.AsciiString.contentEqualsIgnoreCase;
+
+import dev.tachyonmcp.core.protocol.Protocol;
+import dev.tachyonmcp.core.protocol.Protocols;
+import dev.tachyonmcp.core.protocol.mcp.McpHeaderNames;
+import dev.tachyonmcp.core.protocol.mcp.v2026_07_28.McpProtocol;
+import io.netty.channel.ChannelHandler.Sharable;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.util.AsciiString;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Keeps the HTTP view of an MCP request and the executed view from diverging, rejecting anything
+ * that lets them with {@code 400 Bad Request}.
+ *
+ * <p>SEP-2243 mirrors routing-critical values ({@code Mcp-Method}, {@code Mcp-Name},
+ * {@code Mcp-Param-*}) into HTTP headers precisely so gateways, WAFs and rate limiters can decide
+ * without parsing the JSON body. That only holds while both views agree, which two things break:
+ *
+ * <ul>
+ *   <li><b>A repeated field line.</b> Netty's {@code HttpHeaders#get} takes the first value, while
+ *       an intermediary taking the last one sees something else. For {@code MCP-Protocol-Version}
+ *       the disagreement is a downgrade — the server negotiates the first value and skips the newer
+ *       revision's validation while the proxy believes the newer revision applied.
+ *   <li><b>A mirrored header on a request that does not negotiate 2026-07-28.</b> Header/body
+ *       agreement is enforced only by that revision's {@code RequestValidationHandler}; on any
+ *       older version the mirrors are never compared to the body, so {@code Mcp-Method: tools/list}
+ *       would route past a gateway while the body ran {@code tools/call}. The mirrors were
+ *       introduced by 2026-07-28, so no legitimate older client sends them.
+ * </ul>
+ *
+ * <p>Runs before {@code http-aggregator}, so no {@code get()} downstream can be misled, and applies
+ * to every HTTP method: {@code MCP-Session-Id} and {@code Last-Event-ID} matter on GET/DELETE too.
+ * Rejection is therefore plain text rather than JSON-RPC {@code -32020}: the body carrying the id to
+ * echo hasn't been assembled yet, and malformed transport metadata is not an MCP-level mismatch.
+ * Same treatment duplicate {@code Host}/{@code Origin} already get in
+ * {@link DnsRebindingProtectionHandler}.
+ *
+ * <p>Duplicates are rejected even when both values are identical — otherwise an intermediary can
+ * still disagree about whether the field is singular.
+ */
+@Sharable
+public final class McpHeaderGuardHandler extends ChannelInboundHandlerAdapter {
+
+    /** Shared instance: the handler is stateless. */
+    public static final McpHeaderGuardHandler INSTANCE = new McpHeaderGuardHandler();
+
+    private static final AsciiString PROTOCOL_VERSION = AsciiString.cached(McpHeaderNames.MCP_PROTOCOL_VERSION);
+    private static final AsciiString SESSION_ID = AsciiString.cached(McpHeaderNames.MCP_SESSION_ID);
+    private static final AsciiString METHOD = AsciiString.cached(McpHeaderNames.MCP_METHOD);
+    private static final AsciiString NAME = AsciiString.cached(McpHeaderNames.MCP_NAME);
+    private static final AsciiString LAST_EVENT_ID = AsciiString.cached(McpHeaderNames.LAST_EVENT_ID);
+
+    private static final Set<String> SUPPORTED_VERSIONS =
+            Protocols.list().stream().map(Protocol::versionString).collect(Collectors.toUnmodifiableSet());
+
+    private static final String DUPLICATE_MESSAGE = "Duplicate MCP header";
+    private static final String VERSION_MESSAGE =
+            "SEP-2243 headers require " + McpHeaderNames.MCP_PROTOCOL_VERSION + ": " + McpProtocol.VERSION;
+
+    @Override
+    public void channelRead(ChannelHandlerContext ctx, Object msg) {
+        if (msg instanceof HttpRequest req) {
+            // The offending header name is deliberately not echoed: it is client-controlled input.
+            var rejection = validate(req.headers());
+            if (rejection != null) {
+                rejectAndClose(ctx, msg, HttpResponseStatus.BAD_REQUEST, rejection);
+                return;
+            }
+        }
+        ctx.fireChannelRead(msg);
+    }
+
+    /**
+     * The rejection reason, or {@code null} when the request is well-formed. {@code names()} keeps
+     * case variants as distinct entries while {@code getAll} matches case-insensitively, so
+     * {@code Mcp-Method} plus {@code mcp-method} still collapses into a duplicate.
+     */
+    private static @Nullable String validate(HttpHeaders headers) {
+        var sawMirror = false;
+        for (var name : headers.names()) {
+            var mirror = isMirrored(name);
+            if (!mirror && !isSingleton(name)) {
+                continue;
+            }
+            if (headers.getAll(name).size() > 1) {
+                return DUPLICATE_MESSAGE;
+            }
+            sawMirror |= mirror;
+        }
+        // Safe to read now: a duplicated version header would already have been rejected above.
+        return sawMirror ? mirrorsWithoutValidation(headers.get(PROTOCOL_VERSION)) : null;
+    }
+
+    /**
+     * Whether mirrors on this request would go unchecked. A version this server does not support is
+     * left alone: {@code UnsupportedProtocolVersionHandler} answers it with the more specific
+     * {@code -32022}, and preempting that with a bare 400 loses the supported-version list. An absent
+     * header negotiates an older revision, so its mirrors are unvalidated all the same.
+     */
+    private static @Nullable String mirrorsWithoutValidation(@Nullable String version) {
+        if (McpProtocol.VERSION.equals(version)) {
+            return null;
+        }
+        return version == null || SUPPORTED_VERSIONS.contains(version) ? VERSION_MESSAGE : null;
+    }
+
+    /** The SEP-2243 mirrors of body values, meaningful only under {@link McpProtocol#VERSION}. */
+    private static boolean isMirrored(CharSequence name) {
+        return contentEqualsIgnoreCase(name, METHOD)
+                || contentEqualsIgnoreCase(name, NAME)
+                || McpHeaderNames.isParamHeader(name);
+    }
+
+    /** MCP headers that carry exactly one value on any protocol version. */
+    private static boolean isSingleton(CharSequence name) {
+        return contentEqualsIgnoreCase(name, PROTOCOL_VERSION)
+                || contentEqualsIgnoreCase(name, SESSION_ID)
+                || contentEqualsIgnoreCase(name, LAST_EVENT_ID);
+    }
+}

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/transport/netty/http/StatelessValidatorHandler.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/transport/netty/http/StatelessValidatorHandler.java
@@ -1,7 +1,7 @@
 /* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
 package dev.tachyonmcp.core.transport.netty.http;
 
-import static dev.tachyonmcp.core.transport.netty.ChannelHandlerUtils.sendPlainTextAndClose;
+import static dev.tachyonmcp.core.transport.netty.ChannelHandlerUtils.rejectAndClose;
 
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
@@ -23,13 +23,14 @@ public class StatelessValidatorHandler extends ChannelInboundHandlerAdapter {
             var sessionId = req.headers().get("MCP-Session-Id");
             var lastEventId = req.headers().get("Last-Event-ID");
             if (sessionId != null || lastEventId != null) {
-                sendPlainTextAndClose(ctx, HttpResponseStatus.NOT_FOUND, "Stateless server does not support sessions");
+                rejectAndClose(ctx, msg, HttpResponseStatus.NOT_FOUND, "Stateless server does not support sessions");
                 return;
             }
 
             if (req.method() == HttpMethod.DELETE) {
-                sendPlainTextAndClose(
+                rejectAndClose(
                         ctx,
+                        msg,
                         HttpResponseStatus.METHOD_NOT_ALLOWED,
                         "Session management not available in stateless mode");
                 return;

--- a/tachyon-core/src/test/java/dev/tachyonmcp/core/protocol/mcp/v2026_07_28/transport/RequestValidationHandlerTest.java
+++ b/tachyon-core/src/test/java/dev/tachyonmcp/core/protocol/mcp/v2026_07_28/transport/RequestValidationHandlerTest.java
@@ -1,0 +1,90 @@
+/* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
+package dev.tachyonmcp.core.protocol.mcp.v2026_07_28.transport;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import dev.tachyonmcp.core.protocol.mcp.v2026_07_28.McpProtocol;
+import dev.tachyonmcp.core.server.internal.ServerEngine;
+import dev.tachyonmcp.core.transport.netty.ProtocolVersionHandler;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.http.DefaultFullHttpRequest;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpVersion;
+import io.netty.util.ReferenceCountUtil;
+import java.nio.charset.StandardCharsets;
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * A raw HTTP client can't transmit the 0x80-0xFF/control-character bytes SEP-2243 forbids in an
+ * {@code Mcp-Param-*} header (a real client either rejects them at {@code header()} time or
+ * substitutes {@code '?'}), so this exercises {@link RequestValidationHandler} directly with a
+ * hand-built header value instead of going through an HTTP client, per the sibling
+ * {@code McpHeaderGuardHandlerTest}/{@code ProtocolVersionHandlerTest} pattern.
+ */
+class RequestValidationHandlerTest {
+
+    private final EmbeddedChannel channel = new EmbeddedChannel(
+            new ProtocolVersionHandler("/mcp"), new RequestValidationHandler(mock(ServerEngine.class)));
+
+    @AfterEach
+    void tearDown() {
+        channel.finishAndReleaseAll();
+    }
+
+    private static DefaultFullHttpRequest notificationRequest(String body) {
+        var req = new DefaultFullHttpRequest(
+                HttpVersion.HTTP_1_1, HttpMethod.POST, "/mcp", Unpooled.copiedBuffer(body, StandardCharsets.UTF_8));
+        req.headers().set("MCP-Protocol-Version", McpProtocol.VERSION);
+        req.headers().set("Mcp-Method", "notifications/cancelled");
+        return req;
+    }
+
+    private @Nullable HttpResponseStatus rejectionStatus() {
+        Object out = channel.readOutbound();
+        try {
+            return out instanceof HttpResponse resp ? resp.status() : null;
+        } finally {
+            ReferenceCountUtil.release(out);
+        }
+    }
+
+    /** Mcp-Method is required on notifications too (this revision defines notifications/cancelled). */
+    @Test
+    void rejectsNotificationWithMismatchedMethodHeader() {
+        var req = notificationRequest(
+                "{\"jsonrpc\": \"2.0\", \"method\": \"notifications/cancelled\", \"params\": {\"requestId\": \"1\"}}");
+        req.headers().set("Mcp-Method", "notifications/other");
+
+        channel.writeInbound(req);
+
+        assertThat(rejectionStatus()).isEqualTo(HttpResponseStatus.BAD_REQUEST);
+    }
+
+    /** Not scoped to tools/call: the char-format rule applies to notifications too. */
+    @Test
+    void rejectsNotificationWithInvalidCharacterParamHeader() {
+        var req = notificationRequest(
+                "{\"jsonrpc\": \"2.0\", \"method\": \"notifications/cancelled\", \"params\": {\"requestId\": \"1\"}}");
+        req.headers().set("Mcp-Param-Reason", "us-westé");
+
+        channel.writeInbound(req);
+
+        assertThat(rejectionStatus()).isEqualTo(HttpResponseStatus.BAD_REQUEST);
+    }
+
+    @Test
+    void acceptsNotificationWithoutParamHeaders() {
+        var req = notificationRequest(
+                "{\"jsonrpc\": \"2.0\", \"method\": \"notifications/cancelled\", \"params\": {\"requestId\": \"1\"}}");
+
+        channel.writeInbound(req);
+
+        assertThat(rejectionStatus()).isNull();
+    }
+}

--- a/tachyon-core/src/test/java/dev/tachyonmcp/core/server/features/tools/DefaultToolRegistryTest.java
+++ b/tachyon-core/src/test/java/dev/tachyonmcp/core/server/features/tools/DefaultToolRegistryTest.java
@@ -690,7 +690,8 @@ class DefaultToolRegistryTest {
 
     @Test
     void shouldRejectNestedHeaderAnnotation() {
-        // SEP-2243 conformance: a nested x-mcp-header must be rejected, not silently ignored.
+        // Tachyon-only restriction (not a conformance requirement): a nested x-mcp-header must be
+        // rejected, not silently ignored.
         var schema = parseJson("""
             {"type":"object","properties":{
               "target":{"type":"object","properties":{
@@ -700,6 +701,29 @@ class DefaultToolRegistryTest {
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("x-mcp-header")
                 .hasMessageContaining("nested");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"123", "true", "{}", "[]", "null"})
+    void shouldRejectNonStringHeaderAnnotationValue(String annotationValue) {
+        var schema = parseJson("""
+                {"type":"object","properties":{"p":{"type":"string","x-mcp-header":%s}}}
+                """.formatted(annotationValue));
+        assertThatThrownBy(() -> registry.register(testTool("non-string-annotation", null, schema)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("x-mcp-header");
+    }
+
+    @Test
+    void shouldRejectNestedNonStringHeaderAnnotationValue() {
+        var schema = parseJson("""
+                {"type":"object","properties":{
+                  "target":{"type":"object","properties":{
+                    "region":{"type":"string","x-mcp-header":123}}}}}
+                """);
+        assertThatThrownBy(() -> registry.register(testTool("nested-non-string", null, schema)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("x-mcp-header");
     }
 
     @ParameterizedTest

--- a/tachyon-core/src/test/java/dev/tachyonmcp/core/server/features/tools/DefaultToolRegistryTest.java
+++ b/tachyon-core/src/test/java/dev/tachyonmcp/core/server/features/tools/DefaultToolRegistryTest.java
@@ -51,6 +51,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import tools.jackson.databind.JsonNode;
 
 class DefaultToolRegistryTest {
@@ -685,6 +686,97 @@ class DefaultToolRegistryTest {
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("inputSchema")
                 .hasMessageContaining("\"type\": \"object\"");
+    }
+
+    @Test
+    void shouldRejectNestedHeaderAnnotation() {
+        // SEP-2243 conformance: a nested x-mcp-header must be rejected, not silently ignored.
+        var schema = parseJson("""
+            {"type":"object","properties":{
+              "target":{"type":"object","properties":{
+                "region":{"type":"string","x-mcp-header":"Region"}}}}}
+            """);
+        assertThatThrownBy(() -> registry.register(testTool("nested", null, schema)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("x-mcp-header")
+                .hasMessageContaining("nested");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"array", "object", "null", "number"})
+    void shouldRejectHeaderAnnotationOnNonPrimitiveType(String type) {
+        // SEP-2243: string/integer/boolean only; number's string form is not canonical.
+        var schema = parseJson("""
+                {"type":"object","properties":{"p":{"type":"%s","x-mcp-header":"P"}}}
+                """.formatted(type));
+        assertThatThrownBy(() -> registry.register(testTool("bad-type-" + type, null, schema)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("x-mcp-header")
+                .hasMessageContaining(type);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", "My Region", "Region:Primary", "R\u00e9gion"})
+    void shouldRejectMalformedHeaderAnnotationName(String headerName) {
+        // SEP-2243: the value must be a non-empty RFC 9110 token (1*tchar).
+        var schema = parseJson("""
+                {"type":"object","properties":{"p":{"type":"string","x-mcp-header":"%s"}}}
+                """.formatted(headerName));
+        assertThatThrownBy(() -> registry.register(testTool("bad-name", null, schema)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("x-mcp-header");
+    }
+
+    @Test
+    void shouldRejectHeaderAnnotationNameWithControlCharacter() {
+        // Tab is legal in a header *value* but not in a field-name token. It has to reach the parser
+        // as a JSON escape: a literal control character is not valid inside a JSON string.
+        var schema = parseJson("""
+            {"type":"object","properties":{"p":{"type":"string","x-mcp-header":"Region\\u0009Tab"}}}
+            """);
+        assertThatThrownBy(() -> registry.register(testTool("tab-name", null, schema)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("x-mcp-header");
+    }
+
+    @Test
+    void shouldAcceptPropertyNamedLikeTheHeaderKeyword() {
+        // A "properties" key is an author-chosen name, not a schema keyword, so it must not be
+        // mistaken for an annotation sitting off the properties chain.
+        var schema = parseJson("""
+            {"type":"object","properties":{"x-mcp-header":{"type":"string"}}}
+            """);
+        registry.register(testTool("keyword-named-property", null, schema));
+        assertThat(registry.find("keyword-named-property")).isPresent();
+    }
+
+    @Test
+    void shouldRejectDuplicateHeaderAnnotationNamesIgnoringCase() {
+        // Two properties on one header make it ambiguous for an intermediary.
+        var schema = parseJson("""
+            {"type":"object","properties":{
+              "a":{"type":"string","x-mcp-header":"Region"},
+              "b":{"type":"string","x-mcp-header":"REGION"}}}
+            """);
+        assertThatThrownBy(() -> registry.register(testTool("dup-header", null, schema)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("x-mcp-header")
+                .hasMessageContaining("'a'")
+                .hasMessageContaining("'b'")
+                .hasMessageContaining("unique ignoring case");
+    }
+
+    @Test
+    void shouldRejectHeaderAnnotationInsideArrayItems() {
+        // Also below the top level, and there is no single argument to mirror either.
+        var schema = parseJson("""
+            {"type":"object","properties":{
+              "rows":{"type":"array","items":{"type":"object","properties":{
+                "region":{"type":"string","x-mcp-header":"Region"}}}}}}
+            """);
+        assertThatThrownBy(() -> registry.register(testTool("unreachable", null, schema)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("x-mcp-header");
     }
 
     @Test

--- a/tachyon-core/src/test/java/dev/tachyonmcp/core/transport/netty/http/McpHeaderGuardHandlerTest.java
+++ b/tachyon-core/src/test/java/dev/tachyonmcp/core/transport/netty/http/McpHeaderGuardHandlerTest.java
@@ -1,0 +1,212 @@
+/* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
+package dev.tachyonmcp.core.transport.netty.http;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.tachyonmcp.core.protocol.mcp.v2026_07_28.McpProtocol;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.http.DefaultFullHttpRequest;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpVersion;
+import io.netty.util.ReferenceCountUtil;
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * The HTTP view of a request and the executed view must not be able to diverge. Two things let them:
+ * a repeated singleton MCP header (an intermediary reads the last value, Netty reads the first), and
+ * a SEP-2243 mirror sent on a request that does not negotiate {@link McpProtocol#VERSION} (nothing
+ * ever compares it to the body). Both must be rejected with {@code 400}, before anything downstream
+ * calls {@code headers().get}.
+ */
+class McpHeaderGuardHandlerTest {
+
+    private final EmbeddedChannel channel = new EmbeddedChannel(McpHeaderGuardHandler.INSTANCE);
+
+    @AfterEach
+    void releaseChannel() {
+        channel.finishAndReleaseAll();
+    }
+
+    private static DefaultFullHttpRequest request() {
+        var req = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/mcp");
+        req.headers().set(HttpHeaderNames.HOST, "localhost:8096");
+        req.headers().set("MCP-Protocol-Version", McpProtocol.VERSION);
+        return req;
+    }
+
+    /** Returns the status of a rejection response written outbound (releasing it), or {@code null}. */
+    private @Nullable HttpResponseStatus rejectionStatus() {
+        Object out = channel.readOutbound();
+        try {
+            return out instanceof HttpResponse resp ? resp.status() : null;
+        } finally {
+            ReferenceCountUtil.release(out);
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"MCP-Protocol-Version", "MCP-Session-Id", "Mcp-Method", "Mcp-Name", "Last-Event-ID"})
+    void rejectsDuplicateSingletonHeaderWithDifferentValues(String header) {
+        var req = request();
+        req.headers().add(header, "first");
+        req.headers().add(header, "second");
+        channel.writeInbound(req);
+        assertThat(rejectionStatus()).isEqualTo(HttpResponseStatus.BAD_REQUEST);
+        assertThat(channel.inboundMessages())
+                .as("a rejected request must not reach the next handler")
+                .isEmpty();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"MCP-Protocol-Version", "MCP-Session-Id", "Mcp-Method", "Mcp-Name", "Last-Event-ID"})
+    void rejectsDuplicateSingletonHeaderWithIdenticalValues(String header) {
+        var req = request();
+        req.headers().add(header, "same");
+        req.headers().add(header, "same");
+        channel.writeInbound(req);
+        assertThat(rejectionStatus())
+                .as("identical duplicates are still ambiguous about whether the field is singular")
+                .isEqualTo(HttpResponseStatus.BAD_REQUEST);
+    }
+
+    @Test
+    void rejectsDuplicateHeaderNamesDifferingOnlyInCase() {
+        var req = request();
+        req.headers().add("Mcp-Method", "tools/call");
+        req.headers().add("mcp-method", "tools/list");
+        channel.writeInbound(req);
+        assertThat(rejectionStatus())
+                .as("HTTP field names are case-insensitive")
+                .isEqualTo(HttpResponseStatus.BAD_REQUEST);
+    }
+
+    @Test
+    void rejectsDuplicateParamHeaders() {
+        var req = request();
+        req.headers().add("Mcp-Param-Region", "us-west1");
+        req.headers().add("Mcp-Param-Region", "eu-west1");
+        channel.writeInbound(req);
+        assertThat(rejectionStatus()).isEqualTo(HttpResponseStatus.BAD_REQUEST);
+    }
+
+    @Test
+    void rejectsDuplicateParamHeadersDifferingOnlyInCase() {
+        var req = request();
+        req.headers().add("Mcp-Param-Region", "us-west1");
+        req.headers().add("mcp-param-region", "eu-west1");
+        channel.writeInbound(req);
+        assertThat(rejectionStatus()).isEqualTo(HttpResponseStatus.BAD_REQUEST);
+    }
+
+    @Test
+    void forwardsDistinctParamHeaders() {
+        var req = request();
+        req.headers().add("Mcp-Param-Region", "us-west1");
+        req.headers().add("Mcp-Param-Zone", "a");
+        assertThat(channel.writeInbound(req))
+                .as("two different mirrored arguments are not a duplicate")
+                .isTrue();
+        assertThat(rejectionStatus()).isNull();
+    }
+
+    @Test
+    void rejectsDuplicateSessionIdOnDelete() {
+        var req = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.DELETE, "/mcp");
+        req.headers().add("MCP-Session-Id", "sess_a");
+        req.headers().add("MCP-Session-Id", "sess_b");
+        channel.writeInbound(req);
+        assertThat(rejectionStatus()).as("session binding is not POST-only").isEqualTo(HttpResponseStatus.BAD_REQUEST);
+    }
+
+    @Test
+    void forwardsSingleValuedMcpHeaders() {
+        var req = request();
+        req.headers().add("Mcp-Method", "tools/call");
+        req.headers().add("Mcp-Name", "echo");
+        req.headers().add("Mcp-Param-Region", "us-west1");
+        assertThat(channel.writeInbound(req)).isTrue();
+        assertThat(rejectionStatus()).isNull();
+    }
+
+    @Test
+    void forwardsDuplicateNonMcpHeaders() {
+        var req = request();
+        req.headers().add(HttpHeaderNames.ACCEPT, "application/json");
+        req.headers().add(HttpHeaderNames.ACCEPT, "text/event-stream");
+        assertThat(channel.writeInbound(req))
+                .as("Accept is legitimately repeatable; only MCP singletons are policed")
+                .isTrue();
+        assertThat(rejectionStatus()).isNull();
+    }
+
+    @Test
+    void releasesRejectedInboundRequest() {
+        var req = request();
+        req.headers().add("Mcp-Method", "tools/call");
+        req.headers().add("Mcp-Method", "tools/list");
+        channel.writeInbound(req);
+        assertThat(req.refCnt())
+                .as("a rejected inbound request must be released, not leaked")
+                .isZero();
+        assertThat(rejectionStatus()).isEqualTo(HttpResponseStatus.BAD_REQUEST);
+    }
+
+    /**
+     * Header/body agreement is enforced only by the 2026-07-28 {@code RequestValidationHandler}, so a
+     * mirror sent under any older version is never compared to the body: a gateway would route on
+     * {@code Mcp-Method: tools/list} while the body ran {@code tools/call}.
+     */
+    @ParameterizedTest
+    @ValueSource(strings = {"Mcp-Method", "Mcp-Name", "Mcp-Param-Region"})
+    void rejectsMirroredHeaderOnOlderProtocolVersion(String header) {
+        var req = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/mcp");
+        req.headers().set(HttpHeaderNames.HOST, "localhost:8096");
+        req.headers().set("MCP-Protocol-Version", "2025-11-25");
+        req.headers().add(header, "tools/list");
+        channel.writeInbound(req);
+        assertThat(rejectionStatus()).isEqualTo(HttpResponseStatus.BAD_REQUEST);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"Mcp-Method", "Mcp-Name", "Mcp-Param-Region"})
+    void rejectsMirroredHeaderWithNoProtocolVersion(String header) {
+        var req = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/mcp");
+        req.headers().set(HttpHeaderNames.HOST, "localhost:8096");
+        req.headers().add(header, "tools/list");
+        channel.writeInbound(req);
+        assertThat(rejectionStatus())
+                .as("an absent version header negotiates an older revision, which never checks the mirror")
+                .isEqualTo(HttpResponseStatus.BAD_REQUEST);
+    }
+
+    @Test
+    void forwardsOlderProtocolVersionWithoutMirroredHeaders() {
+        var req = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/mcp");
+        req.headers().set(HttpHeaderNames.HOST, "localhost:8096");
+        req.headers().set("MCP-Protocol-Version", "2025-11-25");
+        assertThat(channel.writeInbound(req))
+                .as("older clients never sent the mirrors; nothing to guard")
+                .isTrue();
+        assertThat(rejectionStatus()).isNull();
+    }
+
+    @Test
+    void rejectsDuplicateVersionHeaderBeforeReadingItForTheMirrorGate() {
+        var req = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/mcp");
+        req.headers().set(HttpHeaderNames.HOST, "localhost:8096");
+        req.headers().add("MCP-Protocol-Version", "2025-11-25");
+        req.headers().add("MCP-Protocol-Version", McpProtocol.VERSION);
+        req.headers().add("Mcp-Method", "tools/call");
+        channel.writeInbound(req);
+        assertThat(rejectionStatus())
+                .as("the gate must never resolve the version from an ambiguous field")
+                .isEqualTo(HttpResponseStatus.BAD_REQUEST);
+    }
+}

--- a/tachyon-testkit/src/main/java/dev/tachyonmcp/testkit/McpHttpResponseAssert.java
+++ b/tachyon-testkit/src/main/java/dev/tachyonmcp/testkit/McpHttpResponseAssert.java
@@ -1,0 +1,87 @@
+/* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
+package dev.tachyonmcp.testkit;
+
+import dev.tachyonmcp.testkit.JsonRpcResponseAssert.JsonRpcErrorAssert;
+import dev.tachyonmcp.testkit.JsonRpcResponseAssert.JsonRpcSuccessAssert;
+import java.net.http.HttpResponse;
+import org.assertj.core.api.AbstractAssert;
+
+/**
+ * Assertions over a raw MCP HTTP response, for the cases {@link JsonRpcResponseAssert} alone cannot
+ * cover: the HTTP status, and rejections the transport answers in plain text before a JSON-RPC
+ * envelope exists (a duplicate header, an unusable protocol version, an oversized body).
+ *
+ * <p>Chains into the JSON-RPC assertions once the status is checked:
+ *
+ * <pre>{@code
+ * assertThatResponse(response).hasStatus(400).isJsonRpcError().hasId(9).hasErrorCode(-32020);
+ * assertThatResponse(response).isRejectedWith(400, "Duplicate MCP header");
+ * }</pre>
+ */
+public final class McpHttpResponseAssert extends AbstractAssert<McpHttpResponseAssert, HttpResponse<String>> {
+
+    private McpHttpResponseAssert(HttpResponse<String> response) {
+        super(response, McpHttpResponseAssert.class);
+    }
+
+    /**
+     * Creates assertions for an MCP HTTP response.
+     *
+     * @param response the HTTP response
+     * @return assertions over that response
+     */
+    public static McpHttpResponseAssert assertThatResponse(HttpResponse<String> response) {
+        return new McpHttpResponseAssert(response);
+    }
+
+    /**
+     * Verifies the HTTP status, reporting the body on failure — it usually says why.
+     *
+     * @param expected the expected HTTP status code
+     * @return this assertion for chaining
+     */
+    public McpHttpResponseAssert hasStatus(int expected) {
+        isNotNull();
+        if (actual.statusCode() != expected) {
+            failWithMessage("Expected HTTP status <%d> but was <%d>: %s", expected, actual.statusCode(), actual.body());
+        }
+        return this;
+    }
+
+    /**
+     * Verifies a plain-text transport rejection: the status, and the exact body. Asserting the body
+     * matters — a JSON-RPC error carries the same status, so the status alone would not prove which
+     * layer rejected the request.
+     *
+     * @param expectedStatus the expected HTTP status code
+     * @param expectedBody   the expected plain-text body
+     * @return this assertion for chaining
+     */
+    public McpHttpResponseAssert isRejectedWith(int expectedStatus, String expectedBody) {
+        hasStatus(expectedStatus);
+        if (!expectedBody.equals(actual.body())) {
+            failWithMessage("Expected plain-text body <%s> but was <%s>", expectedBody, actual.body());
+        }
+        return this;
+    }
+
+    /**
+     * Verifies the body is a JSON-RPC error and returns error-only assertions.
+     *
+     * @return assertions for the JSON-RPC error branch
+     */
+    public JsonRpcErrorAssert isJsonRpcError() {
+        isNotNull();
+        return JsonRpcResponseAssert.assertThat(actual).isJsonRpcError();
+    }
+
+    /**
+     * Verifies the body is a successful JSON-RPC response and returns success-only assertions.
+     *
+     * @return assertions for the JSON-RPC success branch
+     */
+    public JsonRpcSuccessAssert isSuccess() {
+        isNotNull();
+        return JsonRpcResponseAssert.assertThat(actual).isSuccess();
+    }
+}


### PR DESCRIPTION
Keeps the HTTP view of a request and the executed view from diverging, which is the whole point of mirroring routing values into headers.

Request validation:

- Reject duplicate singleton MCP headers pre-aggregation (McpHeaderGuardHandler). Netty's HttpHeaders#get takes the first value while an intermediary may take the last; for MCP-Protocol-Version that disagreement is a silent downgrade.
- Reject SEP-2243 mirrors on requests that negotiate an older revision, where nothing would ever compare them to the body. A version this server does not support is left alone, so UnsupportedProtocolVersionError still answers it with the supported-version list.
- Validate Mcp-Method on notifications too. The header is required for "all requests and notifications", and this revision does define a client-to-server one (ClientNotification = CancelledNotification).
- Enforce the Mcp-Param-* character restrictions. Netty already rejects NUL/CR/LF but passes 0x80-0xFF through as ISO-8859-1.
- Compare mirrored numbers numerically. JSON Schema accepts 42.0 as an integer, so the previous string-only path skipped the header comparison entirely and left the value spoofable. Values past 2^53-1 are rejected: they cannot round-trip through a JavaScript intermediary intact.

Tool registration:

- Validate x-mcp-header annotations: non-empty RFC 9110 token, case-insensitively unique, primitive types only, top-level properties only. A nested annotation is now rejected rather than silently ignored — the SEP's constraints allow any depth but its conformance suite requires servers to reject, and an annotation a server accepts but never validates leaves the header spoofable.

Transport hygiene:

- Share the reject-and-drop guard across every pre-aggregation validator. The Accept and stateless handlers never released the rejected message, and the endpoint validator forwarded trailing HttpContent after closing.

Documents the new rejections and x-mcp-header itself, which was undocumented. Notes that a session id is not an authentication credential.

make ci passes, conformance included.