### PR TITLE
feat(interceptors): add McpInterceptor SPI and OpenTelemetry integration (#149)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,19 @@ jobs:
           distribution: temurin
           cache: maven
 
+      - name: Set up Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: 24
+
+      - name: Cache npx conformance package
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: npm-conformance-${{ runner.os }}-${{ hashFiles('conformance/src/test/java/dev/tachyonmcp/conformance/*ConformanceTest.java') }}
+          restore-keys: |
+            npm-conformance-${{ runner.os }}-
+
       - name: Build and Verify
         run: make ci
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ application framework.
   TTL cleanup.
 - **Production transport** -- Netty backpressure, graceful shutdown, DNS-rebinding protection,
   CORS, and native transport auto-detection (`io_uring` → `epoll` → `kqueue` → NIO).
+- **Observability seam** -- an `McpInterceptor` wraps every request and notification; the optional `tachyon-otel` module ships the OpenTelemetry MCP semantic conventions.
 
 ## Quickstart
 
@@ -104,6 +105,7 @@ See the [quickstart](docs/quickstart.md) for Java and Kotlin examples plus a `cu
 - [Tools](docs/tools.md), [resources](docs/resources.md), and [tasks](docs/tasks.md) -- feature APIs and examples
 - [Annotations](docs/annotations.md) -- mcp-java, LangChain4j, and Spring AI providers
 - [Extensions](docs/extensions.md) and [MCP Skills](docs/extensions/mcp-skills.md) -- custom protocol methods and SEP support
+- [Observability](docs/observability.md) -- interceptors, OpenTelemetry, and auditing
 - [Kotlin DSL](docs/kotlin.md) -- builders, scopes, and suspending handlers
 - [Examples](examples/README.md) -- runnable Java and Kotlin servers
 - [FAQ](docs/faq.md) -- frameworks, concurrency, deployment, and compatibility

--- a/conformance/src/test/java/dev/tachyonmcp/conformance/AbstractConformanceServer.java
+++ b/conformance/src/test/java/dev/tachyonmcp/conformance/AbstractConformanceServer.java
@@ -36,12 +36,12 @@ import org.jspecify.annotations.Nullable;
 abstract class AbstractConformanceServer {
 
     // language=json
-    protected static final JsonSchema INPUT_SCHEMA_NO_ARGS = parseJson("""
+    protected static final JsonSchema INPUT_SCHEMA_NO_ARGS = JsonSchema.unchecked("""
         {"type": "object", "properties": {}, "additionalProperties": false}
         """);
 
     // language=json
-    protected static final JsonSchema INPUT_SCHEMA_WITH_PROMPT = parseJson("""
+    protected static final JsonSchema INPUT_SCHEMA_WITH_PROMPT = JsonSchema.unchecked("""
         {
             "type": "object",
             "properties": {"prompt": {"type": "string"}},
@@ -51,7 +51,7 @@ abstract class AbstractConformanceServer {
         """);
 
     // language=json
-    protected static final JsonSchema INPUT_SCHEMA_WITH_MESSAGE = parseJson("""
+    protected static final JsonSchema INPUT_SCHEMA_WITH_MESSAGE = JsonSchema.unchecked("""
         {
             "type": "object",
             "properties": {"message": {"type": "string"}},
@@ -69,16 +69,18 @@ abstract class AbstractConformanceServer {
 
     private static final String HMAC_SECRET = "conformance-test-hmac-secret";
 
-    protected static JsonSchema parseJson(String json) {
-        return JsonSchema.from(json, String.class);
-    }
-
     protected static FormInputRequest buildFormElicitation(String message, String propName, String propType) {
-        var schema = new LinkedHashMap<String, Object>();
-        schema.put("type", "object");
-        schema.put("properties", Map.of(propName, Map.of("type", propType)));
-        schema.put("required", List.of(propName));
-        return FormInputRequest.of(message, schema);
+        // language=Json
+        final var jsonSchema = JsonSchema.unchecked("""
+            {
+                "type": "object",
+                "properties": {
+                    "%s": {"type": "%s"}
+                },
+                "required": ["%s"]
+            }
+            """.formatted(propName, propType, propName));
+        return FormInputRequest.builder().message(message).requestedSchema(jsonSchema).build();
     }
 
     protected static RpcMethodRequest buildSamplingRequest(String questionText) {
@@ -111,7 +113,7 @@ abstract class AbstractConformanceServer {
 
     private static JsonSchema buildJsonSchema() {
         // language=json
-        return parseJson("""
+        return JsonSchema.unchecked("""
             {
                 "$schema": "https://json-schema.org/draft/2020-12/schema",
                 "type": "object",
@@ -170,7 +172,7 @@ abstract class AbstractConformanceServer {
      */
     private void registerTools(ServerEngine server) {
         // language=json
-        var echoSchema = parseJson("""
+        var echoSchema = JsonSchema.unchecked("""
             {
                 "type": "object",
                 "properties": {"message": {"type": "string", "description": "Message to echo"}}

--- a/conformance/src/test/java/dev/tachyonmcp/conformance/AbstractConformanceServer.java
+++ b/conformance/src/test/java/dev/tachyonmcp/conformance/AbstractConformanceServer.java
@@ -80,7 +80,10 @@ abstract class AbstractConformanceServer {
                 "required": ["%s"]
             }
             """.formatted(propName, propType, propName));
-        return FormInputRequest.builder().message(message).requestedSchema(jsonSchema).build();
+        return FormInputRequest.builder()
+                .message(message)
+                .requestedSchema(jsonSchema)
+                .build();
     }
 
     protected static RpcMethodRequest buildSamplingRequest(String questionText) {

--- a/conformance/src/test/resources/junit-platform.properties
+++ b/conformance/src/test/resources/junit-platform.properties
@@ -1,4 +1,4 @@
 junit.jupiter.execution.parallel.enabled = true
 junit.jupiter.execution.parallel.mode.default = concurrent
 junit.jupiter.execution.parallel.config.executor-service=WORKER_THREAD_POOL
-junit.jupiter.execution.timeout.default = 1 m
+junit.jupiter.execution.timeout.default = 3 m

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,10 @@
 - [Annotations](annotations.md)
 - [JSON and JSON Schema](json.md)
 
+## Operate
+
+- [Observability: interceptors, OpenTelemetry, auditing](observability.md)
+
 ## Testing
 
 - [Testkit](testkit.md)

--- a/docs/architecture/guidance.md
+++ b/docs/architecture/guidance.md
@@ -414,16 +414,38 @@ type.** Spring's lasting wound is four competing seams — `Filter`, `HandlerInt
 
 - The seam is `McpDispatcher.decodeAndHandleAsync` plus `dispatchNotification`, so `initialize`,
   every request, and every notification are covered by one chain.
+- **The seam is synchronous**: `intercept` returns an `McpOutcome`, blocking on the dispatch virtual
+  thread. Do not reintroduce `CompletionStage` here. Blocking is what makes chain and handler share
+  one stack, and that single stack is what keeps the outbound-stream binding
+  (`OutboundSseStreamMessageRouter`, thread-scoped) and any caller `ThreadLocal` — OpenTelemetry
+  `Context`, MDC — in scope for the handler. An async seam cannot promise that, and its
+  "call `proceed()` on the intercept thread or lose progress notifications" rule was a documented
+  footgun rather than a contract anything enforced.
+- **Failures are values, not a second channel.** `Chain.proceed()` never throws on the remainder's
+  behalf: `InterceptorChain` catches and routes through `McpOutcomes`, so an interceptor writes one
+  `switch` and no `catch`. `McpOutcome.Failure.cause()` exists so folding a throw into a value does
+  not lose the stack trace an audit log or tracer needs; only `Failure.error()` reaches the client.
 - Registration is explicit (`ServerBuilder.withInterceptors`), first registered = outermost.
   **No `ServiceLoader` discovery** — auto-discovery is what makes interceptor ordering unfixable
   once a third-party jar joins the chain.
-- `McpInterceptor` and `McpInterceptor.Chain` are *user-implemented*: adding a method breaks every
-  implementor, so they are frozen. `McpInvocation` is *library-implemented* and documented as
-  not-for-implementation, so it may grow methods freely. Classify any new SPI type this way before
-  adding it.
+- `McpInterceptor` is *user-implemented*: adding a method breaks every implementor, so it is
+  frozen. `McpInterceptor.Chain` and `McpInvocation` are *library-implemented* and documented as
+  not-for-implementation, so they may grow methods freely — which is what leaves room for a future
+  `proceed(McpInvocation)` (request rewriting). Do not ship a `Chain` test double that would make
+  application code implement it again. Classify any new SPI type this way before adding it.
 - The zero-interceptor path must stay allocation-free — it is the default for every existing user.
 - Outbound (server→client) interception, when it lands, is a second `Chain` on the same
-  `McpInterceptor`, never a rival interface.
+  `McpInterceptor`, never a rival interface. ⚠️ It must then be synchronous too, which requires
+  outbound writes to originate on a virtual thread rather than the event loop — verify that before
+  designing it.
+- ⚠️ A handler whose stage stays pending for the life of an SSE subscription
+  (`subscriptions/listen`) parks the dispatch thread for that long once an interceptor is
+  registered. Bounded by the open connection it belongs to, which costs more than the parked
+  continuation; see the `ponytail:` note on `McpDispatcher.handled` for the split to make if it
+  ever matters.
+- `ThreadLocal` in `OutboundSseStreamMessageRouter` becomes `ScopedValue` when the baseline reaches
+  Java 25 (final in JEP 506; the module is `@InternalApi`, so the swap is not breaking). Never put
+  `ScopedValue` or `StructuredTaskScope` in a public signature, or that bump turns into one.
 
 ## 🔴 Resolve protocol facts before they leave core
 

--- a/docs/architecture/guidance.md
+++ b/docs/architecture/guidance.md
@@ -405,4 +405,38 @@ JSpecify `@Nullable` is the baseline (`@NullMarked` at package level). Reach for
 
 A stringly-typed attribute bag has two failure modes that compile clean and break at runtime — an unchecked cast on every read (`getAttribute(String)` lets the caller pick any `T`, wrong guess throws `ClassCastException` far from the write site), and silent collision (two unrelated features reusing the same string key overwrite each other). `AttributeKey<T>` fixes both: the key carries `T` so there's no cast at the call site, and keys are identity-based (`AttributeKey.of(name)` returns a distinct object per call, no name-interning registry) so two keys can never collide — retrieval requires holding the actual key instance, not guessing a string. Use this for any future context-carried extension/scratch state; don't reintroduce a generic `Map<String,Object>` surface on a handler-facing type.
 
+## 🔴 One cross-cutting seam: `McpInterceptor`
+
+Tracing, auditing, authorization, rate limiting and metrics are all `McpInterceptor`s
+(`tachyon-api`, `dev.tachyonmcp.api.server.interceptor`). **Do not add a second per-request hook
+type.** Spring's lasting wound is four competing seams — `Filter`, `HandlerInterceptor`, `@Around`,
+`WebFilter` — with no rule for choosing between them.
+
+- The seam is `McpDispatcher.decodeAndHandleAsync` plus `dispatchNotification`, so `initialize`,
+  every request, and every notification are covered by one chain.
+- Registration is explicit (`ServerBuilder.withInterceptors`), first registered = outermost.
+  **No `ServiceLoader` discovery** — auto-discovery is what makes interceptor ordering unfixable
+  once a third-party jar joins the chain.
+- `McpInterceptor` and `McpInterceptor.Chain` are *user-implemented*: adding a method breaks every
+  implementor, so they are frozen. `McpInvocation` is *library-implemented* and documented as
+  not-for-implementation, so it may grow methods freely. Classify any new SPI type this way before
+  adding it.
+- The zero-interceptor path must stay allocation-free — it is the default for every existing user.
+- Outbound (server→client) interception, when it lands, is a second `Chain` on the same
+  `McpInterceptor`, never a rival interface.
+
+## 🔴 Resolve protocol facts before they leave core
+
+An interceptor sits *before* response mapping, so anything it needs about the response must be
+resolved for it. `McpOutcome` is that resolution: the dispatcher classifies the handler result
+through the negotiated `ProtocolResponseMapper` (`McpOutcomes`) and hands interceptors
+`Success` / `PayloadFailure` / `Failure(error, jsonRpcCode)`.
+
+**No module outside `tachyon-core` may re-derive a protocol-version-specific mapping.** The
+temptation is a switch over `ServerError.Kind` → JSON-RPC code; it is wrong, because 2025-11-25 and
+2026-07-28 disagree on several kinds (`RESOURCE_NOT_FOUND` is `-32002` vs `-32602`,
+`HEADER_MISMATCH` `-32001` vs `-32020`). When an integration needs a protocol fact, add the query to
+`ProtocolResponseMapper` — as `isPayloadError` did for `CallToolResult.isError` — and let each codec
+answer for its own wire shape.
+
 Testing handler dispatch/error mapping: see [`tachyon-development` skill](../../.agents/skills/tachyon-development/SKILL.md).

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,8 +1,12 @@
 # Observability
 
-Tachyon has one cross-cutting seam: `McpInterceptor`. It wraps **every** inbound MCP operation —
-`initialize`, every request, every notification — and is where tracing, auditing, authorization and
-rate limiting belong. There is deliberately no second per-request hook type.
+Tachyon has one cross-cutting seam: `McpInterceptor`. It wraps every MCP operation that reaches a
+handler — `initialize`, requests and notifications alike — and is where tracing, auditing,
+authorization and rate limiting belong. There is deliberately no second per-request hook type.
+
+⚠️ Requests refused before handler lookup do **not** reach the chain: unknown method, unknown or
+missing session, a method gated off by a disabled extension. An audit or metrics interceptor
+undercounts exactly those.
 
 ## The interceptor SPI
 
@@ -10,22 +14,29 @@ rate limiting belong. There is deliberately no second per-request hook type.
 package dev.tachyonmcp.api.server.interceptor;
 
 public interface McpInterceptor {
-    CompletionStage<McpOutcome> intercept(McpInvocation invocation, Chain chain);
+    McpOutcome intercept(McpInvocation invocation, Chain chain) throws Exception;
 
     interface Chain {
-        CompletionStage<McpOutcome> proceed();
+        /** Runs the rest of the chain and the handler, blocking until they produce an outcome. */
+        McpOutcome proceed();
 
         /** Short-circuits; the wire code is resolved for you. */
-        CompletionStage<McpOutcome> reject(ServerError error);
+        McpOutcome reject(ServerError error);
     }
 }
 
 public sealed interface McpOutcome {
     record Success(@Nullable Object result) implements McpOutcome {}
     record PayloadFailure(@Nullable Object result) implements McpOutcome {}
-    record Failure(ServerError error, int jsonRpcCode) implements McpOutcome {}
+    record Failure(ServerError error, int jsonRpcCode, @Nullable Throwable cause) implements McpOutcome {}
 }
 ```
+
+The seam is **synchronous**: `intercept` runs on the dispatch virtual thread and blocks until the
+rest of the chain is done, so an interceptor is ordinary sequential code — `try/finally` for timing,
+a `for` loop for retry, a `Semaphore` for a concurrency bound. Blocking is the point of a virtual
+thread; chain and handler share one stack, which is what keeps the handler's outbound stream and
+any `ThreadLocal` context (OpenTelemetry's `Context`, MDC) in scope for the whole dispatch.
 
 `McpOutcome` is what the dispatcher produces *after* resolving the result against the negotiated
 protocol version, so an interceptor sees what the wire will actually carry:
@@ -34,7 +45,7 @@ protocol version, so an interceptor sees what the wire will actually carry:
 |---|---|
 | `Success` | the response carries the handler's result |
 | `PayloadFailure` | JSON-RPC success, but the payload reports failure — today a `tools/call` with `isError: true` |
-| `Failure` | JSON-RPC error; `jsonRpcCode` is this protocol version's code |
+| `Failure` | JSON-RPC error; `jsonRpcCode` is this protocol version's code, `cause()` the exception it came from (or `null`) |
 
 🔴 Never re-derive a JSON-RPC code from `ServerError.Kind`. MCP 2025-11-25 and 2026-07-28 map
 several kinds differently (`RESOURCE_NOT_FOUND` is `-32002` on one and `-32602` on the other), which
@@ -75,24 +86,54 @@ TachyonServer(port = 8080) {
 ### Contract
 
 - **One instance serves every concurrent operation.** Implementations must be thread-safe and keep
-  no per-request state in fields — keep it in local variables and close over it in the returned
-  stage. 🔴 Not in `invocation.context()`: that attribute space is scoped to the *connection*, so
-  concurrent requests on one connection share it.
-- `intercept` runs on the handler's virtual thread. Blocking for I/O is fine; `synchronized` is not
-  (it pins the carrier thread) — use `ReentrantLock`.
-- Call `chain.proceed()` from the `intercept` thread. The stage it returns may complete on another.
-  🔴 Deferring `proceed()` to another thread detaches the handler from the dispatch's outbound
-  stream, silently dropping any progress notification the handler sends. Delay the *response*, never
-  the call to `proceed()`.
+  no per-request state in fields — keep it in local variables. 🔴 Not in `invocation.context()`:
+  that attribute space is scoped to the *connection*, so concurrent requests on one connection
+  share it.
+- Blocking for I/O is fine; `synchronized` is not (it pins the carrier thread) — use
+  `ReentrantLock`. The chain and the handler share one stack, so a pinning interceptor pins the
+  handler too.
+- **Failures are values.** `chain.proceed()` returns `Failure` for a throwing handler and for a
+  throwing downstream interceptor alike, and never throws on their behalf — one `switch`, no
+  `catch`. Use `finally` to cover an exception thrown by *this* interceptor.
+- An exception thrown out of `intercept` becomes a JSON-RPC internal error, exactly as a throwing
+  handler does, and reaches an outer interceptor as `Failure.cause()`. Only the sanitized
+  `Failure.error()` goes to the client.
 - An `McpInvocation` is valid only during the interception; `sessionId()` reads through the live
   dispatch. Copy out what you need rather than retaining it.
 - Returning `chain.reject(error)` instead of `chain.proceed()` short-circuits the handler — the
   authorization and rate-limiting path.
-- Errors travel as a failed `CompletionStage`. An exception thrown out of `intercept` is mapped to
-  a JSON-RPC internal error, exactly as a throwing handler is.
+- `chain.proceed()` may be called more than once; each call re-runs the rest of the chain and the
+  handler.
 
-Implement `McpInterceptor` and `Chain`; do **not** implement `McpInvocation` — it gains methods
-between releases.
+Implement `McpInterceptor`; do **not** implement `Chain` or `McpInvocation` — both are
+library-implemented and gain methods between releases. Test an interceptor against a running server.
+
+### Bounding concurrency
+
+Nothing in Tachyon caps in-flight requests: an unbounded virtual-thread executor will happily run
+10k slow tool calls against a downstream that tolerates 500. A synchronous chain makes the bound six
+lines, and `try/finally` cannot leak a permit:
+
+```java
+final class AdmissionInterceptor implements McpInterceptor {
+
+    private final Semaphore permits = new Semaphore(512);
+
+    @Override
+    public McpOutcome intercept(McpInvocation invocation, Chain chain) throws Exception {
+        if (!permits.tryAcquire(50, TimeUnit.MILLISECONDS)) {
+            return chain.reject(new ServerError(ServerError.Kind.INVALID_REQUEST, "Server overloaded"));
+        }
+        try {
+            return chain.proceed();
+        } finally {
+            permits.release();
+        }
+    }
+}
+```
+
+Register it outermost so the permit covers everything behind it.
 
 ## OpenTelemetry
 
@@ -194,7 +235,7 @@ final class AuditInterceptor implements McpInterceptor {
     private static final Logger log = LoggerFactory.getLogger(AuditInterceptor.class);
 
     @Override
-    public CompletionStage<Object> intercept(McpInvocation invocation, Chain chain) {
+    public McpOutcome intercept(McpInvocation invocation, Chain chain) {
         // Copied up front: the invocation is only valid for the duration of the interception.
         final var method = invocation.method();
         final var target = invocation.targetName().orElse("-");
@@ -202,14 +243,16 @@ final class AuditInterceptor implements McpInterceptor {
         final var sessionId = invocation.sessionId();
         final var startNanos = System.nanoTime();
 
-        return chain.proceed().whenComplete((outcome, error) -> log.info(
+        final var outcome = chain.proceed();
+        log.info(
                 "mcp method={} target={} id={} session={} outcome={} ms={}",
                 method,
                 target,
                 requestId,
                 sessionId,
-                error != null ? "failed" : describe(outcome),
-                (System.nanoTime() - startNanos) / 1_000_000));
+                describe(outcome),
+                (System.nanoTime() - startNanos) / 1_000_000);
+        return outcome;
     }
 
     private static String describe(McpOutcome outcome) {

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,235 @@
+# Observability
+
+Tachyon has one cross-cutting seam: `McpInterceptor`. It wraps **every** inbound MCP operation —
+`initialize`, every request, every notification — and is where tracing, auditing, authorization and
+rate limiting belong. There is deliberately no second per-request hook type.
+
+## The interceptor SPI
+
+```java
+package dev.tachyonmcp.api.server.interceptor;
+
+public interface McpInterceptor {
+    CompletionStage<McpOutcome> intercept(McpInvocation invocation, Chain chain);
+
+    interface Chain {
+        CompletionStage<McpOutcome> proceed();
+
+        /** Short-circuits; the wire code is resolved for you. */
+        CompletionStage<McpOutcome> reject(ServerError error);
+    }
+}
+
+public sealed interface McpOutcome {
+    record Success(@Nullable Object result) implements McpOutcome {}
+    record PayloadFailure(@Nullable Object result) implements McpOutcome {}
+    record Failure(ServerError error, int jsonRpcCode) implements McpOutcome {}
+}
+```
+
+`McpOutcome` is what the dispatcher produces *after* resolving the result against the negotiated
+protocol version, so an interceptor sees what the wire will actually carry:
+
+| Case | Meaning |
+|---|---|
+| `Success` | the response carries the handler's result |
+| `PayloadFailure` | JSON-RPC success, but the payload reports failure — today a `tools/call` with `isError: true` |
+| `Failure` | JSON-RPC error; `jsonRpcCode` is this protocol version's code |
+
+🔴 Never re-derive a JSON-RPC code from `ServerError.Kind`. MCP 2025-11-25 and 2026-07-28 map
+several kinds differently (`RESOURCE_NOT_FOUND` is `-32002` on one and `-32602` on the other), which
+is exactly why `Failure` carries the resolved code and `Chain.reject` resolves it for you.
+
+`McpInvocation` describes the operation:
+
+| Method | Value |
+|---|---|
+| `method()` | `tools/call`, `initialize`, `notifications/cancelled`, … |
+| `requestId()` | JSON-RPC id, or `null` for a notification |
+| `sessionId()` | MCP session id, or `null` in stateless mode |
+| `protocolVersion()` | negotiated version, e.g. `2025-11-25` |
+| `targetName()` | top-level `name` param — the tool or prompt being called |
+| `resourceUri()` | top-level `uri` param — `resources/read` and friends |
+| `params()` | raw wire params as a `JsonDocument`, encoded lazily on first call |
+| `context()` | the handler-facing `InteractionContext` |
+
+### Registration
+
+```java
+var server = TachyonServer.builder()
+        .withInterceptors(tracing, audit)   // tracing is the outermost
+        .build();
+```
+
+Repeated calls append. There is no `ServiceLoader` discovery: the application owns the order, and
+no dependency can silently insert itself into the chain.
+
+Kotlin:
+
+```kotlin
+TachyonServer(port = 8080) {
+    interceptors(tracing, audit)
+}
+```
+
+### Contract
+
+- **One instance serves every concurrent operation.** Implementations must be thread-safe and keep
+  no per-request state in fields — keep it in local variables and close over it in the returned
+  stage. 🔴 Not in `invocation.context()`: that attribute space is scoped to the *connection*, so
+  concurrent requests on one connection share it.
+- `intercept` runs on the handler's virtual thread. Blocking for I/O is fine; `synchronized` is not
+  (it pins the carrier thread) — use `ReentrantLock`.
+- Call `chain.proceed()` from the `intercept` thread. The stage it returns may complete on another.
+  🔴 Deferring `proceed()` to another thread detaches the handler from the dispatch's outbound
+  stream, silently dropping any progress notification the handler sends. Delay the *response*, never
+  the call to `proceed()`.
+- An `McpInvocation` is valid only during the interception; `sessionId()` reads through the live
+  dispatch. Copy out what you need rather than retaining it.
+- Returning `chain.reject(error)` instead of `chain.proceed()` short-circuits the handler — the
+  authorization and rate-limiting path.
+- Errors travel as a failed `CompletionStage`. An exception thrown out of `intercept` is mapped to
+  a JSON-RPC internal error, exactly as a throwing handler is.
+
+Implement `McpInterceptor` and `Chain`; do **not** implement `McpInvocation` — it gains methods
+between releases.
+
+## OpenTelemetry
+
+`integrations/tachyon-otel` implements the
+[OpenTelemetry MCP semantic conventions](https://github.com/open-telemetry/semantic-conventions-genai/tree/main/model/mcp),
+against `opentelemetry-semconv-incubating`.
+
+```xml
+<dependency>
+    <groupId>dev.tachyonmcp</groupId>
+    <artifactId>tachyon-otel</artifactId>
+</dependency>
+```
+
+```java
+var server = TachyonServer.builder()
+        .withInterceptors(McpTelemetryInterceptor.create(GlobalOpenTelemetry.get()))
+        .withTools(tools -> tools.register(t -> t.name("forecast"), (ctx, req) -> forecast(req)))
+        .build();
+```
+
+It emits one `SERVER` span per operation, named `{mcp.method.name} {target}` (`tools/call forecast`),
+plus the `mcp.server.operation.duration` histogram in seconds.
+
+| Attribute | Where |
+|---|---|
+| `mcp.method.name`, `mcp.protocol.version`, `network.transport`, `network.protocol.name` | span + metric |
+| `gen_ai.tool.name`, `gen_ai.operation.name=execute_tool` (on `tools/call`) | span + metric |
+| `gen_ai.prompt.name` (on `prompts/get`) | span + metric |
+| `error.type`, `rpc.response.status_code` (a **string**, per semconv) | span + metric |
+| `mcp.session.id`, `jsonrpc.request.id`, `mcp.resource.uri` | span only |
+| `gen_ai.tool.call.arguments` | span only, **opt-in** |
+
+Session and request ids are kept off the histogram on purpose — one time series per request would
+melt a metrics backend.
+
+### About the semconv constants
+
+`jsonrpc.request.id`, `rpc.response.status_code`, `error.type` and the `network.*` keys come from
+the generated `opentelemetry-semconv` / `-incubating` constants.
+
+The `mcp.*` and `gen_ai.*` keys do not: the incubating artifact **deprecated** them with *"Moved to
+the OpenTelemetry GenAI semantic conventions repository"*, and that repository publishes no Java
+artifact — `io.opentelemetry.semconv` still ships only `opentelemetry-semconv` and
+`opentelemetry-semconv-incubating`. Importing constants that are deprecated with nowhere to go
+means warnings now and a broken build when OTel removes them, so those keys are declared in
+`McpAttributes` instead, the way OpenTelemetry's own instrumentation libraries handle unstable
+conventions. That class is deleted the day a GenAI semconv Java artifact ships.
+
+### Span status
+
+Only genuine server faults set the span status to `ERROR`. The conventions list the JSON-RPC codes a
+server returns because the *caller* sent something it could not serve — `-32700`, `-32600`, `-32601`,
+`-32602`, `-32002` — and those leave the status `UNSET` while still recording
+`rpc.response.status_code`.
+
+### Trace context
+
+Spans are parented by `Context.current()`.
+
+- **With the OpenTelemetry Java agent** (`-javaagent:opentelemetry-javaagent.jar`): the agent
+  instruments Netty and the JDK executors, so the incoming `traceparent` header is extracted, an
+  HTTP `SERVER` span is created, and the context survives Tachyon's async hops. MCP spans appear as
+  children of the HTTP span with no extra configuration. **This is the supported setup.**
+- **SDK only, no agent**: MCP spans are roots. This interceptor does not read HTTP headers itself —
+  adding a Netty library instrumentation through `pipelineCustomizer` is not enough either, because
+  library mode does not propagate context across the executor hop.
+
+### Security
+
+`gen_ai.tool.call.arguments` is **off by default**. Tool arguments routinely carry credentials and
+personal data, and spans are commonly exported to third-party backends. Enable it deliberately:
+
+```java
+McpTelemetryInterceptor.builder(GlobalOpenTelemetry.get())
+        .recordPayloads(true)
+        .build();
+```
+
+Tool *results* are never recorded — rendering a `ToolResult` as a span attribute would mean
+serializing a domain object outside the server's configured payload serializer.
+
+### Not covered yet
+
+| Gap | Why |
+|---|---|
+| W3C `traceparent` extraction without the agent | inbound HTTP headers do not reach the dispatcher |
+| `mcp.server.session.duration` | needs a session open/close hook, not a per-request seam |
+| `client.address` / `client.port` | not exposed on the channel context |
+| Outbound `mcp.client` spans (`sampling/createMessage`, `elicitation/create`) | server→client requests do not pass through the chain |
+
+## Auditing
+
+Auditing needs no separate API — it is an interceptor:
+
+```java
+final class AuditInterceptor implements McpInterceptor {
+
+    private static final Logger log = LoggerFactory.getLogger(AuditInterceptor.class);
+
+    @Override
+    public CompletionStage<Object> intercept(McpInvocation invocation, Chain chain) {
+        // Copied up front: the invocation is only valid for the duration of the interception.
+        final var method = invocation.method();
+        final var target = invocation.targetName().orElse("-");
+        final var requestId = invocation.requestId();
+        final var sessionId = invocation.sessionId();
+        final var startNanos = System.nanoTime();
+
+        return chain.proceed().whenComplete((outcome, error) -> log.info(
+                "mcp method={} target={} id={} session={} outcome={} ms={}",
+                method,
+                target,
+                requestId,
+                sessionId,
+                error != null ? "failed" : describe(outcome),
+                (System.nanoTime() - startNanos) / 1_000_000));
+    }
+
+    private static String describe(McpOutcome outcome) {
+        return switch (outcome) {
+            case McpOutcome.Success ignored -> "ok";
+            case McpOutcome.PayloadFailure ignored -> "tool_error";
+            case McpOutcome.Failure f -> f.error().kind() + "/" + f.jsonRpcCode();
+        };
+    }
+}
+```
+
+`invocation.params()` gives the raw request JSON when the audit trail needs the payload. Treat it as
+confidential — log it at `TRACE`, or redact before writing. See the
+[logging policy](https://kpavlov.me/blog/logging-policy/).
+
+## Slow request logging
+
+Independent of interceptors, the server can warn about handlers that exceed a threshold:
+
+```java
+TachyonServer.builder().monitoring(m -> m.slowRequestLogging().slowRequestThreshold(Duration.ofSeconds(5)));
+```

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/InterceptorChainTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/InterceptorChainTest.java
@@ -3,6 +3,7 @@ package dev.tachyonmcp.e2e.mcp;
 
 import static dev.tachyonmcp.testkit.McpHttpResponseAssert.assertThatResponse;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.InstanceOfAssertFactories.type;
 import static org.awaitility.Awaitility.await;
 
 import dev.tachyonmcp.api.json.JsonDocument;
@@ -11,17 +12,17 @@ import dev.tachyonmcp.api.server.features.tools.ToolResult;
 import dev.tachyonmcp.api.server.interceptor.McpInterceptor;
 import dev.tachyonmcp.api.server.interceptor.McpInvocation;
 import dev.tachyonmcp.api.server.interceptor.McpOutcome;
+import dev.tachyonmcp.e2e.mcp.v2025_11_25.AbstractStatefulMcpE2eTest;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.List;
 import java.util.Objects;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArrayList;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 
 /** E2E contract of the {@link McpInterceptor} seam, exercised through a real MCP client. */
-class InterceptorChainTest extends AbstractMcpE2eTest {
+class InterceptorChainTest extends AbstractStatefulMcpE2eTest {
 
     private static final String CALL_ECHO =
             // language=json
@@ -29,10 +30,11 @@ class InterceptorChainTest extends AbstractMcpE2eTest {
             {"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"echo","arguments":{"text":"hi"}}}
             """;
 
-    @Override
-    protected SessionMode sessionMode() {
-        return SessionMode.STATEFUL;
-    }
+    private static final String CALL_ECHO_WITH_PROGRESS =
+            // language=json
+            """
+            {"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"echo","arguments":{"text":"hi"},"_meta":{"progressToken":"tok-1"}}}
+            """;
 
     @Override
     protected void startDefaultServer() {
@@ -86,9 +88,13 @@ class InterceptorChainTest extends AbstractMcpE2eTest {
         startServer(b -> b.withInterceptors(observing(seen)), s -> {});
 
         try (var client = createTestClient()) {
-            client.initialize();
+            var sessionId = client.initialize();
 
-            assertThat(observationOf(seen, "initialize").requestId()).isNotNull();
+            var initialize = observationOf(seen, "initialize");
+            assertThat(initialize.requestId()).isNotNull();
+            // stateful: the dispatcher establishes the session before the chain runs, so an
+            // interceptor wrapping initialize already sees the id the response will carry
+            assertThat(initialize.sessionId()).isEqualTo(sessionId);
         }
     }
 
@@ -108,6 +114,9 @@ class InterceptorChainTest extends AbstractMcpE2eTest {
             var notification = observationOf(seen, "notifications/initialized");
             assertThat(notification.requestId()).isNull();
             assertThat(notification.target()).isNull();
+            // the channel is bound to the session before dispatch, so a notification
+            // interceptor sees it even though the notification carries no request id
+            assertThat(notification.sessionId()).isEqualTo(sessionId);
         }
     }
 
@@ -155,11 +164,14 @@ class InterceptorChainTest extends AbstractMcpE2eTest {
     }
 
     @Test
-    void aFailedStageFromAnInterceptorBecomesAnInternalError() throws Exception {
+    void aCheckedExceptionFromAnInterceptorBecomesAnInternalError() throws Exception {
         startServer(
-                b -> b.withInterceptors((invocation, chain) -> "tools/call".equals(invocation.method())
-                        ? CompletableFuture.failedStage(new IOException("downstream unavailable"))
-                        : chain.proceed()),
+                b -> b.withInterceptors((invocation, chain) -> {
+                    if ("tools/call".equals(invocation.method())) {
+                        throw new IOException("downstream unavailable");
+                    }
+                    return chain.proceed();
+                }),
                 s -> s.tools().register(t -> t.name("echo"), (ctx, request) -> ToolResult.text("hi")));
 
         try (var client = createTestClient()) {
@@ -169,6 +181,72 @@ class InterceptorChainTest extends AbstractMcpE2eTest {
 
             assertThatResponse(response).isJsonRpcError().hasErrorCode(-32603);
             assertThat(response.body()).doesNotContain("downstream unavailable");
+        }
+    }
+
+    @Test
+    void anInnerFailureReachesAnOuterInterceptorAsAnOutcomeWithItsCause() throws Exception {
+        var outcomes = new CopyOnWriteArrayList<McpOutcome>();
+        startServer(
+                b -> b.withInterceptors(
+                        (invocation, chain) -> {
+                            // the outer interceptor needs no catch: the throw downstream is a value here
+                            var outcome = chain.proceed();
+                            if ("tools/call".equals(invocation.method())) {
+                                outcomes.add(outcome);
+                            }
+                            return outcome;
+                        },
+                        (invocation, chain) -> {
+                            if ("tools/call".equals(invocation.method())) {
+                                throw new IllegalStateException("inner exploded");
+                            }
+                            return chain.proceed();
+                        }),
+                s -> s.tools().register(t -> t.name("echo"), (ctx, request) -> ToolResult.text("hi")));
+
+        try (var client = createTestClient()) {
+            var sessionId = client.initialize();
+
+            assertThatResponse(client.post(sessionId, CALL_ECHO))
+                    .isJsonRpcError()
+                    .hasErrorCode(-32603);
+
+            assertThat(outcomes)
+                    .singleElement()
+                    .asInstanceOf(type(McpOutcome.Failure.class))
+                    .satisfies(failure -> {
+                        assertThat(failure.jsonRpcCode()).isEqualTo(-32603);
+                        assertThat(failure.error().kind()).isEqualTo(ServerError.Kind.INTERNAL_ERROR);
+                        // the sanitized message goes to the client, the cause stays server-side
+                        assertThat(failure.error().message()).isEqualTo("Internal error");
+                        assertThat(failure.cause()).hasMessage("inner exploded");
+                    });
+        }
+    }
+
+    /**
+     * The handler publishes to the outbound stream that the <em>dispatch</em> bound, which is
+     * thread-scoped. An interceptor sits on that same thread, so the binding is still in scope when
+     * the handler emits — if it were not, {@code progress(...)} would be a silent no-op and the
+     * response would never upgrade to SSE.
+     */
+    @Test
+    void aHandlerProgressNotificationSurvivesTheChain() throws Exception {
+        startServer(
+                b -> b.withInterceptors((invocation, chain) -> chain.proceed()),
+                s -> s.tools().register(t -> t.name("echo"), (ctx, request) -> {
+                    ctx.notifications().progress(request.progressToken(), 1, 1, "working");
+                    return ToolResult.text("hi");
+                }));
+
+        try (var client = createTestClient()) {
+            var sessionId = client.initialize();
+
+            var response = client.post(sessionId, CALL_ECHO_WITH_PROGRESS);
+
+            assertThat(response.headers().firstValue("content-type").orElse("")).startsWith("text/event-stream");
+            assertThat(response.body()).contains("notifications/progress").contains("\"progressToken\":\"tok-1\"");
         }
     }
 
@@ -183,9 +261,12 @@ class InterceptorChainTest extends AbstractMcpE2eTest {
         try (var client = createTestClient()) {
             var sessionId = client.initialize();
 
-            var listed = client.post(sessionId, """
-                {"jsonrpc":"2.0","id":2,"method":"tools/list"}
-                """);
+            var listed = client.post(
+                    sessionId,
+                    // language=json
+                    """
+                    {"jsonrpc":"2.0","id":2,"method":"tools/list"}
+                    """);
             assertThatResponse(listed).isJsonRpcError().hasErrorCode(-32601);
 
             // the rest of the surface is untouched
@@ -197,16 +278,22 @@ class InterceptorChainTest extends AbstractMcpE2eTest {
     void outcomeCarriesTheResolvedJsonRpcCode() throws Exception {
         var outcomes = new CopyOnWriteArrayList<McpOutcome>();
         startServer(
-                b -> b.withInterceptors(
-                        (invocation, chain) -> chain.proceed().whenComplete((outcome, error) -> outcomes.add(outcome))),
+                b -> b.withInterceptors((invocation, chain) -> {
+                    var outcome = chain.proceed();
+                    outcomes.add(outcome);
+                    return outcome;
+                }),
                 s -> s.tools().register(t -> t.name("echo"), (ctx, request) -> ToolResult.text("hi")));
 
         try (var client = createTestClient()) {
             var sessionId = client.initialize();
 
-            var response = client.post(sessionId, """
-                {"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"absent","arguments":{}}}
-                """);
+            var response = client.post(
+                    sessionId,
+                    // language=json
+                    """
+                    {"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"absent","arguments":{}}}
+                    """);
             assertThatResponse(response).isJsonRpcError().hasErrorCode(-32602);
 
             assertThat(outcomes)
@@ -225,11 +312,13 @@ class InterceptorChainTest extends AbstractMcpE2eTest {
     void aToolReportingIsErrorIsAPayloadFailureOnASuccessfulResponse() throws Exception {
         var outcomes = new CopyOnWriteArrayList<McpOutcome>();
         startServer(
-                b -> b.withInterceptors((invocation, chain) -> chain.proceed().whenComplete((outcome, error) -> {
+                b -> b.withInterceptors((invocation, chain) -> {
+                    var outcome = chain.proceed();
                     if ("tools/call".equals(invocation.method())) {
                         outcomes.add(outcome);
                     }
-                })),
+                    return outcome;
+                }),
                 s -> s.tools().register(t -> t.name("echo"), (ctx, request) -> ToolResult.error("nope")));
 
         try (var client = createTestClient()) {
@@ -242,6 +331,45 @@ class InterceptorChainTest extends AbstractMcpE2eTest {
         }
     }
 
+    /**
+     * A notification handler is the innermost link of the chain, so a throw there must arrive as an
+     * outcome like any other failure — not as an exception out of {@code proceed()}.
+     */
+    @Test
+    void aThrowingNotificationHandlerReachesTheInterceptorAsAFailure() throws Exception {
+        // Given a server whose only interceptor records whatever proceed() hands back
+        var outcomes = new CopyOnWriteArrayList<McpOutcome>();
+        startServer(
+                b -> b.withInterceptors((invocation, chain) -> {
+                    var outcome = chain.proceed();
+                    if ("notifications/cancelled".equals(invocation.method())) {
+                        outcomes.add(outcome);
+                    }
+                    return outcome;
+                }),
+                s -> {});
+
+        try (var client = createTestClient()) {
+            var sessionId = client.initialize();
+
+            // When a cancellation arrives with a reason of the wrong JSON type, which makes the
+            // notification's own param mapping throw
+            client.post(
+                    sessionId,
+                    // language=json
+                    """
+                    {"jsonrpc":"2.0","method":"notifications/cancelled","params":{"requestId":"1","reason":{"x":1}}}
+                    """);
+
+            // Then the interceptor observed a Failure carrying the cause, and never saw a throw
+            await().atMost(Duration.ofSeconds(5))
+                    .untilAsserted(() -> assertThat(outcomes)
+                            .singleElement()
+                            .asInstanceOf(type(McpOutcome.Failure.class))
+                            .satisfies(failure -> assertThat(failure.cause()).isNotNull()));
+        }
+    }
+
     /** Records entry and exit so ordering is observable from the outside. */
     private static McpInterceptor recorder(List<String> trace, String name) {
         return (invocation, chain) -> {
@@ -249,7 +377,11 @@ class InterceptorChainTest extends AbstractMcpE2eTest {
                 return chain.proceed();
             }
             trace.add(name + ">");
-            return chain.proceed().whenComplete((result, error) -> trace.add(name + "<"));
+            try {
+                return chain.proceed();
+            } finally {
+                trace.add(name + "<");
+            }
         };
     }
 

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/InterceptorChainTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/InterceptorChainTest.java
@@ -1,0 +1,294 @@
+/* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
+package dev.tachyonmcp.e2e.mcp;
+
+import static dev.tachyonmcp.testkit.McpHttpResponseAssert.assertThatResponse;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import dev.tachyonmcp.api.json.JsonDocument;
+import dev.tachyonmcp.api.server.domain.ServerError;
+import dev.tachyonmcp.api.server.features.tools.ToolResult;
+import dev.tachyonmcp.api.server.interceptor.McpInterceptor;
+import dev.tachyonmcp.api.server.interceptor.McpInvocation;
+import dev.tachyonmcp.api.server.interceptor.McpOutcome;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.Test;
+
+/** E2E contract of the {@link McpInterceptor} seam, exercised through a real MCP client. */
+class InterceptorChainTest extends AbstractMcpE2eTest {
+
+    private static final String CALL_ECHO =
+            // language=json
+            """
+            {"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"echo","arguments":{"text":"hi"}}}
+            """;
+
+    @Override
+    protected SessionMode sessionMode() {
+        return SessionMode.STATEFUL;
+    }
+
+    @Override
+    protected void startDefaultServer() {
+        startEmptyServer();
+    }
+
+    @Test
+    void interceptorsRunOutermostFirstAndWrapTheHandler() throws Exception {
+        var trace = new CopyOnWriteArrayList<String>();
+        startServer(
+                b -> b.withInterceptors(recorder(trace, "outer"), recorder(trace, "inner")),
+                s -> s.tools().register(t -> t.name("echo"), (ctx, request) -> {
+                    trace.add("handler");
+                    return ToolResult.text("hi");
+                }));
+
+        try (var client = createTestClient()) {
+            var sessionId = client.initialize();
+
+            var response = client.post(sessionId, CALL_ECHO);
+
+            assertThatResponse(response).isSuccess().hasTextContent("hi");
+            assertThat(trace).containsExactly("outer>", "inner>", "handler", "inner<", "outer<");
+        }
+    }
+
+    @Test
+    void interceptorSeesMethodTargetSessionAndParams() throws Exception {
+        var seen = new CopyOnWriteArrayList<Observed>();
+        startServer(
+                b -> b.withInterceptors(observing(seen)),
+                s -> s.tools().register(t -> t.name("echo"), (ctx, request) -> ToolResult.text("hi")));
+
+        try (var client = createTestClient()) {
+            var sessionId = client.initialize();
+            assertThatResponse(client.post(sessionId, CALL_ECHO)).isSuccess();
+
+            var toolCall = observationOf(seen, "tools/call");
+            assertThat(toolCall.target()).isEqualTo("echo");
+            assertThat(toolCall.resourceUri()).isNull();
+            assertThat(toolCall.sessionId()).isEqualTo(sessionId);
+            assertThat(toolCall.protocolVersion()).isEqualTo("2025-11-25");
+            assertThat(toolCall.requestId()).isEqualTo("1");
+            assertThat(toolCall.paramsJson()).contains("\"echo\"").contains("\"hi\"");
+        }
+    }
+
+    @Test
+    void initializeIsIntercepted() throws Exception {
+        var seen = new CopyOnWriteArrayList<Observed>();
+        startServer(b -> b.withInterceptors(observing(seen)), s -> {});
+
+        try (var client = createTestClient()) {
+            client.initialize();
+
+            assertThat(observationOf(seen, "initialize").requestId()).isNotNull();
+        }
+    }
+
+    @Test
+    void notificationsAreInterceptedWithoutARequestId() throws Exception {
+        var seen = new CopyOnWriteArrayList<Observed>();
+        startServer(b -> b.withInterceptors(observing(seen)), s -> {});
+
+        try (var client = createTestClient()) {
+            var sessionId = client.initialize();
+
+            // notifications are dispatched off the request thread — 202 returns before the chain runs
+            await().atMost(Duration.ofSeconds(5))
+                    .untilAsserted(
+                            () -> assertThat(seen).extracting(Observed::method).contains("notifications/initialized"));
+
+            var notification = observationOf(seen, "notifications/initialized");
+            assertThat(notification.requestId()).isNull();
+            assertThat(notification.target()).isNull();
+        }
+    }
+
+    @Test
+    void interceptorMayShortCircuitWithAServerError() throws Exception {
+        var handlerRan = new CopyOnWriteArrayList<String>();
+        startServer(
+                b -> b.withInterceptors((invocation, chain) -> "tools/call".equals(invocation.method())
+                        ? chain.reject(new ServerError(ServerError.Kind.INVALID_REQUEST, "blocked by policy"))
+                        : chain.proceed()),
+                s -> s.tools().register(t -> t.name("echo"), (ctx, request) -> {
+                    handlerRan.add("handler");
+                    return ToolResult.text("hi");
+                }));
+
+        try (var client = createTestClient()) {
+            var sessionId = client.initialize();
+
+            var response = client.post(sessionId, CALL_ECHO);
+
+            assertThatResponse(response).isJsonRpcError().hasErrorCode(-32600).hasErrorMessage("blocked by policy");
+            assertThat(handlerRan).isEmpty();
+        }
+    }
+
+    @Test
+    void aThrowingInterceptorBecomesAnInternalError() throws Exception {
+        startServer(
+                b -> b.withInterceptors((invocation, chain) -> {
+                    if ("tools/call".equals(invocation.method())) {
+                        throw new IllegalStateException("interceptor exploded");
+                    }
+                    return chain.proceed();
+                }),
+                s -> s.tools().register(t -> t.name("echo"), (ctx, request) -> ToolResult.text("hi")));
+
+        try (var client = createTestClient()) {
+            var sessionId = client.initialize();
+
+            var response = client.post(sessionId, CALL_ECHO);
+
+            assertThatResponse(response).isJsonRpcError().hasErrorCode(-32603);
+            assertThat(response.body()).doesNotContain("interceptor exploded");
+        }
+    }
+
+    @Test
+    void aFailedStageFromAnInterceptorBecomesAnInternalError() throws Exception {
+        startServer(
+                b -> b.withInterceptors((invocation, chain) -> "tools/call".equals(invocation.method())
+                        ? CompletableFuture.failedStage(new IOException("downstream unavailable"))
+                        : chain.proceed()),
+                s -> s.tools().register(t -> t.name("echo"), (ctx, request) -> ToolResult.text("hi")));
+
+        try (var client = createTestClient()) {
+            var sessionId = client.initialize();
+
+            var response = client.post(sessionId, CALL_ECHO);
+
+            assertThatResponse(response).isJsonRpcError().hasErrorCode(-32603);
+            assertThat(response.body()).doesNotContain("downstream unavailable");
+        }
+    }
+
+    @Test
+    void anInterceptorMayDisableASingleMethod() throws Exception {
+        startServer(
+                b -> b.withInterceptors((invocation, chain) -> "tools/list".equals(invocation.method())
+                        ? chain.reject(new ServerError(ServerError.Kind.METHOD_NOT_FOUND, "tool listing disabled"))
+                        : chain.proceed()),
+                s -> s.tools().register(t -> t.name("echo"), (ctx, request) -> ToolResult.text("hi")));
+
+        try (var client = createTestClient()) {
+            var sessionId = client.initialize();
+
+            var listed = client.post(sessionId, """
+                {"jsonrpc":"2.0","id":2,"method":"tools/list"}
+                """);
+            assertThatResponse(listed).isJsonRpcError().hasErrorCode(-32601);
+
+            // the rest of the surface is untouched
+            assertThatResponse(client.post(sessionId, CALL_ECHO)).isSuccess();
+        }
+    }
+
+    @Test
+    void outcomeCarriesTheResolvedJsonRpcCode() throws Exception {
+        var outcomes = new CopyOnWriteArrayList<McpOutcome>();
+        startServer(
+                b -> b.withInterceptors(
+                        (invocation, chain) -> chain.proceed().whenComplete((outcome, error) -> outcomes.add(outcome))),
+                s -> s.tools().register(t -> t.name("echo"), (ctx, request) -> ToolResult.text("hi")));
+
+        try (var client = createTestClient()) {
+            var sessionId = client.initialize();
+
+            var response = client.post(sessionId, """
+                {"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"absent","arguments":{}}}
+                """);
+            assertThatResponse(response).isJsonRpcError().hasErrorCode(-32602);
+
+            assertThat(outcomes)
+                    .filteredOn(McpOutcome.Failure.class::isInstance)
+                    .map(McpOutcome.Failure.class::cast)
+                    .singleElement()
+                    .satisfies(failure -> {
+                        // the code the wire actually carried, resolved by the protocol codec
+                        assertThat(failure.jsonRpcCode()).isEqualTo(-32602);
+                        assertThat(failure.error().kind()).isEqualTo(ServerError.Kind.INVALID_PARAMS);
+                    });
+        }
+    }
+
+    @Test
+    void aToolReportingIsErrorIsAPayloadFailureOnASuccessfulResponse() throws Exception {
+        var outcomes = new CopyOnWriteArrayList<McpOutcome>();
+        startServer(
+                b -> b.withInterceptors((invocation, chain) -> chain.proceed().whenComplete((outcome, error) -> {
+                    if ("tools/call".equals(invocation.method())) {
+                        outcomes.add(outcome);
+                    }
+                })),
+                s -> s.tools().register(t -> t.name("echo"), (ctx, request) -> ToolResult.error("nope")));
+
+        try (var client = createTestClient()) {
+            var sessionId = client.initialize();
+
+            // still a JSON-RPC success on the wire — the failure lives inside the payload
+            assertThatResponse(client.post(sessionId, CALL_ECHO)).isSuccess().isToolError();
+
+            assertThat(outcomes).singleElement().isInstanceOf(McpOutcome.PayloadFailure.class);
+        }
+    }
+
+    /** Records entry and exit so ordering is observable from the outside. */
+    private static McpInterceptor recorder(List<String> trace, String name) {
+        return (invocation, chain) -> {
+            if (!"tools/call".equals(invocation.method())) {
+                return chain.proceed();
+            }
+            trace.add(name + ">");
+            return chain.proceed().whenComplete((result, error) -> trace.add(name + "<"));
+        };
+    }
+
+    /**
+     * An {@link McpInvocation} is only valid during the interception, so the interceptor copies out
+     * what the test asserts on rather than retaining the invocation.
+     */
+    private record Observed(
+            String method,
+            @Nullable String requestId,
+            @Nullable String sessionId,
+            String protocolVersion,
+            @Nullable String target,
+            @Nullable String resourceUri,
+            @Nullable String paramsJson) {
+
+        static Observed of(McpInvocation invocation) {
+            return new Observed(
+                    invocation.method(),
+                    Objects.toString(invocation.requestId(), null),
+                    invocation.sessionId(),
+                    invocation.protocolVersion(),
+                    invocation.targetName().orElse(null),
+                    invocation.resourceUri().orElse(null),
+                    invocation.params().map(JsonDocument::json).orElse(null));
+        }
+    }
+
+    private static McpInterceptor observing(List<Observed> seen) {
+        return (invocation, chain) -> {
+            seen.add(Observed.of(invocation));
+            return chain.proceed();
+        };
+    }
+
+    private static Observed observationOf(List<Observed> seen, String method) {
+        return seen.stream()
+                .filter(observed -> method.equals(observed.method()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("no interception recorded for " + method + ", saw " + seen));
+    }
+}

--- a/integrations/pom.xml
+++ b/integrations/pom.xml
@@ -24,5 +24,6 @@
         <module>tachyon-annotations-langchain4j</module>
         <module>tachyon-annotations-spring-ai</module>
         <module>tachyon-tasks-temporal</module>
+        <module>tachyon-otel</module>
     </modules>
 </project>

--- a/integrations/tachyon-otel/pom.xml
+++ b/integrations/tachyon-otel/pom.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2026 Konstantin Pavlov and contributors.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>dev.tachyonmcp</groupId>
+        <artifactId>tachyon-integrations</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>tachyon-otel</artifactId>
+
+    <name>Tachyon MCP — OpenTelemetry</name>
+    <description>OpenTelemetry MCP semantic conventions for Tachyon servers</description>
+
+    <properties>
+        <opentelemetry.version>1.51.0</opentelemetry.version>
+        <opentelemetry-semconv.version>1.43.0-alpha</opentelemetry-semconv.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.opentelemetry</groupId>
+                <artifactId>opentelemetry-bom</artifactId>
+                <version>${opentelemetry.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>dev.tachyonmcp</groupId>
+            <artifactId>tachyon-api</artifactId>
+        </dependency>
+        <!-- Instrumentation depends on the OTel API only; the application supplies the SDK. -->
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+        </dependency>
+        <!--
+          Generated semantic-convention constants. The MCP registry lives in the incubating
+          artifact (alpha-versioned, as OTel marks these attributes unstable); it depends on the
+          stable opentelemetry-semconv, so this one entry covers Error/Network too.
+        -->
+        <dependency>
+            <groupId>io.opentelemetry.semconv</groupId>
+            <artifactId>opentelemetry-semconv-incubating</artifactId>
+            <version>${opentelemetry-semconv.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>dev.tachyonmcp</groupId>
+            <artifactId>tachyon-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>dev.tachyonmcp</groupId>
+            <artifactId>tachyon-testkit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk-testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/integrations/tachyon-otel/src/main/java/dev/tachyonmcp/otel/McpAttributes.java
+++ b/integrations/tachyon-otel/src/main/java/dev/tachyonmcp/otel/McpAttributes.java
@@ -1,0 +1,57 @@
+/* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
+package dev.tachyonmcp.otel;
+
+import io.opentelemetry.api.common.AttributeKey;
+
+/**
+ * The MCP and GenAI semantic-convention keys that {@code opentelemetry-semconv-incubating} has
+ * deprecated — <em>"Moved to the OpenTelemetry GenAI semantic conventions repository"</em> — and
+ * the values that go with them.
+ *
+ * <p>They are declared here rather than imported because the move has no destination yet: <a
+ * href="https://github.com/open-telemetry/semantic-conventions-genai">semantic-conventions-genai</a>
+ * publishes no Java artifact, so {@code io.opentelemetry.semconv} still ships only {@code
+ * opentelemetry-semconv} and {@code opentelemetry-semconv-incubating}. Importing the deprecated
+ * constants would mean warnings today and a broken build the release OTel removes them; copying
+ * them is what OpenTelemetry's own instrumentation libraries do for unstable conventions.
+ *
+ * <p>🔥 Delete this class and import the generated constants once a GenAI semconv Java artifact
+ * ships. The literals below are the contract — keep them verbatim.
+ *
+ * <p>Everything still maintained in the semconv artifacts is imported normally: {@code
+ * jsonrpc.request.id}, {@code rpc.response.status_code}, {@code error.type} and the {@code
+ * network.*} keys.
+ *
+ * @see <a href="https://github.com/open-telemetry/semantic-conventions-genai/tree/main/model/mcp">
+ *     semantic-conventions-genai / model / mcp</a>
+ */
+final class McpAttributes {
+
+    static final AttributeKey<String> MCP_METHOD_NAME = AttributeKey.stringKey("mcp.method.name");
+    static final AttributeKey<String> MCP_SESSION_ID = AttributeKey.stringKey("mcp.session.id");
+    static final AttributeKey<String> MCP_PROTOCOL_VERSION = AttributeKey.stringKey("mcp.protocol.version");
+    static final AttributeKey<String> MCP_RESOURCE_URI = AttributeKey.stringKey("mcp.resource.uri");
+
+    static final AttributeKey<String> GEN_AI_TOOL_NAME = AttributeKey.stringKey("gen_ai.tool.name");
+    static final AttributeKey<String> GEN_AI_PROMPT_NAME = AttributeKey.stringKey("gen_ai.prompt.name");
+    static final AttributeKey<String> GEN_AI_OPERATION_NAME = AttributeKey.stringKey("gen_ai.operation.name");
+
+    /**
+     * Never generated into the semconv artifact at all — it exists only in the GenAI conventions
+     * repository, and is opt-in there because tool arguments carry credentials and personal data.
+     */
+    static final AttributeKey<String> GEN_AI_TOOL_CALL_ARGUMENTS = AttributeKey.stringKey("gen_ai.tool.call.arguments");
+
+    /** {@code mcp.method.name} values this instrumentation branches on. */
+    static final String TOOLS_CALL = "tools/call";
+
+    static final String PROMPTS_GET = "prompts/get";
+
+    /** {@code gen_ai.operation.name} value for a tool call. */
+    static final String EXECUTE_TOOL = "execute_tool";
+
+    /** {@code error.type} value for a {@code CallToolResult} carrying {@code isError: true}. */
+    static final String TOOL_ERROR = "tool_error";
+
+    private McpAttributes() {}
+}

--- a/integrations/tachyon-otel/src/main/java/dev/tachyonmcp/otel/McpTelemetryInterceptor.java
+++ b/integrations/tachyon-otel/src/main/java/dev/tachyonmcp/otel/McpTelemetryInterceptor.java
@@ -1,0 +1,294 @@
+/* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
+package dev.tachyonmcp.otel;
+
+import static dev.tachyonmcp.otel.McpAttributes.EXECUTE_TOOL;
+import static dev.tachyonmcp.otel.McpAttributes.GEN_AI_OPERATION_NAME;
+import static dev.tachyonmcp.otel.McpAttributes.GEN_AI_PROMPT_NAME;
+import static dev.tachyonmcp.otel.McpAttributes.GEN_AI_TOOL_CALL_ARGUMENTS;
+import static dev.tachyonmcp.otel.McpAttributes.GEN_AI_TOOL_NAME;
+import static dev.tachyonmcp.otel.McpAttributes.MCP_METHOD_NAME;
+import static dev.tachyonmcp.otel.McpAttributes.MCP_PROTOCOL_VERSION;
+import static dev.tachyonmcp.otel.McpAttributes.MCP_RESOURCE_URI;
+import static dev.tachyonmcp.otel.McpAttributes.MCP_SESSION_ID;
+import static dev.tachyonmcp.otel.McpAttributes.PROMPTS_GET;
+import static dev.tachyonmcp.otel.McpAttributes.TOOLS_CALL;
+import static dev.tachyonmcp.otel.McpAttributes.TOOL_ERROR;
+import static io.opentelemetry.semconv.ErrorAttributes.ERROR_TYPE;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PROTOCOL_NAME;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TRANSPORT;
+import static io.opentelemetry.semconv.incubating.JsonrpcIncubatingAttributes.JSONRPC_REQUEST_ID;
+import static io.opentelemetry.semconv.incubating.RpcIncubatingAttributes.RPC_RESPONSE_STATUS_CODE;
+
+import dev.tachyonmcp.api.server.interceptor.McpInterceptor;
+import dev.tachyonmcp.api.server.interceptor.McpInvocation;
+import dev.tachyonmcp.api.server.interceptor.McpOutcome;
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.common.AttributesBuilder;
+import io.opentelemetry.api.metrics.DoubleHistogram;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.StatusCode;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.semconv.NetworkAttributes;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.CompletionStage;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Records an OpenTelemetry {@code SERVER} span and an {@code mcp.server.operation.duration}
+ * measurement for every inbound MCP request and notification, following the OpenTelemetry MCP
+ * semantic conventions.
+ *
+ * <pre>{@code
+ * var server = TachyonServer.builder()
+ *         .withInterceptors(McpTelemetryInterceptor.create(GlobalOpenTelemetry.get()))
+ *         .build();
+ * }</pre>
+ *
+ * <p>Attribute keys come from {@code opentelemetry-semconv-incubating} where it still maintains
+ * them. The {@code mcp.*} and {@code gen_ai.*} keys it has deprecated in favour of the GenAI
+ * conventions repository live in {@link McpAttributes} instead — see that class for why.
+ *
+ * <h2>Trace context</h2>
+ *
+ * <p>Spans are parented by {@link io.opentelemetry.context.Context#current()}. Under the
+ * OpenTelemetry Java agent that is the Netty HTTP server span, so an incoming {@code traceparent}
+ * header is already extracted and propagated across Tachyon's executor hops — MCP spans slot
+ * underneath the HTTP span with no extra configuration. Without the agent they are root spans: this
+ * interceptor does not read HTTP headers itself.
+ *
+ * <h2>Payloads</h2>
+ *
+ * <p>Tool arguments are <b>not</b> recorded by default — they routinely carry credentials and
+ * personal data, which is why the conventions mark them opt-in. Enable deliberately with {@link
+ * Builder#recordPayloads(boolean)}. Tool <em>results</em> are never recorded: rendering a {@code
+ * ToolResult} as a span attribute would mean serializing a domain object outside the server's
+ * configured payload serializer.
+ *
+ * @author Konstantin Pavlov
+ * @see <a href="https://github.com/open-telemetry/semantic-conventions-genai/tree/main/model/mcp">
+ *     semantic-conventions-genai / model / mcp</a>
+ */
+public final class McpTelemetryInterceptor implements McpInterceptor {
+
+    private static final String INSTRUMENTATION_NAME = "dev.tachyonmcp.otel";
+    private static final String OPERATION_DURATION = "mcp.server.operation.duration";
+    private static final double NANOS_PER_SECOND = 1_000_000_000.0;
+
+    /**
+     * JSON-RPC codes a server returns because the <em>caller</em> sent something it could not
+     * serve. The conventions say these must not count as server errors, and state the rule in terms
+     * of codes — which is why the code is resolved by the dispatcher and handed to us rather than
+     * re-derived here from {@code ServerError.Kind}, whose mapping differs between MCP versions.
+     */
+    private static final Set<Integer> CALLER_FAULT_CODES = Set.of(-32700, -32600, -32601, -32602, -32002);
+
+    private final Tracer tracer;
+    private final DoubleHistogram operationDuration;
+    private final boolean recordPayloads;
+
+    private McpTelemetryInterceptor(OpenTelemetry openTelemetry, boolean recordPayloads) {
+        this.tracer = openTelemetry.getTracer(INSTRUMENTATION_NAME);
+        this.operationDuration = openTelemetry
+                .getMeter(INSTRUMENTATION_NAME)
+                .histogramBuilder(OPERATION_DURATION)
+                .setUnit("s")
+                .setDescription("MCP request or notification duration as observed on the receiver")
+                .build();
+        this.recordPayloads = recordPayloads;
+    }
+
+    /**
+     * Creates an interceptor with payload recording disabled.
+     *
+     * @param openTelemetry the OpenTelemetry instance supplying the tracer and meter
+     * @return a new interceptor
+     */
+    public static McpTelemetryInterceptor create(OpenTelemetry openTelemetry) {
+        return builder(openTelemetry).build();
+    }
+
+    /**
+     * Returns a builder for an interceptor.
+     *
+     * @param openTelemetry the OpenTelemetry instance supplying the tracer and meter
+     * @return a new builder
+     */
+    public static Builder builder(OpenTelemetry openTelemetry) {
+        return new Builder(openTelemetry);
+    }
+
+    @Override
+    public CompletionStage<McpOutcome> intercept(McpInvocation invocation, Chain chain) {
+        // Built once: the metric keeps only the low-cardinality half, the span gets all of it.
+        // Session and request ids must never reach the histogram -- one time series per request.
+        final var shared = sharedAttributes(invocation);
+        final var span = tracer.spanBuilder(spanName(invocation))
+                .setSpanKind(SpanKind.SERVER)
+                .setAllAttributes(shared)
+                .setAllAttributes(spanOnlyAttributes(invocation))
+                .startSpan();
+        final var startNanos = System.nanoTime();
+        try (var ignored = span.makeCurrent()) {
+            return chain.proceed()
+                    .whenComplete((outcome, error) -> end(span, shared, invocation, outcome, error, startNanos));
+        } catch (RuntimeException | Error e) {
+            end(span, shared, invocation, null, e, startNanos);
+            throw e;
+        }
+    }
+
+    /**
+     * Builds the span name as {@code {method} {target}}, falling back to the bare method when the
+     * operation addresses no low-cardinality target. The resource URI is deliberately excluded from
+     * the name — it is high-cardinality.
+     */
+    private static String spanName(McpInvocation invocation) {
+        final var target = target(invocation);
+        return target == null ? invocation.method() : invocation.method() + " " + target;
+    }
+
+    /**
+     * The registered tool or prompt this operation addresses, or {@code null} for every other
+     * method.
+     *
+     * <p>Gated by method on purpose. {@link McpInvocation#targetName()} reports the top-level {@code
+     * name} parameter of <em>any</em> method, including custom extension methods whose {@code name}
+     * may be unbounded — a user id, a document key. Only tool and prompt names are the bounded
+     * values the conventions mean by "target", and only they are safe in a span name or a metric
+     * dimension.
+     */
+    private static @Nullable String target(McpInvocation invocation) {
+        return switch (invocation.method()) {
+            case TOOLS_CALL, PROMPTS_GET -> invocation.targetName().orElse(null);
+            default -> null;
+        };
+    }
+
+    private static boolean isToolCall(McpInvocation invocation) {
+        return TOOLS_CALL.equals(invocation.method());
+    }
+
+    /** Attributes shared by the span and the duration histogram. All low-cardinality. */
+    private static Attributes sharedAttributes(McpInvocation invocation) {
+        final var builder = Attributes.builder()
+                .put(MCP_METHOD_NAME, invocation.method())
+                .put(MCP_PROTOCOL_VERSION, invocation.protocolVersion())
+                .put(NETWORK_TRANSPORT, NetworkAttributes.NetworkTransportValues.TCP)
+                .put(NETWORK_PROTOCOL_NAME, "http");
+        final var target = target(invocation);
+        if (target != null) {
+            if (isToolCall(invocation)) {
+                builder.put(GEN_AI_TOOL_NAME, target).put(GEN_AI_OPERATION_NAME, EXECUTE_TOOL);
+            } else {
+                builder.put(GEN_AI_PROMPT_NAME, target);
+            }
+        }
+        return builder.build();
+    }
+
+    /** Identifying attributes that belong on a span but would explode a metric's cardinality. */
+    private static Attributes spanOnlyAttributes(McpInvocation invocation) {
+        final var builder = Attributes.builder();
+        final var requestId = invocation.requestId();
+        if (requestId != null) {
+            builder.put(JSONRPC_REQUEST_ID, requestId.toString());
+        }
+        final var sessionId = invocation.sessionId();
+        if (sessionId != null) {
+            builder.put(MCP_SESSION_ID, sessionId);
+        }
+        invocation.resourceUri().ifPresent(uri -> builder.put(MCP_RESOURCE_URI, uri));
+        return builder.build();
+    }
+
+    private void end(
+            Span span,
+            Attributes shared,
+            McpInvocation invocation,
+            @Nullable McpOutcome outcome,
+            @Nullable Throwable error,
+            long startNanos) {
+        final var metricAttributes = Attributes.builder().putAll(shared);
+        if (error != null) {
+            final var unwrapped =
+                    error instanceof CompletionException ce && ce.getCause() != null ? ce.getCause() : error;
+            span.recordException(unwrapped);
+            span.setStatus(StatusCode.ERROR, Objects.toString(unwrapped.getMessage(), ""));
+            classify(span, metricAttributes, unwrapped.getClass().getName());
+        } else if (outcome != null) {
+            recordOutcome(span, metricAttributes, outcome);
+            if (recordPayloads && isToolCall(invocation)) {
+                invocation.params().ifPresent(params -> span.setAttribute(GEN_AI_TOOL_CALL_ARGUMENTS, params.json()));
+            }
+        }
+        span.end();
+        operationDuration.record((System.nanoTime() - startNanos) / NANOS_PER_SECOND, metricAttributes.build());
+    }
+
+    /**
+     * Applies the conventions' error classification to an outcome the dispatcher already resolved
+     * against the negotiated protocol version. A code the caller caused — a bad request, an unknown
+     * method or resource — is reported through {@code rpc.response.status_code} but leaves the span
+     * status {@code UNSET}: the server behaved correctly.
+     */
+    private static void recordOutcome(Span span, AttributesBuilder metricAttributes, McpOutcome outcome) {
+        switch (outcome) {
+            case McpOutcome.Success ignored -> {}
+            case McpOutcome.PayloadFailure ignored -> classify(span, metricAttributes, TOOL_ERROR);
+            case McpOutcome.Failure(var error, var jsonRpcCode) -> {
+                final var code = String.valueOf(jsonRpcCode);
+                span.setAttribute(RPC_RESPONSE_STATUS_CODE, code);
+                metricAttributes.put(RPC_RESPONSE_STATUS_CODE, code);
+                classify(span, metricAttributes, error.kind().name());
+                if (!CALLER_FAULT_CODES.contains(jsonRpcCode)) {
+                    span.setStatus(StatusCode.ERROR, error.message());
+                }
+            }
+        }
+    }
+
+    private static void classify(Span span, AttributesBuilder metricAttributes, String errorType) {
+        span.setAttribute(ERROR_TYPE, errorType);
+        metricAttributes.put(ERROR_TYPE, errorType);
+    }
+
+    /** Builder for {@link McpTelemetryInterceptor}. */
+    public static final class Builder {
+
+        private final OpenTelemetry openTelemetry;
+        private boolean recordPayloads;
+
+        private Builder(OpenTelemetry openTelemetry) {
+            this.openTelemetry = Objects.requireNonNull(openTelemetry, "openTelemetry cannot be null");
+        }
+
+        /**
+         * Records {@code tools/call} arguments as the {@code gen_ai.tool.call.arguments} span
+         * attribute.
+         *
+         * <p>Off by default. Tool arguments frequently carry credentials and personal data, and
+         * spans are commonly exported to third-party backends — enable only where that is
+         * acceptable.
+         *
+         * @param recordPayloads whether to record tool call arguments
+         * @return this builder
+         */
+        public Builder recordPayloads(boolean recordPayloads) {
+            this.recordPayloads = recordPayloads;
+            return this;
+        }
+
+        /**
+         * Builds the interceptor.
+         *
+         * @return a new interceptor
+         */
+        public McpTelemetryInterceptor build() {
+            return new McpTelemetryInterceptor(openTelemetry, recordPayloads);
+        }
+    }
+}

--- a/integrations/tachyon-otel/src/main/java/dev/tachyonmcp/otel/McpTelemetryInterceptor.java
+++ b/integrations/tachyon-otel/src/main/java/dev/tachyonmcp/otel/McpTelemetryInterceptor.java
@@ -34,7 +34,6 @@ import io.opentelemetry.semconv.NetworkAttributes;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletionException;
-import java.util.concurrent.CompletionStage;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -122,7 +121,7 @@ public final class McpTelemetryInterceptor implements McpInterceptor {
     }
 
     @Override
-    public CompletionStage<McpOutcome> intercept(McpInvocation invocation, Chain chain) {
+    public McpOutcome intercept(McpInvocation invocation, Chain chain) {
         // Built once: the metric keeps only the low-cardinality half, the span gets all of it.
         // Session and request ids must never reach the histogram -- one time series per request.
         final var shared = sharedAttributes(invocation);
@@ -132,9 +131,11 @@ public final class McpTelemetryInterceptor implements McpInterceptor {
                 .setAllAttributes(spanOnlyAttributes(invocation))
                 .startSpan();
         final var startNanos = System.nanoTime();
+        // The scope encloses the handler, so a span the handler starts is a child of this one.
         try (var ignored = span.makeCurrent()) {
-            return chain.proceed()
-                    .whenComplete((outcome, error) -> end(span, shared, invocation, outcome, error, startNanos));
+            final var outcome = chain.proceed();
+            end(span, shared, invocation, outcome, null, startNanos);
+            return outcome;
         } catch (RuntimeException | Error e) {
             end(span, shared, invocation, null, e, startNanos);
             throw e;
@@ -214,8 +215,7 @@ public final class McpTelemetryInterceptor implements McpInterceptor {
             long startNanos) {
         final var metricAttributes = Attributes.builder().putAll(shared);
         if (error != null) {
-            final var unwrapped =
-                    error instanceof CompletionException ce && ce.getCause() != null ? ce.getCause() : error;
+            final var unwrapped = unwrap(error);
             span.recordException(unwrapped);
             span.setStatus(StatusCode.ERROR, Objects.toString(unwrapped.getMessage(), ""));
             classify(span, metricAttributes, unwrapped.getClass().getName());
@@ -239,16 +239,26 @@ public final class McpTelemetryInterceptor implements McpInterceptor {
         switch (outcome) {
             case McpOutcome.Success ignored -> {}
             case McpOutcome.PayloadFailure ignored -> classify(span, metricAttributes, TOOL_ERROR);
-            case McpOutcome.Failure(var error, var jsonRpcCode) -> {
+            case McpOutcome.Failure(var error, var jsonRpcCode, var cause) -> {
                 final var code = String.valueOf(jsonRpcCode);
                 span.setAttribute(RPC_RESPONSE_STATUS_CODE, code);
                 metricAttributes.put(RPC_RESPONSE_STATUS_CODE, code);
                 classify(span, metricAttributes, error.kind().name());
+                if (cause != null) {
+                    // A handler or inner interceptor threw; the dispatcher folded it into the
+                    // outcome, so this is the only place the stack trace is still available.
+                    span.recordException(unwrap(cause));
+                }
                 if (!CALLER_FAULT_CODES.contains(jsonRpcCode)) {
                     span.setStatus(StatusCode.ERROR, error.message());
                 }
             }
         }
+    }
+
+    /** Strips the {@code CompletionException} an async handler's failure may still be wrapped in. */
+    private static Throwable unwrap(Throwable error) {
+        return error instanceof CompletionException ce && ce.getCause() != null ? ce.getCause() : error;
     }
 
     private static void classify(Span span, AttributesBuilder metricAttributes, String errorType) {

--- a/integrations/tachyon-otel/src/main/java/dev/tachyonmcp/otel/package-info.java
+++ b/integrations/tachyon-otel/src/main/java/dev/tachyonmcp/otel/package-info.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2026 Konstantin Pavlov and contributors.
+ */
+
+/**
+ * OpenTelemetry instrumentation for Tachyon MCP servers, implementing the OpenTelemetry MCP
+ * semantic conventions on top of the {@code McpInterceptor} seam.
+ */
+@NullMarked
+package dev.tachyonmcp.otel;
+
+import org.jspecify.annotations.NullMarked;

--- a/integrations/tachyon-otel/src/main/java/dev/tachyonmcp/otel/package-info.java
+++ b/integrations/tachyon-otel/src/main/java/dev/tachyonmcp/otel/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Konstantin Pavlov and contributors.
+ * Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors.
  */
 
 /**

--- a/integrations/tachyon-otel/src/test/java/dev/tachyonmcp/otel/McpTelemetryInterceptorTest.java
+++ b/integrations/tachyon-otel/src/test/java/dev/tachyonmcp/otel/McpTelemetryInterceptorTest.java
@@ -57,6 +57,8 @@ import org.junit.jupiter.params.provider.CsvSource;
  */
 class McpTelemetryInterceptorTest {
 
+    private static final String HANDLER_SPAN = "handler-work";
+
     private InMemorySpanExporter spans;
     private InMemoryMetricReader metrics;
     private OpenTelemetrySdk otel;
@@ -309,6 +311,32 @@ class McpTelemetryInterceptorTest {
         return matching.getFirst();
     }
 
+    /**
+     * Locks the invariant that the interceptor's span scope encloses the handler, so a span the
+     * handler starts joins the trace instead of becoming a root. A synchronous chain gets this for
+     * free — chain and handler share the thread — which is why {@code makeCurrent()} must stay
+     * wrapped around {@code chain.proceed()} and never be narrowed to the span construction.
+     */
+    @Test
+    @DisplayName("a span started inside a handler is a child of the interceptor's span")
+    void handlerSpanIsChildOfTheInterceptorSpan() throws Exception {
+        withServer(telemetry(), client -> {
+            var sessionId = initialized(client);
+
+            assertThat(client.post(
+                            sessionId,
+                            // language=json
+                            """
+                            {"jsonrpc":"2.0","id":30,"method":"tools/call","params":{"name":"nested","arguments":{}}}"""))
+                    .isSuccess();
+
+            var serverSpan = spanFor("tools/call nested");
+            var handlerSpan = spanFor(HANDLER_SPAN);
+            assertThat(handlerSpan.getParentSpanId()).isEqualTo(serverSpan.getSpanId());
+            assertThat(handlerSpan.getTraceId()).isEqualTo(serverSpan.getTraceId());
+        });
+    }
+
     /** {@code id} 10 backs the {@code jsonrpc.request.id} assertion in {@link #toolCallSpan()}. */
     private static String callForecast() {
         // language=json
@@ -324,13 +352,21 @@ class McpTelemetryInterceptorTest {
         }
     }
 
-    private static TachyonServer startServer(McpTelemetryInterceptor interceptor) {
+    private TachyonServer startServer(McpTelemetryInterceptor interceptor) {
         return McpTestServers.start(
                 builder -> builder.withInterceptors(interceptor).session(session -> session.enabled(true)), server -> {
                     server.tools().register(tool -> tool.name("forecast"), (ctx, request) -> ToolResult.text("sunny"));
                     server.tools().register(tool -> tool.name("failing"), (ctx, request) -> ToolResult.error("nope"));
                     server.tools().register(tool -> tool.name("throwing"), (ctx, request) -> {
                         throw new IOException("boom");
+                    });
+                    server.tools().register(tool -> tool.name("nested"), (ctx, request) -> {
+                        // the handler's own instrumentation, parented by whatever is current
+                        var inner = otel.getTracer("handler")
+                                .spanBuilder(HANDLER_SPAN)
+                                .startSpan();
+                        inner.end();
+                        return ToolResult.text("nested");
                     });
                     server.resources()
                             .register(

--- a/integrations/tachyon-otel/src/test/java/dev/tachyonmcp/otel/McpTelemetryInterceptorTest.java
+++ b/integrations/tachyon-otel/src/test/java/dev/tachyonmcp/otel/McpTelemetryInterceptorTest.java
@@ -1,0 +1,346 @@
+/* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
+package dev.tachyonmcp.otel;
+
+import static dev.tachyonmcp.otel.McpAttributes.EXECUTE_TOOL;
+import static dev.tachyonmcp.otel.McpAttributes.GEN_AI_OPERATION_NAME;
+import static dev.tachyonmcp.otel.McpAttributes.GEN_AI_TOOL_CALL_ARGUMENTS;
+import static dev.tachyonmcp.otel.McpAttributes.GEN_AI_TOOL_NAME;
+import static dev.tachyonmcp.otel.McpAttributes.MCP_METHOD_NAME;
+import static dev.tachyonmcp.otel.McpAttributes.MCP_PROTOCOL_VERSION;
+import static dev.tachyonmcp.otel.McpAttributes.MCP_RESOURCE_URI;
+import static dev.tachyonmcp.otel.McpAttributes.MCP_SESSION_ID;
+import static dev.tachyonmcp.otel.McpAttributes.TOOL_ERROR;
+import static dev.tachyonmcp.testkit.JsonRpcResponseAssert.assertThat;
+import static io.opentelemetry.semconv.ErrorAttributes.ERROR_TYPE;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PROTOCOL_NAME;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TRANSPORT;
+import static io.opentelemetry.semconv.incubating.JsonrpcIncubatingAttributes.JSONRPC_REQUEST_ID;
+import static io.opentelemetry.semconv.incubating.RpcIncubatingAttributes.RPC_RESPONSE_STATUS_CODE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import dev.tachyonmcp.api.server.domain.TextResourceContents;
+import dev.tachyonmcp.api.server.features.tools.ToolResult;
+import dev.tachyonmcp.core.server.TachyonServer;
+import dev.tachyonmcp.testkit.Mcp20251125Client;
+import dev.tachyonmcp.testkit.Mcp20260728Client;
+import dev.tachyonmcp.testkit.McpClient;
+import dev.tachyonmcp.testkit.McpTestClients;
+import dev.tachyonmcp.testkit.McpTestServers;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.StatusCode;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.metrics.SdkMeterProvider;
+import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
+import io.opentelemetry.semconv.NetworkAttributes;
+import java.io.IOException;
+import java.time.Duration;
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+/**
+ * E2E: a real Tachyon server with {@link McpTelemetryInterceptor} registered, driven over HTTP by
+ * the testkit client, asserting the spans and metrics an OpenTelemetry backend would receive.
+ *
+ * <p>Conventions under test: <a
+ * href="https://github.com/open-telemetry/semantic-conventions-genai/tree/main/model/mcp">
+ * semantic-conventions-genai / model / mcp</a>.
+ */
+class McpTelemetryInterceptorTest {
+
+    private InMemorySpanExporter spans;
+    private InMemoryMetricReader metrics;
+    private OpenTelemetrySdk otel;
+
+    @BeforeEach
+    void setUp() {
+        spans = InMemorySpanExporter.create();
+        metrics = InMemoryMetricReader.create();
+        otel = OpenTelemetrySdk.builder()
+                .setTracerProvider(SdkTracerProvider.builder()
+                        .addSpanProcessor(SimpleSpanProcessor.create(spans))
+                        .build())
+                .setMeterProvider(
+                        SdkMeterProvider.builder().registerMetricReader(metrics).build())
+                .build();
+    }
+
+    @AfterEach
+    void tearDown() {
+        otel.close();
+    }
+
+    /**
+     * The regression test for the whole outcome design: the two protocol versions encode {@code
+     * RESOURCE_NOT_FOUND} differently, so a status code the interceptor derived on its own would be
+     * wrong on one of them.
+     */
+    @ParameterizedTest(name = "{0} encodes an unknown resource as {1}")
+    @CsvSource({Mcp20251125Client.PROTOCOL_VERSION + ",-32002", Mcp20260728Client.PROTOCOL_VERSION + ",-32602"})
+    @DisplayName("rpc.response.status_code comes from the protocol codec, not from the interceptor")
+    void statusCodeIsResolvedPerProtocolVersion(String protocolVersion, String expectedCode) throws Exception {
+        try (var server = startServer(telemetry());
+                var client = McpTestClients.forVersion(server.port(), protocolVersion)) {
+            var sessionId = initialized(client);
+
+            var response = client.post(
+                    sessionId,
+                    // language=json
+                    """
+                    {"jsonrpc":"2.0","id":20,"method":"resources/read","params":{"uri":"resource://absent"}}""");
+            assertThat(response).isJsonRpcError();
+
+            var span = spanFor("resources/read");
+            assertThat(span.getAttributes().asMap())
+                    .containsEntry(RPC_RESPONSE_STATUS_CODE, expectedCode)
+                    .containsEntry(ERROR_TYPE, "RESOURCE_NOT_FOUND")
+                    .containsEntry(MCP_PROTOCOL_VERSION, protocolVersion);
+            // the caller asked for something that isn't there — not a server fault
+            assertThat(span.getStatus().getStatusCode()).isEqualTo(StatusCode.UNSET);
+        }
+    }
+
+    @Test
+    @DisplayName("tools/call produces a SERVER span '{method} {tool}' with GenAI attributes and no payload")
+    void toolCallSpan() throws Exception {
+        withServer(telemetry(), client -> {
+            var sessionId = initialized(client);
+            var response = client.post(sessionId, callForecast());
+
+            assertThat(response).isSuccess().hasTextContent("sunny");
+
+            var span = spanFor("tools/call forecast");
+            assertThat(span.getKind()).isEqualTo(SpanKind.SERVER);
+            assertThat(span.getStatus().getStatusCode()).isEqualTo(StatusCode.UNSET);
+            assertThat(span.getAttributes().asMap())
+                    .containsEntry(MCP_METHOD_NAME, "tools/call")
+                    .containsEntry(GEN_AI_TOOL_NAME, "forecast")
+                    .containsEntry(GEN_AI_OPERATION_NAME, EXECUTE_TOOL)
+                    .containsEntry(MCP_PROTOCOL_VERSION, Mcp20251125Client.PROTOCOL_VERSION)
+                    .containsEntry(MCP_SESSION_ID, sessionId)
+                    .containsEntry(JSONRPC_REQUEST_ID, "10")
+                    .containsEntry(NETWORK_TRANSPORT, NetworkAttributes.NetworkTransportValues.TCP)
+                    .containsEntry(NETWORK_PROTOCOL_NAME, "http")
+                    .doesNotContainKey(ERROR_TYPE)
+                    .doesNotContainKey(RPC_RESPONSE_STATUS_CODE)
+                    // opt_in per the conventions: arguments carry credentials and personal data
+                    .doesNotContainKey(GEN_AI_TOOL_CALL_ARGUMENTS);
+        });
+    }
+
+    @Test
+    @DisplayName("recordPayloads(true) records tool arguments as JSON")
+    void payloadsWhenOptedIn() throws Exception {
+        withServer(telemetryRecordingPayloads(), client -> {
+            var sessionId = initialized(client);
+            client.post(sessionId, callForecast());
+
+            assertThat(spanFor("tools/call forecast").getAttributes().get(GEN_AI_TOOL_CALL_ARGUMENTS))
+                    .contains("\"city\"")
+                    .contains("Berlin");
+        });
+    }
+
+    @Test
+    @DisplayName("a tool returning ToolResult.error is error.type=tool_error on a successful span")
+    void toolErrorIsClassified() throws Exception {
+        withServer(telemetry(), client -> {
+            var sessionId = initialized(client);
+            var response = client.post(
+                    sessionId,
+                    // language=json
+                    """
+                    {"jsonrpc":"2.0","id":11,"method":"tools/call","params":{"name":"failing","arguments":{}}}""");
+
+            assertThat(response).isSuccess().isToolError();
+
+            // A payload failure is still a JSON-RPC success: no status code, span not failed.
+            var span = spanFor("tools/call failing");
+            assertThat(span.getStatus().getStatusCode()).isEqualTo(StatusCode.UNSET);
+            assertThat(span.getAttributes().asMap())
+                    .containsEntry(ERROR_TYPE, TOOL_ERROR)
+                    .doesNotContainKey(RPC_RESPONSE_STATUS_CODE);
+        });
+    }
+
+    @Test
+    @DisplayName("a throwing tool fails the span: INTERNAL_ERROR, JSON-RPC -32603, status ERROR")
+    void throwingToolFailsSpan() throws Exception {
+        withServer(telemetry(), client -> {
+            var sessionId = initialized(client);
+            var response = client.post(
+                    sessionId,
+                    // language=json
+                    """
+                    {"jsonrpc":"2.0","id":12,"method":"tools/call","params":{"name":"throwing","arguments":{}}}""");
+
+            assertThat(response).isJsonRpcError().hasErrorCode(-32603);
+
+            var span = spanFor("tools/call throwing");
+            assertThat(span.getStatus().getStatusCode()).isEqualTo(StatusCode.ERROR);
+            assertThat(span.getAttributes().asMap())
+                    .containsEntry(ERROR_TYPE, "INTERNAL_ERROR")
+                    .containsEntry(RPC_RESPONSE_STATUS_CODE, "-32603");
+        });
+    }
+
+    @Test
+    @DisplayName("an unknown tool records the JSON-RPC code but leaves the span UNSET — the caller's fault")
+    void callerFaultIsNotAServerFault() throws Exception {
+        withServer(telemetry(), client -> {
+            var sessionId = initialized(client);
+            var response = client.post(
+                    sessionId,
+                    // language=json
+                    """
+                    {"jsonrpc":"2.0","id":13,"method":"tools/call","params":{"name":"absent","arguments":{}}}""");
+
+            assertThat(response).isJsonRpcError().hasErrorCode(-32602);
+
+            var span = spanFor("tools/call absent");
+            assertThat(span.getStatus().getStatusCode()).isEqualTo(StatusCode.UNSET);
+            assertThat(span.getAttributes().asMap())
+                    .containsEntry(RPC_RESPONSE_STATUS_CODE, "-32602")
+                    .containsEntry(ERROR_TYPE, "INVALID_PARAMS");
+        });
+    }
+
+    @Test
+    @DisplayName("resources/read carries mcp.resource.uri but keeps it out of the span name")
+    void resourceUriAttribute() throws Exception {
+        withServer(telemetry(), client -> {
+            var sessionId = initialized(client);
+            var response = client.post(
+                    sessionId,
+                    // language=json
+                    """
+                    {"jsonrpc":"2.0","id":14,"method":"resources/read","params":{"uri":"resource://greeting"}}""");
+
+            assertThat(response).isSuccess();
+
+            assertThat(spanFor("resources/read").getAttributes().get(MCP_RESOURCE_URI))
+                    .isEqualTo("resource://greeting");
+        });
+    }
+
+    @Test
+    @DisplayName("notifications are traced, without a jsonrpc.request.id")
+    void notificationSpan() throws Exception {
+        withServer(telemetry(), client -> {
+            initialized(client);
+
+            var span = awaitSpanFor("notifications/initialized");
+            assertThat(span.getKind()).isEqualTo(SpanKind.SERVER);
+            assertThat(span.getAttributes().asMap())
+                    .containsEntry(MCP_METHOD_NAME, "notifications/initialized")
+                    .doesNotContainKey(JSONRPC_REQUEST_ID);
+        });
+    }
+
+    @Test
+    @DisplayName("initialize is intercepted too; the duration histogram omits high-cardinality ids")
+    void durationHistogramCoversEveryOperation() throws Exception {
+        withServer(telemetry(), client -> {
+            var sessionId = initialized(client);
+            client.post(sessionId, callForecast());
+            awaitSpanFor("notifications/initialized");
+
+            assertThat(spans.getFinishedSpanItems())
+                    .extracting(SpanData::getName)
+                    .contains("initialize", "notifications/initialized", "tools/call forecast");
+
+            var histogram = metrics.collectAllMetrics().stream()
+                    .filter(metric -> "mcp.server.operation.duration".equals(metric.getName()))
+                    .findFirst()
+                    .orElseThrow();
+            assertThat(histogram.getUnit()).isEqualTo("s");
+            assertThat(histogram.getHistogramData().getPoints())
+                    .hasSizeGreaterThanOrEqualTo(3)
+                    .allSatisfy(point -> assertThat(point.getAttributes().asMap())
+                            .containsKey(MCP_METHOD_NAME)
+                            .containsKey(MCP_PROTOCOL_VERSION)
+                            .doesNotContainKey(MCP_SESSION_ID)
+                            .doesNotContainKey(JSONRPC_REQUEST_ID));
+        });
+    }
+
+    private McpTelemetryInterceptor telemetry() {
+        return McpTelemetryInterceptor.create(otel);
+    }
+
+    private McpTelemetryInterceptor telemetryRecordingPayloads() {
+        return McpTelemetryInterceptor.builder(otel).recordPayloads(true).build();
+    }
+
+    /**
+     * Completes the handshake and returns the session id, or {@code null} on 2026-07-28 — that
+     * revision removed {@code initialize} and sessions; every request self-describes instead.
+     *
+     * <p>{@link McpClient#initialize()} already sends {@code notifications/initialized}; sending it
+     * again here would double every notification span.
+     */
+    private static @Nullable String initialized(McpClient client) throws Exception {
+        return client instanceof Mcp20260728Client ? null : client.initialize();
+    }
+
+    /** Notifications are dispatched off the request thread — the 202 returns before the chain ends. */
+    private SpanData awaitSpanFor(String name) {
+        await().atMost(Duration.ofSeconds(5))
+                .untilAsserted(() -> assertThat(spans.getFinishedSpanItems())
+                        .extracting(SpanData::getName)
+                        .contains(name));
+        return spanFor(name);
+    }
+
+    private SpanData spanFor(String name) {
+        var matching = spans.getFinishedSpanItems().stream()
+                .filter(span -> name.equals(span.getName()))
+                .toList();
+        assertThat(matching).as("spans named '%s'", name).hasSize(1);
+        return matching.getFirst();
+    }
+
+    /** {@code id} 10 backs the {@code jsonrpc.request.id} assertion in {@link #toolCallSpan()}. */
+    private static String callForecast() {
+        // language=json
+        return """
+                {"jsonrpc":"2.0","id":10,"method":"tools/call",\
+                "params":{"name":"forecast","arguments":{"city":"Berlin"}}}""";
+    }
+
+    private void withServer(McpTelemetryInterceptor interceptor, ClientScenario scenario) throws Exception {
+        try (var server = startServer(interceptor);
+                var client = new Mcp20251125Client(server.port())) {
+            scenario.run(client);
+        }
+    }
+
+    private static TachyonServer startServer(McpTelemetryInterceptor interceptor) {
+        return McpTestServers.start(
+                builder -> builder.withInterceptors(interceptor).session(session -> session.enabled(true)), server -> {
+                    server.tools().register(tool -> tool.name("forecast"), (ctx, request) -> ToolResult.text("sunny"));
+                    server.tools().register(tool -> tool.name("failing"), (ctx, request) -> ToolResult.error("nope"));
+                    server.tools().register(tool -> tool.name("throwing"), (ctx, request) -> {
+                        throw new IOException("boom");
+                    });
+                    server.resources()
+                            .register(
+                                    resource -> resource.name("greeting").uri("resource://greeting"),
+                                    (ctx, request) -> TextResourceContents.of(request.uri(), "hello", "text/plain"));
+                });
+    }
+
+    @FunctionalInterface
+    private interface ClientScenario {
+        void run(Mcp20251125Client client) throws Exception;
+    }
+}

--- a/tachyon-api/src/main/java/dev/tachyonmcp/api/server/interceptor/McpInterceptor.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/api/server/interceptor/McpInterceptor.java
@@ -1,0 +1,102 @@
+/* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
+package dev.tachyonmcp.api.server.interceptor;
+
+import dev.tachyonmcp.api.annotations.ExperimentalApi;
+import dev.tachyonmcp.api.server.domain.ServerError;
+import java.util.concurrent.CompletionStage;
+
+/**
+ * Around-advice over one inbound MCP request or notification — the server's single cross-cutting
+ * seam. Register with {@code ServerBuilder.withInterceptors(...)}; the first interceptor registered
+ * is the outermost.
+ *
+ * <p>Every dispatched operation passes through the chain, including {@code initialize} and
+ * notifications. A typical interceptor measures, records and forwards:
+ *
+ * <pre>{@code
+ * final class TimingInterceptor implements McpInterceptor {
+ *     public CompletionStage<McpOutcome> intercept(McpInvocation invocation, Chain chain) {
+ *         final var method = invocation.method();          // copied out, not retained
+ *         final var startNanos = System.nanoTime();
+ *         return chain.proceed()
+ *                 .whenComplete((outcome, error) -> record(method, System.nanoTime() - startNanos));
+ *     }
+ * }
+ * }</pre>
+ *
+ * <p>An interceptor that inspects what happened switches over the {@link McpOutcome}, which the
+ * dispatcher has already resolved against the negotiated protocol version:
+ *
+ * <pre>{@code
+ * switch (outcome) {
+ *     case McpOutcome.Success s -> {}
+ *     case McpOutcome.PayloadFailure p -> countToolError();
+ *     case McpOutcome.Failure f -> count(f.jsonRpcCode(), f.error().kind());
+ * }
+ * }</pre>
+ *
+ * <h2>Contract</h2>
+ *
+ * <ul>
+ *   <li><strong>One instance serves every concurrent operation.</strong> Implementations must be
+ *       thread-safe and must not hold per-request state in fields. Keep it in local variables and
+ *       close over it in the returned stage, as the timing example above does — <em>not</em> in
+ *       {@link McpInvocation#context()}, whose attribute space is shared by every request on the
+ *       connection.
+ *   <li>Do not retain the {@link McpInvocation} beyond the returned stage; see its javadoc.
+ *   <li>{@link #intercept} runs on the handler's <b>virtual thread</b>. Blocking for I/O is the
+ *       intended contract, but never use {@code synchronized}, native methods, or anything else
+ *       that pins the carrier thread; prefer {@link java.util.concurrent.locks.ReentrantLock}.
+ *   <li>{@link Chain#proceed()} must be called from the {@link #intercept} thread. The stage it
+ *       returns may complete on a different one. Handing {@code proceed()} to another thread or
+ *       deferring it past the return of {@link #intercept} detaches the handler from the dispatch's
+ *       outbound stream binding, and progress notifications sent by the handler are silently
+ *       dropped — throttle by delaying the <em>response</em>, never the call to {@code proceed()}.
+ *   <li>Returning {@link Chain#reject(ServerError)} instead of {@link Chain#proceed()}
+ *       short-circuits the handler — the authorization and rate-limiting use case.
+ *   <li>Errors travel as a failed {@link CompletionStage}; an exception thrown out of {@link
+ *       #intercept} is mapped to a JSON-RPC internal error, exactly as a throwing handler is.
+ * </ul>
+ *
+ * @author Konstantin Pavlov
+ */
+@ExperimentalApi
+@FunctionalInterface
+public interface McpInterceptor {
+
+    /**
+     * Wraps the dispatch of one MCP operation.
+     *
+     * @param invocation the operation being dispatched
+     * @param chain      continuation to the next interceptor, or to the handler
+     * @return a stage yielding the outcome, which an interceptor may substitute
+     */
+    CompletionStage<McpOutcome> intercept(McpInvocation invocation, Chain chain);
+
+    /**
+     * Continuation handed to an {@link McpInterceptor}: invokes the next interceptor in the chain,
+     * or the method handler when this is the innermost one.
+     *
+     * <p>Implemented by Tachyon; application code implements it only in tests.
+     */
+    interface Chain {
+
+        /**
+         * Proceeds to the next interceptor or to the handler.
+         *
+         * @return a stage yielding the outcome, failed if the remainder of the chain failed
+         */
+        CompletionStage<McpOutcome> proceed();
+
+        /**
+         * Short-circuits the dispatch with a JSON-RPC error, without invoking the handler.
+         *
+         * <p>Resolves the wire code for the protocol version in play, so callers never hand-write
+         * one — two MCP versions encode the same {@link ServerError.Kind} differently.
+         *
+         * @param error the error to answer with
+         * @return a completed stage carrying the corresponding {@link McpOutcome.Failure}
+         */
+        CompletionStage<McpOutcome> reject(ServerError error);
+    }
+}

--- a/tachyon-api/src/main/java/dev/tachyonmcp/api/server/interceptor/McpInterceptor.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/api/server/interceptor/McpInterceptor.java
@@ -3,32 +3,33 @@ package dev.tachyonmcp.api.server.interceptor;
 
 import dev.tachyonmcp.api.annotations.ExperimentalApi;
 import dev.tachyonmcp.api.server.domain.ServerError;
-import java.util.concurrent.CompletionStage;
 
 /**
  * Around-advice over one inbound MCP request or notification — the server's single cross-cutting
- * seam. Register with {@code ServerBuilder.withInterceptors(...)}; the first interceptor registered
- * is the outermost.
+ * seam, where tracing, auditing, authorization and rate limiting belong. Register with {@code
+ * ServerBuilder.withInterceptors(...)}; the first registered is the outermost.
  *
- * <p>Every dispatched operation passes through the chain, including {@code initialize} and
- * notifications. A typical interceptor measures, records and forwards:
+ * <p>{@link #intercept} runs on the dispatch <b>virtual thread</b> and blocks until the rest of the
+ * chain is done, so an interceptor is ordinary sequential code:
  *
  * <pre>{@code
  * final class TimingInterceptor implements McpInterceptor {
- *     public CompletionStage<McpOutcome> intercept(McpInvocation invocation, Chain chain) {
- *         final var method = invocation.method();          // copied out, not retained
+ *     public McpOutcome intercept(McpInvocation invocation, Chain chain) {
  *         final var startNanos = System.nanoTime();
- *         return chain.proceed()
- *                 .whenComplete((outcome, error) -> record(method, System.nanoTime() - startNanos));
+ *         try {
+ *             return chain.proceed();
+ *         } finally {
+ *             record(invocation.method(), System.nanoTime() - startNanos);
+ *         }
  *     }
  * }
  * }</pre>
  *
- * <p>An interceptor that inspects what happened switches over the {@link McpOutcome}, which the
- * dispatcher has already resolved against the negotiated protocol version:
+ * <p>Failures are values, already resolved against the negotiated protocol version — so inspecting
+ * what happened is one {@code switch} and no {@code catch}:
  *
  * <pre>{@code
- * switch (outcome) {
+ * switch (chain.proceed()) {
  *     case McpOutcome.Success s -> {}
  *     case McpOutcome.PayloadFailure p -> countToolError();
  *     case McpOutcome.Failure f -> count(f.jsonRpcCode(), f.error().kind());
@@ -38,24 +39,21 @@ import java.util.concurrent.CompletionStage;
  * <h2>Contract</h2>
  *
  * <ul>
- *   <li><strong>One instance serves every concurrent operation.</strong> Implementations must be
- *       thread-safe and must not hold per-request state in fields. Keep it in local variables and
- *       close over it in the returned stage, as the timing example above does — <em>not</em> in
- *       {@link McpInvocation#context()}, whose attribute space is shared by every request on the
- *       connection.
- *   <li>Do not retain the {@link McpInvocation} beyond the returned stage; see its javadoc.
- *   <li>{@link #intercept} runs on the handler's <b>virtual thread</b>. Blocking for I/O is the
- *       intended contract, but never use {@code synchronized}, native methods, or anything else
- *       that pins the carrier thread; prefer {@link java.util.concurrent.locks.ReentrantLock}.
- *   <li>{@link Chain#proceed()} must be called from the {@link #intercept} thread. The stage it
- *       returns may complete on a different one. Handing {@code proceed()} to another thread or
- *       deferring it past the return of {@link #intercept} detaches the handler from the dispatch's
- *       outbound stream binding, and progress notifications sent by the handler are silently
- *       dropped — throttle by delaying the <em>response</em>, never the call to {@code proceed()}.
- *   <li>Returning {@link Chain#reject(ServerError)} instead of {@link Chain#proceed()}
- *       short-circuits the handler — the authorization and rate-limiting use case.
- *   <li>Errors travel as a failed {@link CompletionStage}; an exception thrown out of {@link
- *       #intercept} is mapped to a JSON-RPC internal error, exactly as a throwing handler is.
+ *   <li>Covers every operation that reaches a handler, {@code initialize} and notifications
+ *       included. Requests refused earlier — unknown method, unknown or missing session — never
+ *       reach the chain.
+ *   <li>One instance serves every concurrent operation: be thread-safe and keep per-request state
+ *       in locals, never in fields nor in {@link McpInvocation#context()}, whose attribute space is
+ *       shared by every request on the connection.
+ *   <li>Do not retain the {@link McpInvocation} beyond the call; see its javadoc.
+ *   <li>Blocking for I/O is intended, but nothing may pin the carrier thread — prefer
+ *       {@link java.util.concurrent.locks.ReentrantLock} over {@code synchronized}. Chain and
+ *       handler share one stack, so a pinning interceptor pins the handler too.
+ *   <li>An exception thrown out of {@link #intercept} becomes a JSON-RPC internal error, exactly as
+ *       a throwing handler does, and reaches an outer interceptor as
+ *       {@link McpOutcome.Failure#cause()}. Cover it with {@code finally}, not {@code catch}.
+ *   <li>{@link Chain#reject(ServerError)} short-circuits the handler — the authorization and
+ *       rate-limiting path. {@link Chain#proceed()} may be called more than once (retry).
  * </ul>
  *
  * @author Konstantin Pavlov
@@ -65,28 +63,35 @@ import java.util.concurrent.CompletionStage;
 public interface McpInterceptor {
 
     /**
-     * Wraps the dispatch of one MCP operation.
+     * Wraps the dispatch of one MCP operation. Runs on the dispatch virtual thread and may block.
      *
      * @param invocation the operation being dispatched
      * @param chain      continuation to the next interceptor, or to the handler
-     * @return a stage yielding the outcome, which an interceptor may substitute
+     * @return the outcome, which an interceptor may substitute
+     * @throws Exception any failure; mapped to a JSON-RPC internal error, as a throwing handler is
      */
-    CompletionStage<McpOutcome> intercept(McpInvocation invocation, Chain chain);
+    McpOutcome intercept(McpInvocation invocation, Chain chain) throws Exception;
 
     /**
-     * Continuation handed to an {@link McpInterceptor}: invokes the next interceptor in the chain,
-     * or the method handler when this is the innermost one.
+     * Continuation handed to an {@link McpInterceptor}: the next interceptor in the chain, or the
+     * method handler when this is the innermost one.
      *
-     * <p>Implemented by Tachyon; application code implements it only in tests.
+     * <p><strong>Not for implementation outside Tachyon.</strong> Methods may be added in any
+     * release, so implementing it in application code will break on upgrade. Test an interceptor
+     * against a running server instead.
      */
     interface Chain {
 
         /**
-         * Proceeds to the next interceptor or to the handler.
+         * Runs the remainder of the chain and the handler, blocking until they produce an outcome.
          *
-         * @return a stage yielding the outcome, failed if the remainder of the chain failed
+         * <p>Never throws on their behalf: a downstream failure comes back as
+         * {@link McpOutcome.Failure}, carrying the resolved wire code and the originating
+         * {@link McpOutcome.Failure#cause() cause}.
+         *
+         * @return the outcome of the remainder of the dispatch
          */
-        CompletionStage<McpOutcome> proceed();
+        McpOutcome proceed();
 
         /**
          * Short-circuits the dispatch with a JSON-RPC error, without invoking the handler.
@@ -95,8 +100,8 @@ public interface McpInterceptor {
          * one — two MCP versions encode the same {@link ServerError.Kind} differently.
          *
          * @param error the error to answer with
-         * @return a completed stage carrying the corresponding {@link McpOutcome.Failure}
+         * @return the corresponding {@link McpOutcome.Failure}
          */
-        CompletionStage<McpOutcome> reject(ServerError error);
+        McpOutcome reject(ServerError error);
     }
 }

--- a/tachyon-api/src/main/java/dev/tachyonmcp/api/server/interceptor/McpInvocation.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/api/server/interceptor/McpInvocation.java
@@ -12,16 +12,17 @@ import org.jspecify.annotations.Nullable;
  * View of the single MCP operation an {@link McpInterceptor} is wrapped around — the request or
  * notification as it arrived on the wire.
  *
- * <p><strong>Valid only for the duration of the interception.</strong> {@link #method()}, {@link
- * #targetName()}, {@link #resourceUri()} and {@link #params()} are fixed by the inbound message,
- * but {@link #sessionId()} and {@link #protocolVersion()} read through the live dispatch — {@code
- * sessionId()} is {@code null} when an {@code initialize} interception starts and non-null once the
- * session exists. Do not retain the invocation past the stage returned by {@link
- * McpInterceptor#intercept}; copy out the values you need instead.
+ * <p><strong>One instance per dispatched operation, valid only for the duration of the
+ * interception.</strong> Everything but {@link #sessionId()} and {@link #protocolVersion()} is
+ * fixed by the inbound message; those two read through the live dispatch. Do not retain the
+ * invocation past the {@link McpInterceptor#intercept} call; copy out what you need.
  *
- * <p><strong>Not for implementation outside Tachyon.</strong> This is a consumer interface: methods
- * may be added in any release, so implementing it in application code will break on upgrade. Only
- * {@link McpInterceptor} and {@link McpInterceptor.Chain} are meant to be implemented.
+ * <p>Per-operation is the <em>instance</em>, not the attribute space behind {@link #context()},
+ * which every request on the connection shares — see that method.
+ *
+ * <p><strong>Not for implementation outside Tachyon.</strong> Methods may be added in any release,
+ * so implementing it in application code will break on upgrade. Only {@link McpInterceptor} is
+ * meant to be implemented.
  *
  * @author Konstantin Pavlov
  */
@@ -45,10 +46,13 @@ public interface McpInvocation {
     RequestId requestId();
 
     /**
-     * Returns the MCP session id, or {@code null} in stateless mode and before {@code initialize}
-     * has established a session.
+     * Returns the MCP session id, or {@code null} in stateless mode.
      *
-     * @return the session id, or {@code null}
+     * <p>Non-null for every operation on a stateful session, {@code initialize} included — the
+     * dispatcher establishes the session before running the chain, so an interceptor wrapping
+     * {@code initialize} already sees the id the response will carry.
+     *
+     * @return the session id, or {@code null} in stateless mode
      */
     @Nullable
     String sessionId();
@@ -65,9 +69,8 @@ public interface McpInvocation {
      * tools/call} and the prompt name for {@code prompts/get} — or empty when this operation names
      * no target.
      *
-     * <p>Read straight off the wire params, so it is available without decoding the request and
-     * without parsing {@link #params()}. This is what an authorization interceptor gates on and
-     * what a tracing interceptor uses for the span name.
+     * <p>Read straight off the wire params, so it costs no decode and no parse of {@link #params()}.
+     * This is what an authorization interceptor gates on and a tracing interceptor names spans by.
      *
      * @return the targeted tool or prompt name, or empty
      */
@@ -101,10 +104,9 @@ public interface McpInvocation {
      * outbound notifications, and the attribute space.
      *
      * <p>🔴 That attribute space ({@link InteractionContext#get}/{@link InteractionContext#set}) is
-     * scoped to the <em>connection</em>, not to this operation: concurrent requests on one
-     * connection share it, and a value survives into later requests. It is not a place to stash
-     * per-request state such as a timer or a span — keep that in local variables and close over it
-     * in the stage returned by {@link McpInterceptor#intercept}.
+     * scoped to the <em>connection</em>, not to this operation: concurrent requests share it and a
+     * value survives into later ones. Not a place for per-request state such as a timer or a span —
+     * {@link McpInterceptor#intercept} is ordinary blocking code, so keep that in locals.
      *
      * @return the interaction context
      */

--- a/tachyon-api/src/main/java/dev/tachyonmcp/api/server/interceptor/McpInvocation.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/api/server/interceptor/McpInvocation.java
@@ -1,0 +1,112 @@
+/* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
+package dev.tachyonmcp.api.server.interceptor;
+
+import dev.tachyonmcp.api.annotations.ExperimentalApi;
+import dev.tachyonmcp.api.json.JsonDocument;
+import dev.tachyonmcp.api.runtime.InteractionContext;
+import dev.tachyonmcp.api.server.domain.RequestId;
+import java.util.Optional;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * View of the single MCP operation an {@link McpInterceptor} is wrapped around — the request or
+ * notification as it arrived on the wire.
+ *
+ * <p><strong>Valid only for the duration of the interception.</strong> {@link #method()}, {@link
+ * #targetName()}, {@link #resourceUri()} and {@link #params()} are fixed by the inbound message,
+ * but {@link #sessionId()} and {@link #protocolVersion()} read through the live dispatch — {@code
+ * sessionId()} is {@code null} when an {@code initialize} interception starts and non-null once the
+ * session exists. Do not retain the invocation past the stage returned by {@link
+ * McpInterceptor#intercept}; copy out the values you need instead.
+ *
+ * <p><strong>Not for implementation outside Tachyon.</strong> This is a consumer interface: methods
+ * may be added in any release, so implementing it in application code will break on upgrade. Only
+ * {@link McpInterceptor} and {@link McpInterceptor.Chain} are meant to be implemented.
+ *
+ * @author Konstantin Pavlov
+ */
+@ExperimentalApi
+public interface McpInvocation {
+
+    /**
+     * Returns the JSON-RPC method being dispatched, e.g. {@code tools/call}, {@code initialize} or
+     * {@code notifications/cancelled}.
+     *
+     * @return the method name
+     */
+    String method();
+
+    /**
+     * Returns the JSON-RPC request id, or {@code null} when this operation is a notification.
+     *
+     * @return the request id, or {@code null} for notifications
+     */
+    @Nullable
+    RequestId requestId();
+
+    /**
+     * Returns the MCP session id, or {@code null} in stateless mode and before {@code initialize}
+     * has established a session.
+     *
+     * @return the session id, or {@code null}
+     */
+    @Nullable
+    String sessionId();
+
+    /**
+     * Returns the negotiated MCP protocol version for this channel.
+     *
+     * @return the protocol version, e.g. {@code 2025-11-25}
+     */
+    String protocolVersion();
+
+    /**
+     * Returns the value of the top-level {@code name} parameter — the tool name for {@code
+     * tools/call} and the prompt name for {@code prompts/get} — or empty when this operation names
+     * no target.
+     *
+     * <p>Read straight off the wire params, so it is available without decoding the request and
+     * without parsing {@link #params()}. This is what an authorization interceptor gates on and
+     * what a tracing interceptor uses for the span name.
+     *
+     * @return the targeted tool or prompt name, or empty
+     */
+    Optional<String> targetName();
+
+    /**
+     * Returns the value of the top-level {@code uri} parameter — the resource URI for {@code
+     * resources/read}, {@code resources/subscribe} and {@code resources/unsubscribe} — or empty
+     * when this operation names no resource.
+     *
+     * @return the targeted resource URI, or empty
+     */
+    Optional<String> resourceUri();
+
+    /**
+     * Returns the raw JSON-RPC {@code params} of this operation, or empty when it carried none.
+     *
+     * <p>Encoded lazily on first call and cached: interceptors that never inspect the payload pay
+     * nothing. The document describes the wire params exactly as received — the decoded,
+     * protocol-neutral request is not exposed here.
+     *
+     * <p><strong>Handle as untrusted, potentially confidential input.</strong> Tool arguments
+     * routinely carry credentials and personal data; log them at {@code TRACE} only, or not at all.
+     *
+     * @return the raw params document, or empty when the operation had no params
+     */
+    Optional<JsonDocument> params();
+
+    /**
+     * Returns the handler-facing interaction context backing this operation — extension checks,
+     * outbound notifications, and the attribute space.
+     *
+     * <p>🔴 That attribute space ({@link InteractionContext#get}/{@link InteractionContext#set}) is
+     * scoped to the <em>connection</em>, not to this operation: concurrent requests on one
+     * connection share it, and a value survives into later requests. It is not a place to stash
+     * per-request state such as a timer or a span — keep that in local variables and close over it
+     * in the stage returned by {@link McpInterceptor#intercept}.
+     *
+     * @return the interaction context
+     */
+    InteractionContext context();
+}

--- a/tachyon-api/src/main/java/dev/tachyonmcp/api/server/interceptor/McpOutcome.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/api/server/interceptor/McpOutcome.java
@@ -8,11 +8,14 @@ import org.jspecify.annotations.Nullable;
 /**
  * What one MCP operation produced, already resolved against the negotiated protocol version.
  *
- * <p>An {@link McpInterceptor} observes the outcome instead of the raw handler result, because the
- * facts an interceptor needs — above all the JSON-RPC error code the response will carry — are
- * decided by the protocol codec, which runs after the handler. Resolving here keeps that mapping in
- * the one place that owns it: two MCP versions encode the same {@link ServerError.Kind}
+ * <p>An {@link McpInterceptor} observes this instead of the raw handler result, because the fact it
+ * most needs — the JSON-RPC error code the response will carry — is decided by the protocol codec,
+ * which runs after the handler. Two MCP versions encode the same {@link ServerError.Kind}
  * differently, so any code that re-derived it would be wrong on one of them.
+ *
+ * <p>It is also the <em>only</em> channel a failure travels on: a throwing handler and a throwing
+ * downstream interceptor both arrive as {@link Failure}, never as an exception out of
+ * {@link McpInterceptor.Chain#proceed()}.
  *
  * @author Konstantin Pavlov
  */
@@ -48,6 +51,12 @@ public sealed interface McpOutcome {
      *
      * @param error       the protocol-neutral error
      * @param jsonRpcCode the code this protocol version puts on the wire for {@code error}
+     * @param cause       the exception this failure came from, or {@code null} when the handler
+     *                    returned the error or an interceptor
+     *                    {@link McpInterceptor.Chain#reject(ServerError) rejected}. Kept so folding
+     *                    exceptions into outcomes does not lose the stack trace an audit log or
+     *                    tracer needs; only {@code error} reaches the client.
      */
-    record Failure(ServerError error, int jsonRpcCode) implements McpOutcome {}
+    record Failure(
+            ServerError error, int jsonRpcCode, @Nullable Throwable cause) implements McpOutcome {}
 }

--- a/tachyon-api/src/main/java/dev/tachyonmcp/api/server/interceptor/McpOutcome.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/api/server/interceptor/McpOutcome.java
@@ -1,0 +1,53 @@
+/* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
+package dev.tachyonmcp.api.server.interceptor;
+
+import dev.tachyonmcp.api.annotations.ExperimentalApi;
+import dev.tachyonmcp.api.server.domain.ServerError;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * What one MCP operation produced, already resolved against the negotiated protocol version.
+ *
+ * <p>An {@link McpInterceptor} observes the outcome instead of the raw handler result, because the
+ * facts an interceptor needs — above all the JSON-RPC error code the response will carry — are
+ * decided by the protocol codec, which runs after the handler. Resolving here keeps that mapping in
+ * the one place that owns it: two MCP versions encode the same {@link ServerError.Kind}
+ * differently, so any code that re-derived it would be wrong on one of them.
+ *
+ * @author Konstantin Pavlov
+ */
+@ExperimentalApi
+public sealed interface McpOutcome {
+
+    /**
+     * The handler produced a result and the JSON-RPC response carries it.
+     *
+     * @param result the handler's result, already mapped to its wire shape; {@code null} for
+     *               notifications, which have no response
+     */
+    record Success(@Nullable Object result) implements McpOutcome {}
+
+    /**
+     * The JSON-RPC call succeeded, but the result payload itself reports a failure — today only a
+     * {@code tools/call} whose {@code CallToolResult} carries {@code isError: true}.
+     *
+     * <p>Still a success on the wire: the client receives a {@code result}, not an {@code error}.
+     * The distinction exists for observability and policy, which need to tell "the tool ran and
+     * said no" apart from "the tool ran and said yes".
+     *
+     * @param result the handler's result, already mapped to its wire shape
+     */
+    record PayloadFailure(@Nullable Object result) implements McpOutcome {}
+
+    /**
+     * The operation failed and the response is a JSON-RPC error envelope.
+     *
+     * <p>Prefer {@link McpInterceptor.Chain#reject(ServerError)} over constructing this directly —
+     * it resolves {@code jsonRpcCode} for the protocol version in play, which is not something
+     * calling code should have to know.
+     *
+     * @param error       the protocol-neutral error
+     * @param jsonRpcCode the code this protocol version puts on the wire for {@code error}
+     */
+    record Failure(ServerError error, int jsonRpcCode) implements McpOutcome {}
+}

--- a/tachyon-api/src/main/java/dev/tachyonmcp/api/server/interceptor/package-info.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/api/server/interceptor/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Konstantin Pavlov and contributors.
+ * Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors.
  */
 
 /**

--- a/tachyon-api/src/main/java/dev/tachyonmcp/api/server/interceptor/package-info.java
+++ b/tachyon-api/src/main/java/dev/tachyonmcp/api/server/interceptor/package-info.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2026 Konstantin Pavlov and contributors.
+ */
+
+/**
+ * The server's single cross-cutting seam: around-advice over every inbound MCP request and
+ * notification.
+ *
+ * <p>Tracing, auditing, authorization, rate limiting and metrics are all expressed as an {@link
+ * dev.tachyonmcp.api.server.interceptor.McpInterceptor}. There is deliberately no second
+ * per-request hook type.
+ */
+@NullMarked
+package dev.tachyonmcp.api.server.interceptor;
+
+import org.jspecify.annotations.NullMarked;

--- a/tachyon-bom/pom.xml
+++ b/tachyon-bom/pom.xml
@@ -72,6 +72,11 @@
                 <artifactId>tachyon-annotations-langchain4j</artifactId>
                 <version>${project.version}</version>
             </dependency>
+            <dependency>
+                <groupId>dev.tachyonmcp</groupId>
+                <artifactId>tachyon-otel</artifactId>
+                <version>${project.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 </project>

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/ProtocolResponseMapper.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/ProtocolResponseMapper.java
@@ -80,6 +80,23 @@ public interface ProtocolResponseMapper {
     /** Maps a tool call result into protocol-specific shape. */
     Object callToolResult(ToolResult result);
 
+    /**
+     * Whether a result already mapped by {@link #callToolResult(ToolResult)} reports a failure
+     * <em>inside its payload</em> rather than as a JSON-RPC error — today, a {@code CallToolResult}
+     * flagged {@code isError}.
+     *
+     * <p>Only the codec knows its own wire shape, which is why this lives here: by the time a
+     * result leaves the tool handler the protocol-neutral {@link ToolResult.Error} is gone. Feeds
+     * {@code McpOutcome.PayloadFailure}, so observers can tell "the tool ran and said no" from "the
+     * tool ran and said yes".
+     *
+     * @param result a mapped result, or {@code null}
+     * @return {@code true} if the payload reports a failure
+     */
+    default boolean isPayloadError(@Nullable Object result) {
+        return false;
+    }
+
     /** Maps a paginated list of resource descriptors into protocol-specific shape. */
     Object listResourcesResult(List<ResourceDescriptor> resources, @Nullable String nextCursor);
 

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/mcp/v2025_11_25/codecs/McpResponseMapper.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/mcp/v2025_11_25/codecs/McpResponseMapper.java
@@ -150,6 +150,11 @@ public class McpResponseMapper implements ProtocolResponseMapper {
         };
     }
 
+    @Override
+    public boolean isPayloadError(@Nullable Object result) {
+        return result instanceof CallToolResult mapped && Boolean.TRUE.equals(mapped.isError());
+    }
+
     protected static @Nullable Map<String, JsonNode> resolveMeta(ToolResult result) {
         var meta = result.meta();
         return meta == null || meta.isEmpty() ? null : JsonUtils.toJsonNodeMap(meta);

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/mcp/v2026_07_28/codecs/McpResponseMapper.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/protocol/mcp/v2026_07_28/codecs/McpResponseMapper.java
@@ -219,6 +219,12 @@ public final class McpResponseMapper extends dev.tachyonmcp.core.protocol.mcp.v2
         };
     }
 
+    /** Overrides the 2025-11-25 check: this version has its own generated {@code CallToolResult}. */
+    @Override
+    public boolean isPayloadError(@Nullable Object result) {
+        return result instanceof CallToolResult mapped && Boolean.TRUE.equals(mapped.isError());
+    }
+
     @Override
     public Object inputRequiredResult(
             Map<String, ? extends InputRequest> inputRequests,

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/DefaultServerBuilder.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/DefaultServerBuilder.java
@@ -13,6 +13,7 @@ import dev.tachyonmcp.api.server.features.completions.Completions;
 import dev.tachyonmcp.api.server.features.prompts.Prompts;
 import dev.tachyonmcp.api.server.features.resources.Resources;
 import dev.tachyonmcp.api.server.features.tools.Tools;
+import dev.tachyonmcp.api.server.interceptor.McpInterceptor;
 import dev.tachyonmcp.core.server.config.CapabilitiesConfig;
 import dev.tachyonmcp.core.server.config.NetworkConfig;
 import dev.tachyonmcp.core.server.config.ServerConfig;
@@ -26,6 +27,7 @@ import io.netty.channel.ChannelPipeline;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -45,6 +47,7 @@ final class DefaultServerBuilder implements ServerBuilder {
     private final RuntimeConfig.Builder runtimeBuilder = RuntimeConfig.builder();
     private final MonitoringConfig.Builder monitoringBuilder = MonitoringConfig.builder();
     private final List<ServerExtension> extensions = new ArrayList<>();
+    private final List<McpInterceptor> interceptors = new ArrayList<>();
     private final Set<String> extensionIds = new HashSet<>();
     private final List<Consumer<TachyonServer>> bootstrapRegistrations = new ArrayList<>();
 
@@ -246,6 +249,14 @@ final class DefaultServerBuilder implements ServerBuilder {
         extensions.add(extension);
     }
 
+    @Override
+    public ServerBuilder withInterceptors(McpInterceptor... interceptors) {
+        for (var interceptor : interceptors) {
+            this.interceptors.add(Objects.requireNonNull(interceptor, "interceptor cannot be null"));
+        }
+        return this;
+    }
+
     /**
      * Sets a thread factory for virtual-thread-per-task executor creation. The server owns this
      * executor and will shut it down on close.
@@ -333,6 +344,7 @@ final class DefaultServerBuilder implements ServerBuilder {
                 payloadDeserializer,
                 null,
                 allExtensions,
+                List.copyOf(interceptors),
                 pipelineCustomizer);
         try {
             bootstrapRegistrations.forEach(registrar -> registrar.accept(server));

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/DefaultTachyonServer.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/DefaultTachyonServer.java
@@ -22,6 +22,7 @@ import dev.tachyonmcp.api.server.features.tasks.TaskSnapshot;
 import dev.tachyonmcp.api.server.features.tasks.TaskSupport;
 import dev.tachyonmcp.api.server.features.tasks.Tasks;
 import dev.tachyonmcp.api.server.features.tools.Tools;
+import dev.tachyonmcp.api.server.interceptor.McpInterceptor;
 import dev.tachyonmcp.api.server.session.SessionIdGenerator;
 import dev.tachyonmcp.core.protocol.Protocol;
 import dev.tachyonmcp.core.protocol.ProtocolResponseMapper;
@@ -113,6 +114,7 @@ final class DefaultTachyonServer implements ServerEngine, ExtensionContext {
     private final ConcurrentHashMap<RequestId, PendingRequestEntry> pendingRequests = new ConcurrentHashMap<>();
     private final ExecutorService executor;
     private final List<ServerExtension> extensions;
+    private final List<McpInterceptor> interceptors;
     private final @Nullable Consumer<ChannelPipeline> pipelineCustomizer;
     private final Map<String, String> extensionMethodOwners = new ConcurrentHashMap<>();
     private final Map<String, ServerExtension> extensionsById = new ConcurrentHashMap<>();
@@ -284,12 +286,14 @@ final class DefaultTachyonServer implements ServerEngine, ExtensionContext {
             @Nullable PayloadDeserializer payloadDeserializer,
             @Nullable JsonSchemaFactory<?> schemaFactory,
             @Nullable List<ServerExtension> extensions,
+            @Nullable List<McpInterceptor> interceptors,
             @Nullable Consumer<ChannelPipeline> pipelineCustomizer) {
         this.executor = executor;
         this.config = Objects.requireNonNull(config, "config cannot be null");
         this.sessionEventStore = Objects.requireNonNull(sessionEventStore, "sessionEventStore cannot be null");
         this.port = config.network().port();
         this.extensions = extensions != null ? extensions : List.of();
+        this.interceptors = interceptors != null ? List.copyOf(interceptors) : List.of();
         this.pipelineCustomizer = pipelineCustomizer;
         this.sessionManager = new SessionManager(sessionStore);
         final JsonSchemaValidator inputValidator1 =
@@ -601,6 +605,11 @@ final class DefaultTachyonServer implements ServerEngine, ExtensionContext {
     @Override
     public @Nullable String extensionForMethod(String method) {
         return extensionMethodOwners.get(method);
+    }
+
+    @Override
+    public List<McpInterceptor> interceptors() {
+        return interceptors;
     }
 
     @Override

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/DispatchInvocation.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/DispatchInvocation.java
@@ -1,0 +1,108 @@
+/* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
+package dev.tachyonmcp.core.server;
+
+import dev.tachyonmcp.api.annotations.InternalApi;
+import dev.tachyonmcp.api.json.JsonDocument;
+import dev.tachyonmcp.api.runtime.InteractionContext;
+import dev.tachyonmcp.api.server.domain.RequestId;
+import dev.tachyonmcp.api.server.interceptor.McpInvocation;
+import dev.tachyonmcp.core.server.session.DispatchContext;
+import dev.tachyonmcp.core.transport.jsonrpc.JsonRpcCodec;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * {@link McpInvocation} backed by the live {@link DispatchContext} of one dispatch. Session id and
+ * protocol version are read through the context on each call, so an invocation handed to an
+ * interceptor before {@code initialize} established a session reports the session once it exists.
+ */
+@InternalApi
+final class DispatchInvocation implements McpInvocation {
+
+    private final String method;
+    private final DispatchContext context;
+    private final @Nullable Object rawParams;
+
+    private volatile @Nullable JsonDocument params;
+
+    DispatchInvocation(String method, DispatchContext context, @Nullable Object rawParams) {
+        this.method = method;
+        this.context = context;
+        this.rawParams = rawParams;
+    }
+
+    /**
+     * Encodes raw JSON-RPC {@code params} as a JSON string, or {@code null} when the value carries
+     * nothing serializable (absent params, or a scalar the wire never produces here).
+     */
+    static @Nullable String encodeParams(@Nullable Object rawParams) {
+        if (rawParams instanceof Map || rawParams instanceof List) {
+            return JsonRpcCodec.writeValueAsString(rawParams);
+        }
+        return rawParams instanceof String s ? s : null;
+    }
+
+    @Override
+    public String method() {
+        return method;
+    }
+
+    @Override
+    public @Nullable RequestId requestId() {
+        return context.requestId();
+    }
+
+    @Override
+    public @Nullable String sessionId() {
+        return context.sessionId();
+    }
+
+    @Override
+    public String protocolVersion() {
+        return context.protocolVersion();
+    }
+
+    @Override
+    public Optional<String> targetName() {
+        return stringParam("name");
+    }
+
+    @Override
+    public Optional<String> resourceUri() {
+        return stringParam("uri");
+    }
+
+    private Optional<String> stringParam(String key) {
+        return rawParams instanceof Map<?, ?> map && map.get(key) instanceof String value && !value.isBlank()
+                ? Optional.of(value)
+                : Optional.empty();
+    }
+
+    @Override
+    public Optional<JsonDocument> params() {
+        var cached = params;
+        if (cached == null) {
+            final var json = encodeParams(rawParams);
+            if (json == null || json.isBlank()) {
+                // Nothing to cache. Recomputing costs two instanceof checks, so a param-less
+                // operation pays less for the miss than a second field would cost every request.
+                return Optional.empty();
+            }
+            cached = JsonDocument.of(json);
+            params = cached;
+        }
+        return Optional.of(cached);
+    }
+
+    @Override
+    public InteractionContext context() {
+        return context;
+    }
+
+    @Override
+    public String toString() {
+        return "McpInvocation[method=" + method + ", requestId=" + requestId() + ", sessionId=" + sessionId() + "]";
+    }
+}

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/InterceptorChain.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/InterceptorChain.java
@@ -9,14 +9,16 @@ import dev.tachyonmcp.api.server.interceptor.McpOutcome;
 import dev.tachyonmcp.core.server.session.DispatchContext;
 import java.util.List;
 import java.util.Objects;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
 import java.util.function.Supplier;
 
 /**
  * Immutable node in the {@link McpInterceptor} chain: each {@link #proceed()} builds the node for
  * the next interceptor rather than advancing a shared cursor, so an interceptor may call {@code
  * proceed()} more than once (retry) and two threads never race on the position.
+ *
+ * <p>Runs entirely on the dispatch virtual thread, so chain and handler share one stack — which is
+ * what keeps the dispatch's thread-scoped outbound-stream binding
+ * ({@link OutboundSseStreamMessageRouter}) in scope for the handler.
  */
 @InternalApi
 final class InterceptorChain implements McpInterceptor.Chain {
@@ -25,14 +27,14 @@ final class InterceptorChain implements McpInterceptor.Chain {
     private final int index;
     private final McpInvocation invocation;
     private final DispatchContext context;
-    private final Supplier<CompletionStage<McpOutcome>> terminal;
+    private final Supplier<McpOutcome> terminal;
 
     private InterceptorChain(
             List<McpInterceptor> interceptors,
             int index,
             McpInvocation invocation,
             DispatchContext context,
-            Supplier<CompletionStage<McpOutcome>> terminal) {
+            Supplier<McpOutcome> terminal) {
         this.interceptors = interceptors;
         this.index = index;
         this.invocation = invocation;
@@ -45,34 +47,36 @@ final class InterceptorChain implements McpInterceptor.Chain {
      * terminal}. Callers must check for an empty {@code interceptors} list first — the
      * zero-interceptor path is meant to allocate nothing.
      */
-    static CompletionStage<McpOutcome> run(
+    static McpOutcome run(
             List<McpInterceptor> interceptors,
             McpInvocation invocation,
             DispatchContext context,
-            Supplier<CompletionStage<McpOutcome>> terminal) {
+            Supplier<McpOutcome> terminal) {
         return new InterceptorChain(interceptors, 0, invocation, context, terminal).proceed();
     }
 
     @Override
-    public CompletionStage<McpOutcome> proceed() {
-        if (index == interceptors.size()) {
-            return terminal.get();
-        }
-        final var interceptor = interceptors.get(index);
+    public McpOutcome proceed() {
+        // Failures are values on this seam: everything downstream -- the next interceptor or the
+        // handler -- is classified here, so proceed() never throws on the remainder's behalf and an
+        // outer interceptor observes the same Failure the wire will carry instead of having to catch.
         try {
+            if (index == interceptors.size()) {
+                return terminal.get();
+            }
+            final var interceptor = interceptors.get(index);
             final var next = new InterceptorChain(interceptors, index + 1, invocation, context, terminal);
             return Objects.requireNonNull(
                     interceptor.intercept(invocation, next),
                     () -> interceptor.getClass().getName() + ".intercept returned null");
         } catch (Exception e) {
-            // Same failure channel as a throwing handler, so McpDispatcher maps it to -32603.
-            return CompletableFuture.failedFuture(e);
+            return McpOutcomes.failure(invocation.method(), e, context);
         }
     }
 
     @Override
-    public CompletionStage<McpOutcome> reject(ServerError error) {
+    public McpOutcome reject(ServerError error) {
         Objects.requireNonNull(error, "error");
-        return CompletableFuture.<McpOutcome>completedStage(McpOutcomes.failure(error, context));
+        return McpOutcomes.failure(error, context);
     }
 }

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/InterceptorChain.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/InterceptorChain.java
@@ -1,0 +1,78 @@
+/* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
+package dev.tachyonmcp.core.server;
+
+import dev.tachyonmcp.api.annotations.InternalApi;
+import dev.tachyonmcp.api.server.domain.ServerError;
+import dev.tachyonmcp.api.server.interceptor.McpInterceptor;
+import dev.tachyonmcp.api.server.interceptor.McpInvocation;
+import dev.tachyonmcp.api.server.interceptor.McpOutcome;
+import dev.tachyonmcp.core.server.session.DispatchContext;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Supplier;
+
+/**
+ * Immutable node in the {@link McpInterceptor} chain: each {@link #proceed()} builds the node for
+ * the next interceptor rather than advancing a shared cursor, so an interceptor may call {@code
+ * proceed()} more than once (retry) and two threads never race on the position.
+ */
+@InternalApi
+final class InterceptorChain implements McpInterceptor.Chain {
+
+    private final List<McpInterceptor> interceptors;
+    private final int index;
+    private final McpInvocation invocation;
+    private final DispatchContext context;
+    private final Supplier<CompletionStage<McpOutcome>> terminal;
+
+    private InterceptorChain(
+            List<McpInterceptor> interceptors,
+            int index,
+            McpInvocation invocation,
+            DispatchContext context,
+            Supplier<CompletionStage<McpOutcome>> terminal) {
+        this.interceptors = interceptors;
+        this.index = index;
+        this.invocation = invocation;
+        this.context = context;
+        this.terminal = terminal;
+    }
+
+    /**
+     * Runs {@code invocation} through every interceptor, outermost first, ending in {@code
+     * terminal}. Callers must check for an empty {@code interceptors} list first — the
+     * zero-interceptor path is meant to allocate nothing.
+     */
+    static CompletionStage<McpOutcome> run(
+            List<McpInterceptor> interceptors,
+            McpInvocation invocation,
+            DispatchContext context,
+            Supplier<CompletionStage<McpOutcome>> terminal) {
+        return new InterceptorChain(interceptors, 0, invocation, context, terminal).proceed();
+    }
+
+    @Override
+    public CompletionStage<McpOutcome> proceed() {
+        if (index == interceptors.size()) {
+            return terminal.get();
+        }
+        final var interceptor = interceptors.get(index);
+        try {
+            final var next = new InterceptorChain(interceptors, index + 1, invocation, context, terminal);
+            return Objects.requireNonNull(
+                    interceptor.intercept(invocation, next),
+                    () -> interceptor.getClass().getName() + ".intercept returned null");
+        } catch (Exception e) {
+            // Same failure channel as a throwing handler, so McpDispatcher maps it to -32603.
+            return CompletableFuture.failedFuture(e);
+        }
+    }
+
+    @Override
+    public CompletionStage<McpOutcome> reject(ServerError error) {
+        Objects.requireNonNull(error, "error");
+        return CompletableFuture.<McpOutcome>completedStage(McpOutcomes.failure(error, context));
+    }
+}

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/McpDispatcher.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/McpDispatcher.java
@@ -5,6 +5,8 @@ import dev.tachyonmcp.api.annotations.InternalApi;
 import dev.tachyonmcp.api.runtime.AttributeKey;
 import dev.tachyonmcp.api.server.domain.RequestId;
 import dev.tachyonmcp.api.server.domain.ServerError;
+import dev.tachyonmcp.api.server.interceptor.McpInterceptor;
+import dev.tachyonmcp.api.server.interceptor.McpOutcome;
 import dev.tachyonmcp.api.server.session.SessionIdGenerator;
 import dev.tachyonmcp.core.protocol.ProtocolResponseMapper;
 import dev.tachyonmcp.core.protocol.Protocols;
@@ -27,8 +29,6 @@ import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpVersion;
 import java.nio.charset.StandardCharsets;
-import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CancellationException;
@@ -243,9 +243,7 @@ public class McpDispatcher {
             DispatchContext context,
             @Nullable Session session,
             RpcMethodHandler<I, O> handler) {
-        var paramsStr = rawParams instanceof Map || rawParams instanceof List
-                ? JsonRpcCodec.writeValueAsString(rawParams)
-                : rawParams instanceof String s ? s : null;
+        var paramsStr = DispatchInvocation.encodeParams(rawParams);
 
         return CompletableFuture.supplyAsync(
                         () -> {
@@ -266,33 +264,55 @@ public class McpDispatcher {
                                             m.slowRequestThreshold().toMillis())
                                     : CompletableFuture.completedFuture(null);
                             try {
-                                CompletionStage<O> stage = OutboundSseStreamMessageRouter.withDispatchContext(
+                                CompletionStage<McpOutcome> stage = OutboundSseStreamMessageRouter.withDispatchContext(
                                         session != null ? session.id() : null,
                                         outboundSseStream,
-                                        () -> decodeAndHandleAsync(handler, context, rawParams));
+                                        () -> decodeAndHandleAsync(method, handler, context, rawParams));
                                 return stage.whenComplete((r, e) -> watchdog.cancel(false));
                             } catch (Exception e) {
                                 watchdog.cancel(false);
-                                return CompletableFuture.failedFuture(e);
+                                return CompletableFuture.<McpOutcome>failedFuture(e);
                             }
                         },
                         executor)
                 .thenCompose(stage -> stage)
                 // handle(), not handleAsync(executor): encoding is a cheap ByteBuf serialize and the
                 // completing thread is never the event loop — no need to burn a VT per request on it.
-                .handle((result, ex) -> {
-                    if (ex != null) {
-                        return handleHandlerError(id, method, ex, context);
-                    }
-                    return handleSuccessOrError(id, method, result, null, context);
-                });
+                .handle((outcome, ex) -> ex != null
+                        ? errorResult(id, classifyThrowable(id, method, ex), context)
+                        : toDispatchResult(id, method, outcome, null, context));
     }
 
     /**
      * Fixed decode-then-handle skeleton every dispatch path shares -- the single call site each
-     * routes through, and the seam a future interceptor/chain wraps around.
+     * routes through, and the seam {@link McpInterceptor}s wrap around.
+     *
+     * <p>Classification happens here rather than after the chain unwinds, so an interceptor
+     * observes the outcome the wire will actually carry -- above all the JSON-RPC error code, which
+     * only the protocol codec can resolve.
      */
-    private <I, O> CompletionStage<O> decodeAndHandleAsync(
+    private <I, O> CompletionStage<McpOutcome> decodeAndHandleAsync(
+            String method, RpcMethodHandler<I, O> handler, DispatchContext context, @Nullable Object rawParams) {
+        var interceptors = server.interceptors();
+        if (interceptors.isEmpty()) {
+            return classified(method, handler, context, rawParams);
+        }
+        return InterceptorChain.run(
+                interceptors,
+                new DispatchInvocation(method, context, rawParams),
+                context,
+                () -> classified(method, handler, context, rawParams));
+    }
+
+    private <I, O> CompletionStage<McpOutcome> classified(
+            String method, RpcMethodHandler<I, O> handler, DispatchContext context, @Nullable Object rawParams) {
+        return decodeAndHandle(handler, context, rawParams)
+                .handle((result, ex) -> ex != null
+                        ? McpOutcomes.failure(classifyThrowable(context.requestId(), method, ex), context)
+                        : McpOutcomes.of(result, context));
+    }
+
+    private <I, O> CompletionStage<O> decodeAndHandle(
             RpcMethodHandler<I, O> handler, DispatchContext context, @Nullable Object rawParams) {
         try {
             I decoded = handler.decode(context, rawParams);
@@ -302,26 +322,37 @@ public class McpDispatcher {
         }
     }
 
-    private DispatchResult handleHandlerError(RequestId id, String method, Throwable ex, DispatchContext context) {
+    /** Maps a thrown/failed handler into the protocol-neutral error the response will carry. */
+    private ServerError classifyThrowable(@Nullable RequestId id, String method, Throwable ex) {
         var unwrapped = ex instanceof CompletionException ce && ce.getCause() != null ? ce.getCause() : ex;
         if (unwrapped instanceof CancellationException) {
             logger.debug("Handler cancelled: method={}, id={}", method, id);
-            return errorResult(id, ServerErrors.internalError("Internal error"), context);
+            return ServerErrors.internalError("Internal error");
         }
         if (unwrapped instanceof RequestMappingException rme) {
             logger.debug("Request mapping failed: method={}, id={}: {}", method, id, rme.getMessage());
-            return errorResult(id, rme.error(), context);
+            return rme.error();
         }
         logger.warn("Handler exception: method={}, id={}: {}", method, id, unwrapped.getMessage(), unwrapped);
-        return errorResult(id, ServerErrors.internalError("Internal error"), context);
+        return ServerErrors.internalError("Internal error");
     }
 
-    private <O> DispatchResult handleSuccessOrError(
-            RequestId id, String method, O result, @Nullable String sessionId, DispatchContext context) {
-        if (result instanceof ServerError error) {
-            logger.debug("Handler error for {}: {}", method, error.message());
-            return errorResult(id, error, context);
-        }
+    private DispatchResult toDispatchResult(
+            RequestId id, String method, McpOutcome outcome, @Nullable String sessionId, DispatchContext context) {
+        return switch (outcome) {
+            case McpOutcome.Failure(var error, var ignored) -> {
+                logger.debug("Handler error for {}: {}", method, error.message());
+                yield errorResult(id, error, context);
+            }
+            // A payload failure is a JSON-RPC success on the wire -- the distinction exists for
+            // observers, not for the client, so both arms encode identically.
+            case McpOutcome.PayloadFailure(var result) -> encodedResponse(id, result, sessionId, context);
+            case McpOutcome.Success(var result) -> encodedResponse(id, result, sessionId, context);
+        };
+    }
+
+    private DispatchResult encodedResponse(
+            RequestId id, @Nullable Object result, @Nullable String sessionId, DispatchContext context) {
         return new DispatchResult.Response(encodeResponse(id, result, context.responseMapper()), sessionId, 200);
     }
 
@@ -330,6 +361,32 @@ public class McpDispatcher {
     }
 
     public DispatchResult dispatchNotification(
+            String method,
+            @Nullable Object params,
+            @Nullable String sessionId,
+            @Nullable ChannelContext channelContext) {
+        var interceptors = server.interceptors();
+        if (interceptors.isEmpty()) {
+            return handleNotification(method, params, sessionId, channelContext);
+        }
+        // A notification has no response, so its answer is always Accepted: an interceptor that
+        // defers cannot hold one up, and one that rejects only suppresses the handler.
+        var context = dispatchContext(channelContext);
+        InterceptorChain.run(interceptors, new DispatchInvocation(method, context, params), context, () -> {
+                    handleNotification(method, params, sessionId, channelContext);
+                    return CompletableFuture.<McpOutcome>completedStage(new McpOutcome.Success(null));
+                })
+                .whenComplete((outcome, ex) -> {
+                    if (ex != null) {
+                        logger.warn("Notification interceptor failed: method={}: {}", method, ex.getMessage(), ex);
+                    } else if (outcome instanceof McpOutcome.Failure(var error, var ignored)) {
+                        logger.debug("Notification rejected by interceptor: method={}: {}", method, error.message());
+                    }
+                });
+        return DispatchResult.Accepted.INSTANCE;
+    }
+
+    private DispatchResult handleNotification(
             String method,
             @Nullable Object params,
             @Nullable String sessionId,
@@ -415,20 +472,20 @@ public class McpDispatcher {
                                 if (!server.isStateless()) {
                                     ic.setSession(server.createSession(generateSessionId(channelContext)));
                                 }
-                                return (CompletionStage<Object>) decodeAndHandleAsync(handler, ic, rawParams);
+                                return decodeAndHandleAsync(METHOD_INITIALIZE, handler, ic, rawParams);
                             } catch (Exception e) {
-                                return CompletableFuture.failedFuture(e);
+                                return CompletableFuture.<McpOutcome>failedFuture(e);
                             }
                         },
                         executor)
                 .thenCompose(stage -> stage)
-                .handle((result, ex) -> {
+                .handle((outcome, ex) -> {
                     if (ex != null) {
-                        return handleHandlerError(id, "initialize", ex, ic);
+                        return errorResult(id, classifyThrowable(id, METHOD_INITIALIZE, ex), ic);
                     }
                     final var session = ic.session();
                     var sessionId = session != null ? session.id() : null;
-                    return handleSuccessOrError(id, "initialize", result, sessionId, ic);
+                    return toDispatchResult(id, METHOD_INITIALIZE, outcome, sessionId, ic);
                 });
     }
 
@@ -438,7 +495,7 @@ public class McpDispatcher {
         return new DispatchResult.Response(body, null, wireError.httpStatus());
     }
 
-    private static byte[] encodeResponse(RequestId id, Object result, ProtocolResponseMapper mapper) {
+    private static byte[] encodeResponse(RequestId id, @Nullable Object result, ProtocolResponseMapper mapper) {
         if (result instanceof String s) {
             return JsonRpcCodec.serializeResponse(id, s);
         }
@@ -447,7 +504,10 @@ public class McpDispatcher {
             return JsonRpcCodec.serializeResponse(id, resultJson);
         } catch (Exception e) {
             logger.error(
-                    "JSON serialization failed for {}: {}", result.getClass().getSimpleName(), e.getMessage(), e);
+                    "JSON serialization failed for {}: {}",
+                    result == null ? "null" : result.getClass().getSimpleName(),
+                    e.getMessage(),
+                    e);
             return encodeError(id, ServerErrors.internalError("Failed to encode response"), mapper);
         }
     }

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/McpDispatcher.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/McpDispatcher.java
@@ -5,6 +5,7 @@ import dev.tachyonmcp.api.annotations.InternalApi;
 import dev.tachyonmcp.api.runtime.AttributeKey;
 import dev.tachyonmcp.api.server.domain.RequestId;
 import dev.tachyonmcp.api.server.domain.ServerError;
+import dev.tachyonmcp.api.server.features.HandlerFutures;
 import dev.tachyonmcp.api.server.interceptor.McpInterceptor;
 import dev.tachyonmcp.api.server.interceptor.McpOutcome;
 import dev.tachyonmcp.api.server.session.SessionIdGenerator;
@@ -31,9 +32,7 @@ import io.netty.handler.codec.http.HttpVersion;
 import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
 import org.jspecify.annotations.Nullable;
@@ -279,7 +278,7 @@ public class McpDispatcher {
                 // handle(), not handleAsync(executor): encoding is a cheap ByteBuf serialize and the
                 // completing thread is never the event loop — no need to burn a VT per request on it.
                 .handle((outcome, ex) -> ex != null
-                        ? errorResult(id, classifyThrowable(id, method, ex), context)
+                        ? errorResult(id, McpOutcomes.classify(id, method, ex), context)
                         : toDispatchResult(id, method, outcome, null, context));
     }
 
@@ -290,6 +289,11 @@ public class McpDispatcher {
      * <p>Classification happens here rather than after the chain unwinds, so an interceptor
      * observes the outcome the wire will actually carry -- above all the JSON-RPC error code, which
      * only the protocol codec can resolve.
+     *
+     * <p>With no interceptor registered the handler's stage is returned untouched, so the default
+     * path neither allocates a chain node nor blocks the dispatch thread on an async handler. The
+     * {@link McpInterceptor} seam is synchronous, so once one is registered the chain and the
+     * handler share this thread until the outcome exists.
      */
     private <I, O> CompletionStage<McpOutcome> decodeAndHandleAsync(
             String method, RpcMethodHandler<I, O> handler, DispatchContext context, @Nullable Object rawParams) {
@@ -297,19 +301,37 @@ public class McpDispatcher {
         if (interceptors.isEmpty()) {
             return classified(method, handler, context, rawParams);
         }
-        return InterceptorChain.run(
+        return CompletableFuture.completedStage(InterceptorChain.run(
                 interceptors,
                 new DispatchInvocation(method, context, rawParams),
                 context,
-                () -> classified(method, handler, context, rawParams));
+                () -> handled(method, handler, context, rawParams)));
     }
 
     private <I, O> CompletionStage<McpOutcome> classified(
             String method, RpcMethodHandler<I, O> handler, DispatchContext context, @Nullable Object rawParams) {
         return decodeAndHandle(handler, context, rawParams)
-                .handle((result, ex) -> ex != null
-                        ? McpOutcomes.failure(classifyThrowable(context.requestId(), method, ex), context)
-                        : McpOutcomes.of(result, context));
+                .handle((result, ex) ->
+                        ex != null ? McpOutcomes.failure(method, ex, context) : McpOutcomes.of(result, context));
+    }
+
+    /**
+     * Terminal of the interceptor chain: decodes, handles, and blocks for the result on this
+     * virtual thread.
+     *
+     * <p>ponytail: a handler whose stage stays pending for the life of an SSE subscription
+     * ({@code subscriptions/listen}) parks this thread for that long. Bounded by the open
+     * connection it belongs to, which costs more than the parked continuation. Split the terminal
+     * so a streaming handler returns at stream-establish if that ever shows up in a heap dump.
+     */
+    private <I, O> McpOutcome handled(
+            String method, RpcMethodHandler<I, O> handler, DispatchContext context, @Nullable Object rawParams) {
+        try {
+            I decoded = handler.decode(context, rawParams);
+            return McpOutcomes.of(HandlerFutures.joinInterruptibly(handler.handleAsync(context, decoded)), context);
+        } catch (Exception e) {
+            return McpOutcomes.failure(method, e, context);
+        }
     }
 
     private <I, O> CompletionStage<O> decodeAndHandle(
@@ -322,25 +344,10 @@ public class McpDispatcher {
         }
     }
 
-    /** Maps a thrown/failed handler into the protocol-neutral error the response will carry. */
-    private ServerError classifyThrowable(@Nullable RequestId id, String method, Throwable ex) {
-        var unwrapped = ex instanceof CompletionException ce && ce.getCause() != null ? ce.getCause() : ex;
-        if (unwrapped instanceof CancellationException) {
-            logger.debug("Handler cancelled: method={}, id={}", method, id);
-            return ServerErrors.internalError("Internal error");
-        }
-        if (unwrapped instanceof RequestMappingException rme) {
-            logger.debug("Request mapping failed: method={}, id={}: {}", method, id, rme.getMessage());
-            return rme.error();
-        }
-        logger.warn("Handler exception: method={}, id={}: {}", method, id, unwrapped.getMessage(), unwrapped);
-        return ServerErrors.internalError("Internal error");
-    }
-
     private DispatchResult toDispatchResult(
             RequestId id, String method, McpOutcome outcome, @Nullable String sessionId, DispatchContext context) {
         return switch (outcome) {
-            case McpOutcome.Failure(var error, var ignored) -> {
+            case McpOutcome.Failure(var error, var ignoredCode, var ignoredCause) -> {
                 logger.debug("Handler error for {}: {}", method, error.message());
                 yield errorResult(id, error, context);
             }
@@ -369,20 +376,22 @@ public class McpDispatcher {
         if (interceptors.isEmpty()) {
             return handleNotification(method, params, sessionId, channelContext);
         }
-        // A notification has no response, so its answer is always Accepted: an interceptor that
-        // defers cannot hold one up, and one that rejects only suppresses the handler.
+        // A notification has no response, so its answer is always Accepted: an interceptor can only
+        // suppress the handler, never change what the client is told. The transport has already
+        // acked before dispatching here (see McpOperationHandler), so blocking the chain is free.
         var context = dispatchContext(channelContext);
-        InterceptorChain.run(interceptors, new DispatchInvocation(method, context, params), context, () -> {
+        var outcome =
+                InterceptorChain.run(interceptors, new DispatchInvocation(method, context, params), context, () -> {
                     handleNotification(method, params, sessionId, channelContext);
-                    return CompletableFuture.<McpOutcome>completedStage(new McpOutcome.Success(null));
-                })
-                .whenComplete((outcome, ex) -> {
-                    if (ex != null) {
-                        logger.warn("Notification interceptor failed: method={}: {}", method, ex.getMessage(), ex);
-                    } else if (outcome instanceof McpOutcome.Failure(var error, var ignored)) {
-                        logger.debug("Notification rejected by interceptor: method={}: {}", method, error.message());
-                    }
+                    return new McpOutcome.Success(null);
                 });
+        if (outcome instanceof McpOutcome.Failure(var error, var ignoredCode, var cause)) {
+            if (cause != null) {
+                logger.warn("Notification interceptor failed: method={}: {}", method, cause.getMessage(), cause);
+            } else {
+                logger.debug("Notification rejected by interceptor: method={}: {}", method, error.message());
+            }
+        }
         return DispatchResult.Accepted.INSTANCE;
     }
 
@@ -481,7 +490,7 @@ public class McpDispatcher {
                 .thenCompose(stage -> stage)
                 .handle((outcome, ex) -> {
                     if (ex != null) {
-                        return errorResult(id, classifyThrowable(id, METHOD_INITIALIZE, ex), ic);
+                        return errorResult(id, McpOutcomes.classify(id, METHOD_INITIALIZE, ex), ic);
                     }
                     final var session = ic.session();
                     var sessionId = session != null ? session.id() : null;

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/McpOutcomes.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/McpOutcomes.java
@@ -1,0 +1,39 @@
+/* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
+package dev.tachyonmcp.core.server;
+
+import dev.tachyonmcp.api.annotations.InternalApi;
+import dev.tachyonmcp.api.server.domain.ServerError;
+import dev.tachyonmcp.api.server.interceptor.McpOutcome;
+import dev.tachyonmcp.core.server.session.DispatchContext;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Turns a handler result into the {@link McpOutcome} interceptors observe, resolving everything
+ * protocol-specific through the negotiated {@code ProtocolResponseMapper}.
+ *
+ * <p>Single home for the classification so the intercepted and non-intercepted dispatch paths
+ * cannot drift apart, and so nothing outside {@code tachyon-core} ever re-derives a JSON-RPC error
+ * code — the two MCP versions map several {@link ServerError.Kind}s differently.
+ */
+@InternalApi
+final class McpOutcomes {
+
+    private McpOutcomes() {}
+
+    /** Classifies a completed handler result. Errors are values here, not only failures. */
+    static McpOutcome of(@Nullable Object result, DispatchContext context) {
+        if (result instanceof ServerError error) {
+            return failure(error, context);
+        }
+        if (context.responseMapper().isPayloadError(result)) {
+            return new McpOutcome.PayloadFailure(result);
+        }
+        return new McpOutcome.Success(result);
+    }
+
+    /** Resolves {@code error} to the wire code this protocol version uses. */
+    static McpOutcome.Failure failure(ServerError error, DispatchContext context) {
+        return new McpOutcome.Failure(
+                error, context.responseMapper().error(error).code());
+    }
+}

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/McpOutcomes.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/McpOutcomes.java
@@ -2,14 +2,21 @@
 package dev.tachyonmcp.core.server;
 
 import dev.tachyonmcp.api.annotations.InternalApi;
+import dev.tachyonmcp.api.server.domain.RequestId;
 import dev.tachyonmcp.api.server.domain.ServerError;
 import dev.tachyonmcp.api.server.interceptor.McpOutcome;
+import dev.tachyonmcp.core.protocol.RequestMappingException;
+import dev.tachyonmcp.core.server.domain.ServerErrors;
 import dev.tachyonmcp.core.server.session.DispatchContext;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletionException;
 import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
- * Turns a handler result into the {@link McpOutcome} interceptors observe, resolving everything
- * protocol-specific through the negotiated {@code ProtocolResponseMapper}.
+ * Turns a handler result or a thrown exception into the {@link McpOutcome} interceptors observe,
+ * resolving everything protocol-specific through the negotiated {@code ProtocolResponseMapper}.
  *
  * <p>Single home for the classification so the intercepted and non-intercepted dispatch paths
  * cannot drift apart, and so nothing outside {@code tachyon-core} ever re-derives a JSON-RPC error
@@ -17,6 +24,8 @@ import org.jspecify.annotations.Nullable;
  */
 @InternalApi
 final class McpOutcomes {
+
+    private static final Logger logger = LoggerFactory.getLogger(McpOutcomes.class);
 
     private McpOutcomes() {}
 
@@ -33,7 +42,35 @@ final class McpOutcomes {
 
     /** Resolves {@code error} to the wire code this protocol version uses. */
     static McpOutcome.Failure failure(ServerError error, DispatchContext context) {
+        return failure(error, context, null);
+    }
+
+    private static McpOutcome.Failure failure(ServerError error, DispatchContext context, @Nullable Throwable cause) {
         return new McpOutcome.Failure(
-                error, context.responseMapper().error(error).code());
+                error, context.responseMapper().error(error).code(), cause);
+    }
+
+    /**
+     * Classifies a throwable from a handler or an interceptor. The cause rides along on the outcome
+     * so an outer interceptor can trace or audit it; only the sanitized {@link ServerError} reaches
+     * the client.
+     */
+    static McpOutcome.Failure failure(String method, Throwable throwable, DispatchContext context) {
+        return failure(classify(context.requestId(), method, throwable), context, throwable);
+    }
+
+    /** Maps a thrown/failed handler or interceptor into the protocol-neutral error the response will carry. */
+    static ServerError classify(@Nullable RequestId id, String method, Throwable ex) {
+        var unwrapped = ex instanceof CompletionException ce && ce.getCause() != null ? ce.getCause() : ex;
+        if (unwrapped instanceof CancellationException) {
+            logger.debug("Handler cancelled: method={}, id={}", method, id);
+            return ServerErrors.internalError("Internal error");
+        }
+        if (unwrapped instanceof RequestMappingException rme) {
+            logger.debug("Request mapping failed: method={}, id={}: {}", method, id, rme.getMessage());
+            return rme.error();
+        }
+        logger.warn("Handler exception: method={}, id={}: {}", method, id, unwrapped.getMessage(), unwrapped);
+        return ServerErrors.internalError("Internal error");
     }
 }

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/ServerBuilder.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/ServerBuilder.java
@@ -11,6 +11,7 @@ import dev.tachyonmcp.api.server.features.completions.Completions;
 import dev.tachyonmcp.api.server.features.prompts.Prompts;
 import dev.tachyonmcp.api.server.features.resources.Resources;
 import dev.tachyonmcp.api.server.features.tools.Tools;
+import dev.tachyonmcp.api.server.interceptor.McpInterceptor;
 import dev.tachyonmcp.core.server.config.CapabilitiesConfig;
 import dev.tachyonmcp.core.server.config.NetworkConfig;
 import dev.tachyonmcp.core.server.config.ServerConfig;
@@ -82,6 +83,22 @@ public interface ServerBuilder {
      * Registers one or more {@link ServerExtension}.
      */
     ServerBuilder withExtensions(ServerExtension... extensions);
+
+    /**
+     * Registers one or more {@link McpInterceptor}s — the server's single cross-cutting seam,
+     * wrapping every inbound MCP request and notification (tracing, auditing, authorization, rate
+     * limiting).
+     *
+     * <p>The first interceptor registered is the <b>outermost</b>. Repeated calls append, so order
+     * across calls is call order. There is deliberately no {@link java.util.ServiceLoader}
+     * discovery: the application owns the order, and no dependency can silently insert itself into
+     * the chain.
+     *
+     * @param interceptors the interceptors to append, outermost first
+     * @return this builder
+     */
+    @ExperimentalApi
+    ServerBuilder withInterceptors(McpInterceptor... interceptors);
 
     /** Sets the thread factory used by the server-owned virtual-thread-per-task executor. */
     ServerBuilder threadFactory(ThreadFactory threadFactory);

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/internal/ServerEngine.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/internal/ServerEngine.java
@@ -7,6 +7,7 @@ import dev.tachyonmcp.api.server.domain.ProgressToken;
 import dev.tachyonmcp.api.server.domain.RequestId;
 import dev.tachyonmcp.api.server.domain.ServerCapabilities;
 import dev.tachyonmcp.api.server.features.tasks.TaskSnapshot;
+import dev.tachyonmcp.api.server.interceptor.McpInterceptor;
 import dev.tachyonmcp.api.server.session.SessionIdGenerator;
 import dev.tachyonmcp.core.protocol.ProtocolResponseMapper;
 import dev.tachyonmcp.core.runtime.Session;
@@ -69,6 +70,12 @@ public interface ServerEngine extends TachyonServer {
     /** Returns the handler for a method, or {@code null} if not registered. */
     @Nullable
     RpcMethodHandler<?, ?> getHandler(String method);
+
+    /**
+     * Returns the registered interceptors in outermost-first order, empty when none. Fixed at
+     * build time and shared per request.
+     */
+    List<McpInterceptor> interceptors();
 
     /** Returns the extension ID that owns the given method, or {@code null} if none. */
     @Nullable

--- a/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/config/TachyonServerBuilder.kt
+++ b/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/config/TachyonServerBuilder.kt
@@ -17,6 +17,7 @@ import dev.tachyonmcp.api.server.features.resources.ResourceTemplateDescriptor
 import dev.tachyonmcp.api.server.features.tasks.TaskSupport
 import dev.tachyonmcp.api.server.features.tools.ToolDescriptor
 import dev.tachyonmcp.api.server.features.tools.ToolResult
+import dev.tachyonmcp.api.server.interceptor.McpInterceptor
 import dev.tachyonmcp.core.server.ServerBuilder
 import dev.tachyonmcp.core.server.config.NetworkConfig
 import dev.tachyonmcp.core.server.features.resources.MimeTypes
@@ -496,6 +497,14 @@ public class TachyonServerBuilder
         /** Registers one or more [ServerExtension]s, e.g. from `tachyon-extensions`. */
         public fun extensions(vararg extensions: ServerExtension): TachyonServerBuilder =
             this.also { delegate.withExtensions(*extensions) }
+
+        /**
+         * Registers one or more [McpInterceptor]s wrapping every inbound MCP request and
+         * notification. The first registered is the outermost; repeated calls append.
+         */
+        @ExperimentalApi
+        public fun interceptors(vararg interceptors: McpInterceptor): TachyonServerBuilder =
+            this.also { delegate.withInterceptors(*interceptors) }
 
         /** Configures the JSON payload boundary: serde, schema factory, and validators. */
         @OptIn(ExperimentalContracts::class)


### PR DESCRIPTION
## Summary

Adds an experimental McpInterceptor API with invocation metadata and protocol-resolved McpOutcome values. Integrates ordered interceptor execution into requests, initialization, and notifications. Adds protocol-specific payload-error mapping. Adds the tachyon-otel module with spans, metrics, outcome classification, and optional payload recording. Adds end-to-end tests and observability documentation.

Issue: #149

### New Features

- Added configurable interceptors for all incoming MCP requests and notifications.
- Added interceptor metadata, request outcomes, short-circuiting, and error handling.
- Added optional OpenTelemetry tracing and metrics, including operation duration and outcome details.
- Added Kotlin support for registering interceptors.

### Bug Fixes

- Improved protocol-aware classification of payload failures and JSON-RPC error responses.

### Documentation

- Added guidance and examples for interceptors, observability, auditing, telemetry, and security considerations.

### Tests

- Added end-to-end coverage for interceptor behavior and OpenTelemetry instrumentation.

