### PR TITLE
docs: add deployment guide

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,7 @@
 - [Quickstart](quickstart.md)
 - [Frequently asked questions](faq.md)
 - [Configuration](configuration.md)
+- [Deployment](deployment.md)
 
 ## Build MCP features
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -37,6 +37,9 @@ Configured via `network { }` / `NetworkConfig.Builder`.
 
 `.port(int)` is also available as a top-level `ServerBuilder` shortcut.
 
+For `host`, `port` and hostname settings when the server runs on a platform, see
+[deployment](deployment.md).
+
 ### Keep-alive for long-running tools
 
 ```mermaid
@@ -147,6 +150,9 @@ network { allowedHosts += "host.docker.internal:8096" }
 Entries are bare authorities, not URLs, matched case-insensitively; an entry without a port
 matches that host on any port. See `DnsRebindingProtectionHandler`'s class docs for exact
 matching rules (bracketed IPv6, multiple/missing `Host` headers, HTTP/1.0 exemption).
+
+A server behind a public hostname must add that hostname here or every request through it is
+rejected. See [deployment](deployment.md#3-public-hostname).
 
 ### `Mcp-Param-*` character restrictions
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -54,9 +54,9 @@ passed straight through.
 
 How the value reaches the app depends on the platform.
 
-- Some platforms hand the app its assigned hostname in the environment. Read it
-  at startup and the deployment is one pass. Use the platform's bare-hostname
-  variable, not its URL variable.
+- Some platforms hand the app its own hostname in the environment. Read it at
+  startup and the deployment is one pass. Take the bare-hostname variable if the
+  platform offers both, since the full-URL one is rejected here.
 - Otherwise the hostname is not known until the app exists, so it is two passes:
   deploy, read the assigned hostname, set it, deploy again.
 
@@ -118,8 +118,16 @@ One deployment of it, on [Dockhold](https://dockhold.eu):
 [tachyon-weather-dockhold](https://github.com/Maziar110/tachyon-weather-dockhold).
 That repo is a Dockerfile which fetches a tagged Tachyon release, builds this one
 example, and runs it on a trimmed `jlink` runtime. It sets `HOST=0.0.0.0`, and
-its entrypoint fills `ALLOWED_HOST` from the hostname the platform hands the
-container, so the deployment is one pass:
+its entrypoint defaults `ALLOWED_HOST` to `DOCKHOLD_APP_HOSTNAME`, the assigned
+hostname, so the deployment is one pass:
+
+```sh
+[ -z "$ALLOWED_HOST" ] && [ -n "$DOCKHOLD_APP_HOSTNAME" ] \
+    && export ALLOWED_HOST="$DOCKHOLD_APP_HOSTNAME"
+```
+
+`DOCKHOLD_APP_HOSTNAME` is the bare authority. There is a `DOCKHOLD_APP_URL`
+too, which carries the scheme and is the wrong one for `allowedHosts`.
 
 ```text
 https://app.dockhold.eu/new?repo=https://github.com/Maziar110/tachyon-weather-dockhold

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,107 @@
+# Deployment — Tachyon MCP Server
+
+A Tachyon server is a plain Java process with an embedded Netty listener, so it
+runs anywhere that runs a JVM or a container. Three settings usually change when
+it moves off a developer machine.
+
+Full option reference: [configuration](configuration.md). Stateless mode,
+long-running tools and shutdown behaviour: [FAQ](faq.md#deployment-and-operations).
+
+## 1. Bind address
+
+`host` defaults to `127.0.0.1`. A platform routes to the process from outside,
+so the server has to listen on every interface.
+
+```java
+.network(n -> n.host("0.0.0.0"))
+```
+
+## 2. Port
+
+Most platforms assign the port and pass it in the environment. Read it there
+instead of hard-coding one.
+
+```java
+.network(n -> n.port(Integer.parseInt(System.getenv().getOrDefault("PORT", "8080"))))
+```
+
+## 3. Public hostname
+
+This is the one that is easy to miss.
+
+[DNS-rebinding protection](configuration.md#dns-rebinding-protection) is on by
+default, and it accepts only `localhost` and loopback authorities. A public
+hostname is neither. Until `allowedHosts` names it, the server answers
+`403 Forbidden` to every request that arrives through that hostname.
+
+```java
+.network(n -> {
+    var allowedHost = System.getenv("ALLOWED_HOST");
+    if (allowedHost != null && !allowedHost.isBlank()) {
+        n.allowedHosts(allowedHost);
+    }
+})
+```
+
+Entries are bare authorities, not URLs. `example.com` matches that host on any
+port, `example.com:8096` only that port.
+
+Most platforms do not reveal the hostname until the app exists, so deployment is
+two passes: deploy, read the assigned hostname, set it, deploy again.
+
+### Verify the guard is on
+
+A successful request does not prove the allowlist works, because an unset
+allowlist and a correct one both let a good request through on localhost. Send a
+request the server has to refuse. A trailing dot is the same host to DNS but a
+different string to the guard:
+
+```shell
+curl -s -o /dev/null -w '%{http_code}\n' -X POST https://YOUR-HOST/mcp
+curl -s -o /dev/null -w '%{http_code}\n' -X POST -H 'Host: YOUR-HOST.' https://YOUR-HOST/mcp
+```
+
+The second must return `403`. If both return the same code, the `Host` check is
+not filtering anything and the first result proved nothing.
+
+## Browser clients
+
+`allowedHosts` widens the `Host` check only. A request carrying an `Origin`
+header that is not loopback is still rejected, so a browser page cannot reach a
+remote Tachyon server. Clients that send no `Origin` are unaffected, which is
+most MCP clients.
+
+## More than one instance
+
+Sessions are off by default, and a stateless server scales horizontally with no
+sticky routing. A server that sets `session.enabled(true)` keeps sessions and
+events in memory, so more than one instance needs sticky routing or shared
+`SessionStore` and `SessionEventStore` implementations. See
+[session configuration](configuration.md#session).
+
+## Containers
+
+- The JVM has to be PID 1, or it never receives the platform's stop signal and
+  `shutdownGracePeriod` never runs. Use the exec form of `CMD`, or `exec` the
+  JVM from an entrypoint script.
+- The filesystem is ephemeral on most platforms. Anything written at runtime is
+  gone after the next deploy.
+
+## Worked example
+
+[`examples/weather-mcp`](../examples/weather-mcp) reads `HOST`, `PORT` and
+`ALLOWED_HOST` from the environment, so it needs no code change to run remotely.
+
+One deployment of it, on [Dockhold](https://dockhold.eu):
+[tachyon-weather-dockhold](https://github.com/Maziar110/tachyon-weather-dockhold).
+That repo is a Dockerfile which fetches a tagged Tachyon release, builds this one
+example, and runs it on a trimmed `jlink` runtime. It sets `HOST=0.0.0.0` and
+leaves `ALLOWED_HOST` for the second pass described above. Deploy form:
+
+```
+https://app.dockhold.eu/new?repo=https://github.com/Maziar110/tachyon-weather-dockhold
+```
+
+Set `ALLOWED_HOST` to the hostname the platform assigns, deploy again, then run
+the two `curl` checks above. Platform limits and pricing are documented at
+[dockhold.eu](https://dockhold.eu).

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -34,6 +34,10 @@ default, and it accepts only `localhost` and loopback authorities. A public
 hostname is neither. Until `allowedHosts` names it, the server answers
 `403 Forbidden` to every request that arrives through that hostname.
 
+`host` and `allowedHosts` are unrelated. `host` decides which interface the
+server binds. `allowedHosts` decides which `Host` headers it answers. Binding
+more widely never affects the `403`.
+
 ```java
 .network(n -> {
     var allowedHost = System.getenv("ALLOWED_HOST");
@@ -44,10 +48,17 @@ hostname is neither. Until `allowedHosts` names it, the server answers
 ```
 
 Entries are bare authorities, not URLs. `example.com` matches that host on any
-port, `example.com:8096` only that port.
+port, `example.com:8096` only that port. An entry holding a scheme or a path is
+rejected when the server is built, so a variable containing a full URL cannot be
+passed straight through.
 
-Most platforms do not reveal the hostname until the app exists, so deployment is
-two passes: deploy, read the assigned hostname, set it, deploy again.
+How the value reaches the app depends on the platform.
+
+- Some platforms hand the app its assigned hostname in the environment. Read it
+  at startup and the deployment is one pass. Use the platform's bare-hostname
+  variable, not its URL variable.
+- Otherwise the hostname is not known until the app exists, so it is two passes:
+  deploy, read the assigned hostname, set it, deploy again.
 
 ### Verify the guard is on
 
@@ -57,12 +68,21 @@ request the server has to refuse. A trailing dot is the same host to DNS but a
 different string to the guard:
 
 ```shell
-curl -s -o /dev/null -w '%{http_code}\n' -X POST https://YOUR-HOST/mcp
-curl -s -o /dev/null -w '%{http_code}\n' -X POST -H 'Host: YOUR-HOST.' https://YOUR-HOST/mcp
+probe() {
+    code=$(curl -s -o /dev/null -w '%{http_code}' -X POST -H "Host: $1" https://YOUR-HOST/mcp)
+    case "$code" in
+        000) echo "$1: no HTTP response (DNS, TLS or connection failure)" ;;
+        *)   echo "$1: $code" ;;
+    esac
+}
+probe 'YOUR-HOST'
+probe 'YOUR-HOST.'
 ```
 
 The second must return `403`. If both return the same code, the `Host` check is
-not filtering anything and the first result proved nothing.
+not filtering anything and the first result proved nothing. Treat `000` as a
+failed probe rather than a result: two failed requests also match each other,
+and they say nothing about the guard.
 
 ## Browser clients
 
@@ -81,9 +101,11 @@ events in memory, so more than one instance needs sticky routing or shared
 
 ## Containers
 
-- The JVM has to be PID 1, or it never receives the platform's stop signal and
-  `shutdownGracePeriod` never runs. Use the exec form of `CMD`, or `exec` the
-  JVM from an entrypoint script.
+- The JVM has to receive the platform's stop signal, or `shutdownGracePeriod`
+  never runs. That means the JVM is PID 1, or its parent forwards signals to it
+  (an init process, or an entrypoint that `exec`s the JVM). The usual failure is
+  a shell wrapper that stays PID 1 and swallows the signal. The exec form of
+  `CMD` is the safe default.
 - The filesystem is ephemeral on most platforms. Anything written at runtime is
   gone after the next deploy.
 
@@ -95,13 +117,13 @@ events in memory, so more than one instance needs sticky routing or shared
 One deployment of it, on [Dockhold](https://dockhold.eu):
 [tachyon-weather-dockhold](https://github.com/Maziar110/tachyon-weather-dockhold).
 That repo is a Dockerfile which fetches a tagged Tachyon release, builds this one
-example, and runs it on a trimmed `jlink` runtime. It sets `HOST=0.0.0.0` and
-leaves `ALLOWED_HOST` for the second pass described above. Deploy form:
+example, and runs it on a trimmed `jlink` runtime. It sets `HOST=0.0.0.0`, and
+its entrypoint fills `ALLOWED_HOST` from the hostname the platform hands the
+container, so the deployment is one pass:
 
-```
+```text
 https://app.dockhold.eu/new?repo=https://github.com/Maziar110/tachyon-weather-dockhold
 ```
 
-Set `ALLOWED_HOST` to the hostname the platform assigns, deploy again, then run
-the two `curl` checks above. Platform limits and pricing are documented at
-[dockhold.eu](https://dockhold.eu).
+Deploy it, then run the two `probe` calls above against the assigned hostname.
+Platform limits and pricing are documented at [dockhold.eu](https://dockhold.eu).


### PR DESCRIPTION
From the discussion in #230. Adds `docs/deployment.md` and refers to it from `configuration.md`, as you asked. Also listed in `docs/README.md`.

It covers what changes when a server leaves a developer machine: bind address, port from the environment, and naming the public hostname in `allowedHosts`.

**Updated after your review:**

- `host` and `allowedHosts` are separated explicitly now. Binding wider never affects the 403, and conflating the two is what made the section confusing.
- Two passes is no longer presented as the only way. Where a platform hands the app its assigned hostname in the environment, it is one pass. That is working end to end now: the container reads the assigned hostname at startup and the first deploy serves.
- `allowedHosts` rejects any entry holding a scheme or a path, so a platform variable containing a full URL fails at construction rather than returning 403. The page says to use the bare-hostname form.
- The verification snippet now rejects `000`. `curl -s` hides DNS, TLS and connection errors, and two failed probes both print `000`, which reads as "the guard is off" when nothing was measured. CodeRabbit caught that one and it was right.
- Signal handling was stated too absolutely. PID 1 is one way, a parent that forwards `SIGTERM` is another. The failure case is a shell that swallows it.

Measured on a live deployment with no `ALLOWED_HOST` set by hand:

```text
Host: <assigned hostname>     -> 200
Host: <assigned hostname>.    -> 403
```

The trailing-dot request is the useful control because it still routes to the app while differing as a string.

Checks run:

- The three Java snippets compile against `tachyon-core`.
- `mvn spotless:check -pl '!reports' -Plint,tests` passes.
- Every relative link and anchor resolves, and the shell snippet parses under `sh -n`.

The worked example at the end points at Dockhold. Disclosure: I am the founder of Dockhold. Happy to cut that section, or replace it with a platform-neutral note, if you would rather the page named no vendor. Nothing else on the page depends on it.
