### PR TITLE
fix(e2e): handle v2026-07-28 protocol differences in contract tests

### DIFF
--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/AbstractMcpE2eTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/AbstractMcpE2eTest.java
@@ -4,7 +4,6 @@ package dev.tachyonmcp.e2e.mcp;
 import dev.tachyonmcp.core.server.ServerBuilder;
 import dev.tachyonmcp.core.server.TachyonServer;
 import dev.tachyonmcp.core.server.internal.ServerEngine;
-import dev.tachyonmcp.testkit.Mcp20251125Client;
 import dev.tachyonmcp.testkit.Mcp20260728Client;
 import dev.tachyonmcp.testkit.McpClient;
 import dev.tachyonmcp.testkit.McpTestClients;
@@ -15,7 +14,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.TestInstance;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public abstract class AbstractMcpE2eTest {
+public abstract class AbstractMcpE2eTest<C extends McpClient> {
 
     protected TachyonServer server;
     protected int port;
@@ -44,13 +43,9 @@ public abstract class AbstractMcpE2eTest {
         closeCustomServerIfRunning();
     }
 
-    protected Mcp20251125Client createTestClient() {
-        return createTestClient(port);
-    }
+    protected abstract C createTestClient();
 
-    protected Mcp20251125Client createTestClient(int port) {
-        return new Mcp20251125Client(port);
-    }
+    protected abstract C createTestClient(int port);
 
     protected McpClient createTestClient(String protocolVersion) {
         return McpTestClients.forVersion(port, protocolVersion);

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/AbstractResourceContractTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/AbstractResourceContractTest.java
@@ -15,10 +15,10 @@ import org.junit.jupiter.api.Test;
  * scenarios stay version-specific (2026-07-28 replaced {@code resources/subscribe} with
  * {@code subscriptions/listen}) and are not part of this contract.
  */
-public abstract class AbstractResourceContractTest extends AbstractStatelessMcpE2eTest {
+public abstract class AbstractResourceContractTest<C extends McpClient> extends AbstractStatelessMcpE2eTest<C> {
 
     /** Returns a client ready to send requests (handshake already performed, if the version needs one). */
-    protected abstract McpClient readyClient() throws Exception;
+    protected abstract C readyClient() throws Exception;
 
     /** The wire error code for {@code resources/read} on an unknown URI. */
     protected abstract int resourceNotFoundErrorCode();

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/AbstractSchemaValidationContractTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/AbstractSchemaValidationContractTest.java
@@ -15,18 +15,30 @@ import dev.tachyonmcp.api.server.features.prompts.PromptDescriptor;
 import dev.tachyonmcp.api.server.features.tools.ToolDescriptor;
 import dev.tachyonmcp.api.server.features.tools.ToolResult;
 import dev.tachyonmcp.core.server.json.NetworkntJsonSchemaValidator;
+import dev.tachyonmcp.testkit.McpClient;
 import java.util.List;
 import java.util.Map;
+import net.javacrumbs.jsonunit.core.Option;
 import org.junit.jupiter.api.Test;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.node.JsonNodeFactory;
 
-class SchemaValidationTest extends AbstractStatelessMcpE2eTest {
+/**
+ * Input/output schema validation scenarios that hold under both MCP protocol revisions: only the
+ * client creation and the response envelope differ (2026-07-28 adds {@code resultType}/{@code
+ * ttlMs}/{@code cacheScope}), supplied by subclasses in {@code v2025_11_25}/{@code v2026_07_28}.
+ * Version-specific structured-content tests (array fallback under 2025-11-25) stay in the
+ * version-specific subclasses.
+ */
+public abstract class AbstractSchemaValidationContractTest<T extends McpClient> extends AbstractStatelessMcpE2eTest<T> {
 
-    private static final JsonSchemaValidator VALIDATOR = new NetworkntJsonSchemaValidator();
+    /** Returns a client ready to send requests (handshake already performed, if the version needs one). */
+    protected abstract T readyClient() throws Exception;
 
-    private static final JsonSchema TOOL_SCHEMA = JsonSchema.from(buildToolSchema(), JsonNode.class);
-    private static final JsonSchema PROMPT_SCHEMA = JsonSchema.from(buildPromptSchema(), JsonNode.class);
+    protected static final JsonSchemaValidator VALIDATOR = new NetworkntJsonSchemaValidator();
+
+    protected static final JsonSchema TOOL_SCHEMA = JsonSchema.from(buildToolSchema(), JsonNode.class);
+    protected static final JsonSchema PROMPT_SCHEMA = JsonSchema.from(buildPromptSchema(), JsonNode.class);
 
     // region: Tool input schema validation
 
@@ -38,14 +50,12 @@ class SchemaValidationTest extends AbstractStatelessMcpE2eTest {
                         .register(validatedTool(), (context, request) -> ToolResult.text("ok"))
                         .register(validatedTool2(), (context, request) -> ToolResult.text("ok")));
 
-        try (var client = createTestClient()) {
-            client.initialize();
-
+        try (var client = readyClient()) {
             var r1 = client.post("""
                 {"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"validated","arguments":{"name":"John","age":30}}}
                 """);
             assertThat(r1.statusCode()).isEqualTo(200);
-            assertThatJson(r1.body()).isEqualTo("""
+            assertThatJson(r1.body()).when(Option.IGNORING_EXTRA_FIELDS).isEqualTo("""
                 {"jsonrpc":"2.0","id":2,"result":{"content":[{"type":"text","text":"ok"}]}}
                 """);
 
@@ -53,7 +63,7 @@ class SchemaValidationTest extends AbstractStatelessMcpE2eTest {
                 {"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"validated2","arguments":{"email":"john@example.com","age":25}}}
                 """);
             assertThat(r2.statusCode()).isEqualTo(200);
-            assertThatJson(r2.body()).isEqualTo("""
+            assertThatJson(r2.body()).when(Option.IGNORING_EXTRA_FIELDS).isEqualTo("""
                 {"jsonrpc":"2.0","id":3,"result":{"content":[{"type":"text","text":"ok"}]}}
                 """);
 
@@ -61,7 +71,7 @@ class SchemaValidationTest extends AbstractStatelessMcpE2eTest {
                 {"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"validated2","arguments":{"email":"john@example.com"}}}
                 """);
             assertThat(r3.statusCode()).isEqualTo(200);
-            assertThatJson(r3.body()).isEqualTo("""
+            assertThatJson(r3.body()).when(Option.IGNORING_EXTRA_FIELDS).isEqualTo("""
                 {"jsonrpc":"2.0","id":4,"result":{"content":[{"type":"text","text":"ok"}]}}
                 """);
         }
@@ -73,8 +83,7 @@ class SchemaValidationTest extends AbstractStatelessMcpE2eTest {
                 b -> b.json(j -> j.inputSchemaValidator(VALIDATOR).outputSchemaValidator(VALIDATOR)),
                 s -> s.tools().register(validatedTool(), (context, request) -> ToolResult.text("ok")));
 
-        try (var client = createTestClient()) {
-            client.initialize();
+        try (var client = readyClient()) {
             var response = client.post("""
                 {"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"validated","arguments":{"name":"John","age":30}}}
                 """);
@@ -84,18 +93,17 @@ class SchemaValidationTest extends AbstractStatelessMcpE2eTest {
             var expected = """
                 {"jsonrpc":"2.0","id":2,"result":{"content":[{"type":"text","text":"ok"}]}}
                 """;
-            assertThatJson(response.body()).isEqualTo(expected);
+            assertThatJson(response.body()).when(Option.IGNORING_EXTRA_FIELDS).isEqualTo(expected);
         }
     }
 
     @Test
-    void shouldRejectToolCallWithMissingRequiredField() throws Exception {
+    protected void shouldRejectToolCallWithMissingRequiredField() throws Exception {
         startServer(
                 b -> b.json(j -> j.inputSchemaValidator(VALIDATOR).outputSchemaValidator(VALIDATOR)),
                 s -> s.tools().register(validatedTool(), (context, request) -> ToolResult.text("ok")));
 
-        try (var client = createTestClient()) {
-            client.initialize();
+        try (var client = readyClient()) {
             var response = client.post("""
                 {"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"validated","arguments":{"age":30}}}
                 """);
@@ -110,13 +118,12 @@ class SchemaValidationTest extends AbstractStatelessMcpE2eTest {
     }
 
     @Test
-    void shouldRejectToolCallWithWrongType() throws Exception {
+    protected void shouldRejectToolCallWithWrongType() throws Exception {
         startServer(
                 b -> b.json(j -> j.schemaValidator(VALIDATOR)),
                 s -> s.tools().register(validatedTool(), (context, request) -> ToolResult.text("ok")));
 
-        try (var client = createTestClient()) {
-            client.initialize();
+        try (var client = readyClient()) {
             var response = client.post("""
                 {"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"validated","arguments":{"name":123}}}
                 """);
@@ -153,81 +160,13 @@ class SchemaValidationTest extends AbstractStatelessMcpE2eTest {
                                 // "count" is a string, not the integer the outputSchema requires.
                                 (context, request) -> ToolResult.structured(Map.of("count", "not-a-number"))));
 
-        try (var client = createTestClient()) {
-            client.initialize();
+        try (var client = readyClient()) {
             var response = client.post("""
                 {"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"bad-structured-output","arguments":{}}}
                 """);
 
             assertThat(response.statusCode()).isEqualTo(200);
             assertThat(response).isSuccess().hasId(2).isToolError().hasTextContent("string found, integer expected");
-        }
-    }
-
-    @Test
-    void shouldFallBackToTextOnlyForArrayStructuredContentUnder20251125() throws Exception {
-        // 2026-07-28 permits array/scalar outputSchema and structuredContent (see
-        // dev.tachyonmcp.e2e.mcp20260728.StructuredOutputSchemaShapeTest); 2025-11-25's
-        // structuredContent is object-only on the wire, so a valid array result falls back to the
-        // backwards-compat text block instead of being rejected or crashing.
-        startServer(
-                b -> b.json(j -> j.inputSchemaValidator(VALIDATOR).outputSchemaValidator(VALIDATOR)),
-                s -> s.tools()
-                        .register(
-                                ToolDescriptor.builder()
-                                        .name("array-structured-output")
-                                        .description("Returns an array structured result")
-                                        .outputSchema("{\"type\":\"array\",\"items\":{\"type\":\"integer\"}}")
-                                        .build(),
-                                (context, request) -> ToolResult.structured(List.of(1, 2, 3))));
-
-        try (var client = createTestClient()) {
-            client.initialize();
-            var response = client.post("""
-                {"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"array-structured-output","arguments":{}}}
-                """);
-
-            assertThat(response.statusCode()).isEqualTo(200);
-            assertThat(response).isSuccess().hasId(2).hasTextContent("[1,2,3]");
-        }
-    }
-
-    @Test
-    void shouldEmitBothHandlerTextAndArrayFallbackTextUnder20251125() throws Exception {
-        // Regression: for a non-object structured value, the handler's own text block (from
-        // ToolResult.structured(payload, text)) must not suppress the serialized-JSON fallback --
-        // under 2025-11-25 that fallback is the array's only representation on the wire, since
-        // structuredContent can't carry it.
-        startServer(
-                b -> b.json(j -> j.inputSchemaValidator(VALIDATOR).outputSchemaValidator(VALIDATOR)),
-                s -> s.tools()
-                        .register(
-                                ToolDescriptor.builder()
-                                        .name("array-structured-output-with-text")
-                                        .description("Returns an array structured result plus an explicit text block")
-                                        .outputSchema("{\"type\":\"array\",\"items\":{\"type\":\"integer\"}}")
-                                        .build(),
-                                (context, request) -> ToolResult.structured(List.of(1, 2), "summary")));
-
-        try (var client = createTestClient()) {
-            client.initialize();
-            var response = client.post("""
-                {"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"array-structured-output-with-text","arguments":{}}}
-                """);
-
-            assertThat(response.statusCode()).isEqualTo(200);
-            assertThat(response)
-                    .isSuccess()
-                    .hasId(2)
-                    .hasContentExactly(
-                            JsonNodeFactory.instance
-                                    .objectNode()
-                                    .put("type", "text")
-                                    .put("text", "summary"),
-                            JsonNodeFactory.instance
-                                    .objectNode()
-                                    .put("type", "text")
-                                    .put("text", "[1,2]"));
         }
     }
 
@@ -249,8 +188,7 @@ class SchemaValidationTest extends AbstractStatelessMcpE2eTest {
                                 PROMPT_SCHEMA),
                         List.of(PromptMessage.of(Role.USER, TextContent.of("Hello {name}"))));
 
-        try (var client = createTestClient()) {
-            client.initialize();
+        try (var client = readyClient()) {
             var response = client.post("""
                 {"jsonrpc":"2.0","id":2,"method":"prompts/get","params":{"name":"validated-prompt","arguments":{"name":"John"}}}
                 """);
@@ -264,12 +202,12 @@ class SchemaValidationTest extends AbstractStatelessMcpE2eTest {
                   ]
                 }}
                 """;
-            assertThatJson(response.body()).isEqualTo(expected);
+            assertThatJson(response.body()).when(Option.IGNORING_EXTRA_FIELDS).isEqualTo(expected);
         }
     }
 
     @Test
-    void shouldRejectPromptWithMissingRequiredField() throws Exception {
+    protected void shouldRejectPromptWithMissingRequiredField() throws Exception {
         startServer(it -> it.json(j -> j.schemaValidator(VALIDATOR)));
 
         server.prompts()
@@ -282,8 +220,7 @@ class SchemaValidationTest extends AbstractStatelessMcpE2eTest {
                                 PROMPT_SCHEMA),
                         List.of(PromptMessage.of(Role.USER, TextContent.of("Hello {name}"))));
 
-        try (var client = createTestClient()) {
-            client.initialize();
+        try (var client = readyClient()) {
             var response = client.post("""
                 {"jsonrpc":"2.0","id":2,"method":"prompts/get","params":{"name":"validated-prompt","arguments":{}}}
                 """);
@@ -301,7 +238,7 @@ class SchemaValidationTest extends AbstractStatelessMcpE2eTest {
 
     // region: Tool handler
 
-    private static ToolDescriptor validatedTool() {
+    protected static ToolDescriptor validatedTool() {
         return ToolDescriptor.builder()
                 .name("validated")
                 .description("A tool with input schema validation")
@@ -309,7 +246,7 @@ class SchemaValidationTest extends AbstractStatelessMcpE2eTest {
                 .build();
     }
 
-    private static ToolDescriptor validatedTool2() {
+    protected static ToolDescriptor validatedTool2() {
         return ToolDescriptor.builder()
                 .name("validated2")
                 .description("Another tool with a distinct input schema")

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/AbstractStatelessMcpE2eTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/AbstractStatelessMcpE2eTest.java
@@ -1,6 +1,7 @@
 /* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
 package dev.tachyonmcp.e2e.mcp;
 
+import dev.tachyonmcp.testkit.McpClient;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -9,7 +10,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-public abstract class AbstractStatelessMcpE2eTest extends AbstractMcpE2eTest {
+public abstract class AbstractStatelessMcpE2eTest<C extends McpClient> extends AbstractMcpE2eTest<C> {
 
     private static final HttpClient HTTP_CLIENT = HttpClient.newHttpClient();
 

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/AbstractStringSchemaContractTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/AbstractStringSchemaContractTest.java
@@ -8,16 +8,27 @@ import static org.assertj.core.api.Assertions.assertThat;
 import dev.tachyonmcp.api.json.JsonSchema;
 import dev.tachyonmcp.api.server.features.tools.ToolDescriptor;
 import dev.tachyonmcp.api.server.features.tools.ToolResult;
+import dev.tachyonmcp.testkit.McpClient;
+import net.javacrumbs.jsonunit.core.Option;
 import org.junit.jupiter.api.Test;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 
-class StringSchemaTest extends AbstractStatelessMcpE2eTest {
+/**
+ * String-based JSON schema scenarios that hold under both MCP protocol revisions: only the client
+ * creation and the response envelope differ (2026-07-28 adds {@code resultType}/{@code ttlMs}/{@code
+ * cacheScope}), supplied by subclasses in {@code v2025_11_25}/{@code v2026_07_28}. Assertions use
+ * {@link Option#IGNORING_EXTRA_FIELDS} where the envelope shape diverges.
+ */
+public abstract class AbstractStringSchemaContractTest<C extends McpClient> extends AbstractStatelessMcpE2eTest<C> {
 
-    private static final String INPUT_SCHEMA_JSON =
+    /** Returns a client ready to send requests (handshake already performed, if the version needs one). */
+    protected abstract C readyClient() throws Exception;
+
+    static final String INPUT_SCHEMA_JSON =
             "{\"type\":\"object\",\"properties\":{\"x\":{\"type\":\"string\"}},\"required\":[\"x\"]}";
 
-    private static final String OUTPUT_SCHEMA_JSON =
+    static final String OUTPUT_SCHEMA_JSON =
             "{\"type\":\"object\",\"properties\":{\"y\":{\"type\":\"integer\"}},\"required\":[\"y\"]}";
 
     @Test
@@ -30,14 +41,13 @@ class StringSchemaTest extends AbstractStatelessMcpE2eTest {
                                 .outputSchema(OUTPUT_SCHEMA_JSON),
                         (ctx, request) -> ToolResult.text("ok")));
 
-        try (var client = createTestClient()) {
-            client.initialize();
+        try (var client = readyClient()) {
             var response = client.post("""
                 {"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}
                 """);
 
             assertThat(response.statusCode()).isEqualTo(200);
-            assertThatJson(response.body()).isEqualTo("""
+            assertThatJson(response.body()).when(Option.IGNORING_EXTRA_FIELDS).isEqualTo("""
                     {
                       "jsonrpc":"2.0",
                       "id":2,
@@ -92,8 +102,7 @@ class StringSchemaTest extends AbstractStatelessMcpE2eTest {
                             (ctx, request) -> ToolResult.text("node"));
         });
 
-        try (var client = createTestClient()) {
-            client.initialize();
+        try (var client = readyClient()) {
             var r1 = client.post("""
                 {"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}
                 """);
@@ -123,8 +132,7 @@ class StringSchemaTest extends AbstractStatelessMcpE2eTest {
                                 .build(),
                         (ctx, request) -> ToolResult.text("called")));
 
-        try (var client = createTestClient()) {
-            client.initialize();
+        try (var client = readyClient()) {
             var response = client.post("""
                 {"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"call-test","arguments":{"x":"hello"}}}
                 """);

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/AbstractToolCapabilitiesContractTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/AbstractToolCapabilitiesContractTest.java
@@ -1,7 +1,7 @@
 /* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
 package dev.tachyonmcp.e2e.mcp;
 
-import static dev.tachyonmcp.testkit.JsonRpcResponseAssert.assertThat;
+import static dev.tachyonmcp.testkit.McpHttpResponseAssert.assertThatResponse;
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -14,6 +14,7 @@ import dev.tachyonmcp.api.server.features.tools.ToolResult;
 import dev.tachyonmcp.testkit.McpClient;
 import java.net.http.HttpResponse;
 import java.util.stream.Stream;
+import net.javacrumbs.jsonunit.core.Option;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -23,7 +24,17 @@ import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.node.JsonNodeFactory;
 
-class ToolCapabilitiesTest extends AbstractStatelessMcpE2eTest {
+/**
+ * Tool descriptor metadata, structured content, and registration scenarios that hold under both MCP
+ * protocol revisions: only the client creation and the {@code tools/list} response envelope differ
+ * (2026-07-28 adds {@code resultType}/{@code ttlMs}/{@code cacheScope}), supplied by subclasses in
+ * {@code v2025_11_25}/{@code v2026_07_28}. Assertions use {@link Option#IGNORING_EXTRA_FIELDS} where
+ * the envelope shape diverges.
+ */
+public abstract class AbstractToolCapabilitiesContractTest<C extends McpClient> extends AbstractStatelessMcpE2eTest<C> {
+
+    /** Returns a client ready to send requests (handshake already performed, if the version needs one). */
+    protected abstract C readyClient() throws Exception;
 
     // region: Output Schema Tests
 
@@ -41,7 +52,7 @@ class ToolCapabilitiesTest extends AbstractStatelessMcpE2eTest {
         }
         startServerWith(s -> s.tools().register(descriptor, OK));
 
-        try (var client = createTestClient()) {
+        try (var client = readyClient()) {
             var response = listTools(client);
 
             final String expected;
@@ -98,7 +109,7 @@ class ToolCapabilitiesTest extends AbstractStatelessMcpE2eTest {
                     }
                     """.formatted(toolName, toolName);
             }
-            assertThatJson(response.body()).isEqualTo(expected);
+            assertThatJson(response.body()).when(Option.IGNORING_EXTRA_FIELDS).isEqualTo(expected);
         }
     }
 
@@ -109,7 +120,7 @@ class ToolCapabilitiesTest extends AbstractStatelessMcpE2eTest {
                 .register(outputSchemaToolDescriptor(OUTPUT_SCHEMA), OK)
                 .register(simpleToolDescriptor("tool-b", "Tool B"), OK));
 
-        try (var client = createTestClient()) {
+        try (var client = readyClient()) {
             var response = listTools(client);
 
             var mapper = new ObjectMapper();
@@ -137,11 +148,11 @@ class ToolCapabilitiesTest extends AbstractStatelessMcpE2eTest {
 
     @ParameterizedTest(name = "[{index}] {0}")
     @MethodSource
-    void shouldIncludeExecutionTaskSupport(String toolName, boolean hasExecution, ToolDescriptor descriptor)
+    protected void shouldIncludeExecutionTaskSupport(String toolName, boolean hasExecution, ToolDescriptor descriptor)
             throws Exception {
         startServerWith(s -> s.tools().register(descriptor, OK));
 
-        try (var client = createTestClient()) {
+        try (var client = readyClient()) {
             var response = listTools(client);
 
             assertThatJson(response.body()).inPath("$.result.tools[0].name").isEqualTo(toolName);
@@ -173,14 +184,14 @@ class ToolCapabilitiesTest extends AbstractStatelessMcpE2eTest {
         startEmptyServer();
         server.tools().register(builder -> builder.name("minimal-tool"), OK);
 
-        try (var client = createTestClient()) {
+        try (var client = readyClient()) {
             var response = listTools(client);
 
             // language=JSON
             var expected = """
                 {"jsonrpc":"2.0","id":2,"result":{"tools":[{"name":"minimal-tool", "inputSchema":{"type":"object"}}]}}
                 """;
-            assertThatJson(response.body()).isEqualTo(expected.trim());
+            assertThatJson(response.body()).when(Option.IGNORING_EXTRA_FIELDS).isEqualTo(expected.trim());
         }
     }
 
@@ -199,14 +210,13 @@ class ToolCapabilitiesTest extends AbstractStatelessMcpE2eTest {
                             return ToolResult.structured(echo, "Echo: " + msg);
                         }));
 
-        try (var client = createTestClient()) {
-            client.initialize();
+        try (var client = readyClient()) {
             var response = client.post("""
                 {"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"structured","arguments":{"message":"hi"}}}
                 """);
 
             assertThat(response.statusCode()).isEqualTo(200);
-            assertThat(response).isSuccess().hasTextContent("Echo: hi");
+            assertThatResponse(response).isSuccess().hasTextContent("Echo: hi");
             assertThatJson(response.body())
                     .inPath("$.result.structuredContent")
                     .isObject()
@@ -217,7 +227,7 @@ class ToolCapabilitiesTest extends AbstractStatelessMcpE2eTest {
     // endregion
 
     @Test
-    void shouldRegisterWithFullDescriptor() throws Exception {
+    protected void shouldRegisterWithFullDescriptor() throws Exception {
         var annotations = ToolAnnotations.of(null, true, false, null, null);
         startEmptyServer();
         server.tools()
@@ -231,13 +241,13 @@ class ToolCapabilitiesTest extends AbstractStatelessMcpE2eTest {
                                 .annotations(annotations),
                         OK);
 
-        try (var client = createTestClient()) {
+        try (var client = readyClient()) {
             var response = listTools(client);
 
             var expected = """
                 {"jsonrpc":"2.0","id":2,"result":{"tools":[{"name":"full-tool","title":"Full Tool","description":"A tool with all metadata","inputSchema":{"type":"object","properties":{"message":{"type":"string","description":"Input"}},"required":["message"]},"outputSchema":{"type":"object","properties":{"result":{"type":"string","description":"The output result"}}},"execution":{"taskSupport":"optional"},"annotations":{"readOnlyHint":true,"destructiveHint":false}}]}}
                 """;
-            assertThatJson(response.body()).isEqualTo(expected.trim());
+            assertThatJson(response.body()).when(Option.IGNORING_EXTRA_FIELDS).isEqualTo(expected.trim());
         }
     }
 
@@ -245,14 +255,13 @@ class ToolCapabilitiesTest extends AbstractStatelessMcpE2eTest {
 
     // region: Tool Handler Implementations
 
-    private static HttpResponse<String> listTools(McpClient client) throws Exception {
-        client.initialize();
+    protected static HttpResponse<String> listTools(McpClient client) throws Exception {
         return client.post("""
                 {"jsonrpc":"2.0","id":2,"method":"tools/list"}
                 """);
     }
 
-    private static ToolDescriptor outputSchemaToolDescriptor(JsonSchema outputSchema) {
+    public static ToolDescriptor outputSchemaToolDescriptor(JsonSchema outputSchema) {
         return ToolDescriptor.builder()
                 .name("output-schema-tool")
                 .description("A tool with output schema")
@@ -261,7 +270,7 @@ class ToolCapabilitiesTest extends AbstractStatelessMcpE2eTest {
                 .build();
     }
 
-    private static ToolDescriptor simpleToolDescriptor(String name, String description) {
+    public static ToolDescriptor simpleToolDescriptor(String name, String description) {
         return ToolDescriptor.builder()
                 .name(name)
                 .description(description)
@@ -269,7 +278,7 @@ class ToolCapabilitiesTest extends AbstractStatelessMcpE2eTest {
                 .build();
     }
 
-    private static ToolDescriptor taskAwareToolDescriptor(TaskSupport taskSupport) {
+    public static ToolDescriptor taskAwareToolDescriptor(TaskSupport taskSupport) {
         return ToolDescriptor.builder()
                 .name("task-aware-tool")
                 .description("A task-aware tool")
@@ -280,7 +289,7 @@ class ToolCapabilitiesTest extends AbstractStatelessMcpE2eTest {
 
     // ---- JSON schemas ----
 
-    private static final JsonSchema OUTPUT_SCHEMA = JsonSchema.from(buildOutputSchema(), JsonNode.class);
+    public static final JsonSchema OUTPUT_SCHEMA = JsonSchema.from(buildOutputSchema(), JsonNode.class);
 
     private static JsonNode buildOutputSchema() {
         var schema = JsonNodeFactory.instance.objectNode();
@@ -292,9 +301,9 @@ class ToolCapabilitiesTest extends AbstractStatelessMcpE2eTest {
         return schema;
     }
 
-    private static final JsonSchema INPUT_SCHEMA = JsonSchema.from(buildInputSchema(), JsonNode.class);
+    public static final JsonSchema INPUT_SCHEMA = JsonSchema.from(buildInputSchema(), JsonNode.class);
 
-    private static final ToolFn OK = (ctx, request) -> ToolResult.text("ok");
+    public static final ToolFn OK = (ctx, request) -> ToolResult.text("ok");
 
     private static JsonNode buildInputSchema() {
         var schema = JsonNodeFactory.instance.objectNode();

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/AbstractToolErrorContractTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/AbstractToolErrorContractTest.java
@@ -4,9 +4,19 @@ package dev.tachyonmcp.e2e.mcp;
 import static dev.tachyonmcp.testkit.McpHttpResponseAssert.assertThatResponse;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import dev.tachyonmcp.testkit.McpClient;
 import org.junit.jupiter.api.Test;
 
-class ToolErrorTest extends AbstractStatelessMcpE2eTest {
+/**
+ * Tool error handling scenarios that hold under both MCP protocol revisions: exception mapping to
+ * JSON-RPC error codes ({@code -32603} for handler failure, {@code -32602} for invalid params) and
+ * message redaction. Only the client creation differs, supplied by subclasses in {@code
+ * v2025_11_25}/{@code v2026_07_28}.
+ */
+public abstract class AbstractToolErrorContractTest<C extends McpClient> extends AbstractStatelessMcpE2eTest<C> {
+
+    /** Returns a client ready to send requests (handshake already performed, if the version needs one). */
+    protected abstract C readyClient() throws Exception;
 
     @Override
     protected void startDefaultServer() {
@@ -20,8 +30,7 @@ class ToolErrorTest extends AbstractStatelessMcpE2eTest {
 
     @Test
     void toolThrowsAfterSseUpgradeStillClosesStream() throws Exception {
-        try (var client = createTestClient()) {
-            client.initialize();
+        try (var client = readyClient()) {
             var body = """
                 {"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"boom","arguments":{}}}
                 """;
@@ -37,14 +46,13 @@ class ToolErrorTest extends AbstractStatelessMcpE2eTest {
     }
 
     @Test
-    void shouldRedactIllegalArgumentExceptionFromInvalidParamsError() throws Exception {
+    protected void shouldRedactIllegalArgumentExceptionFromInvalidParamsError() throws Exception {
         startServerWith(s -> s.tools()
                 .register(builder -> builder.name("bad-arg").description("Rejects input"), (context, request) -> {
                     throw new IllegalArgumentException("sensitive internal detail");
                 }));
 
-        try (var client = createTestClient()) {
-            client.initialize();
+        try (var client = readyClient()) {
             var response = client.sendRpc("""
                 {"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"bad-arg","arguments":{}}}
                 """);

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/AcceptHeaderValidationTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/AcceptHeaderValidationTest.java
@@ -3,6 +3,7 @@ package dev.tachyonmcp.e2e.mcp;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import dev.tachyonmcp.testkit.Mcp20251125Client;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -17,7 +18,17 @@ import org.junit.jupiter.api.Test;
  * aggregator, where its {@code FullHttpRequest} match never fired and validation was silently
  * skipped.
  */
-class AcceptHeaderValidationTest extends AbstractStatelessMcpE2eTest {
+class AcceptHeaderValidationTest extends AbstractStatelessMcpE2eTest<Mcp20251125Client> {
+
+    @Override
+    protected Mcp20251125Client createTestClient() {
+        return createTestClient(port);
+    }
+
+    @Override
+    protected Mcp20251125Client createTestClient(int port) {
+        return new Mcp20251125Client(port);
+    }
 
     // language=JSON
     private static final String INIT_BODY =

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/CompletionTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/CompletionTest.java
@@ -7,10 +7,22 @@ import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import dev.tachyonmcp.api.server.features.completions.CompletionResult;
+import dev.tachyonmcp.testkit.Mcp20251125Client;
+import dev.tachyonmcp.testkit.McpClient;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
-class CompletionTest extends AbstractStatelessMcpE2eTest {
+class CompletionTest extends AbstractStatelessMcpE2eTest<McpClient> {
+
+    @Override
+    protected Mcp20251125Client createTestClient() {
+        return createTestClient(port);
+    }
+
+    @Override
+    protected Mcp20251125Client createTestClient(int port) {
+        return new Mcp20251125Client(port);
+    }
 
     @Test
     void shouldCompletePromptArgument() throws Exception {

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/DnsRebindingTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/DnsRebindingTest.java
@@ -3,6 +3,8 @@ package dev.tachyonmcp.e2e.mcp;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import dev.tachyonmcp.testkit.Mcp20251125Client;
+import dev.tachyonmcp.testkit.McpClient;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -14,7 +16,17 @@ import org.junit.jupiter.api.Test;
  * that socket, raced the next request onto it, and intermittently saw "other side closed".
  * Signalling {@code Connection: close} stops the client from reusing the socket.
  */
-class DnsRebindingTest extends AbstractStatelessMcpE2eTest {
+class DnsRebindingTest extends AbstractStatelessMcpE2eTest<McpClient> {
+
+    @Override
+    protected Mcp20251125Client createTestClient() {
+        return createTestClient(port);
+    }
+
+    @Override
+    protected Mcp20251125Client createTestClient(int port) {
+        return new Mcp20251125Client(port);
+    }
 
     // language=JSON
     private static final String INIT_BODY = """

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/ListPaginationE2eTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/ListPaginationE2eTest.java
@@ -8,13 +8,25 @@ import dev.tachyonmcp.api.server.features.prompts.PromptDescriptor;
 import dev.tachyonmcp.api.server.features.resources.ResourceDescriptor;
 import dev.tachyonmcp.api.server.features.resources.ResourceFn;
 import dev.tachyonmcp.api.server.features.tasks.TaskSnapshot;
+import dev.tachyonmcp.testkit.Mcp20251125Client;
+import dev.tachyonmcp.testkit.McpClient;
 import dev.tachyonmcp.testkit.TestTaskConnector;
 import java.time.Instant;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import tools.jackson.databind.ObjectMapper;
 
-class ListPaginationE2eTest extends AbstractStatelessMcpE2eTest {
+class ListPaginationE2eTest extends AbstractStatelessMcpE2eTest<McpClient> {
+
+    @Override
+    protected Mcp20251125Client createTestClient() {
+        return createTestClient(port);
+    }
+
+    @Override
+    protected Mcp20251125Client createTestClient(int port) {
+        return new Mcp20251125Client(port);
+    }
 
     private static final ObjectMapper MAPPER = new ObjectMapper();
     private static final ResourceFn EMPTY_RESOURCE =

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/MaxContentLengthTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/MaxContentLengthTest.java
@@ -3,6 +3,8 @@ package dev.tachyonmcp.e2e.mcp;
 
 import static dev.tachyonmcp.testkit.McpHttpResponseAssert.assertThatResponse;
 
+import dev.tachyonmcp.testkit.Mcp20251125Client;
+import dev.tachyonmcp.testkit.McpClient;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 
@@ -10,7 +12,17 @@ import org.junit.jupiter.api.Test;
  * Pins that {@code NetworkConfig.maxContentLength} actually reaches the
  * {@code HttpObjectAggregator}: a body past the 1 MiB default is refused, not parsed.
  */
-class MaxContentLengthTest extends AbstractStatelessMcpE2eTest {
+class MaxContentLengthTest extends AbstractStatelessMcpE2eTest<McpClient> {
+
+    @Override
+    protected Mcp20251125Client createTestClient() {
+        return createTestClient(port);
+    }
+
+    @Override
+    protected Mcp20251125Client createTestClient(int port) {
+        return new Mcp20251125Client(port);
+    }
 
     @Test
     void rejectsBodyLargerThanMaxContentLength() throws Exception {

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/McpNegativeScenariosTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/McpNegativeScenariosTest.java
@@ -7,6 +7,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import dev.tachyonmcp.api.server.domain.PromptMessage;
 import dev.tachyonmcp.api.server.features.prompts.PromptDescriptor;
+import dev.tachyonmcp.testkit.Mcp20251125Client;
 import io.modelcontextprotocol.client.McpClient;
 import io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport;
 import java.util.List;
@@ -18,7 +19,17 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 @TestInstance(Lifecycle.PER_CLASS)
-class McpNegativeScenariosTest extends AbstractStatelessMcpE2eTest {
+class McpNegativeScenariosTest extends AbstractStatelessMcpE2eTest<dev.tachyonmcp.testkit.McpClient> {
+
+    @Override
+    protected Mcp20251125Client createTestClient() {
+        return createTestClient(port);
+    }
+
+    @Override
+    protected Mcp20251125Client createTestClient(int port) {
+        return new Mcp20251125Client(port);
+    }
 
     @Test
     void shouldRejectUnknownTool() {

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/PageSizeConfigTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/PageSizeConfigTest.java
@@ -6,10 +6,22 @@ import static org.assertj.core.api.Assertions.assertThat;
 import dev.tachyonmcp.api.json.JsonSchema;
 import dev.tachyonmcp.api.server.features.tools.ToolDescriptor;
 import dev.tachyonmcp.api.server.features.tools.ToolResult;
+import dev.tachyonmcp.testkit.Mcp20251125Client;
+import dev.tachyonmcp.testkit.McpClient;
 import org.junit.jupiter.api.Test;
 import tools.jackson.databind.ObjectMapper;
 
-class PageSizeConfigTest extends AbstractStatelessMcpE2eTest {
+class PageSizeConfigTest extends AbstractStatelessMcpE2eTest<McpClient> {
+
+    @Override
+    protected Mcp20251125Client createTestClient() {
+        return createTestClient(port);
+    }
+
+    @Override
+    protected Mcp20251125Client createTestClient(int port) {
+        return new Mcp20251125Client(port);
+    }
 
     private static final ObjectMapper MAPPER = new ObjectMapper();
 

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/PayloadSerdeTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/PayloadSerdeTest.java
@@ -12,13 +12,25 @@ import dev.tachyonmcp.api.server.features.tools.ToolDescriptor;
 import dev.tachyonmcp.api.server.features.tools.ToolResult;
 import dev.tachyonmcp.core.server.json.JacksonPayloadSerde;
 import dev.tachyonmcp.core.server.json.NetworkntJsonSchemaValidator;
+import dev.tachyonmcp.testkit.Mcp20251125Client;
+import dev.tachyonmcp.testkit.McpClient;
 import java.lang.reflect.Type;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import tools.jackson.databind.node.JsonNodeFactory;
 import tools.jackson.databind.node.ObjectNode;
 
-class PayloadSerdeTest extends AbstractStatelessMcpE2eTest {
+class PayloadSerdeTest extends AbstractStatelessMcpE2eTest<McpClient> {
+
+    @Override
+    protected Mcp20251125Client createTestClient() {
+        return createTestClient(port);
+    }
+
+    @Override
+    protected Mcp20251125Client createTestClient(int port) {
+        return new Mcp20251125Client(port);
+    }
 
     private static final JsonNodeFactory JSON = JsonNodeFactory.instance;
 

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/PostStartRegistrationTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/PostStartRegistrationTest.java
@@ -10,10 +10,22 @@ import dev.tachyonmcp.api.server.domain.TextResourceContents;
 import dev.tachyonmcp.api.server.features.prompts.PromptDescriptor;
 import dev.tachyonmcp.api.server.features.prompts.PromptResult;
 import dev.tachyonmcp.api.server.features.resources.ResourceDescriptor;
+import dev.tachyonmcp.testkit.Mcp20251125Client;
+import dev.tachyonmcp.testkit.McpClient;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
-class PostStartRegistrationTest extends AbstractStatelessMcpE2eTest {
+class PostStartRegistrationTest extends AbstractStatelessMcpE2eTest<McpClient> {
+
+    @Override
+    protected Mcp20251125Client createTestClient() {
+        return createTestClient(port);
+    }
+
+    @Override
+    protected Mcp20251125Client createTestClient(int port) {
+        return new Mcp20251125Client(port);
+    }
 
     @Override
     protected void startDefaultServer() {

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/PromptCapabilitiesTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/PromptCapabilitiesTest.java
@@ -8,6 +8,8 @@ import dev.tachyonmcp.api.server.domain.PromptArgument;
 import dev.tachyonmcp.api.server.domain.Role;
 import dev.tachyonmcp.api.server.domain.TextContent;
 import dev.tachyonmcp.api.server.features.prompts.PromptDescriptor;
+import dev.tachyonmcp.testkit.Mcp20251125Client;
+import dev.tachyonmcp.testkit.McpClient;
 import java.util.List;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
@@ -16,7 +18,17 @@ import org.junit.jupiter.params.provider.CsvSource;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 
-class PromptCapabilitiesTest extends AbstractStatelessMcpE2eTest {
+class PromptCapabilitiesTest extends AbstractStatelessMcpE2eTest<McpClient> {
+
+    @Override
+    protected Mcp20251125Client createTestClient() {
+        return createTestClient(port);
+    }
+
+    @Override
+    protected Mcp20251125Client createTestClient(int port) {
+        return new Mcp20251125Client(port);
+    }
 
     @Override
     protected void startDefaultServer() {

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/PromptsTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/PromptsTest.java
@@ -13,12 +13,24 @@ import dev.tachyonmcp.api.server.domain.PromptMessage;
 import dev.tachyonmcp.api.server.domain.TextResourceContents;
 import dev.tachyonmcp.api.server.features.prompts.PromptDescriptor;
 import dev.tachyonmcp.api.server.features.prompts.PromptResult;
+import dev.tachyonmcp.testkit.Mcp20251125Client;
+import dev.tachyonmcp.testkit.McpClient;
 import java.util.Base64;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import tools.jackson.databind.ObjectMapper;
 
-class PromptsTest extends AbstractStatelessMcpE2eTest {
+class PromptsTest extends AbstractStatelessMcpE2eTest<McpClient> {
+
+    @Override
+    protected Mcp20251125Client createTestClient() {
+        return createTestClient(port);
+    }
+
+    @Override
+    protected Mcp20251125Client createTestClient(int port) {
+        return new Mcp20251125Client(port);
+    }
 
     private static final ObjectMapper MAPPER = new ObjectMapper();
 

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/ResourceTemplateTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/ResourceTemplateTest.java
@@ -4,9 +4,21 @@ package dev.tachyonmcp.e2e.mcp;
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 
 import dev.tachyonmcp.api.server.domain.TextResourceContents;
+import dev.tachyonmcp.testkit.Mcp20251125Client;
+import dev.tachyonmcp.testkit.McpClient;
 import org.junit.jupiter.api.Test;
 
-class ResourceTemplateTest extends AbstractStatelessMcpE2eTest {
+class ResourceTemplateTest extends AbstractStatelessMcpE2eTest<McpClient> {
+
+    @Override
+    protected Mcp20251125Client createTestClient() {
+        return createTestClient(port);
+    }
+
+    @Override
+    protected Mcp20251125Client createTestClient(int port) {
+        return new Mcp20251125Client(port);
+    }
 
     @Test
     void shouldReadResourceFromSingleParamTemplate() throws Exception {

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/SharedStatelessServerConcurrencyTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/SharedStatelessServerConcurrencyTest.java
@@ -4,6 +4,8 @@ package dev.tachyonmcp.e2e.mcp;
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import dev.tachyonmcp.testkit.Mcp20251125Client;
+import dev.tachyonmcp.testkit.McpClient;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
@@ -12,7 +14,17 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
 
-class SharedStatelessServerConcurrencyTest extends AbstractStatelessMcpE2eTest {
+class SharedStatelessServerConcurrencyTest extends AbstractStatelessMcpE2eTest<McpClient> {
+
+    @Override
+    protected Mcp20251125Client createTestClient() {
+        return createTestClient(port);
+    }
+
+    @Override
+    protected Mcp20251125Client createTestClient(int port) {
+        return new Mcp20251125Client(port);
+    }
 
     private static final int CLIENT_COUNT = 32;
     private static final long TIMEOUT_SECONDS = 10;

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/StatelessMcpSdkTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/StatelessMcpSdkTest.java
@@ -8,10 +8,22 @@ import dev.tachyonmcp.api.server.domain.PromptMessage;
 import dev.tachyonmcp.api.server.domain.Role;
 import dev.tachyonmcp.api.server.domain.TextContent;
 import dev.tachyonmcp.api.server.features.prompts.PromptDescriptor;
+import dev.tachyonmcp.testkit.Mcp20251125Client;
+import dev.tachyonmcp.testkit.McpClient;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
-class StatelessMcpSdkTest extends AbstractStatelessMcpE2eTest implements McpSdkContract {
+class StatelessMcpSdkTest extends AbstractStatelessMcpE2eTest<McpClient> implements McpSdkContract {
+
+    @Override
+    protected Mcp20251125Client createTestClient() {
+        return createTestClient(port);
+    }
+
+    @Override
+    protected Mcp20251125Client createTestClient(int port) {
+        return new Mcp20251125Client(port);
+    }
 
     @Override
     public int port() {

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/v2025_11_25/InputRequiredResultTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/v2025_11_25/InputRequiredResultTest.java
@@ -1,5 +1,5 @@
 /* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
-package dev.tachyonmcp.e2e.mcp;
+package dev.tachyonmcp.e2e.mcp.v2025_11_25;
 
 import static dev.tachyonmcp.testkit.JsonRpcResponseAssert.assertThat;
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
@@ -14,6 +14,8 @@ import dev.tachyonmcp.api.server.features.tools.AbstractToolHandler;
 import dev.tachyonmcp.api.server.features.tools.ToolDescriptor;
 import dev.tachyonmcp.api.server.features.tools.ToolRequest;
 import dev.tachyonmcp.api.server.features.tools.ToolResult;
+import dev.tachyonmcp.e2e.mcp.AbstractStatelessMcpE2eTest;
+import dev.tachyonmcp.testkit.Mcp20251125Client;
 import java.time.Duration;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -24,7 +26,17 @@ import org.awaitility.Awaitility;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 
-class InputRequiredResultTest extends AbstractStatelessMcpE2eTest {
+class InputRequiredResultTest extends AbstractStatelessMcpE2eTest<Mcp20251125Client> {
+
+    @Override
+    protected Mcp20251125Client createTestClient() {
+        return createTestClient(port);
+    }
+
+    @Override
+    protected Mcp20251125Client createTestClient(int port) {
+        return new Mcp20251125Client(port);
+    }
 
     @Test
     void basicElicitationFlow() throws Exception {

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/v2025_11_25/ResourceContractTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/v2025_11_25/ResourceContractTest.java
@@ -2,12 +2,22 @@
 package dev.tachyonmcp.e2e.mcp.v2025_11_25;
 
 import dev.tachyonmcp.e2e.mcp.AbstractResourceContractTest;
-import dev.tachyonmcp.testkit.McpClient;
+import dev.tachyonmcp.testkit.Mcp20251125Client;
 
-class ResourceContractTest extends AbstractResourceContractTest {
+class ResourceContractTest extends AbstractResourceContractTest<Mcp20251125Client> {
 
     @Override
-    protected McpClient readyClient() throws Exception {
+    protected Mcp20251125Client createTestClient() {
+        return createTestClient(port);
+    }
+
+    @Override
+    protected Mcp20251125Client createTestClient(int port) {
+        return new Mcp20251125Client(port);
+    }
+
+    @Override
+    protected Mcp20251125Client readyClient() throws Exception {
         var client = createTestClient();
         client.initialize();
         return client;

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/v2025_11_25/SchemaValidationContractTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/v2025_11_25/SchemaValidationContractTest.java
@@ -1,0 +1,100 @@
+/* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
+package dev.tachyonmcp.e2e.mcp.v2025_11_25;
+
+import static dev.tachyonmcp.testkit.JsonRpcResponseAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.tachyonmcp.api.json.JsonSchemaValidator;
+import dev.tachyonmcp.api.server.features.tools.ToolDescriptor;
+import dev.tachyonmcp.api.server.features.tools.ToolResult;
+import dev.tachyonmcp.core.server.json.NetworkntJsonSchemaValidator;
+import dev.tachyonmcp.e2e.mcp.AbstractSchemaValidationContractTest;
+import dev.tachyonmcp.testkit.Mcp20251125Client;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.node.JsonNodeFactory;
+
+/**
+ * 2025-11-25 schema validation contract: shared scenarios plus version-specific structured content
+ * tests. Under 2025-11-25, {@code structuredContent} is object-only on the wire, so array results
+ * fall back to the text block instead of being sent as structured content.
+ */
+class SchemaValidationContractTest extends AbstractSchemaValidationContractTest<Mcp20251125Client> {
+
+    private static final JsonSchemaValidator VALIDATOR = new NetworkntJsonSchemaValidator();
+
+    @Override
+    protected Mcp20251125Client createTestClient() {
+        return createTestClient(port);
+    }
+
+    @Override
+    protected Mcp20251125Client createTestClient(int port) {
+        return new Mcp20251125Client(port);
+    }
+
+    @Override
+    protected Mcp20251125Client readyClient() throws Exception {
+        var client = createTestClient();
+        client.initialize();
+        return client;
+    }
+
+    @Test
+    void shouldFallBackToTextOnlyForArrayStructuredContentUnder20251125() throws Exception {
+        startServer(
+                b -> b.json(j -> j.inputSchemaValidator(VALIDATOR).outputSchemaValidator(VALIDATOR)),
+                s -> s.tools()
+                        .register(
+                                ToolDescriptor.builder()
+                                        .name("array-structured-output")
+                                        .description("Returns an array structured result")
+                                        .outputSchema("{\"type\":\"array\",\"items\":{\"type\":\"integer\"}}")
+                                        .build(),
+                                (context, request) -> ToolResult.structured(List.of(1, 2, 3))));
+
+        try (var client = readyClient()) {
+            var response = client.post("""
+                {"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"array-structured-output","arguments":{}}}
+                """);
+
+            assertThat(response.statusCode()).isEqualTo(200);
+            assertThat(response).isSuccess().hasId(2).hasTextContent("[1,2,3]").doesNotHaveStructuredContent();
+        }
+    }
+
+    @Test
+    void shouldEmitBothHandlerTextAndArrayFallbackTextUnder20251125() throws Exception {
+        startServer(
+                b -> b.json(j -> j.inputSchemaValidator(VALIDATOR).outputSchemaValidator(VALIDATOR)),
+                s -> s.tools()
+                        .register(
+                                ToolDescriptor.builder()
+                                        .name("array-structured-output-with-text")
+                                        .description("Returns an array structured result plus an explicit text block")
+                                        .outputSchema("{\"type\":\"array\",\"items\":{\"type\":\"integer\"}}")
+                                        .build(),
+                                (context, request) -> ToolResult.structured(List.of(1, 2), "summary")));
+
+        try (var client = readyClient()) {
+            var response = client.post("""
+                {"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"array-structured-output-with-text","arguments":{}}}
+                """);
+
+            assertThat(response.statusCode()).isEqualTo(200);
+            assertThat(response)
+                    .isSuccess()
+                    .hasId(2)
+                    .doesNotHaveStructuredContent()
+                    .hasContentExactly(
+                            JsonNodeFactory.instance
+                                    .objectNode()
+                                    .put("type", "text")
+                                    .put("text", "summary"),
+                            JsonNodeFactory.instance
+                                    .objectNode()
+                                    .put("type", "text")
+                                    .put("text", "[1,2]"));
+        }
+    }
+}

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/v2025_11_25/ServerInfoTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/v2025_11_25/ServerInfoTest.java
@@ -5,11 +5,23 @@ import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 
 import dev.tachyonmcp.api.server.domain.Icon;
 import dev.tachyonmcp.e2e.mcp.AbstractStatelessMcpE2eTest;
+import dev.tachyonmcp.testkit.Mcp20251125Client;
+import dev.tachyonmcp.testkit.McpClient;
 import dev.tachyonmcp.testkit.TestTaskConnector;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
-class ServerInfoTest extends AbstractStatelessMcpE2eTest {
+class ServerInfoTest extends AbstractStatelessMcpE2eTest<McpClient> {
+
+    @Override
+    protected Mcp20251125Client createTestClient() {
+        return createTestClient(port);
+    }
+
+    @Override
+    protected Mcp20251125Client createTestClient(int port) {
+        return new Mcp20251125Client(port);
+    }
 
     @Test
     void allCapabilitiesEnabled() throws Exception {

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/v2025_11_25/StringSchemaContractTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/v2025_11_25/StringSchemaContractTest.java
@@ -1,15 +1,10 @@
 /* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
 package dev.tachyonmcp.e2e.mcp.v2025_11_25;
 
-import dev.tachyonmcp.e2e.mcp.AbstractMcpE2eTest;
+import dev.tachyonmcp.e2e.mcp.AbstractStringSchemaContractTest;
 import dev.tachyonmcp.testkit.Mcp20251125Client;
 
-public abstract class AbstractStatefulMcpE2eTest extends AbstractMcpE2eTest<Mcp20251125Client> {
-
-    @Override
-    protected final SessionMode sessionMode() {
-        return SessionMode.STATEFUL;
-    }
+class StringSchemaContractTest extends AbstractStringSchemaContractTest<Mcp20251125Client> {
 
     @Override
     protected Mcp20251125Client createTestClient() {
@@ -19,5 +14,12 @@ public abstract class AbstractStatefulMcpE2eTest extends AbstractMcpE2eTest<Mcp2
     @Override
     protected Mcp20251125Client createTestClient(int port) {
         return new Mcp20251125Client(port);
+    }
+
+    @Override
+    protected Mcp20251125Client readyClient() throws Exception {
+        var client = createTestClient();
+        client.initialize();
+        return client;
     }
 }

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/v2025_11_25/ToolCapabilitiesContractTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/v2025_11_25/ToolCapabilitiesContractTest.java
@@ -1,15 +1,10 @@
 /* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
 package dev.tachyonmcp.e2e.mcp.v2025_11_25;
 
-import dev.tachyonmcp.e2e.mcp.AbstractMcpE2eTest;
+import dev.tachyonmcp.e2e.mcp.AbstractToolCapabilitiesContractTest;
 import dev.tachyonmcp.testkit.Mcp20251125Client;
 
-public abstract class AbstractStatefulMcpE2eTest extends AbstractMcpE2eTest<Mcp20251125Client> {
-
-    @Override
-    protected final SessionMode sessionMode() {
-        return SessionMode.STATEFUL;
-    }
+class ToolCapabilitiesContractTest extends AbstractToolCapabilitiesContractTest<Mcp20251125Client> {
 
     @Override
     protected Mcp20251125Client createTestClient() {
@@ -19,5 +14,12 @@ public abstract class AbstractStatefulMcpE2eTest extends AbstractMcpE2eTest<Mcp2
     @Override
     protected Mcp20251125Client createTestClient(int port) {
         return new Mcp20251125Client(port);
+    }
+
+    @Override
+    protected Mcp20251125Client readyClient() throws Exception {
+        var client = createTestClient();
+        client.initialize();
+        return client;
     }
 }

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/v2025_11_25/ToolErrorContractTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/v2025_11_25/ToolErrorContractTest.java
@@ -1,15 +1,10 @@
 /* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
 package dev.tachyonmcp.e2e.mcp.v2025_11_25;
 
-import dev.tachyonmcp.e2e.mcp.AbstractMcpE2eTest;
+import dev.tachyonmcp.e2e.mcp.AbstractToolErrorContractTest;
 import dev.tachyonmcp.testkit.Mcp20251125Client;
 
-public abstract class AbstractStatefulMcpE2eTest extends AbstractMcpE2eTest<Mcp20251125Client> {
-
-    @Override
-    protected final SessionMode sessionMode() {
-        return SessionMode.STATEFUL;
-    }
+class ToolErrorContractTest extends AbstractToolErrorContractTest<Mcp20251125Client> {
 
     @Override
     protected Mcp20251125Client createTestClient() {
@@ -19,5 +14,12 @@ public abstract class AbstractStatefulMcpE2eTest extends AbstractMcpE2eTest<Mcp2
     @Override
     protected Mcp20251125Client createTestClient(int port) {
         return new Mcp20251125Client(port);
+    }
+
+    @Override
+    protected Mcp20251125Client readyClient() throws Exception {
+        var client = createTestClient();
+        client.initialize();
+        return client;
     }
 }

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/v2025_11_25/ToolNotificationsTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/v2025_11_25/ToolNotificationsTest.java
@@ -8,10 +8,22 @@ import dev.tachyonmcp.api.server.features.tools.ToolResult;
 import dev.tachyonmcp.core.server.config.CapabilitiesConfig;
 import dev.tachyonmcp.e2e.mcp.AbstractStatelessMcpE2eTest;
 import dev.tachyonmcp.e2e.mcp.EchoToolHandler;
+import dev.tachyonmcp.testkit.Mcp20251125Client;
+import dev.tachyonmcp.testkit.McpClient;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 
-class ToolNotificationsTest extends AbstractStatelessMcpE2eTest {
+class ToolNotificationsTest extends AbstractStatelessMcpE2eTest<McpClient> {
+
+    @Override
+    protected Mcp20251125Client createTestClient() {
+        return createTestClient(port);
+    }
+
+    @Override
+    protected Mcp20251125Client createTestClient(int port) {
+        return new Mcp20251125Client(port);
+    }
 
     @Override
     protected void startDefaultServer() {

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/v2026_07_28/CachingHintsTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/v2026_07_28/CachingHintsTest.java
@@ -8,6 +8,8 @@ import dev.tachyonmcp.api.server.domain.TextResourceContents;
 import dev.tachyonmcp.api.server.features.prompts.PromptDescriptor;
 import dev.tachyonmcp.api.server.features.resources.ResourceDescriptor;
 import dev.tachyonmcp.e2e.mcp.AbstractStatelessMcpE2eTest;
+import dev.tachyonmcp.testkit.Mcp20260728Client;
+import dev.tachyonmcp.testkit.McpTestClients;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -19,7 +21,17 @@ import org.junit.jupiter.api.Test;
  * {@code discoverResult} and falling through to the 2025-11-25 record shapes (no caching fields)
  * for every other list/read method.
  */
-class CachingHintsTest extends AbstractStatelessMcpE2eTest {
+class CachingHintsTest extends AbstractStatelessMcpE2eTest<Mcp20260728Client> {
+
+    @Override
+    protected Mcp20260728Client createTestClient() {
+        return createTestClient(port);
+    }
+
+    @Override
+    protected Mcp20260728Client createTestClient(int port) {
+        return McpTestClients.latest(port);
+    }
 
     @BeforeEach
     void registerFixtures() {

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/v2026_07_28/CustomHeaderValidationTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/v2026_07_28/CustomHeaderValidationTest.java
@@ -5,6 +5,8 @@ import static dev.tachyonmcp.testkit.McpHttpResponseAssert.assertThatResponse;
 
 import dev.tachyonmcp.api.server.features.tools.ToolResult;
 import dev.tachyonmcp.e2e.mcp.AbstractStatelessMcpE2eTest;
+import dev.tachyonmcp.testkit.Mcp20260728Client;
+import dev.tachyonmcp.testkit.McpTestClients;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
@@ -20,7 +22,17 @@ import org.junit.jupiter.api.Test;
  * format when present) and reject on mismatch/invalid-encoding/omission with {@code -32020}
  * (HeaderMismatch).
  */
-class CustomHeaderValidationTest extends AbstractStatelessMcpE2eTest {
+class CustomHeaderValidationTest extends AbstractStatelessMcpE2eTest<Mcp20260728Client> {
+
+    @Override
+    protected Mcp20260728Client createTestClient() {
+        return createTestClient(port);
+    }
+
+    @Override
+    protected Mcp20260728Client createTestClient(int port) {
+        return McpTestClients.latest(port);
+    }
 
     // language=JSON
     private static final String EXECUTE_SQL_SCHEMA = """

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/v2026_07_28/DiscoverCapabilitiesMatchHandlersTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/v2026_07_28/DiscoverCapabilitiesMatchHandlersTest.java
@@ -5,6 +5,8 @@ import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import dev.tachyonmcp.e2e.mcp.AbstractStatelessMcpE2eTest;
+import dev.tachyonmcp.testkit.Mcp20260728Client;
+import dev.tachyonmcp.testkit.McpTestClients;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -15,7 +17,17 @@ import org.junit.jupiter.api.Test;
  * `discover-capabilities-match-handlers` check from `server-stateless`; it only ever failed
  * because {@code tools/list} was rejected for lack of a session (see {@code StatelessDispatchTest}).
  */
-class DiscoverCapabilitiesMatchHandlersTest extends AbstractStatelessMcpE2eTest {
+class DiscoverCapabilitiesMatchHandlersTest extends AbstractStatelessMcpE2eTest<Mcp20260728Client> {
+
+    @Override
+    protected Mcp20260728Client createTestClient() {
+        return createTestClient(port);
+    }
+
+    @Override
+    protected Mcp20260728Client createTestClient(int port) {
+        return McpTestClients.latest(port);
+    }
 
     @Test
     void toolsCapabilityAdvertisedInDiscoverActuallyWorks() throws Exception {

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/v2026_07_28/DiscoverEndpointTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/v2026_07_28/DiscoverEndpointTest.java
@@ -5,9 +5,21 @@ import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import dev.tachyonmcp.e2e.mcp.AbstractStatelessMcpE2eTest;
+import dev.tachyonmcp.testkit.Mcp20260728Client;
+import dev.tachyonmcp.testkit.McpTestClients;
 import org.junit.jupiter.api.Test;
 
-class DiscoverEndpointTest extends AbstractStatelessMcpE2eTest {
+class DiscoverEndpointTest extends AbstractStatelessMcpE2eTest<Mcp20260728Client> {
+
+    @Override
+    protected Mcp20260728Client createTestClient() {
+        return createTestClient(port);
+    }
+
+    @Override
+    protected Mcp20260728Client createTestClient(int port) {
+        return McpTestClients.latest(port);
+    }
 
     @Test
     void discoversTheModernProtocol() throws Exception {

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/v2026_07_28/DiscoverExtensionsTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/v2026_07_28/DiscoverExtensionsTest.java
@@ -5,12 +5,24 @@ import dev.tachyonmcp.api.server.extensions.AdvertiseMode;
 import dev.tachyonmcp.api.server.extensions.ExtensionSettings;
 import dev.tachyonmcp.api.server.extensions.ServerExtension;
 import dev.tachyonmcp.e2e.mcp.AbstractStatelessMcpE2eTest;
+import dev.tachyonmcp.testkit.Mcp20260728Client;
+import dev.tachyonmcp.testkit.McpTestClients;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import tools.jackson.databind.node.JsonNodeFactory;
 
 /** {@code server/discover} (2026-07-28) must advertise registered extensions the same way {@code initialize} does. */
-class DiscoverExtensionsTest extends AbstractStatelessMcpE2eTest {
+class DiscoverExtensionsTest extends AbstractStatelessMcpE2eTest<Mcp20260728Client> {
+
+    @Override
+    protected Mcp20260728Client createTestClient() {
+        return createTestClient(port);
+    }
+
+    @Override
+    protected Mcp20260728Client createTestClient(int port) {
+        return McpTestClients.latest(port);
+    }
 
     private static final String ALWAYS_EXT_ID = "com.example/always";
     private static final String NEVER_EXT_ID = "com.example/never";

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/v2026_07_28/ExtensionNegotiationTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/v2026_07_28/ExtensionNegotiationTest.java
@@ -8,6 +8,9 @@ import dev.tachyonmcp.api.server.extensions.AdvertiseMode;
 import dev.tachyonmcp.api.server.extensions.ExtensionSettings;
 import dev.tachyonmcp.api.server.extensions.ServerExtension;
 import dev.tachyonmcp.e2e.mcp.AbstractStatelessMcpE2eTest;
+import dev.tachyonmcp.testkit.Mcp20260728Client;
+import dev.tachyonmcp.testkit.McpClient;
+import dev.tachyonmcp.testkit.McpTestClients;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.jupiter.api.Test;
 
@@ -17,7 +20,17 @@ import org.junit.jupiter.api.Test;
  * {@code ExtensionNegotiator}, so a negotiated extension's {@link ServerExtension#onConnectionInit}
  * fires under 2026-07-28 too, not just 2025-11-25.
  */
-class ExtensionNegotiationTest extends AbstractStatelessMcpE2eTest {
+class ExtensionNegotiationTest extends AbstractStatelessMcpE2eTest<McpClient> {
+
+    @Override
+    protected Mcp20260728Client createTestClient() {
+        return createTestClient(port);
+    }
+
+    @Override
+    protected Mcp20260728Client createTestClient(int port) {
+        return McpTestClients.latest(port);
+    }
 
     private static final String EXT_ID = "com.example/onconnectinit-test";
 

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/v2026_07_28/HeaderValidationTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/v2026_07_28/HeaderValidationTest.java
@@ -4,6 +4,9 @@ package dev.tachyonmcp.e2e.mcp.v2026_07_28;
 import static dev.tachyonmcp.testkit.McpHttpResponseAssert.assertThatResponse;
 
 import dev.tachyonmcp.e2e.mcp.AbstractStatelessMcpE2eTest;
+import dev.tachyonmcp.testkit.Mcp20260728Client;
+import dev.tachyonmcp.testkit.McpClient;
+import dev.tachyonmcp.testkit.McpTestClients;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
@@ -18,7 +21,17 @@ import org.junit.jupiter.api.Test;
  * where the header doesn't match with JSON-RPC {@code -32020} (HeaderMismatch) and HTTP
  * {@code 400 Bad Request}.
  */
-class HeaderValidationTest extends AbstractStatelessMcpE2eTest {
+class HeaderValidationTest extends AbstractStatelessMcpE2eTest<McpClient> {
+
+    @Override
+    protected Mcp20260728Client createTestClient() {
+        return createTestClient(port);
+    }
+
+    @Override
+    protected Mcp20260728Client createTestClient(int port) {
+        return McpTestClients.latest(port);
+    }
 
     // language=JSON
     private static final String TOOLS_CALL_ECHO_BODY = """

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/v2026_07_28/InputRequiredResultTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/v2026_07_28/InputRequiredResultTest.java
@@ -12,6 +12,8 @@ import dev.tachyonmcp.api.server.domain.RpcMethodRequest;
 import dev.tachyonmcp.api.server.domain.UrlInputRequest;
 import dev.tachyonmcp.api.server.features.tools.ToolResult;
 import dev.tachyonmcp.e2e.mcp.AbstractStatelessMcpE2eTest;
+import dev.tachyonmcp.testkit.Mcp20260728Client;
+import dev.tachyonmcp.testkit.McpTestClients;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -26,7 +28,17 @@ import org.junit.jupiter.api.Test;
  * scenarios only ever failed because the session gate rejected the request before it reached the
  * tool (see {@code StatelessDispatchTest}).
  */
-class InputRequiredResultTest extends AbstractStatelessMcpE2eTest {
+class InputRequiredResultTest extends AbstractStatelessMcpE2eTest<Mcp20260728Client> {
+
+    @Override
+    protected Mcp20260728Client createTestClient() {
+        return createTestClient(port);
+    }
+
+    @Override
+    protected Mcp20260728Client createTestClient(int port) {
+        return McpTestClients.latest(port);
+    }
 
     private static FormInputRequest elicitation(String message, String prop) {
         var schema = new LinkedHashMap<String, Object>();

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/v2026_07_28/LogLevelGatingTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/v2026_07_28/LogLevelGatingTest.java
@@ -6,6 +6,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import dev.tachyonmcp.api.server.domain.LoggingLevel;
 import dev.tachyonmcp.api.server.features.tools.ToolResult;
 import dev.tachyonmcp.e2e.mcp.AbstractStatelessMcpE2eTest;
+import dev.tachyonmcp.testkit.Mcp20260728Client;
+import dev.tachyonmcp.testkit.McpClient;
+import dev.tachyonmcp.testkit.McpTestClients;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -15,7 +18,17 @@ import org.junit.jupiter.api.Test;
  * is no {@code logging/setLevel} RPC and no session to carry a standing threshold. When the
  * request does set a level, only messages at or above it may be sent.
  */
-class LogLevelGatingTest extends AbstractStatelessMcpE2eTest {
+class LogLevelGatingTest extends AbstractStatelessMcpE2eTest<McpClient> {
+
+    @Override
+    protected Mcp20260728Client createTestClient() {
+        return createTestClient(port);
+    }
+
+    @Override
+    protected Mcp20260728Client createTestClient(int port) {
+        return McpTestClients.latest(port);
+    }
 
     // language=JSON
     private static final String NO_ARGS_SCHEMA = "{\"type\": \"object\", \"properties\": {}}";

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/v2026_07_28/MetaValidationTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/v2026_07_28/MetaValidationTest.java
@@ -5,6 +5,9 @@ import static dev.tachyonmcp.testkit.JsonRpcResponseAssert.assertThat;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import dev.tachyonmcp.e2e.mcp.AbstractStatelessMcpE2eTest;
+import dev.tachyonmcp.testkit.Mcp20260728Client;
+import dev.tachyonmcp.testkit.McpClient;
+import dev.tachyonmcp.testkit.McpTestClients;
 import java.net.http.HttpResponse;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -15,7 +18,17 @@ import org.junit.jupiter.api.Test;
  * field is malformed: the server must reject it with JSON-RPC {@code -32602} (Invalid params) and
  * HTTP {@code 400 Bad Request}, and the error response must still carry the original request id.
  */
-class MetaValidationTest extends AbstractStatelessMcpE2eTest {
+class MetaValidationTest extends AbstractStatelessMcpE2eTest<McpClient> {
+
+    @Override
+    protected Mcp20260728Client createTestClient() {
+        return createTestClient(port);
+    }
+
+    @Override
+    protected Mcp20260728Client createTestClient(int port) {
+        return McpTestClients.latest(port);
+    }
 
     private static final String VALID_META = """
             "io.modelcontextprotocol/protocolVersion": "2026-07-28",

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/v2026_07_28/MetadataE2eTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/v2026_07_28/MetadataE2eTest.java
@@ -16,6 +16,9 @@ import dev.tachyonmcp.api.server.features.resources.ResourceDescriptor;
 import dev.tachyonmcp.api.server.features.resources.ResourceTemplateDescriptor;
 import dev.tachyonmcp.api.server.features.tools.ToolResult;
 import dev.tachyonmcp.e2e.mcp.AbstractStatelessMcpE2eTest;
+import dev.tachyonmcp.testkit.Mcp20260728Client;
+import dev.tachyonmcp.testkit.McpClient;
+import dev.tachyonmcp.testkit.McpTestClients;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -27,7 +30,17 @@ import org.junit.jupiter.api.Test;
  * flows through list operations, and request {@code _meta} reaches handlers
  * and appears in results for tools, prompts, and completions.
  */
-class MetadataE2eTest extends AbstractStatelessMcpE2eTest {
+class MetadataE2eTest extends AbstractStatelessMcpE2eTest<McpClient> {
+
+    @Override
+    protected Mcp20260728Client createTestClient() {
+        return createTestClient(port);
+    }
+
+    @Override
+    protected Mcp20260728Client createTestClient(int port) {
+        return McpTestClients.latest(port);
+    }
 
     // language=JSON
     private static final String NO_ARGS_SCHEMA = "{\"type\": \"object\", \"properties\": {}}";

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/v2026_07_28/MissingCapabilityTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/v2026_07_28/MissingCapabilityTest.java
@@ -8,6 +8,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import dev.tachyonmcp.api.server.features.tools.ToolResult;
 import dev.tachyonmcp.core.server.domain.MissingRequiredClientCapabilityException;
 import dev.tachyonmcp.e2e.mcp.AbstractStatelessMcpE2eTest;
+import dev.tachyonmcp.testkit.Mcp20260728Client;
+import dev.tachyonmcp.testkit.McpClient;
+import dev.tachyonmcp.testkit.McpTestClients;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -20,7 +23,17 @@ import org.junit.jupiter.api.Test;
  * it to the wire error, whose HTTP status (400) is now spec-tied via
  * {@code v2026_07_28.codecs.McpResponseMapper}.
  */
-class MissingCapabilityTest extends AbstractStatelessMcpE2eTest {
+class MissingCapabilityTest extends AbstractStatelessMcpE2eTest<McpClient> {
+
+    @Override
+    protected Mcp20260728Client createTestClient() {
+        return createTestClient(port);
+    }
+
+    @Override
+    protected Mcp20260728Client createTestClient(int port) {
+        return McpTestClients.latest(port);
+    }
 
     @BeforeEach
     void registerFixtures() {

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/v2026_07_28/RemovedMethodsTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/v2026_07_28/RemovedMethodsTest.java
@@ -5,6 +5,9 @@ import static dev.tachyonmcp.testkit.JsonRpcResponseAssert.assertThat;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import dev.tachyonmcp.e2e.mcp.AbstractStatelessMcpE2eTest;
+import dev.tachyonmcp.testkit.Mcp20260728Client;
+import dev.tachyonmcp.testkit.McpClient;
+import dev.tachyonmcp.testkit.McpTestClients;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -18,7 +21,17 @@ import org.junit.jupiter.params.provider.ValueSource;
  * only this revision must answer them with HTTP 404 and JSON-RPC {@code -32601} (Method not found),
  * not dispatch them as it would under 2025-11-25.
  */
-class RemovedMethodsTest extends AbstractStatelessMcpE2eTest {
+class RemovedMethodsTest extends AbstractStatelessMcpE2eTest<McpClient> {
+
+    @Override
+    protected Mcp20260728Client createTestClient() {
+        return createTestClient(port);
+    }
+
+    @Override
+    protected Mcp20260728Client createTestClient(int port) {
+        return McpTestClients.latest(port);
+    }
 
     @ParameterizedTest
     @ValueSource(strings = {"initialize", "ping", "logging/setLevel", "resources/subscribe", "resources/unsubscribe"})

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/v2026_07_28/ResourceContractTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/v2026_07_28/ResourceContractTest.java
@@ -4,13 +4,24 @@ package dev.tachyonmcp.e2e.mcp.v2026_07_28;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import dev.tachyonmcp.e2e.mcp.AbstractResourceContractTest;
-import dev.tachyonmcp.testkit.McpClient;
+import dev.tachyonmcp.testkit.Mcp20260728Client;
+import dev.tachyonmcp.testkit.McpTestClients;
 import org.junit.jupiter.api.Test;
 
-class ResourceContractTest extends AbstractResourceContractTest {
+class ResourceContractTest extends AbstractResourceContractTest<Mcp20260728Client> {
 
     @Override
-    protected McpClient readyClient() {
+    protected Mcp20260728Client createTestClient() {
+        return createTestClient(port);
+    }
+
+    @Override
+    protected Mcp20260728Client createTestClient(int port) {
+        return McpTestClients.latest(port);
+    }
+
+    @Override
+    protected Mcp20260728Client readyClient() {
         return createModernTestClient();
     }
 

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/v2026_07_28/SchemaValidationContractTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/v2026_07_28/SchemaValidationContractTest.java
@@ -1,0 +1,99 @@
+/* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
+package dev.tachyonmcp.e2e.mcp.v2026_07_28;
+
+import static dev.tachyonmcp.testkit.JsonRpcResponseAssert.assertThat;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.tachyonmcp.api.server.domain.PromptArgument;
+import dev.tachyonmcp.api.server.domain.PromptMessage;
+import dev.tachyonmcp.api.server.domain.Role;
+import dev.tachyonmcp.api.server.domain.TextContent;
+import dev.tachyonmcp.api.server.features.prompts.PromptDescriptor;
+import dev.tachyonmcp.api.server.features.tools.ToolResult;
+import dev.tachyonmcp.e2e.mcp.AbstractSchemaValidationContractTest;
+import dev.tachyonmcp.testkit.Mcp20260728Client;
+import dev.tachyonmcp.testkit.McpTestClients;
+import java.util.List;
+import net.javacrumbs.jsonunit.core.Option;
+import org.junit.jupiter.api.Test;
+
+class SchemaValidationContractTest extends AbstractSchemaValidationContractTest<Mcp20260728Client> {
+
+    @Override
+    protected Mcp20260728Client createTestClient() {
+        return createTestClient(port);
+    }
+
+    @Override
+    protected Mcp20260728Client createTestClient(int port) {
+        return McpTestClients.latest(port);
+    }
+
+    @Override
+    protected Mcp20260728Client readyClient() {
+        return createModernTestClient();
+    }
+
+    @Test
+    protected void shouldRejectToolCallWithMissingRequiredField() throws Exception {
+        startServer(
+                b -> b.json(j -> j.inputSchemaValidator(VALIDATOR).outputSchemaValidator(VALIDATOR)),
+                s -> s.tools().register(validatedTool(), (context, request) -> ToolResult.text("ok")));
+
+        try (var client = readyClient()) {
+            var response = client.post("""
+                {"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"validated","arguments":{"age":30}}}
+                """);
+
+            assertThat(response.statusCode()).isEqualTo(400);
+            assertThatJson(response.body()).when(Option.IGNORING_EXTRA_FIELDS).isEqualTo("""
+                {"jsonrpc":"2.0","id":2,"error":{"code":-32602,"message":"required property 'name' not found"}}
+                """);
+        }
+    }
+
+    @Test
+    protected void shouldRejectToolCallWithWrongType() throws Exception {
+        startServer(
+                b -> b.json(j -> j.schemaValidator(VALIDATOR)),
+                s -> s.tools().register(validatedTool(), (context, request) -> ToolResult.text("ok")));
+
+        try (var client = readyClient()) {
+            var response = client.post("""
+                {"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"validated","arguments":{"name":123}}}
+                """);
+
+            assertThat(response.statusCode()).isEqualTo(400);
+            assertThatJson(response.body()).when(Option.IGNORING_EXTRA_FIELDS).isEqualTo("""
+                {"jsonrpc":"2.0","id":2,"error":{"code":-32602,"message":"integer found, string expected"}}
+                """);
+        }
+    }
+
+    @Test
+    protected void shouldRejectPromptWithMissingRequiredField() throws Exception {
+        startServer(it -> it.json(j -> j.schemaValidator(VALIDATOR)));
+
+        server.prompts()
+                .register(
+                        PromptDescriptor.of(
+                                "validated-prompt",
+                                "A validated prompt",
+                                null,
+                                List.of(PromptArgument.of("name", null, "Your name", true)),
+                                PROMPT_SCHEMA),
+                        List.of(PromptMessage.of(Role.USER, TextContent.of("Hello {name}"))));
+
+        try (var client = readyClient()) {
+            var response = client.post("""
+                {"jsonrpc":"2.0","id":2,"method":"prompts/get","params":{"name":"validated-prompt","arguments":{}}}
+                """);
+
+            assertThat(response.statusCode()).isEqualTo(400);
+            assertThatJson(response.body()).when(Option.IGNORING_EXTRA_FIELDS).isEqualTo("""
+                {"jsonrpc":"2.0","id":2,"error":{"code":-32602,"message":"required property 'name' not found"}}
+                """);
+        }
+    }
+}

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/v2026_07_28/StatelessDispatchTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/v2026_07_28/StatelessDispatchTest.java
@@ -6,6 +6,8 @@ import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import dev.tachyonmcp.e2e.mcp.AbstractStatelessMcpE2eTest;
+import dev.tachyonmcp.testkit.Mcp20260728Client;
+import dev.tachyonmcp.testkit.McpTestClients;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -14,7 +16,17 @@ import org.junit.jupiter.api.Test;
  * configuration. Regression test for {@code McpDispatcher} only bypassing the session requirement
  * for {@code server/discover}/{@code ping} instead of every method under this protocol version.
  */
-class StatelessDispatchTest extends AbstractStatelessMcpE2eTest {
+class StatelessDispatchTest extends AbstractStatelessMcpE2eTest<Mcp20260728Client> {
+
+    @Override
+    protected Mcp20260728Client createTestClient() {
+        return createTestClient(port);
+    }
+
+    @Override
+    protected Mcp20260728Client createTestClient(int port) {
+        return McpTestClients.latest(port);
+    }
 
     @Test
     void toolsCallSucceedsWithNoSession() throws Exception {

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/v2026_07_28/StringSchemaContractTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/v2026_07_28/StringSchemaContractTest.java
@@ -1,0 +1,24 @@
+/* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
+package dev.tachyonmcp.e2e.mcp.v2026_07_28;
+
+import dev.tachyonmcp.e2e.mcp.AbstractStringSchemaContractTest;
+import dev.tachyonmcp.testkit.Mcp20260728Client;
+import dev.tachyonmcp.testkit.McpTestClients;
+
+class StringSchemaContractTest extends AbstractStringSchemaContractTest<Mcp20260728Client> {
+
+    @Override
+    protected Mcp20260728Client createTestClient() {
+        return createTestClient(port);
+    }
+
+    @Override
+    protected Mcp20260728Client createTestClient(int port) {
+        return McpTestClients.latest(port);
+    }
+
+    @Override
+    protected Mcp20260728Client readyClient() {
+        return createModernTestClient();
+    }
+}

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/v2026_07_28/StructuredOutputSchemaShapeTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/v2026_07_28/StructuredOutputSchemaShapeTest.java
@@ -13,6 +13,9 @@ import dev.tachyonmcp.api.server.features.tools.ToolResult;
 import dev.tachyonmcp.core.server.features.tasks.TasksExtension;
 import dev.tachyonmcp.core.server.json.JsonUtils;
 import dev.tachyonmcp.e2e.mcp.AbstractStatelessMcpE2eTest;
+import dev.tachyonmcp.testkit.Mcp20260728Client;
+import dev.tachyonmcp.testkit.McpClient;
+import dev.tachyonmcp.testkit.McpTestClients;
 import dev.tachyonmcp.testkit.TestTaskConnector;
 import java.time.Instant;
 import org.junit.jupiter.api.Test;
@@ -23,7 +26,17 @@ import org.junit.jupiter.api.Test;
  * {@code dev.tachyonmcp.e2e.SchemaValidationTest} and the sibling 2025-11-25 fallback coverage for
  * that restriction). These tests cover the array/scalar shapes end to end under 2026-07-28.
  */
-class StructuredOutputSchemaShapeTest extends AbstractStatelessMcpE2eTest {
+class StructuredOutputSchemaShapeTest extends AbstractStatelessMcpE2eTest<McpClient> {
+
+    @Override
+    protected Mcp20260728Client createTestClient() {
+        return createTestClient(port);
+    }
+
+    @Override
+    protected Mcp20260728Client createTestClient(int port) {
+        return McpTestClients.latest(port);
+    }
 
     // language=JSON
     private static final String NO_ARGS_SCHEMA = "{\"type\": \"object\", \"properties\": {}}";

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/v2026_07_28/SubscriptionsListenTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/v2026_07_28/SubscriptionsListenTest.java
@@ -10,6 +10,8 @@ import dev.tachyonmcp.api.server.features.tasks.TaskSnapshot;
 import dev.tachyonmcp.api.server.features.tools.ToolResult;
 import dev.tachyonmcp.core.server.features.tasks.TasksExtension;
 import dev.tachyonmcp.e2e.mcp.AbstractStatelessMcpE2eTest;
+import dev.tachyonmcp.testkit.Mcp20260728Client;
+import dev.tachyonmcp.testkit.McpTestClients;
 import dev.tachyonmcp.testkit.TestTaskConnector;
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -29,7 +31,17 @@ import tools.jackson.databind.node.JsonNodeFactory;
  * MCP 2026-07-28 {@code subscriptions/listen} (SEP-2575): the request-scoped SSE stream that
  * replaces {@code resources/subscribe} and the plain HTTP GET stream for the stateless transport.
  */
-class SubscriptionsListenTest extends AbstractStatelessMcpE2eTest {
+class SubscriptionsListenTest extends AbstractStatelessMcpE2eTest<Mcp20260728Client> {
+
+    @Override
+    protected Mcp20260728Client createTestClient() {
+        return createTestClient(port);
+    }
+
+    @Override
+    protected Mcp20260728Client createTestClient(int port) {
+        return McpTestClients.latest(port);
+    }
 
     @BeforeEach
     void freshServer() {

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/v2026_07_28/TasksExtensionTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/v2026_07_28/TasksExtensionTest.java
@@ -16,6 +16,8 @@ import dev.tachyonmcp.api.server.features.tools.ToolResult;
 import dev.tachyonmcp.core.server.features.tasks.TasksExtension;
 import dev.tachyonmcp.e2e.mcp.AbstractStatelessMcpE2eTest;
 import dev.tachyonmcp.testkit.Mcp20260728Client;
+import dev.tachyonmcp.testkit.McpClient;
+import dev.tachyonmcp.testkit.McpTestClients;
 import dev.tachyonmcp.testkit.TestTaskConnector;
 import java.time.Instant;
 import java.util.Map;
@@ -23,7 +25,17 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
 import tools.jackson.databind.node.JsonNodeFactory;
 
-class TasksExtensionTest extends AbstractStatelessMcpE2eTest {
+class TasksExtensionTest extends AbstractStatelessMcpE2eTest<McpClient> {
+
+    @Override
+    protected Mcp20260728Client createTestClient() {
+        return createTestClient(port);
+    }
+
+    @Override
+    protected Mcp20260728Client createTestClient(int port) {
+        return McpTestClients.latest(port);
+    }
 
     @Test
     void taskProducingToolPublishesSnapshotAndGetRefreshesConnector() throws Exception {

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/v2026_07_28/ToolCapabilitiesContractTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/v2026_07_28/ToolCapabilitiesContractTest.java
@@ -1,0 +1,89 @@
+/* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
+package dev.tachyonmcp.e2e.mcp.v2026_07_28;
+
+import static dev.tachyonmcp.e2e.mcp.AbstractToolCapabilitiesContractTest.INPUT_SCHEMA;
+import static dev.tachyonmcp.e2e.mcp.AbstractToolCapabilitiesContractTest.OK;
+import static dev.tachyonmcp.e2e.mcp.AbstractToolCapabilitiesContractTest.OUTPUT_SCHEMA;
+import static dev.tachyonmcp.e2e.mcp.AbstractToolCapabilitiesContractTest.simpleToolDescriptor;
+import static dev.tachyonmcp.e2e.mcp.AbstractToolCapabilitiesContractTest.taskAwareToolDescriptor;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+
+import dev.tachyonmcp.api.server.domain.ToolAnnotations;
+import dev.tachyonmcp.api.server.features.tasks.TaskSupport;
+import dev.tachyonmcp.api.server.features.tools.ToolDescriptor;
+import dev.tachyonmcp.e2e.mcp.AbstractToolCapabilitiesContractTest;
+import dev.tachyonmcp.testkit.Mcp20260728Client;
+import dev.tachyonmcp.testkit.McpTestClients;
+import java.util.stream.Stream;
+import net.javacrumbs.jsonunit.core.Option;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class ToolCapabilitiesContractTest extends AbstractToolCapabilitiesContractTest<Mcp20260728Client> {
+
+    @Override
+    protected Mcp20260728Client createTestClient() {
+        return createTestClient(port);
+    }
+
+    @Override
+    protected Mcp20260728Client createTestClient(int port) {
+        return McpTestClients.latest(port);
+    }
+
+    @Override
+    protected Mcp20260728Client readyClient() {
+        return createModernTestClient();
+    }
+
+    @ParameterizedTest(name = "[{index}] {0}")
+    @MethodSource
+    protected void shouldIncludeExecutionTaskSupport(String toolName, boolean hasExecution, ToolDescriptor descriptor)
+            throws Exception {
+        startServerWith(s -> s.tools().register(descriptor, OK));
+
+        try (var client = readyClient()) {
+            var response = listTools(client);
+
+            assertThatJson(response.body()).inPath("$.result.tools[0].name").isEqualTo(toolName);
+            // v2026-07-28 does not include execution field in tools/list
+            assertThatJson(response.body())
+                    .inPath("$.result.tools[0]")
+                    .isObject()
+                    .doesNotContainKey("execution");
+        }
+    }
+
+    static Stream<Arguments> shouldIncludeExecutionTaskSupport() {
+        return Stream.of(
+                Arguments.of("task-aware-tool", false, taskAwareToolDescriptor(TaskSupport.OPTIONAL)),
+                Arguments.of("simple", false, simpleToolDescriptor("simple", "A simple tool")));
+    }
+
+    @Test
+    protected void shouldRegisterWithFullDescriptor() throws Exception {
+        var annotations = ToolAnnotations.of(null, true, false, null, null);
+        startEmptyServer();
+        server.tools()
+                .register(
+                        b -> b.name("full-tool")
+                                .title("Full Tool")
+                                .description("A tool with all metadata")
+                                .inputSchema(INPUT_SCHEMA)
+                                .outputSchema(OUTPUT_SCHEMA)
+                                .taskSupport(TaskSupport.OPTIONAL)
+                                .annotations(annotations),
+                        OK);
+
+        try (var client = readyClient()) {
+            var response = listTools(client);
+
+            var expected = """
+                {"jsonrpc":"2.0","id":2,"result":{"tools":[{"name":"full-tool","title":"Full Tool","description":"A tool with all metadata","inputSchema":{"type":"object","properties":{"message":{"type":"string","description":"Input"}},"required":["message"]},"outputSchema":{"type":"object","properties":{"result":{"type":"string","description":"The output result"}}},"annotations":{"readOnlyHint":true,"destructiveHint":false}}]}}
+                """;
+            assertThatJson(response.body()).when(Option.IGNORING_EXTRA_FIELDS).isEqualTo(expected.trim());
+        }
+    }
+}

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/v2026_07_28/ToolErrorContractTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/v2026_07_28/ToolErrorContractTest.java
@@ -1,0 +1,49 @@
+/* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
+package dev.tachyonmcp.e2e.mcp.v2026_07_28;
+
+import static dev.tachyonmcp.testkit.McpHttpResponseAssert.assertThatResponse;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.tachyonmcp.e2e.mcp.AbstractToolErrorContractTest;
+import dev.tachyonmcp.testkit.Mcp20260728Client;
+import dev.tachyonmcp.testkit.McpTestClients;
+import org.junit.jupiter.api.Test;
+
+class ToolErrorContractTest extends AbstractToolErrorContractTest<Mcp20260728Client> {
+
+    @Override
+    protected Mcp20260728Client createTestClient() {
+        return createTestClient(port);
+    }
+
+    @Override
+    protected Mcp20260728Client createTestClient(int port) {
+        return McpTestClients.latest(port);
+    }
+
+    @Override
+    protected Mcp20260728Client readyClient() {
+        return createModernTestClient();
+    }
+
+    @Test
+    protected void shouldRedactIllegalArgumentExceptionFromInvalidParamsError() throws Exception {
+        startServerWith(s -> s.tools()
+                .register(builder -> builder.name("bad-arg").description("Rejects input"), (context, request) -> {
+                    throw new IllegalArgumentException("sensitive internal detail");
+                }));
+
+        try (var client = readyClient()) {
+            var response = client.post("""
+                {"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"bad-arg","arguments":{}}}
+                """);
+            assertThat(response.statusCode()).isEqualTo(400);
+            assertThatResponse(response)
+                    .isJsonRpcError()
+                    .hasId(2)
+                    .hasErrorCode(-32602)
+                    .hasErrorMessage("Invalid params");
+            assertThat(response.body()).doesNotContain("sensitive internal detail");
+        }
+    }
+}

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/v2026_07_28/UnsupportedProtocolVersionTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/v2026_07_28/UnsupportedProtocolVersionTest.java
@@ -6,6 +6,9 @@ import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import dev.tachyonmcp.e2e.mcp.AbstractStatelessMcpE2eTest;
+import dev.tachyonmcp.testkit.Mcp20260728Client;
+import dev.tachyonmcp.testkit.McpClient;
+import dev.tachyonmcp.testkit.McpTestClients;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -19,7 +22,17 @@ import org.junit.jupiter.api.Test;
  * support and echoes the requested one, over HTTP {@code 400 Bad Request}, with the response
  * {@code id} matching the request's JSON-RPC id.
  */
-class UnsupportedProtocolVersionTest extends AbstractStatelessMcpE2eTest {
+class UnsupportedProtocolVersionTest extends AbstractStatelessMcpE2eTest<McpClient> {
+
+    @Override
+    protected Mcp20260728Client createTestClient() {
+        return createTestClient(port);
+    }
+
+    @Override
+    protected Mcp20260728Client createTestClient(int port) {
+        return McpTestClients.latest(port);
+    }
 
     @Test
     void rejectsUnsupportedProtocolVersion() throws Exception {

--- a/e2e/src/test/kotlin/dev/tachyonmcp/e2e/KotlinE2eTest.kt
+++ b/e2e/src/test/kotlin/dev/tachyonmcp/e2e/KotlinE2eTest.kt
@@ -7,13 +7,18 @@ import dev.tachyonmcp.e2e.mcp.AbstractStatelessMcpE2eTest
 import dev.tachyonmcp.kotlin.server.TachyonServer
 import dev.tachyonmcp.kotlin.server.domain.arguments
 import dev.tachyonmcp.kotlin.server.json.KxSerializationSerde
+import dev.tachyonmcp.testkit.Mcp20251125Client
 import io.kotest.assertions.json.shouldEqualJson
 import io.kotest.matchers.equals.shouldEqual
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import org.junit.jupiter.api.Test
 
-internal class KotlinE2eTest : AbstractStatelessMcpE2eTest() {
+internal class KotlinE2eTest : AbstractStatelessMcpE2eTest<Mcp20251125Client>() {
+    override fun createTestClient(): Mcp20251125Client = createTestClient(port)
+
+    override fun createTestClient(port: Int): Mcp20251125Client = Mcp20251125Client(port)
+
     @Serializable
     data class GreetArgs(
         val name: String,

--- a/e2e/src/test/kotlin/dev/tachyonmcp/e2e/ResourcePromptAttributesE2eTest.kt
+++ b/e2e/src/test/kotlin/dev/tachyonmcp/e2e/ResourcePromptAttributesE2eTest.kt
@@ -10,6 +10,7 @@ import dev.tachyonmcp.kotlin.server.domain.PromptArgument
 import dev.tachyonmcp.kotlin.server.features.prompts.PromptDescriptor
 import dev.tachyonmcp.kotlin.server.features.resources.ResourceTemplateDescriptor
 import dev.tachyonmcp.kotlin.server.features.resources.resourceDescriptor
+import dev.tachyonmcp.testkit.Mcp20251125Client
 import io.kotest.matchers.equals.shouldEqual
 import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.string.shouldNotContain
@@ -32,7 +33,11 @@ import org.junit.jupiter.api.Test
  * overload) rather than treated as a wire-format detail like `inputSchema` (prompt-only, also not
  * on the wire, but not gated — just not part of the `Prompt` protocol model).
  */
-internal class ResourcePromptAttributesE2eTest : AbstractStatelessMcpE2eTest() {
+internal class ResourcePromptAttributesE2eTest : AbstractStatelessMcpE2eTest<Mcp20251125Client>() {
+    override fun createTestClient(): Mcp20251125Client = createTestClient(port)
+
+    override fun createTestClient(port: Int): Mcp20251125Client = Mcp20251125Client(port)
+
     @Test
     fun `resource full attribute set round-trips over the wire`() {
         val icon = Icon { src = "https://example.com/resource-icon.png" }

--- a/e2e/src/test/kotlin/dev/tachyonmcp/e2e/TypedToolKotlinE2eTest.kt
+++ b/e2e/src/test/kotlin/dev/tachyonmcp/e2e/TypedToolKotlinE2eTest.kt
@@ -8,6 +8,7 @@ import dev.tachyonmcp.kotlin.server.domain.arguments
 import dev.tachyonmcp.kotlin.server.json.KxSerializationSerde
 import dev.tachyonmcp.kotlin.server.json.ktschema.ktSchemaGenerator
 import dev.tachyonmcp.kotlin.server.registerTool
+import dev.tachyonmcp.testkit.Mcp20251125Client
 import io.kotest.assertions.json.shouldEqualJson
 import io.kotest.matchers.equals.shouldEqual
 import io.kotest.matchers.string.shouldContain
@@ -21,7 +22,11 @@ import org.junit.jupiter.api.Test
  * `META-INF/services`; this module opts the artifact in as a test dependency). Split out from
  * [KotlinE2eTest] because this is the only test class in the module that needs it.
  */
-internal class TypedToolKotlinE2eTest : AbstractStatelessMcpE2eTest() {
+internal class TypedToolKotlinE2eTest : AbstractStatelessMcpE2eTest<Mcp20251125Client>() {
+    override fun createTestClient(): Mcp20251125Client = createTestClient(port)
+
+    override fun createTestClient(port: Int): Mcp20251125Client = Mcp20251125Client(port)
+
     @Serializable
     private data class GreetArgs(
         val name: String,

--- a/tachyon-testkit/src/main/java/dev/tachyonmcp/testkit/JsonRpcResponseAssert.java
+++ b/tachyon-testkit/src/main/java/dev/tachyonmcp/testkit/JsonRpcResponseAssert.java
@@ -227,6 +227,17 @@ public final class JsonRpcResponseAssert extends AbstractAssert<JsonRpcResponseA
             assertThatJson(actual.path("result").path("structuredContent")).isEqualTo(expectedJson);
             return this;
         }
+
+        /** Verifies {@code structuredContent} is absent from the result.
+         *
+         * @return this assertion
+         */
+        public JsonRpcSuccessAssert doesNotHaveStructuredContent() {
+            if (actual.path("result").has("structuredContent")) {
+                failWithMessage("Expected no structuredContent in: %s", actual);
+            }
+            return this;
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary

The E2E test hierarchy is now generic over McpClient. Base contract tests receive initialized clients from protocol-specific subclasses. Existing tests add typed client factories. New 2025-11-25 and 2026-07-28 adapters run shared contract tests. Schema assertions tolerate protocol-specific envelope fields. Version-specific tests cover structured-content fallback, schema errors, tool capabilities, and error redaction.

### Tests

- Expanded end-to-end coverage across supported protocol versions.
- Added contract tests for schema validation, tool capabilities, tool errors, and string schemas.
- Added coverage for structured-content handling, content-size limits, caching hints, and protocol-specific behavior.
- Improved assertions to accommodate version-specific response fields while preserving validation accuracy.

### Refactor

- Standardized test client setup and enabled reusable, protocol-specific test contracts.
