### PR TITLE
feat(testdsl): hasResult(json) assert

### DIFF
--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/AbstractToolCapabilitiesContractTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/AbstractToolCapabilitiesContractTest.java
@@ -215,12 +215,11 @@ public abstract class AbstractToolCapabilitiesContractTest<C extends McpClient> 
                 {"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"structured","arguments":{"message":"hi"}}}
                 """);
 
-            assertThat(response.statusCode()).isEqualTo(200);
-            assertThatResponse(response).isSuccess().hasTextContent("Echo: hi");
-            assertThatJson(response.body())
-                    .inPath("$.result.structuredContent")
-                    .isObject()
-                    .containsKey("echo");
+            assertThatResponse(response)
+                    .hasStatus(200)
+                    .isSuccess()
+                    .hasTextContent("Echo: hi")
+                    .hasStructuredContent("{\"echo\":\"hi\"}");
         }
     }
 

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/PromptsTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/PromptsTest.java
@@ -3,7 +3,6 @@ package dev.tachyonmcp.e2e.mcp;
 
 import static dev.tachyonmcp.testkit.JsonRpcResponseAssert.assertThat;
 import static dev.tachyonmcp.testkit.McpHttpResponseAssert.assertThatResponse;
-import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import dev.tachyonmcp.api.server.domain.EmbeddedResource;
@@ -66,19 +65,15 @@ class PromptsTest extends AbstractStatelessMcpE2eTest<McpClient> {
 
         try (var client = createTestClient()) {
             client.initialize();
-            var response = client.post("""
+            var response = client.sendRpc("""
                 {"jsonrpc":"2.0","id":2,"method":"prompts/get","params":{"name":"greeting"}}
                 """);
 
-            assertThatJson(response.body()).isEqualTo("""
-                    {
-                      "jsonrpc":"2.0",
-                      "id":2,
-                      "result":{"description":"A greeting prompt","messages":[{
-                        "role":"user",
-                        "content":{"type":"text","text":"Hello world!"}
-                      }]}
-                    }
+            assertThat(response).isSuccess().hasId(2).hasResult("""
+                {"description":"A greeting prompt","messages":[{
+                  "role":"user",
+                  "content":{"type":"text","text":"Hello world!"}
+                }]}
                     """);
         }
     }
@@ -166,12 +161,12 @@ class PromptsTest extends AbstractStatelessMcpE2eTest<McpClient> {
 
         try (var client = createTestClient()) {
             client.initialize();
-            var response = client.post("""
+            var response = client.sendRpc("""
                 {"jsonrpc":"2.0","id":2,"method":"prompts/list"}
                 """);
 
-            assertThatJson(response.body()).isEqualTo("""
-                    {"jsonrpc":"2.0","id":2,"result":{"prompts":[]}}
+            assertThat(response).isSuccess().hasId(2).hasResult("""
+                {"prompts":[]}
                     """);
         }
     }
@@ -187,23 +182,19 @@ class PromptsTest extends AbstractStatelessMcpE2eTest<McpClient> {
 
         try (var client = createTestClient()) {
             client.initialize();
-            var response = client.post("""
+            var response = client.sendRpc("""
                 {"jsonrpc":"2.0","id":2,"method":"prompts/get","params":{"name":"embedded"}}
                 """);
 
-            assertThatJson(response.body()).isEqualTo("""
-                    {
-                      "jsonrpc":"2.0",
-                      "id":2,
-                      "result":{"description":"Prompt with embedded resource","messages":[{
-                        "role":"user",
-                        "content":{"type":"resource","resource":{
-                          "uri":"test://embedded",
-                          "mimeType":"text/plain",
-                          "text":"embedded content"
-                        }}
-                      }]}
-                    }
+            assertThat(response).isSuccess().hasId(2).hasResult("""
+                {"description":"Prompt with embedded resource","messages":[{
+                  "role":"user",
+                  "content":{"type":"resource","resource":{
+                    "uri":"test://embedded",
+                    "mimeType":"text/plain",
+                    "text":"embedded content"
+                  }}
+                }]}
                     """);
         }
     }
@@ -219,23 +210,19 @@ class PromptsTest extends AbstractStatelessMcpE2eTest<McpClient> {
 
         try (var client = createTestClient()) {
             client.initialize();
-            var response = client.post("""
+            var response = client.sendRpc("""
                 {"jsonrpc":"2.0","id":2,"method":"prompts/get","params":{"name":"image-prompt"}}
                 """);
 
-            assertThatJson(response.body()).isEqualTo("""
-                    {
-                      "jsonrpc":"2.0",
-                      "id":2,
-                      "result":{"description":"Prompt with image","messages":[{
-                        "role":"user",
-                        "content":{
-                          "type":"image",
-                          "data":"iVBORw0KGgo=",
-                          "mimeType":"image/png"
-                        }
-                      }]}
-                    }
+            assertThat(response).isSuccess().hasId(2).hasResult("""
+                {"description":"Prompt with image","messages":[{
+                  "role":"user",
+                  "content":{
+                    "type":"image",
+                    "data":"iVBORw0KGgo=",
+                    "mimeType":"image/png"
+                  }
+                }]}
                     """);
         }
     }

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/TypedToolRegistrationTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/TypedToolRegistrationTest.java
@@ -1,6 +1,7 @@
 /* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
 package dev.tachyonmcp.e2e.mcp;
 
+import static dev.tachyonmcp.testkit.JsonRpcResponseAssert.assertThat;
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 
 import dev.tachyonmcp.api.json.JsonSchema;
@@ -60,15 +61,11 @@ class TypedToolRegistrationTest {
                     {"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"greet","arguments":{"name":"Ada"}}}
                     """);
 
-            // language=JSON
-            var expected = """
-                    {"jsonrpc":"2.0","id":1,"result":{
-                        "content":[{"type":"text","text":"{\\"greeting\\":\\"Hello, Ada!\\"}"}],
-                        "structuredContent":{"greeting":"Hello, Ada!"},
-                        "resultType":"complete"
-                    }}
-                    """;
-            assertThatJson(response.body()).isEqualTo(expected);
+            assertThat(response).isSuccess().hasId(1).hasResult("""
+                            {"content":[{"type":"text","text":"{\\"greeting\\":\\"Hello, Ada!\\"}"}],
+                             "structuredContent":{"greeting":"Hello, Ada!"},
+                             "resultType":"complete"}
+                            """);
         }
     }
 
@@ -127,15 +124,11 @@ class TypedToolRegistrationTest {
                      "params":{"name":"greet-async","arguments":{"name":"Ada"}}}
                     """);
 
-            // language=JSON
-            var expected = """
-                    {"jsonrpc":"2.0","id":1,"result":{
-                        "content":[{"type":"text","text":"{\\"greeting\\":\\"Hi, Ada!\\"}"}],
-                        "structuredContent":{"greeting":"Hi, Ada!"},
-                        "resultType":"complete"
-                    }}
-                    """;
-            assertThatJson(response.body()).isEqualTo(expected);
+            assertThat(response).isSuccess().hasId(1).hasResult("""
+                            {"content":[{"type":"text","text":"{\\"greeting\\":\\"Hi, Ada!\\"}"}],
+                             "structuredContent":{"greeting":"Hi, Ada!"},
+                             "resultType":"complete"}
+                            """);
         }
     }
 
@@ -229,15 +222,11 @@ class TypedToolRegistrationTest {
                      "params":{"name":"farewell-async-generated","arguments":{"name":"Ada"}}}
                     """);
 
-            // language=JSON
-            var expected = """
-                    {"jsonrpc":"2.0","id":1,"result":{
-                        "content":[{"type":"text","text":"{\\"farewell\\":\\"Bye, Ada!\\"}"}],
-                        "structuredContent":{"farewell":"Bye, Ada!"},
-                        "resultType":"complete"
-                    }}
-                    """;
-            assertThatJson(response.body()).isEqualTo(expected);
+            assertThat(response).isSuccess().hasId(1).hasResult("""
+                            {"content":[{"type":"text","text":"{\\"farewell\\":\\"Bye, Ada!\\"}"}],
+                             "structuredContent":{"farewell":"Bye, Ada!"},
+                             "resultType":"complete"}
+                            """);
         }
     }
 }

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/v2025_11_25/ExtensionsTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/v2025_11_25/ExtensionsTest.java
@@ -3,7 +3,6 @@ package dev.tachyonmcp.e2e.mcp.v2025_11_25;
 
 import static dev.tachyonmcp.testkit.JsonRpcResponseAssert.assertThat;
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import dev.tachyonmcp.api.server.extensions.AdvertiseMode;
 import dev.tachyonmcp.api.server.extensions.ExtensionContext;
@@ -95,14 +94,9 @@ class ExtensionsTest extends AbstractStatefulMcpE2eTest {
             var call = """
                 {"jsonrpc":"2.0","id":2,"method":"internal/hello","params":{"_meta":{"com.example/internal":{}}}}
                 """;
-            var callResp = client.post(sessionId, call);
-            // language=JSON
-            assertThatJson(callResp.body()).isEqualTo("""
-                {
-                  "jsonrpc": "2.0",
-                  "id": 2,
-                  "result": {"message": "Hi!"}
-                }
+            var callResp = client.sendRpc(sessionId, call);
+            assertThat(callResp).isSuccess().hasId(2).hasResult("""
+                    {"message":"Hi!"}
                 """);
         }
     }
@@ -175,14 +169,9 @@ class ExtensionsTest extends AbstractStatefulMcpE2eTest {
             var callWithMeta = """
                     {"jsonrpc":"2.0","id":3,"method":"test/ext-call","params":{"_meta":{"com.example/test":{}}}}
                     """;
-            var resp2 = client.post(sessionId, callWithMeta);
-            // language=JSON
-            assertThatJson(resp2.body()).isEqualTo("""
-                    {
-                      "jsonrpc": "2.0",
-                      "id": 3,
-                      "result": {"status": "ok"}
-                    }
+            var resp2 = client.sendRpc(sessionId, callWithMeta);
+            assertThat(resp2).isSuccess().hasId(3).hasResult("""
+                {"status":"ok"}
                     """);
         }
     }

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/v2025_11_25/ServerInfoTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/v2025_11_25/ServerInfoTest.java
@@ -1,7 +1,7 @@
 /* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
 package dev.tachyonmcp.e2e.mcp.v2025_11_25;
 
-import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static dev.tachyonmcp.testkit.JsonRpcResponseAssert.assertThat;
 
 import dev.tachyonmcp.api.server.domain.Icon;
 import dev.tachyonmcp.e2e.mcp.AbstractStatelessMcpE2eTest;
@@ -43,62 +43,56 @@ class ServerInfoTest extends AbstractStatelessMcpE2eTest<McpClient> {
 
         try (var client = createTestClient()) {
             // language=json
-            final var response = client.post("""
+            final var response = client.sendRpc("""
                 {"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}
                 """);
 
             // language=json
-            final var expected = """
-                    {
-                      "jsonrpc": "2.0",
-                      "id": 1,
-                      "result": {
-                        "protocolVersion": "2025-11-25",
-                        "serverInfo": {
-                          "name": "test-server",
-                          "version": "2.0",
-                          "description": "Test server",
-                          "title": "Test Server",
-                          "websiteUrl": "https://example.com/mcp",
-                          "icons": [{
-                            "src": "https://example.com/icon.png",
-                            "mimeType": "image/png",
-                            "sizes": ["32x32"],
-                            "theme": "light"
-                          }]
-                        },
-                        "instructions": "Test instructions",
-                        "capabilities": {
-                          "logging": {},
-                          "completions": {},
-                          "tools": {
-                            "listChanged": true
-                          },
-                          "resources": {
-                            "subscribe": true,
-                            "listChanged": true
-                          },
-                          "prompts": {
-                            "listChanged": true
-                          },
-                          "tasks": {
-                            "list": {},
-                            "cancel": {},
-                            "requests": {
-                              "tools": {
-                                "call": {}
-                              }
-                            }
-                          },
-                          "extensions": {
-                            "io.modelcontextprotocol/tasks": {}
-                          }
+            assertThat(response).isSuccess().hasId(1).hasResult("""
+                {
+                  "protocolVersion": "2025-11-25",
+                  "serverInfo": {
+                    "name": "test-server",
+                    "version": "2.0",
+                    "description": "Test server",
+                    "title": "Test Server",
+                    "websiteUrl": "https://example.com/mcp",
+                    "icons": [{
+                      "src": "https://example.com/icon.png",
+                      "mimeType": "image/png",
+                      "sizes": ["32x32"],
+                      "theme": "light"
+                    }]
+                  },
+                  "instructions": "Test instructions",
+                  "capabilities": {
+                    "logging": {},
+                    "completions": {},
+                    "tools": {
+                      "listChanged": true
+                    },
+                    "resources": {
+                      "subscribe": true,
+                      "listChanged": true
+                    },
+                    "prompts": {
+                      "listChanged": true
+                    },
+                    "tasks": {
+                      "list": {},
+                      "cancel": {},
+                      "requests": {
+                        "tools": {
+                          "call": {}
                         }
                       }
+                    },
+                    "extensions": {
+                      "io.modelcontextprotocol/tasks": {}
                     }
-                    """;
-
-            assertThatJson(response.body()).isEqualTo(expected);
+                  }
+                }
+                """);
         }
     }
 
@@ -108,24 +102,18 @@ class ServerInfoTest extends AbstractStatelessMcpE2eTest<McpClient> {
 
         try (var client = createTestClient()) {
             // language=json
-            final var response = client.post("""
+            final var response = client.sendRpc(null, """
                 {"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}
                 """);
 
             // language=json
-            final var expected = """
+            assertThat(response).isSuccess().hasId(1).hasResult("""
                 {
-                  "jsonrpc": "2.0",
-                  "id": 1,
-                  "result": {
-                    "protocolVersion":"2025-11-25",
-                    "serverInfo":{"version":"0.1","name":"tachyon-mcp"},
-                    "capabilities": {}
-                  }
+                  "protocolVersion":"2025-11-25",
+                  "serverInfo":{"version":"0.1","name":"tachyon-mcp"},
+                  "capabilities": {}
                 }
-                """;
-
-            assertThatJson(response.body()).isEqualTo(expected);
+                """);
         }
     }
 }

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/v2026_07_28/MetadataE2eTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/v2026_07_28/MetadataE2eTest.java
@@ -1,8 +1,7 @@
 /* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
 package dev.tachyonmcp.e2e.mcp.v2026_07_28;
 
-import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
-import static org.assertj.core.api.Assertions.assertThat;
+import static dev.tachyonmcp.testkit.JsonRpcResponseAssert.assertThat;
 
 import dev.tachyonmcp.api.json.JsonDocument;
 import dev.tachyonmcp.api.json.JsonSchema;
@@ -22,6 +21,7 @@ import dev.tachyonmcp.testkit.McpTestClients;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -122,7 +122,7 @@ class MetadataE2eTest extends AbstractStatelessMcpE2eTest<McpClient> {
     @Test
     void toolCallPreservesArbitraryRequestMetaAndStructuredJsonValue() throws Exception {
         try (var client = createModernTestClient()) {
-            var response = client.post("""
+            var response = client.sendRpc("""
                     {
                       "jsonrpc": "2.0",
                       "id": 10,
@@ -135,18 +135,12 @@ class MetadataE2eTest extends AbstractStatelessMcpE2eTest<McpClient> {
                     }
                     """);
 
-            assertThat(response.statusCode()).as(response.body()).isEqualTo(200);
-            assertThatJson(response.body()).isEqualTo("""
-                    {
-                      "jsonrpc": "2.0",
-                      "id": 10,
-                      "result": {
-                        "content": [{"type": "text", "text": "[1,true]"}],
-                        "structuredContent": [1, true],
-                        "_meta": {"echo-trace": "trace-7"},
-                        "resultType": "complete"
-                      }
-                    }
+            Assertions.assertThat(response.statusCode()).isEqualTo(200);
+            assertThat(response).isSuccess().hasId(10).hasResult("""
+                {"content":[{"type":"text","text":"[1,true]"}],
+                 "structuredContent":[1,true],
+                 "_meta":{"echo-trace":"trace-7"},
+                 "resultType":"complete"}
                     """);
         }
     }
@@ -154,7 +148,7 @@ class MetadataE2eTest extends AbstractStatelessMcpE2eTest<McpClient> {
     @Test
     void toolAndCompletionAcceptMissingMetadata() throws Exception {
         try (var client = createModernTestClient()) {
-            var tool = client.post("""
+            var tool = client.sendRpc("""
                     {
                       "jsonrpc": "2.0",
                       "id": 11,
@@ -162,7 +156,7 @@ class MetadataE2eTest extends AbstractStatelessMcpE2eTest<McpClient> {
                       "params": {"name": "structured_array", "arguments": {}}
                     }
                     """);
-            var completion = client.post("""
+            var completion = client.sendRpc("""
                     {
                       "jsonrpc": "2.0",
                       "id": 12,
@@ -174,28 +168,14 @@ class MetadataE2eTest extends AbstractStatelessMcpE2eTest<McpClient> {
                     }
                     """);
 
-            assertThat(tool.statusCode()).as(tool.body()).isEqualTo(200);
-            assertThat(completion.statusCode()).as(completion.body()).isEqualTo(200);
-            assertThatJson(tool.body()).isEqualTo("""
-                    {
-                      "jsonrpc": "2.0",
-                      "id": 11,
-                      "result": {
-                        "content": [{"type": "text", "text": "[1,true]"}],
-                        "structuredContent": [1, true],
-                        "resultType": "complete"
-                      }
-                    }
+            assertThat(tool).isSuccess().hasId(11).hasResult("""
+                {"content":[{"type":"text","text":"[1,true]"}],
+                 "structuredContent":[1,true],
+                 "resultType":"complete"}
                     """);
-            assertThatJson(completion.body()).isEqualTo("""
-                    {
-                      "jsonrpc": "2.0",
-                      "id": 12,
-                      "result": {
-                        "completion": {"values": ["B-complete"]},
-                        "resultType": "complete"
-                      }
-                    }
+            assertThat(completion).isSuccess().hasId(12).hasResult("""
+                {"completion":{"values":["B-complete"]},
+                 "resultType":"complete"}
                     """);
         }
     }
@@ -203,85 +183,56 @@ class MetadataE2eTest extends AbstractStatelessMcpE2eTest<McpClient> {
     @Test
     void descriptorMetadataFlowsThroughAllListOperations() throws Exception {
         try (var client = createModernTestClient()) {
-            var tools = client.post("{\"jsonrpc\":\"2.0\",\"id\":11,\"method\":\"tools/list\",\"params\":{}}");
-            var resources = client.post("{\"jsonrpc\":\"2.0\",\"id\":12,\"method\":\"resources/list\",\"params\":{}}");
-            var templates = client.post(
-                    "{\"jsonrpc\":\"2.0\",\"id\":13,\"method\":\"resources/templates/list\",\"params\":{}}");
-            var prompts = client.post("{\"jsonrpc\":\"2.0\",\"id\":14,\"method\":\"prompts/list\",\"params\":{}}");
+            var tools = client.sendRpc("""
+                {"jsonrpc":"2.0","id":11,"method":"tools/list","params":{}}""");
+            var resources = client.sendRpc("""
+                    {"jsonrpc":"2.0","id":12,"method":"resources/list","params":{}}""");
+            var templates = client.sendRpc("""
+                    {"jsonrpc":"2.0","id":13,"method":"resources/templates/list","params":{}}""");
+            var prompts = client.sendRpc("""
+                {"jsonrpc":"2.0","id":14,"method":"prompts/list","params":{}}""");
 
-            assertThat(tools.statusCode()).as(tools.body()).isEqualTo(200);
-            assertThat(resources.statusCode()).as(resources.body()).isEqualTo(200);
-            assertThat(templates.statusCode()).as(templates.body()).isEqualTo(200);
-            assertThat(prompts.statusCode()).as(prompts.body()).isEqualTo(200);
-            assertThatJson(tools.body()).isEqualTo("""
-                    {
-                      "jsonrpc": "2.0",
-                      "id": 11,
-                      "result": {
-                        "tools": [
-                          {
-                            "description": "Returns an arbitrary structured JSON value",
-                            "inputSchema": {"type": "object", "properties": {}},
-                            "_meta": {"catalog": "tool"},
-                            "name": "structured_array"
-                          }
-                        ],
-                        "resultType": "complete",
-                        "ttlMs": 0,
-                        "cacheScope": "public"
-                      }
-                    }
+            assertThat(tools).isSuccess().hasId(11).hasResult("""
+                {"tools":[{
+                  "description":"Returns an arbitrary structured JSON value",
+                  "inputSchema":{"type":"object","properties":{}},
+                  "_meta":{"catalog":"tool"},
+                  "name":"structured_array"
+                }],
+                "resultType":"complete",
+                "ttlMs":0,
+                "cacheScope":"public"}
                     """);
-            assertThatJson(resources.body()).isEqualTo("""
-                    {
-                      "jsonrpc": "2.0",
-                      "id": 12,
-                      "result": {
-                        "resources": [{
-                          "uri": "memory://interactive",
-                          "_meta": {"catalog": "resource"},
-                          "name": "interactive-resource"
-                        }],
-                        "resultType": "complete",
-                        "ttlMs": 0,
-                        "cacheScope": "public"
-                      }
-                    }
+            assertThat(resources).isSuccess().hasId(12).hasResult("""
+                {"resources":[{
+                  "uri":"memory://interactive",
+                  "_meta":{"catalog":"resource"},
+                  "name":"interactive-resource"
+                }],
+                "resultType":"complete",
+                "ttlMs":0,
+                "cacheScope":"public"}
                     """);
-            assertThatJson(templates.body()).isEqualTo("""
-                    {
-                      "jsonrpc": "2.0",
-                      "id": 13,
-                      "result": {
-                        "resourceTemplates": [{
-                          "uriTemplate": "memory://interactive/{id}",
-                          "_meta": {"catalog": "template"},
-                          "name": "interactive-template"
-                        }],
-                        "resultType": "complete",
-                        "ttlMs": 0,
-                        "cacheScope": "public"
-                      }
-                    }
+            assertThat(templates).isSuccess().hasId(13).hasResult("""
+                {"resourceTemplates":[{
+                  "uriTemplate":"memory://interactive/{id}",
+                  "_meta":{"catalog":"template"},
+                  "name":"interactive-template"
+                }],
+                "resultType":"complete",
+                "ttlMs":0,
+                "cacheScope":"public"}
                     """);
-            assertThatJson(prompts.body()).isEqualTo("""
-                    {
-                      "jsonrpc": "2.0",
-                      "id": 14,
-                      "result": {
-                        "prompts": [
-                          {"name": "input-meta-prompt"},
-                          {
-                            "description": "Interactive prompt",
-                            "_meta": {"catalog": "prompt"},
-                            "name": "interactive-prompt"
-                          }
-                        ],
-                        "resultType": "complete",
-                        "ttlMs": 0,
-                        "cacheScope": "public"
-                      }
-                    }
+            assertThat(prompts).isSuccess().hasId(14).hasResult("""
+                {"prompts":[
+                  {"name":"input-meta-prompt"},
+                  {"description":"Interactive prompt",
+                   "_meta":{"catalog":"prompt"},
+                   "name":"interactive-prompt"}
+                ],
+                "resultType":"complete",
+                "ttlMs":0,
+                "cacheScope":"public"}
                     """);
         }
     }
@@ -303,26 +254,19 @@ class MetadataE2eTest extends AbstractStatelessMcpE2eTest<McpClient> {
                 """;
 
         try (var client = createModernTestClient()) {
-            var response = client.post(body);
+            var response = client.sendRpc(body);
 
-            assertThat(response.statusCode()).as(response.body()).isEqualTo(200);
-            assertThatJson(response.body()).isEqualTo("""
-                            {
-                              "jsonrpc": "2.0",
-                              "id": 8,
-                              "result": {
-                                "contents": [{
-                                  "uri": "memory://interactive",
-                                  "mimeType": "text/plain",
-                                  "text": "Paris:resource-round-1",
-                                  "_meta": {"source": "interactive-resource"}
-                                }],
-                                "resultType": "complete",
-                                "ttlMs": 0,
-                                "cacheScope": "public"
-                              }
-                            }
-                            """);
+            assertThat(response).isSuccess().hasId(8).hasResult("""
+                {"contents":[{
+                  "uri":"memory://interactive",
+                  "mimeType":"text/plain",
+                  "text":"Paris:resource-round-1",
+                  "_meta":{"source":"interactive-resource"}
+                }],
+                "resultType":"complete",
+                "ttlMs":0,
+                "cacheScope":"public"}
+                """);
         }
     }
 
@@ -343,30 +287,22 @@ class MetadataE2eTest extends AbstractStatelessMcpE2eTest<McpClient> {
                 """;
 
         try (var client = createModernTestClient()) {
-            var response = client.post(body);
+            var response = client.sendRpc(body);
 
-            assertThat(response.statusCode()).as(response.body()).isEqualTo(200);
-            assertThatJson(response.body()).isEqualTo("""
-                            {
-                              "jsonrpc": "2.0",
-                              "id": 9,
-                              "result": {
-                                "description": "Interactive prompt",
-                                "messages": [{
-                                  "role": "user",
-                                  "content": {"type": "text", "text": "Paris:prompt-round-1"}
-                                }],
-                                "resultType": "complete"
-                              }
-                            }
-                            """);
+            assertThat(response).isSuccess().hasId(9).hasResult("""
+                {"description":"Interactive prompt",
+                 "messages":[{"role":"user",
+                   "content":{"type":"text","text":"Paris:prompt-round-1"}
+                 }],
+                 "resultType":"complete"}
+                """);
         }
     }
 
     @Test
     void promptAndCompletionMetadataReachHandlersAndResults() throws Exception {
         try (var client = createModernTestClient()) {
-            var prompt = client.post("""
+            var prompt = client.sendRpc("""
                     {
                       "jsonrpc": "2.0",
                       "id": 15,
@@ -377,7 +313,7 @@ class MetadataE2eTest extends AbstractStatelessMcpE2eTest<McpClient> {
                       }
                     }
                     """);
-            var completion = client.post("""
+            var completion = client.sendRpc("""
                     {
                       "jsonrpc": "2.0",
                       "id": 16,
@@ -389,7 +325,7 @@ class MetadataE2eTest extends AbstractStatelessMcpE2eTest<McpClient> {
                       }
                     }
                     """);
-            var inputRequired = client.post("""
+            var inputRequired = client.sendRpc("""
                     {
                       "jsonrpc": "2.0",
                       "id": 17,
@@ -398,57 +334,30 @@ class MetadataE2eTest extends AbstractStatelessMcpE2eTest<McpClient> {
                     }
                     """);
 
-            assertThat(prompt.statusCode()).as(prompt.body()).isEqualTo(200);
-            assertThat(completion.statusCode()).as(completion.body()).isEqualTo(200);
-            assertThat(inputRequired.statusCode()).as(inputRequired.body()).isEqualTo(200);
-            assertThatJson(prompt.body()).isEqualTo("""
-                    {
-                      "jsonrpc": "2.0",
-                      "id": 15,
-                      "result": {
-                        "description": "Interactive prompt",
-                        "messages": [{
-                          "role": "user",
-                          "content": {"type": "text", "text": "null:null"}
-                        }],
-                        "_meta": {"echo-trace": "prompt-trace"},
-                        "resultType": "complete"
-                      }
-                    }
+            assertThat(prompt).isSuccess().hasId(15).hasResult("""
+                {"description":"Interactive prompt",
+                 "messages":[{"role":"user",
+                   "content":{"type":"text","text":"null:null"}
+                 }],
+                 "_meta":{"echo-trace":"prompt-trace"},
+                 "resultType":"complete"}
                     """);
-            assertThatJson(completion.body()).isEqualTo("""
-                    {
-                      "jsonrpc": "2.0",
-                      "id": 16,
-                      "result": {
-                        "completion": {"values": ["A-complete"]},
-                        "_meta": {"echo-trace": "completion-trace"},
-                        "resultType": "complete"
-                      }
-                    }
+            assertThat(completion).isSuccess().hasId(16).hasResult("""
+                {"completion":{"values":["A-complete"]},
+                 "_meta":{"echo-trace":"completion-trace"},
+                 "resultType":"complete"}
                     """);
-            assertThatJson(inputRequired.body()).isEqualTo("""
-                    {
-                      "jsonrpc": "2.0",
-                      "id": 17,
-                      "result": {
-                        "resultType": "input_required",
-                        "inputRequests": {
-                          "answer": {
-                            "method": "elicitation/create",
-                            "params": {
-                              "message": "Answer?",
-                              "requestedSchema": {
-                                "type": "object",
-                                "properties": {"value": {"type": "string"}}
-                              }
-                            }
-                          }
-                        },
-                        "requestState": "prompt-input-round",
-                        "_meta": {"trace": "input-required"}
-                      }
-                    }
+            assertThat(inputRequired).isSuccess().hasId(17).hasResult("""
+                    {"resultType":"input_required",
+                     "inputRequests":{"answer":{
+                       "method":"elicitation/create",
+                       "params":{
+                         "message":"Answer?",
+                         "requestedSchema":{"type":"object","properties":{"value":{"type":"string"}}}
+                       }
+                     }},
+                     "requestState":"prompt-input-round",
+                     "_meta":{"trace":"input-required"}}
                     """);
         }
     }

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/v2026_07_28/TasksExtensionTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/v2026_07_28/TasksExtensionTest.java
@@ -2,7 +2,6 @@
 package dev.tachyonmcp.e2e.mcp.v2026_07_28;
 
 import static dev.tachyonmcp.testkit.JsonRpcResponseAssert.assertThat;
-import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import dev.tachyonmcp.api.json.JsonSchema;
@@ -53,46 +52,37 @@ class TasksExtensionTest extends AbstractStatelessMcpE2eTest<McpClient> {
         startTasksServer(taskEngine, "book", ToolResult.task(initial));
 
         try (var client = tasksClient()) {
-            var callResponse = client.post("""
+            var callResponse = client.sendRpc("""
                     {"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"book","arguments":{}}}
                     """);
-            assertThat(callResponse).isSuccess().hasResultType("task");
-            assertThatJson(callResponse.body()).isEqualTo("""
+            assertThat(callResponse).isSuccess().hasResultType("task").hasId(1).hasResult("""
                     {
-                      "jsonrpc":"2.0",
-                      "id":1,
-                      "result":{
-                        "taskId":"workflow-1",
-                        "status":"working",
-                        "createdAt":"2026-08-27T07:00:00Z",
-                        "lastUpdatedAt":"2026-08-27T07:00:00Z",
-                        "ttlMs":null,
-                        "resultType":"task"
-                      }
+                  "taskId":"workflow-1",
+                  "status":"working",
+                  "createdAt":"2026-08-27T07:00:00Z",
+                  "lastUpdatedAt":"2026-08-27T07:00:00Z",
+                  "ttlMs":null,
+                  "resultType":"task"
                     }
                     """);
 
             taskEngine.publish(completed);
-            var getResponse = client.post("""
+            var getResponse = client.sendRpc("""
                     {"jsonrpc":"2.0","id":2,"method":"tasks/get","params":{"taskId":"workflow-1"}}
                     """);
-            assertThatJson(getResponse.body()).isEqualTo("""
+            assertThat(getResponse).isSuccess().hasId(2).hasResult("""
                     {
-                      "jsonrpc":"2.0",
-                      "id":2,
-                      "result":{
-                        "taskId":"workflow-1",
-                        "status":"completed",
-                        "statusMessage":"Done",
-                        "createdAt":"2026-08-27T07:00:00Z",
-                        "lastUpdatedAt":"2026-08-27T07:00:01Z",
-                        "ttlMs":null,
-                        "resultType":"complete",
-                        "result":{
-                          "content":[{"type":"text","text":"{\\"bookingId\\":\\"booking-1\\"}"}],
-                          "structuredContent":{"bookingId":"booking-1"},
-                          "resultType":"complete"
-                        }
+                  "taskId":"workflow-1",
+                  "status":"completed",
+                  "statusMessage":"Done",
+                  "createdAt":"2026-08-27T07:00:00Z",
+                  "lastUpdatedAt":"2026-08-27T07:00:01Z",
+                  "ttlMs":null,
+                  "resultType":"complete",
+                  "result":{
+                    "content":[{"type":"text","text":"{\\"bookingId\\":\\"booking-1\\"}"}],
+                    "structuredContent":{"bookingId":"booking-1"},
+                    "resultType":"complete"
                       }
                     }
                     """);
@@ -107,30 +97,26 @@ class TasksExtensionTest extends AbstractStatelessMcpE2eTest<McpClient> {
         startTasksServer(taskEngine, "book", ToolResult.task(initial));
 
         try (var client = tasksClient()) {
-            var response = client.post("""
+            var response = client.sendRpc("""
                     {"jsonrpc":"2.0","id":2,"method":"tasks/cancel","params":{"taskId":"workflow-cancel"}}
                     """);
 
-            assertThatJson(response.body()).isEqualTo("""
-                    {"jsonrpc":"2.0","id":2,"result":{"resultType":"complete"}}
+            assertThat(response).isSuccess().hasId(2).hasResult("""
+                {"resultType":"complete"}
                     """);
             assertThat(taskEngine.cancelledTaskIds()).containsExactly("workflow-cancel");
 
-            var getResponse = client.post("""
+            var getResponse = client.sendRpc("""
                     {"jsonrpc":"2.0","id":3,"method":"tasks/get","params":{"taskId":"workflow-cancel"}}
                     """);
-            assertThatJson(getResponse.body()).isEqualTo("""
+            assertThat(getResponse).isSuccess().hasId(3).hasResult("""
                     {
-                      "jsonrpc":"2.0",
-                      "id":3,
-                      "result":{
-                        "taskId":"workflow-cancel",
-                        "status":"working",
-                        "createdAt":"2026-08-27T07:00:00Z",
-                        "lastUpdatedAt":"2026-08-27T07:00:00Z",
-                        "ttlMs":null,
-                        "resultType":"complete"
-                      }
+                  "taskId":"workflow-cancel",
+                  "status":"working",
+                  "createdAt":"2026-08-27T07:00:00Z",
+                  "lastUpdatedAt":"2026-08-27T07:00:00Z",
+                  "ttlMs":null,
+                  "resultType":"complete"
                     }
                     """);
             assertThat(taskEngine.refreshedTaskIds()).containsExactly("workflow-cancel");
@@ -204,11 +190,11 @@ class TasksExtensionTest extends AbstractStatelessMcpE2eTest<McpClient> {
             client.post("""
                     {"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"book","arguments":{}}}
                     """);
-            var response = client.post("""
+            var response = client.sendRpc("""
                     {"jsonrpc":"2.0","id":2,"method":"tasks/cancel","params":{"taskId":"workflow-done"}}
                     """);
-            assertThatJson(response.body()).isEqualTo("""
-                    {"jsonrpc":"2.0","id":2,"result":{"resultType":"complete"}}
+            assertThat(response).isSuccess().hasId(2).hasResult("""
+                {"resultType":"complete"}
                     """);
             assertThat(taskEngine.cancelledTaskIds()).containsExactly("workflow-done");
         }

--- a/tachyon-testkit/src/main/java/dev/tachyonmcp/testkit/JsonRpcResponseAssert.java
+++ b/tachyon-testkit/src/main/java/dev/tachyonmcp/testkit/JsonRpcResponseAssert.java
@@ -11,11 +11,11 @@ import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 
 /** Fluent, branch-safe assertions over a JSON-RPC response envelope. */
-public final class JsonRpcResponseAssert extends AbstractAssert<JsonRpcResponseAssert, JsonNode> {
+public class JsonRpcResponseAssert extends AbstractAssert<JsonRpcResponseAssert, JsonNode> {
 
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
-    private JsonRpcResponseAssert(JsonNode envelope) {
+    protected JsonRpcResponseAssert(JsonNode envelope) {
         super(envelope, JsonRpcResponseAssert.class);
     }
 
@@ -186,6 +186,17 @@ public final class JsonRpcResponseAssert extends AbstractAssert<JsonRpcResponseA
             if (!result.equals(expected)) {
                 failWithMessage("Expected result <%s> but was <%s> in: %s", expected, result, actual);
             }
+            return this;
+        }
+
+        /**
+         * Verifies the complete JSON-RPC result value.
+         *
+         * @param expectedJson the expected result JSON
+         * @return this assertion
+         */
+        public JsonRpcSuccessAssert hasResult(@Language("json") String expectedJson) {
+            assertThatJson(actual.path("result")).isEqualTo(expectedJson);
             return this;
         }
 

--- a/tachyon-testkit/src/test/java/dev/tachyonmcp/testkit/JsonRpcResponseAssertTest.java
+++ b/tachyon-testkit/src/test/java/dev/tachyonmcp/testkit/JsonRpcResponseAssertTest.java
@@ -5,7 +5,12 @@ import static dev.tachyonmcp.testkit.JsonRpcResponseAssert.assertThatJsonRpcResp
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 
 /** Verifies JSON-RPC envelope branch assertions. */
@@ -101,6 +106,69 @@ class JsonRpcResponseAssertTest {
         assertThatThrownBy(() -> assertThatJsonRpcResponse("""
                             {"jsonrpc":"2.0","id":1,"result":{"content":[]}}
                             """).isSuccess().hasContent())
+                .isInstanceOf(AssertionError.class);
+    }
+
+    static Stream<Arguments> hasResultMatches() {
+        return Stream.of(
+                Arguments.of("object", """
+                                {"jsonrpc":"2.0","id":1,"result":{"content":[]}}
+                                """, JSON.readTree("{\"content\":[]}")),
+                Arguments.of("array", """
+                                {"jsonrpc":"2.0","id":1,"result":[1,2,3]}
+                                """, JSON.readTree("[1,2,3]")),
+                Arguments.of("string", """
+                                {"jsonrpc":"2.0","id":1,"result":"hello"}
+                                """, JSON.readTree("\"hello\"")),
+                Arguments.of("number", """
+                                {"jsonrpc":"2.0","id":1,"result":42}
+                                """, JSON.readTree("42")),
+                Arguments.of("boolean", """
+                                {"jsonrpc":"2.0","id":1,"result":true}
+                                """, JSON.readTree("true")),
+                Arguments.of("null", """
+                                {"jsonrpc":"2.0","id":1,"result":null}
+                                """, JSON.readTree("null")));
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("hasResultMatches")
+    void hasResultMatches(String name, String envelope, JsonNode expected) {
+        assertThatJsonRpcResponse(envelope).isSuccess().hasResult(expected);
+    }
+
+    static Stream<Arguments> hasResultRejects() {
+        return Stream.of(
+                Arguments.of("object mismatch", """
+                                {"jsonrpc":"2.0","id":1,"result":{"content":[]}}
+                                """, JSON.readTree("{\"foo\":\"bar\"}")),
+                Arguments.of("array mismatch", """
+                                {"jsonrpc":"2.0","id":1,"result":[1,2,3]}
+                                """, JSON.readTree("[1,2]")),
+                Arguments.of("string mismatch", """
+                                {"jsonrpc":"2.0","id":1,"result":"hello"}
+                                """, JSON.readTree("\"world\"")),
+                Arguments.of("number mismatch", """
+                                {"jsonrpc":"2.0","id":1,"result":42}
+                                """, JSON.readTree("99")),
+                Arguments.of("boolean mismatch", """
+                                {"jsonrpc":"2.0","id":1,"result":true}
+                                """, JSON.readTree("false")),
+                Arguments.of("null mismatch", """
+                                {"jsonrpc":"2.0","id":1,"result":null}
+                                """, JSON.readTree("0")),
+                Arguments.of("type mismatch object vs array", """
+                                {"jsonrpc":"2.0","id":1,"result":{}}
+                                """, JSON.readTree("[]")),
+                Arguments.of("type mismatch string vs number", """
+                                {"jsonrpc":"2.0","id":1,"result":"1"}
+                                """, JSON.readTree("1")));
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("hasResultRejects")
+    void hasResultRejects(String name, String envelope, JsonNode wrongExpected) {
+        assertThatThrownBy(() -> assertThatJsonRpcResponse(envelope).isSuccess().hasResult(wrongExpected))
                 .isInstanceOf(AssertionError.class);
     }
 }


### PR DESCRIPTION
### New Features

- Added support for validating JSON-RPC result payloads directly against expected JSON.
- Extended response assertions to support reuse through subclassing.

### Tests

- Updated end-to-end coverage to use clearer, fluent response assertions.
- Improved verification of success status, response identifiers, result types, structured content, and task-related responses.
- Added coverage for matching and mismatched result payloads.