### PR TITLE
feat(observability): publish server attributes, enforce exceptionDetail policy, wire OpenTelemetry into examples

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -123,8 +123,7 @@ jobs:
 
       - name: Install jar
         run: |
-          rm -rf ~/.m2/repository/dev/tachyonmcp
-          ./mvnw install -pl tachyon-api,tachyon-core,tachyon-kotlin,tachyon-extensions,tachyon-testkit -am -DskipTests
+          make package
 
       - name: Verify examples
         working-directory: 'examples/${{ matrix.example }}'

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ install-server: ## Build with tests and install to local Maven repo
 package: ## Install artifacts to local Maven repo (skip tests)
 	@echo "📦 Packaging and installing to local repository..."
 	@rm -rf ~/.m2/repository/dev/tachyonmcp/
-	@./mvnw install -pl tachyon-kotlin-kt-schema,tachyon-testkit,tachyon-extensions,integrations -am -DskipTests -Dspotbugs.skip -Dspotless.skip
+	@./mvnw install -DskipTests -Dspotbugs.skip -Dspotless.skip
 
 apidocs:
 	@echo "📚  Building API Docs..."

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ application framework.
   TTL cleanup.
 - **Production transport** -- Netty backpressure, graceful shutdown, DNS-rebinding protection,
   CORS, and native transport auto-detection (`io_uring` → `epoll` → `kqueue` → NIO).
+- **Built-in OpenTelemetry** -- register `tachyon-opentelemetry`'s listener for MCP
+  semantic-convention spans and metrics, with an opt-in policy for payload capture.
 
 ## Quickstart
 
@@ -95,12 +97,14 @@ See the [quickstart](docs/quickstart.md) for Java and Kotlin examples plus a `cu
 | **Agent Skills** | `SkillsExtension` implements the [SEP-2640](docs/extensions/mcp-skills.md) draft: filesystem/classpath registries, `skill://` resources, `skills/list`, `skills/get`, and directory reads |
 | **Extensions** | [SEP-2133](docs/extensions.md) negotiation, custom JSON-RPC methods, capability advertisement, and extension-gated features |
 | **Runtime** | Stateless or resumable sessions, `Last-Event-ID` replay, pluggable stores, virtual-thread handlers, request timeouts, and graceful draining |
+| **Observability** | OpenTelemetry spans and metrics via `tachyon-opentelemetry`, following the [MCP semantic conventions](https://github.com/open-telemetry/semantic-conventions-genai/tree/main/model/mcp), plus an opt-in payload capture policy -- see [docs](docs/observability.md) |
 | **Java and Kotlin** | Independent sync/async Java contracts and a coroutine-first [Kotlin DSL](docs/kotlin.md) |
 | **Testing** | Official conformance suites plus a [testkit](docs/testkit.md) for dynamic servers and fluent JSON-RPC assertions |
 
 ## Documentation and examples
 
 - [Configuration](docs/configuration.md) -- network, native I/O, sessions, CORS, and runtime limits
+- [Observability](docs/observability.md) -- observation listeners, payload capture policy, and the bundled OpenTelemetry integration
 - [Tools](docs/tools.md), [resources](docs/resources.md), and [tasks](docs/tasks.md) -- feature APIs and examples
 - [Annotations](docs/annotations.md) -- mcp-java, LangChain4j, and Spring AI providers
 - [Extensions](docs/extensions.md) and [MCP Skills](docs/extensions/mcp-skills.md) -- custom protocol methods and SEP support

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,7 @@
 - [Quickstart](quickstart.md)
 - [Frequently asked questions](faq.md)
 - [Configuration](configuration.md)
+- [Observability](observability.md)
 - [Deployment](deployment.md)
 
 ## Build MCP features

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -299,6 +299,11 @@ diagnostics and payload capture are off by default. Observation listeners are em
 |---|---|---|
 | `slowRequestLogging` | `false` | Enable slow-request diagnostics (handler watchdog + slow-POST logging) |
 | `slowRequestThreshold` | `10s` | Requests exceeding this duration produce a `warn` log when logging is enabled |
+| `listener` | none | Registers a passive `ObservationListener` (spans, metrics, logs) |
+| `payloadCapture` | all off | Opt-in request/response/exception content capture |
+
+See [Observability](observability.md) for the `ObservationListener` contract, the payload
+capture policy's individual toggles, and the bundled OpenTelemetry integration.
 
 Turning `slowRequestLogging` on activates two diagnostics:
 - **Handler watchdog** — a scheduled timer logs `"Handler slow"` at `debug` level when a handler exceeds the threshold

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -35,7 +35,7 @@ TachyonServer(port = 8080) {
 
 Content capture is **opt-in and off by default**. Every listener sees identity facts (method, session id, protocol version) regardless of policy. Request/response content and exception detail only reach listeners when explicitly enabled.
 
-Configured via `payloadCapture { }` / `PayloadCapturePolicy.Builder`:
+Configured via `payloadCapture { }` -- `PayloadCapturePolicy.Builder` in Java, `PayloadCaptureScope` in Kotlin:
 
 | Option | Default | Description |
 |---|---|---|
@@ -56,8 +56,8 @@ var server = TachyonServer.builder()
 TachyonServer(port = 8080) {
     observability {
         payloadCapture {
-            requestArgs(true)
-            responseContent(true)
+            requestArgs = true
+            responseContent = true
         }
     }
 }
@@ -107,8 +107,8 @@ TachyonServer(port = 8080) {
     observability {
         listener(McpOpenTelemetryListener.create(openTelemetry))
         payloadCapture {
-            requestArgs(true)
-            responseContent(true)
+            requestArgs = true
+            responseContent = true
         }
     }
 }

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,166 @@
+# Observability
+
+Tachyon separates **observation** (spans, metrics, logs) from **payload capture** (what observers may see). Both live under `observability { }` / `ObservabilityConfig.Builder`.
+
+The [`tachyon-opentelemetry`](../integrations/tachyon-opentelemetry) module is the recommended path — it wires Tachyon into OpenTelemetry following the [MCP semantic conventions](https://github.com/open-telemetry/semantic-conventions-genai/tree/main/model/mcp).
+
+## Observation Listeners
+
+`ObservationListener` is a passive, read-only hook into the dispatch lifecycle:
+
+- `start(OperationInfo)` — fires once, before any handler runs
+- `complete(OperationInfo, OperationOutcome)` — fires once, at the terminal boundary
+
+Listeners cannot short-circuit, reject, or substitute results. Exceptions in listeners are fault-isolated and never affect handler execution, responses, or other listeners.
+
+```java
+var server = TachyonServer.builder()
+    .observability(o -> o.listener(myListener))
+    .port(8080)
+    .build();
+```
+
+```kotlin
+TachyonServer(port = 8080) {
+    observability {
+        listener(myListener)
+    }
+}
+```
+
+> [!NOTE]
+> `ObservationListener` is `@InternalApi`. `McpOpenTelemetryListener` is the supported implementation — custom listeners work today but the interface isn't stabilized.
+
+## Payload Capture Policy
+
+Content capture is **opt-in and off by default**. Every listener sees identity facts (method, session id, protocol version) regardless of policy. Request/response content and exception detail only reach listeners when explicitly enabled.
+
+Configured via `payloadCapture { }` / `PayloadCapturePolicy.Builder`:
+
+| Option | Default | Description |
+|---|---|---|
+| `requestArgs` | `false` | Capture request params/arguments |
+| `responseContent` | `false` | Capture encoded response content |
+| `exceptionDetail` | `false` | Capture exception message + stack trace |
+| `rawMessage` | `false` | Reserved for future raw JSON-RPC envelope capture |
+| `maxBytes` | `4096` | Truncation limit (UTF-8 bytes) per captured value |
+
+```java
+var server = TachyonServer.builder()
+    .observability(o -> o.payloadCapture(p -> p.requestArgs(true).responseContent(true)))
+    .port(8080)
+    .build();
+```
+
+```kotlin
+TachyonServer(port = 8080) {
+    observability {
+        payloadCapture {
+            requestArgs(true)
+            responseContent(true)
+        }
+    }
+}
+```
+
+Enable deliberately: tool arguments and results routinely carry credentials and PII. Each toggle gates its own content independently — enabling `exceptionDetail` does not enable `requestArgs`.
+
+## OpenTelemetry Integration
+
+`McpOpenTelemetryListener` (module `dev.tachyonmcp:tachyon-opentelemetry`) records a `SERVER` span and `mcp.server.operation.duration` histogram for every inbound MCP request/notification. It's a passive `ObservationListener` — it only reads what core captured; it never captures payloads on its own.
+
+Depends on `opentelemetry-api` only — you supply the SDK (tracer/meter provider) and exporter:
+
+```java
+var openTelemetry = OpenTelemetrySdk.builder()
+    .setTracerProvider(SdkTracerProvider.builder()
+        .addSpanProcessor(SimpleSpanProcessor.create(LoggingSpanExporter.create()))
+        .build())
+    .setMeterProvider(SdkMeterProvider.builder()
+        .registerMetricReader(PeriodicMetricReader.create(LoggingMetricExporter.create()))
+        .build())
+    .build();
+
+var server = TachyonServer.builder()
+    .observability(o -> o
+        .listener(McpOpenTelemetryListener.create(openTelemetry))
+        .payloadCapture(p -> p.requestArgs(true).responseContent(true)))
+    .port(8080)
+    .build();
+```
+
+```kotlin
+val openTelemetry = OpenTelemetrySdk.builder()
+    .setTracerProvider(
+        SdkTracerProvider.builder()
+            .addSpanProcessor(SimpleSpanProcessor.create(LoggingSpanExporter.create()))
+            .build()
+    )
+    .setMeterProvider(
+        SdkMeterProvider.builder()
+            .registerMetricReader(PeriodicMetricReader.create(LoggingMetricExporter.create()))
+            .build()
+    )
+    .build()
+
+TachyonServer(port = 8080) {
+    observability {
+        listener(McpOpenTelemetryListener.create(openTelemetry))
+        payloadCapture {
+            requestArgs(true)
+            responseContent(true)
+        }
+    }
+}
+```
+
+`LoggingSpanExporter`/`LoggingMetricExporter` (`io.opentelemetry:opentelemetry-exporter-logging`) print telemetry to logs with zero infrastructure — good for quick validation. Add OTLP exporters (`io.opentelemetry:opentelemetry-exporter-otlp`) as additional span processors/metric readers to ship to a collector (Jaeger, Grafana Tempo, Honeycomb, etc.) at `http://localhost:4318`.
+
+### Trace Context
+
+Spans parent from `Context.current()` on the dispatch thread. The listener only attaches scope around synchronous dispatch work (decode, kicking off async handler, and — after reattach — completion callback), so handler-started spans join as children without blocking `CompletionStage`s.
+
+### Attributes
+
+**Always present:**
+
+| Attribute | Example |
+|---|---|
+| `mcp.method.name` | `tools/call` |
+| `jsonrpc.protocol.version` | `2.0` |
+| `network.protocol.name` | `http` |
+| `mcp.protocol.version` | `2025-11-25` |
+| `server.address` / `server.port` | `127.0.0.1` / `8080` |
+
+**When applicable (span + metric):**
+
+| Attribute | When |
+|---|---|
+| `gen_ai.tool.name`, `gen_ai.operation.name` | `tools/call` |
+| `gen_ai.prompt.name` | `prompts/get` |
+| `error.type` | Rejection, tool error, handler/serialization failure |
+| `rpc.response.status_code` | Any JSON-RPC error response |
+
+**Span-only (high cardinality):**
+
+| Attribute | Notes |
+|---|---|
+| `jsonrpc.request.id` | Absent for notifications |
+| `mcp.session.id` | Absent until session exists |
+
+**Opt-in (gated by payload capture):**
+
+| Attribute | Toggle |
+|---|---|
+| `gen_ai.tool.call.arguments` | `requestArgs` |
+| `gen_ai.tool.call.result` | `responseContent` |
+| Exception span event (message + stack) | `exceptionDetail` |
+
+`error.type` distinguishes caller faults (unknown method, bad params, malformed session) — span status `UNSET` — from server faults, which set `StatusCode.ERROR`.
+
+## Examples
+
+- [`examples/weather-mcp`](../examples/weather-mcp) (Java)
+- [`examples/weather-mcp-kotlin`](../examples/weather-mcp-kotlin) (Kotlin)
+
+Both wire `tachyon-opentelemetry` with logging + OTLP exporters and verbose payload capture. Run either and watch spans/metrics print to console, or point a collector at `http://localhost:4318`.

--- a/examples/README.md
+++ b/examples/README.md
@@ -5,8 +5,9 @@ the Maven wrapper build in, so you can run it without installing anything else �
 
 - [**echo-kotlin**](echo-kotlin) — Minimal server with `echo` and `reverse-echo` tools in Kotlin.
 - [**weather-mcp**](weather-mcp) — Java. Full MCP surface: tools, resources, resource templates,
-  prompts, completions and elicitation.
-- [**weather-mcp-kotlin**](weather-mcp-kotlin) — Kotlin port of `weather-mcp`
+  prompts, completions and elicitation. Wired up with `tachyon-opentelemetry` and a verbose
+  payload capture policy — see its README's Observability section.
+- [**weather-mcp-kotlin**](weather-mcp-kotlin) — Kotlin port of `weather-mcp`, same observability setup.
 - [**langchain4j-mcp**](langchain4j-mcp) — Java. A plain LangChain4j `@Tool` method, with no
   Tachyon imports, scanned by `LangChain4jAnnotationProvider` into a running server. Depends on
   `tachyon-annotations-langchain4j`, unreleased — build the Tachyon SNAPSHOT locally first (see

--- a/examples/weather-mcp-kotlin/README.md
+++ b/examples/weather-mcp-kotlin/README.md
@@ -39,3 +39,21 @@ reach your machine can reach the server. Use a specific reachable address instea
 when you can, and keep `ALLOWED_HOST` set so the `Host` check still filters requests.
 
 See [../README.md](../README.md#binding-and-access-from-docker) for the full table.
+
+## Observability
+
+This server wires [`tachyon-opentelemetry`](../../integrations/tachyon-opentelemetry) into a
+minimal `OpenTelemetrySdk` (the `openTelemetry` value in `WeatherServer.kt`) with two exporters
+and a fully verbose payload capture policy (`requestArgs`, `responseContent`, `rawMessage`,
+`exceptionDetail` all on):
+
+- A **logging exporter** — no collector to run, spans and metrics just print to the console.
+- The standard **OTLP/HTTP exporter**, at its default endpoint `http://localhost:4318`. Run a
+  local collector (Jaeger, Grafana Tempo, Honeycomb, ...) to see traces land there too. With no
+  collector running, it logs periodic export failures — expected and harmless; only the logging
+  exporter's output matters for this demo.
+
+Call a tool and watch the log for a `tools/call get-weather` span and its
+`mcp.server.operation.duration` metric.
+
+See [docs/observability.md](../../docs/observability.md) for the full attribute reference.

--- a/examples/weather-mcp-kotlin/pom.xml
+++ b/examples/weather-mcp-kotlin/pom.xml
@@ -35,6 +35,13 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
+                <groupId>dev.tachyonmcp</groupId>
+                <artifactId>tachyon-bom</artifactId>
+                <version>${tachyon.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
                 <groupId>tools.jackson</groupId>
                 <artifactId>jackson-bom</artifactId>
                 <version>${jackson.version}</version>
@@ -62,7 +69,6 @@
         <dependency>
             <groupId>dev.tachyonmcp</groupId>
             <artifactId>tachyon-kotlin</artifactId>
-            <version>${tachyon.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlinx</groupId>
@@ -74,7 +80,6 @@
         <dependency>
             <groupId>dev.tachyonmcp</groupId>
             <artifactId>tachyon-opentelemetry</artifactId>
-            <version>${tachyon.version}</version>
         </dependency>
         <dependency>
             <groupId>io.opentelemetry</groupId>

--- a/examples/weather-mcp-kotlin/pom.xml
+++ b/examples/weather-mcp-kotlin/pom.xml
@@ -29,6 +29,7 @@
         <awaitility.version>4.3.0</awaitility.version>
         <kotlinx-serialization-json.version>1.11.0</kotlinx-serialization-json.version>
         <kt-schema.version>0.8.3</kt-schema.version>
+        <opentelemetry.version>1.65.0</opentelemetry.version>
     </properties>
 
     <dependencyManagement>
@@ -67,6 +68,30 @@
             <groupId>org.jetbrains.kotlinx</groupId>
             <artifactId>kotlinx-serialization-json</artifactId>
             <version>${kotlinx-serialization-json.version}</version>
+        </dependency>
+
+        <!-- OpenTelemetry: MCP semantic-convention spans/metrics; app supplies SDK + exporter -->
+        <dependency>
+            <groupId>dev.tachyonmcp</groupId>
+            <artifactId>tachyon-opentelemetry</artifactId>
+            <version>${tachyon.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk</artifactId>
+            <version>${opentelemetry.version}</version>
+        </dependency>
+        <!-- Prints spans/metrics to the log; zero external infra. -->
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-exporter-logging</artifactId>
+            <version>${opentelemetry.version}</version>
+        </dependency>
+        <!-- Standard OTLP/HTTP exporter; also ships spans/metrics to a collector, if one's running. -->
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-exporter-otlp</artifactId>
+            <version>${opentelemetry.version}</version>
         </dependency>
 
         <dependency>

--- a/examples/weather-mcp-kotlin/src/main/kotlin/com/example/weather/WeatherServer.kt
+++ b/examples/weather-mcp-kotlin/src/main/kotlin/com/example/weather/WeatherServer.kt
@@ -24,6 +24,19 @@ import dev.tachyonmcp.kotlin.server.domain.Icon
 import dev.tachyonmcp.kotlin.server.features.prompts.PromptDescriptor
 import dev.tachyonmcp.kotlin.server.features.resources.ResourceDescriptor
 import dev.tachyonmcp.kotlin.server.json.KxSerializationSerde
+import dev.tachyonmcp.opentelemetry.McpOpenTelemetryListener
+import io.opentelemetry.exporter.logging.LoggingMetricExporter
+import io.opentelemetry.exporter.logging.LoggingSpanExporter
+import io.opentelemetry.exporter.otlp.http.metrics.OtlpHttpMetricExporter
+import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporter
+import io.opentelemetry.sdk.OpenTelemetrySdk
+import io.opentelemetry.sdk.metrics.SdkMeterProvider
+import io.opentelemetry.sdk.metrics.export.PeriodicMetricReader
+import io.opentelemetry.sdk.resources.Resource
+import io.opentelemetry.sdk.trace.SdkTracerProvider
+import io.opentelemetry.sdk.trace.export.BatchSpanProcessor
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor
+import io.opentelemetry.semconv.ServiceAttributes
 import me.kpavlov.kt.schema.generator.json.JsonSchemaConfig
 import me.kpavlov.kt.schema.generator.json.ReflectionClassJsonSchemaGenerator
 import org.slf4j.LoggerFactory
@@ -44,6 +57,55 @@ private val schemaGenerator =
         json = kotlinx.serialization.json.Json { encodeDefaults = false },
         config = JsonSchemaConfig.Default,
     )
+
+/**
+ * Prints spans/metrics to the log with zero external infra, and also ships them via the
+ * standard OTLP/HTTP exporter (default endpoint `http://localhost:4318`) -- point a local
+ * collector (Jaeger, Grafana Tempo, Honeycomb, ...) there to see them land. With no collector
+ * running, the OTLP exporter logs periodic export failures; that's expected and harmless, and
+ * only the logging exporter's output matters for this demo.
+ */
+private val openTelemetryResource =
+    Resource
+        .getDefault()
+        .toBuilder()
+        .put(ServiceAttributes.SERVICE_NAME, "weather-mcp-kotlin")
+        .build()
+
+private val openTelemetry =
+    OpenTelemetrySdk
+        .builder()
+        .setTracerProvider(
+            SdkTracerProvider
+                .builder()
+                .setResource(openTelemetryResource)
+                .addSpanProcessor(SimpleSpanProcessor.create(LoggingSpanExporter.create()))
+                .addSpanProcessor(
+                    BatchSpanProcessor
+                        .builder(OtlpHttpSpanExporter.builder().build())
+                        .build(),
+                )
+                .build(),
+        )
+        .setMeterProvider(
+            SdkMeterProvider
+                .builder()
+                .setResource(openTelemetryResource)
+                .registerMetricReader(
+                    PeriodicMetricReader
+                        .builder(LoggingMetricExporter.create())
+                        .setInterval(Duration.ofSeconds(10))
+                        .build(),
+                )
+                .registerMetricReader(
+                    PeriodicMetricReader
+                        .builder(OtlpHttpMetricExporter.builder().build())
+                        .setInterval(Duration.ofSeconds(10))
+                        .build(),
+                )
+                .build(),
+        )
+        .build()
 
 private data class NarrationStyleInput(
     val forecast: String,
@@ -109,6 +171,16 @@ fun assembleServer(
             version = "1.0"
         }
         session { enabled = true }
+        observability {
+            slowRequestLogging()
+            listener(McpOpenTelemetryListener.create(openTelemetry))
+            payloadCapture {
+                requestArgs(true)
+                responseContent(true)
+                rawMessage(true)
+                exceptionDetail(true)
+            }
+        }
 
         tool(getWeatherToolDescriptor) { getWeather(weatherService) }
 

--- a/examples/weather-mcp-kotlin/src/main/kotlin/com/example/weather/WeatherServer.kt
+++ b/examples/weather-mcp-kotlin/src/main/kotlin/com/example/weather/WeatherServer.kt
@@ -120,6 +120,7 @@ fun main() {
             allowedHost = System.getenv("ALLOWED_HOST"),
         )
     server.start()
+    Runtime.getRuntime().addShutdownHook(Thread { openTelemetry.close() })
     log.info("Connect your MCP client to http://{}:{}/mcp", server.host(), server.port())
 }
 
@@ -174,11 +175,14 @@ fun assembleServer(
         observability {
             slowRequestLogging()
             listener(McpOpenTelemetryListener.create(openTelemetry))
+
             payloadCapture {
+                /*
                 requestArgs(true)
                 responseContent(true)
                 rawMessage(true)
                 exceptionDetail(true)
+                */
             }
         }
 

--- a/examples/weather-mcp/README.md
+++ b/examples/weather-mcp/README.md
@@ -34,3 +34,20 @@ java -jar target/weather-example.jar
 ⚠️ `HOST=0.0.0.0` publishes the port on every interface, not just loopback — anything that can
 reach your machine can reach the server. Use a specific reachable address instead of `0.0.0.0`
 when you can, and keep `ALLOWED_HOST` set so the `Host` check still filters requests.
+
+## Observability
+
+This server wires [`tachyon-opentelemetry`](../../integrations/tachyon-opentelemetry) into a
+minimal `OpenTelemetrySdk` (`WeatherServer.OTEL`) with two exporters and a fully verbose payload
+capture policy (`requestArgs`, `responseContent`, `rawMessage`, `exceptionDetail` all on):
+
+- A **logging exporter** — no collector to run, spans and metrics just print to the console.
+- The standard **OTLP/HTTP exporter**, at its default endpoint `http://localhost:4318`. Run a
+  local collector (Jaeger, Grafana Tempo, Honeycomb, ...) to see traces land there too. With no
+  collector running, it logs periodic export failures — expected and harmless; only the logging
+  exporter's output matters for this demo.
+
+Call a tool and watch the log for a `tools/call get-weather` span and its
+`mcp.server.operation.duration` metric.
+
+See [docs/observability.md](../../docs/observability.md) for the full attribute reference.

--- a/examples/weather-mcp/pom.xml
+++ b/examples/weather-mcp/pom.xml
@@ -27,6 +27,7 @@
         <assertj.version>3.27.7</assertj.version>
         <netty.version>4.2.15.Final</netty.version>
         <slf4j.version>2.0.18</slf4j.version>
+        <opentelemetry.version>1.65.0</opentelemetry.version>
     </properties>
 
     <dependencyManagement>
@@ -53,6 +54,30 @@
             <groupId>dev.tachyonmcp</groupId>
             <artifactId>tachyon-core</artifactId>
             <version>${tachyon.version}</version>
+        </dependency>
+
+        <!-- OpenTelemetry: MCP semantic-convention spans/metrics; app supplies SDK + exporter -->
+        <dependency>
+            <groupId>dev.tachyonmcp</groupId>
+            <artifactId>tachyon-opentelemetry</artifactId>
+            <version>${tachyon.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk</artifactId>
+            <version>${opentelemetry.version}</version>
+        </dependency>
+        <!-- Prints spans/metrics to the log; zero external infra. -->
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-exporter-logging</artifactId>
+            <version>${opentelemetry.version}</version>
+        </dependency>
+        <!-- Standard OTLP/HTTP exporter; also ships spans/metrics to a collector, if one's running. -->
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-exporter-otlp</artifactId>
+            <version>${opentelemetry.version}</version>
         </dependency>
 
         <!-- Recognized by kt-schema-apt out of the box to describe generated JSON schemas -->

--- a/examples/weather-mcp/pom.xml
+++ b/examples/weather-mcp/pom.xml
@@ -33,6 +33,13 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
+                <groupId>dev.tachyonmcp</groupId>
+                <artifactId>tachyon-bom</artifactId>
+                <version>${tachyon.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
                 <groupId>tools.jackson</groupId>
                 <artifactId>jackson-bom</artifactId>
                 <version>${jackson.version}</version>
@@ -53,14 +60,12 @@
         <dependency>
             <groupId>dev.tachyonmcp</groupId>
             <artifactId>tachyon-core</artifactId>
-            <version>${tachyon.version}</version>
         </dependency>
 
         <!-- OpenTelemetry: MCP semantic-convention spans/metrics; app supplies SDK + exporter -->
         <dependency>
             <groupId>dev.tachyonmcp</groupId>
             <artifactId>tachyon-opentelemetry</artifactId>
-            <version>${tachyon.version}</version>
         </dependency>
         <dependency>
             <groupId>io.opentelemetry</groupId>

--- a/examples/weather-mcp/src/main/java/com/example/weather/WeatherServer.java
+++ b/examples/weather-mcp/src/main/java/com/example/weather/WeatherServer.java
@@ -26,6 +26,20 @@ import dev.tachyonmcp.api.server.features.prompts.PromptRequest;
 import dev.tachyonmcp.api.server.features.prompts.PromptResult;
 import dev.tachyonmcp.core.server.TachyonServer;
 import dev.tachyonmcp.core.server.config.CapabilitiesConfig;
+import dev.tachyonmcp.opentelemetry.McpOpenTelemetryListener;
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.exporter.logging.LoggingMetricExporter;
+import io.opentelemetry.exporter.logging.LoggingSpanExporter;
+import io.opentelemetry.exporter.otlp.http.metrics.OtlpHttpMetricExporter;
+import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporter;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.metrics.SdkMeterProvider;
+import io.opentelemetry.sdk.metrics.export.PeriodicMetricReader;
+import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
+import io.opentelemetry.semconv.ServiceAttributes;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -34,6 +48,7 @@ import tools.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.net.http.HttpClient;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.Base64;
 import java.util.List;
 import java.util.Locale;
@@ -49,6 +64,37 @@ public final class WeatherServer {
     static final String SUN_AND_CLOUD = classpathDataUri("/images/sun-and-cloud.png", "image/png");
 
     private static final WeatherService weatherService;
+
+    /**
+     * Prints spans/metrics to the log with zero external infra, and also ships them via the
+     * standard OTLP/HTTP exporter (default endpoint {@code http://localhost:4318}) -- point a
+     * local collector (Jaeger, Grafana Tempo, Honeycomb, ...) there to see them land. With no
+     * collector running, the OTLP exporter logs periodic export failures; that's expected and
+     * harmless, and only the logging exporter's output matters for this demo.
+     */
+    private static final Resource OTEL_RESOURCE = Resource.getDefault().toBuilder()
+            .put(ServiceAttributes.SERVICE_NAME, "weather-mcp")
+            .build();
+
+    private static final OpenTelemetry OTEL = OpenTelemetrySdk.builder()
+            .setTracerProvider(SdkTracerProvider.builder()
+                    .setResource(OTEL_RESOURCE)
+                    .addSpanProcessor(SimpleSpanProcessor.create(LoggingSpanExporter.create()))
+                    .addSpanProcessor(BatchSpanProcessor.builder(
+                                    OtlpHttpSpanExporter.builder().build())
+                            .build())
+                    .build())
+            .setMeterProvider(SdkMeterProvider.builder()
+                    .setResource(OTEL_RESOURCE)
+                    .registerMetricReader(PeriodicMetricReader.builder(LoggingMetricExporter.create())
+                            .setInterval(Duration.ofSeconds(10))
+                            .build())
+                    .registerMetricReader(PeriodicMetricReader.builder(
+                                    OtlpHttpMetricExporter.builder().build())
+                            .setInterval(Duration.ofSeconds(10))
+                            .build())
+                    .build())
+            .build();
 
     static {
         HttpClient httpClient = HttpClient.newBuilder()
@@ -93,6 +139,13 @@ public final class WeatherServer {
                         .icons(Icon.of(LOGO, "image/png", List.of("256x256"), null))
                         .version("1.0"))
                 .capabilities(CapabilitiesConfig.Builder::logging)
+                .observability(o -> o
+                        .slowRequestLogging()
+                        .listener(McpOpenTelemetryListener.create(OTEL))
+                        .payloadCapture(p -> p.requestArgs(true)
+                                .responseContent(true)
+                                .rawMessage(true)
+                                .exceptionDetail(true)))
 
                 .withTools(tools -> tools.register(GetWeatherTool.DESCRIPTOR, GetWeatherTool.fn(weatherService)))
 

--- a/examples/weather-mcp/src/main/java/com/example/weather/WeatherServer.java
+++ b/examples/weather-mcp/src/main/java/com/example/weather/WeatherServer.java
@@ -27,7 +27,6 @@ import dev.tachyonmcp.api.server.features.prompts.PromptResult;
 import dev.tachyonmcp.core.server.TachyonServer;
 import dev.tachyonmcp.core.server.config.CapabilitiesConfig;
 import dev.tachyonmcp.opentelemetry.McpOpenTelemetryListener;
-import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.exporter.logging.LoggingMetricExporter;
 import io.opentelemetry.exporter.logging.LoggingSpanExporter;
 import io.opentelemetry.exporter.otlp.http.metrics.OtlpHttpMetricExporter;
@@ -76,7 +75,7 @@ public final class WeatherServer {
             .put(ServiceAttributes.SERVICE_NAME, "weather-mcp")
             .build();
 
-    private static final OpenTelemetry OTEL = OpenTelemetrySdk.builder()
+    private static final OpenTelemetrySdk OTEL = OpenTelemetrySdk.builder()
             .setTracerProvider(SdkTracerProvider.builder()
                     .setResource(OTEL_RESOURCE)
                     .addSpanProcessor(SimpleSpanProcessor.create(LoggingSpanExporter.create()))
@@ -112,6 +111,7 @@ public final class WeatherServer {
             weatherService
         );
         server.start();
+        Runtime.getRuntime().addShutdownHook(new Thread(OTEL::close));
         log.info("Connect your MCP client to http://{}:{}/mcp", server.host(), server.port());
     }
 

--- a/integrations/tachyon-opentelemetry/src/main/java/dev/tachyonmcp/opentelemetry/McpOpenTelemetryListener.java
+++ b/integrations/tachyon-opentelemetry/src/main/java/dev/tachyonmcp/opentelemetry/McpOpenTelemetryListener.java
@@ -8,11 +8,16 @@ import static dev.tachyonmcp.opentelemetry.McpAttributes.GEN_AI_TOOL_CALL_ARGUME
 import static dev.tachyonmcp.opentelemetry.McpAttributes.GEN_AI_TOOL_CALL_RESULT;
 import static dev.tachyonmcp.opentelemetry.McpAttributes.GEN_AI_TOOL_NAME;
 import static dev.tachyonmcp.opentelemetry.McpAttributes.MCP_METHOD_NAME;
+import static dev.tachyonmcp.opentelemetry.McpAttributes.MCP_PROTOCOL_VERSION;
 import static dev.tachyonmcp.opentelemetry.McpAttributes.MCP_SESSION_ID;
 import static dev.tachyonmcp.opentelemetry.McpAttributes.PROMPTS_GET;
 import static dev.tachyonmcp.opentelemetry.McpAttributes.TOOLS_CALL;
 import static dev.tachyonmcp.opentelemetry.McpAttributes.TOOL_ERROR;
 import static io.opentelemetry.semconv.ErrorAttributes.ERROR_TYPE;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PROTOCOL_NAME;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
+import static io.opentelemetry.semconv.incubating.JsonrpcIncubatingAttributes.JSONRPC_PROTOCOL_VERSION;
 import static io.opentelemetry.semconv.incubating.JsonrpcIncubatingAttributes.JSONRPC_REQUEST_ID;
 import static io.opentelemetry.semconv.incubating.RpcIncubatingAttributes.RPC_RESPONSE_STATUS_CODE;
 
@@ -63,7 +68,10 @@ import org.jspecify.annotations.Nullable;
  * <p>Tool arguments are recorded as {@code gen_ai.tool.call.arguments} only when the server's {@code
  * PayloadCapturePolicy.requestArgs()} is enabled — this listener never captures payloads on its
  * own, it only reads what core already captured into {@link OperationInfo#requestPayload()}. Off by
- * default: arguments routinely carry credentials and personal data.
+ * default: arguments routinely carry credentials and personal data. Likewise, a handler/serialization
+ * failure's exception is recorded as a span exception event (message and stack trace) only when
+ * {@code PayloadCapturePolicy.exceptionDetail()} is enabled; core hands this listener a {@code null}
+ * cause otherwise, and the span still gets an {@code ERROR} status with a generic message.
  *
  * @see <a href="https://github.com/open-telemetry/semantic-conventions-genai/tree/main/model/mcp">
  *     semantic-conventions-genai / model / mcp</a>
@@ -73,6 +81,12 @@ public class McpOpenTelemetryListener implements ObservationListener {
     private static final String INSTRUMENTATION_NAME = "dev.tachyonmcp.opentelemetry";
     private static final String OPERATION_DURATION = "mcp.server.operation.duration";
     private static final double NANOS_PER_SECOND = 1_000_000_000.0;
+
+    /** MCP's wire protocol is JSON-RPC 2.0, unconditionally. */
+    private static final String JSONRPC_VERSION_2_0 = "2.0";
+
+    /** This listener only instruments {@code tachyon-core}'s Streamable HTTP transport. */
+    private static final String NETWORK_PROTOCOL_HTTP = "http";
 
     /**
      * JSON-RPC codes a server returns because the <em>caller</em> sent something it could not
@@ -150,13 +164,28 @@ public class McpOpenTelemetryListener implements ObservationListener {
 
     /** Attributes shared by the span and the duration histogram. All low-cardinality. */
     private static Attributes sharedAttributes(OperationInfo info, @Nullable String target) {
-        var builder = Attributes.builder().put(MCP_METHOD_NAME, info.method());
+        var builder = Attributes.builder()
+                .put(MCP_METHOD_NAME, info.method())
+                .put(JSONRPC_PROTOCOL_VERSION, JSONRPC_VERSION_2_0)
+                .put(NETWORK_PROTOCOL_NAME, NETWORK_PROTOCOL_HTTP);
         if (target != null) {
             if (isToolCall(info)) {
                 builder.put(GEN_AI_TOOL_NAME, target).put(GEN_AI_OPERATION_NAME, EXECUTE_TOOL);
             } else {
                 builder.put(GEN_AI_PROMPT_NAME, target);
             }
+        }
+        var protocolVersion = info.protocolVersion();
+        if (protocolVersion != null) {
+            builder.put(MCP_PROTOCOL_VERSION, protocolVersion);
+        }
+        var serverAddress = info.serverAddress();
+        if (serverAddress != null) {
+            builder.put(SERVER_ADDRESS, serverAddress);
+        }
+        var serverPort = info.serverPort();
+        if (serverPort != null) {
+            builder.put(SERVER_PORT, serverPort.longValue());
         }
         return builder.build();
     }
@@ -214,14 +243,14 @@ public class McpOpenTelemetryListener implements ObservationListener {
                 }
             }
             case OperationOutcome.SerializationFailed serializationFailed -> {
-                span.recordException(serializationFailed.cause());
-                span.setStatus(
-                        StatusCode.ERROR,
-                        Objects.toString(serializationFailed.cause().getMessage(), ""));
-                classify(
-                        span,
-                        metricAttributes,
-                        serializationFailed.cause().getClass().getName());
+                var cause = serializationFailed.cause();
+                if (cause != null) {
+                    span.recordException(cause);
+                    span.setStatus(StatusCode.ERROR, Objects.toString(cause.getMessage(), ""));
+                } else {
+                    span.setStatus(StatusCode.ERROR, "Serialization failed");
+                }
+                classify(span, metricAttributes, serializationFailed.causeType());
             }
             case OperationOutcome.Cancelled ignored -> {}
             case OperationOutcome.NotificationAccepted ignored -> {}

--- a/integrations/tachyon-opentelemetry/src/test/java/dev/tachyonmcp/opentelemetry/McpOpenTelemetryListenerTest.java
+++ b/integrations/tachyon-opentelemetry/src/test/java/dev/tachyonmcp/opentelemetry/McpOpenTelemetryListenerTest.java
@@ -146,7 +146,7 @@ class McpOpenTelemetryListenerTest {
                     .doesNotContainKey(RPC_RESPONSE_STATUS_CODE)
                     // gen_ai.tool.call.result is opt-in (PayloadCapturePolicy.responseContent) and
                     // off here -- this size pins the full attribute set so it can't leak in silently.
-                    .hasSize(10);
+                    .hasSize(11);
         }
     }
 
@@ -221,6 +221,72 @@ class McpOpenTelemetryListenerTest {
             assertThat(response).isJsonRpcError().hasErrorCode(-32603);
 
             var span = spanFor("tools/call throwing");
+            assertThat(span.getEvents())
+                    .anySatisfy(event -> assertThat(event.getAttributes().get(EXCEPTION_MESSAGE))
+                            .contains("boom"));
+        }
+    }
+
+    @Test
+    @DisplayName("PayloadCapturePolicy.exceptionDetail(true) records a resource handler exception on the span")
+    void exceptionDetailWhenOptedInForResource() throws Exception {
+        try (var server = startServer(o -> o.payloadCapture(p -> p.exceptionDetail(true)));
+                var client = new Mcp20251125Client(server.port())) {
+            var sessionId = client.initialize();
+            var response = client.post(
+                    sessionId,
+                    // language=json
+                    """
+                    {"jsonrpc":"2.0","id":18,"method":"resources/read","params":{"uri":"resource://throwing"}}""");
+
+            assertThat(response).isJsonRpcError().hasErrorCode(-32603);
+
+            var span = spanFor("resources/read");
+            assertThat(span.getEvents())
+                    .anySatisfy(event -> assertThat(event.getAttributes().get(EXCEPTION_MESSAGE))
+                            .contains("boom"));
+        }
+    }
+
+    @Test
+    @DisplayName("PayloadCapturePolicy.exceptionDetail(true) records a prompt handler exception on the span")
+    void exceptionDetailWhenOptedInForPrompt() throws Exception {
+        try (var server = startServer(o -> o.payloadCapture(p -> p.exceptionDetail(true)));
+                var client = new Mcp20251125Client(server.port())) {
+            var sessionId = client.initialize();
+            var response = client.post(
+                    sessionId,
+                    // language=json
+                    """
+                    {"jsonrpc":"2.0","id":19,"method":"prompts/get","params":{"name":"throwing"}}""");
+
+            assertThat(response).isJsonRpcError().hasErrorCode(-32603);
+
+            var span = spanFor("prompts/get throwing");
+            assertThat(span.getEvents())
+                    .anySatisfy(event -> assertThat(event.getAttributes().get(EXCEPTION_MESSAGE))
+                            .contains("boom"));
+        }
+    }
+
+    @Test
+    @DisplayName("PayloadCapturePolicy.exceptionDetail(true) records a completion handler exception on the span")
+    void exceptionDetailWhenOptedInForCompletion() throws Exception {
+        try (var server = startServer(o -> o.payloadCapture(p -> p.exceptionDetail(true)));
+                var client = new Mcp20251125Client(server.port())) {
+            var sessionId = client.initialize();
+            var response = client.post(
+                    sessionId,
+                    // language=json
+                    """
+                    {"jsonrpc":"2.0","id":20,"method":"completion/complete","params":{
+                      "ref":{"type":"ref/prompt","name":"throwing"},
+                      "argument":{"name":"language","value":"java"}
+                    }}""");
+
+            assertThat(response).isJsonRpcError().hasErrorCode(-32603);
+
+            var span = spanFor("completion/complete");
             assertThat(span.getEvents())
                     .anySatisfy(event -> assertThat(event.getAttributes().get(EXCEPTION_MESSAGE))
                             .contains("boom"));
@@ -481,7 +547,12 @@ class McpOpenTelemetryListenerTest {
     private TachyonServer startServer(Consumer<ObservabilityConfig.Builder> observabilityConfig) {
         return McpTestServers.start(
                 builder -> builder.session(session -> session.enabled(true))
-                        .capabilities(capabilities -> capabilities.tools(true).logging())
+                        .capabilities(capabilities -> capabilities
+                                .tools(true)
+                                .logging()
+                                .resources()
+                                .prompts()
+                                .completions())
                         .observability(o -> {
                             o.listener(McpOpenTelemetryListener.create(otel));
                             observabilityConfig.accept(o);
@@ -500,6 +571,18 @@ class McpOpenTelemetryListenerTest {
                             .register(
                                     resource -> resource.name("greeting").uri("resource://greeting"),
                                     (ctx, request) -> TextResourceContents.of(request.uri(), "hello", "text/plain"));
+                    server.resources()
+                            .register(
+                                    resource -> resource.name("throwing").uri("resource://throwing"),
+                                    (ctx, request) -> {
+                                        throw new IOException("🔥 boom");
+                                    });
+                    server.prompts().register(prompt -> prompt.name("throwing"), (ctx, request) -> {
+                        throw new IOException("🔥 boom");
+                    });
+                    server.completions().registerForPrompt("throwing", (ctx, request) -> {
+                        throw new IOException("🔥 boom");
+                    });
                 });
     }
 }

--- a/integrations/tachyon-opentelemetry/src/test/java/dev/tachyonmcp/opentelemetry/McpOpenTelemetryListenerTest.java
+++ b/integrations/tachyon-opentelemetry/src/test/java/dev/tachyonmcp/opentelemetry/McpOpenTelemetryListenerTest.java
@@ -7,10 +7,16 @@ import static dev.tachyonmcp.opentelemetry.McpAttributes.GEN_AI_TOOL_CALL_ARGUME
 import static dev.tachyonmcp.opentelemetry.McpAttributes.GEN_AI_TOOL_CALL_RESULT;
 import static dev.tachyonmcp.opentelemetry.McpAttributes.GEN_AI_TOOL_NAME;
 import static dev.tachyonmcp.opentelemetry.McpAttributes.MCP_METHOD_NAME;
+import static dev.tachyonmcp.opentelemetry.McpAttributes.MCP_PROTOCOL_VERSION;
 import static dev.tachyonmcp.opentelemetry.McpAttributes.MCP_SESSION_ID;
 import static dev.tachyonmcp.opentelemetry.McpAttributes.TOOL_ERROR;
 import static dev.tachyonmcp.testkit.JsonRpcResponseAssert.assertThat;
 import static io.opentelemetry.semconv.ErrorAttributes.ERROR_TYPE;
+import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_MESSAGE;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PROTOCOL_NAME;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
+import static io.opentelemetry.semconv.incubating.JsonrpcIncubatingAttributes.JSONRPC_PROTOCOL_VERSION;
 import static io.opentelemetry.semconv.incubating.JsonrpcIncubatingAttributes.JSONRPC_REQUEST_ID;
 import static io.opentelemetry.semconv.incubating.RpcIncubatingAttributes.RPC_RESPONSE_STATUS_CODE;
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
@@ -92,6 +98,11 @@ class McpOpenTelemetryListenerTest {
                     .containsEntry(GEN_AI_TOOL_NAME, "forecast")
                     .containsEntry(GEN_AI_OPERATION_NAME, EXECUTE_TOOL)
                     .containsEntry(MCP_SESSION_ID, sessionId)
+                    .containsEntry(MCP_PROTOCOL_VERSION, Mcp20251125Client.PROTOCOL_VERSION)
+                    .containsEntry(JSONRPC_PROTOCOL_VERSION, "2.0")
+                    .containsEntry(NETWORK_PROTOCOL_NAME, "http")
+                    .containsEntry(SERVER_ADDRESS, server.host())
+                    .containsEntry(SERVER_PORT, (long) server.port())
                     .containsEntry(JSONRPC_REQUEST_ID, "10")
                     .doesNotContainKey(ERROR_TYPE)
                     .doesNotContainKey(RPC_RESPONSE_STATUS_CODE)
@@ -135,7 +146,7 @@ class McpOpenTelemetryListenerTest {
                     .doesNotContainKey(RPC_RESPONSE_STATUS_CODE)
                     // gen_ai.tool.call.result is opt-in (PayloadCapturePolicy.responseContent) and
                     // off here -- this size pins the full attribute set so it can't leak in silently.
-                    .hasSize(6);
+                    .hasSize(10);
         }
     }
 
@@ -190,6 +201,29 @@ class McpOpenTelemetryListenerTest {
             assertThat(span.getAttributes().asMap())
                     .containsEntry(ERROR_TYPE, "INTERNAL_ERROR")
                     .containsEntry(RPC_RESPONSE_STATUS_CODE, "-32603");
+            // opt-in per PayloadCapturePolicy.exceptionDetail (default false): no exception event
+            assertThat(span.getEvents()).isEmpty();
+        }
+    }
+
+    @Test
+    @DisplayName("PayloadCapturePolicy.exceptionDetail(true) records the handler exception on the span")
+    void exceptionDetailWhenOptedIn() throws Exception {
+        try (var server = startServer(o -> o.payloadCapture(p -> p.exceptionDetail(true)));
+                var client = new Mcp20251125Client(server.port())) {
+            var sessionId = client.initialize();
+            var response = client.post(
+                    sessionId,
+                    // language=json
+                    """
+                    {"jsonrpc":"2.0","id":17,"method":"tools/call","params":{"name":"throwing","arguments":{}}}""");
+
+            assertThat(response).isJsonRpcError().hasErrorCode(-32603);
+
+            var span = spanFor("tools/call throwing");
+            assertThat(span.getEvents())
+                    .anySatisfy(event -> assertThat(event.getAttributes().get(EXCEPTION_MESSAGE))
+                            .contains("boom"));
         }
     }
 

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/McpDispatcher.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/McpDispatcher.java
@@ -107,8 +107,36 @@ public class McpDispatcher {
         return server.config().observability().listeners();
     }
 
-    /** Extracts {@code _meta.traceparent} from raw params, independent of payload-capture policy. */
-    private static @Nullable String extractTraceparent(@Nullable Object params) {
+    /**
+     * Builds the {@link OperationInfo} for one operation, filling in the server's bound
+     * address/port when already started (omitted for direct/programmatic dispatch, e.g. tests).
+     */
+    private OperationInfo newOperationInfo(
+            OperationKind kind,
+            String method,
+            @Nullable RequestId id,
+            @Nullable String sessionId,
+            @Nullable Object params,
+            @Nullable ChannelContext channelContext) {
+        var builder = OperationInfo.builder(kind, method, id)
+                .sessionId(sessionId)
+                .traceparent(extractTraceParent(params))
+                .protocolVersion(channelContext != null ? channelContext.protocolVersion() : null);
+        try {
+            builder.serverAddress(server.host()).serverPort(server.port());
+        } catch (IllegalStateException e) {
+            // Server not started (e.g. tests dispatching directly without start()).
+        }
+        return builder.build();
+    }
+
+    /**
+     * Extracts {@code _meta.traceparent} from raw params, independent of payload-capture policy.
+     *
+     * @see <a href="https://github.com/open-telemetry/semantic-conventions-genai/blob/main/docs/gen-ai/mcp.md">
+     * Semantic conventions for Model Context Protocol (MCP)</a>
+     */
+    private static @Nullable String extractTraceParent(@Nullable Object params) {
         if (params instanceof Map<?, ?> map
                 && map.get("_meta") instanceof Map<?, ?> meta
                 && meta.get("traceparent") instanceof String traceparent) {
@@ -185,11 +213,7 @@ public class McpDispatcher {
         Objects.requireNonNull(method, "method");
 
         var kind = METHOD_INITIALIZE.equals(method) ? OperationKind.INITIALIZE : OperationKind.REQUEST;
-        var info = new OperationInfo(kind, method, id);
-        info.traceparent(extractTraceparent(params));
-        if (sessionId != null) {
-            info.sessionId(sessionId);
-        }
+        var info = newOperationInfo(kind, method, id, sessionId, params, channelContext);
         var observation = Observation.start(observationListeners(), info);
 
         var requestCtx = dispatchContext(channelContext, id);
@@ -346,6 +370,8 @@ public class McpDispatcher {
         var reattached = observation.reattach();
         DispatchResult dispatchResult;
         OperationOutcome outcome;
+        var exceptionDetail =
+                context.engine().config().observability().payloadCapture().exceptionDetail();
         try {
             var unwrapped = ex instanceof CompletionException ce && ce.getCause() != null ? ce.getCause() : ex;
             if (unwrapped instanceof CancellationException) {
@@ -357,13 +383,13 @@ public class McpDispatcher {
                 var error = rme.error();
                 dispatchResult = errorResult(id, error, context);
                 outcome = new OperationOutcome.HandlerFailed(
-                        error, context.responseMapper().error(error).code(), unwrapped);
+                        error, context.responseMapper().error(error).code(), exceptionDetail ? unwrapped : null);
             } else {
                 logger.warn("Handler exception: method={}, id={}: {}", method, id, unwrapped.getMessage(), unwrapped);
                 var error = ServerErrors.internalError("Internal error");
                 dispatchResult = errorResult(id, error, context);
                 outcome = new OperationOutcome.HandlerFailed(
-                        error, context.responseMapper().error(error).code(), unwrapped);
+                        error, context.responseMapper().error(error).code(), exceptionDetail ? unwrapped : null);
             }
         } finally {
             observation.closeReattached(reattached);
@@ -385,7 +411,12 @@ public class McpDispatcher {
                 outcome = new OperationOutcome.HandlerFailed(
                         error, context.responseMapper().error(error).code(), null);
             } else {
-                var body = encodeResponse(id, result, context.responseMapper(), observation);
+                var exceptionDetail = context.engine()
+                        .config()
+                        .observability()
+                        .payloadCapture()
+                        .exceptionDetail();
+                var body = encodeResponse(id, result, context.responseMapper(), observation, exceptionDetail);
                 dispatchResult = new DispatchResult.Response(body, sessionId, 200);
                 outcome = new OperationOutcome.Completed();
             }
@@ -405,9 +436,7 @@ public class McpDispatcher {
             @Nullable Object params,
             @Nullable String sessionId,
             @Nullable ChannelContext channelContext) {
-        var info = new OperationInfo(OperationKind.NOTIFICATION, method, null);
-        info.traceparent(extractTraceparent(params));
-        info.sessionId(sessionId);
+        var info = newOperationInfo(OperationKind.NOTIFICATION, method, null, sessionId, params, channelContext);
         var observation = Observation.start(observationListeners(), info);
         observation.closeStart();
 
@@ -538,7 +567,11 @@ public class McpDispatcher {
     }
 
     private static byte[] encodeResponse(
-            RequestId id, Object result, ProtocolResponseMapper mapper, Observation observation) {
+            RequestId id,
+            Object result,
+            ProtocolResponseMapper mapper,
+            Observation observation,
+            boolean exceptionDetail) {
         if (result instanceof String s) {
             return JsonRpcCodec.serializeResponse(id, s);
         }
@@ -548,7 +581,7 @@ public class McpDispatcher {
         } catch (Exception e) {
             logger.error(
                     "JSON serialization failed for {}: {}", result.getClass().getSimpleName(), e.getMessage(), e);
-            observation.markSerializationFailed(e);
+            observation.markSerializationFailed(e, exceptionDetail);
             return encodeError(id, ServerErrors.internalError("Failed to encode response"), mapper);
         }
     }

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/McpDispatcher.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/McpDispatcher.java
@@ -409,7 +409,9 @@ public class McpDispatcher {
                 logger.debug("Handler error for {}: {}", method, error.message());
                 dispatchResult = errorResult(id, error, context);
                 outcome = new OperationOutcome.HandlerFailed(
-                        error, context.responseMapper().error(error).code(), null);
+                        error,
+                        context.responseMapper().error(error).code(),
+                        context.observation().info().exceptionCause());
             } else {
                 var exceptionDetail = context.engine()
                         .config()

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/features/completions/CompletionMethodHandlers.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/features/completions/CompletionMethodHandlers.java
@@ -69,6 +69,7 @@ public final class CompletionMethodHandlers {
                                     } else {
                                         logger.error("Completion handler error", cause);
                                     }
+                                    context.captureExceptionCause(cause);
                                     return error;
                                 }
                                 var values = result.values();

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/features/prompts/PromptMethodHandlers.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/features/prompts/PromptMethodHandlers.java
@@ -111,6 +111,7 @@ public final class PromptMethodHandlers {
                             } else {
                                 logger.error("Prompt handler error for '{}'", mapped.name(), cause);
                             }
+                            context.captureExceptionCause(cause);
                             return error;
                         }
                         var meta = result.meta();

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/features/resources/ResourceMethodHandlers.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/features/resources/ResourceMethodHandlers.java
@@ -146,6 +146,7 @@ public final class ResourceMethodHandlers {
                             } else {
                                 logger.error("Resource handler error for '{}'", uri, cause);
                             }
+                            context.captureExceptionCause(cause);
                             return error;
                         }
                         return context.responseMapper().readResourceResult(List.of(contents));

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/features/tools/ToolMethodHandlers.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/features/tools/ToolMethodHandlers.java
@@ -152,7 +152,7 @@ public final class ToolMethodHandlers {
                     () -> handler.handleAsync(context, request),
                     context.engine().executor(),
                     (toolResult, cause) -> {
-                        if (cause != null) return handlerError(request.name(), cause);
+                        if (cause != null) return handlerError(context, request.name(), cause);
                         sendLogging(context, request.name(), "completed");
                         return mapResult(
                                 context,
@@ -249,7 +249,7 @@ public final class ToolMethodHandlers {
             return errors.isEmpty() ? null : SchemaValidationError.join(errors);
         }
 
-        private Object handlerError(String name, Throwable cause) {
+        private Object handlerError(DispatchContext context, String name, Throwable cause) {
             if (cause instanceof CancellationException) {
                 logger.debug("Tool call cancelled for '{}'", name);
                 return internalError("Tool call cancelled");
@@ -260,6 +260,7 @@ public final class ToolMethodHandlers {
             } else if (error.kind() == ServerError.Kind.INTERNAL_ERROR) {
                 logger.error("Tool handler error for '{}'", name, cause);
             }
+            context.captureExceptionCause(cause);
             return error;
         }
 

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/observability/Observation.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/observability/Observation.java
@@ -78,10 +78,15 @@ public final class Observation {
         override = new OperationOutcome.TaskHandoff(taskId);
     }
 
-    /** Tags the terminal outcome as a serialization failure, overriding whatever {@link #complete} is later called with. */
-    public void markSerializationFailed(Throwable cause) {
+    /**
+     * Tags the terminal outcome as a serialization failure, overriding whatever {@link #complete} is
+     * later called with. {@code exceptionDetail} gates whether the raw throwable is carried onto the
+     * outcome (per the server's opt-in exception-detail capture policy) -- its class name is reported
+     * either way.
+     */
+    public void markSerializationFailed(Throwable cause, boolean exceptionDetail) {
         if (listeners.isEmpty()) return;
-        override = new OperationOutcome.SerializationFailed(cause);
+        override = new OperationOutcome.SerializationFailed(cause.getClass().getName(), exceptionDetail ? cause : null);
     }
 
     /** Tags the terminal outcome as a tool payload failure, overriding whatever {@link #complete} is later called with. */

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/observability/ObservationListener.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/observability/ObservationListener.java
@@ -2,6 +2,7 @@
 package dev.tachyonmcp.core.server.observability;
 
 import dev.tachyonmcp.api.annotations.InternalApi;
+import jdk.jfr.Experimental;
 
 /**
  * A passive, read-only observer of the MCP dispatch lifecycle: {@code start} then exactly one
@@ -17,6 +18,7 @@ import dev.tachyonmcp.api.annotations.InternalApi;
  * other registered listener — every call into a listener is fault-isolated by the dispatcher.
  */
 @InternalApi
+@Experimental
 public interface ObservationListener {
 
     /** Fires once, as early as {@code method} (and {@code id}, if any) is known, before any handler or rejection. */

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/observability/OperationInfo.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/observability/OperationInfo.java
@@ -24,6 +24,9 @@ public final class OperationInfo {
 
     private @Nullable String sessionId;
     private @Nullable String traceParent;
+    private @Nullable String protocolVersion;
+    private @Nullable String serverAddress;
+    private @Nullable Integer serverPort;
     private @Nullable CapturedPayload requestPayload;
     private @Nullable CapturedPayload responsePayload;
     private @Nullable String target;
@@ -32,6 +35,11 @@ public final class OperationInfo {
         this.kind = kind;
         this.method = method;
         this.requestId = requestId;
+    }
+
+    /** A builder covering the fields known up front, at construction time. */
+    public static Builder builder(OperationKind kind, String method, @Nullable RequestId requestId) {
+        return new Builder(kind, method, requestId);
     }
 
     public OperationKind kind() {
@@ -60,6 +68,33 @@ public final class OperationInfo {
 
     public void traceparent(@Nullable String traceparent) {
         this.traceParent = traceparent;
+    }
+
+    /** The MCP protocol version negotiated for the channel this operation arrived on, if known. */
+    public @Nullable String protocolVersion() {
+        return protocolVersion;
+    }
+
+    public void protocolVersion(@Nullable String protocolVersion) {
+        this.protocolVersion = protocolVersion;
+    }
+
+    /** The server's bound host, or {@code null} when the server hadn't started yet at dispatch time. */
+    public @Nullable String serverAddress() {
+        return serverAddress;
+    }
+
+    public void serverAddress(@Nullable String serverAddress) {
+        this.serverAddress = serverAddress;
+    }
+
+    /** The server's bound port, or {@code null} when the server hadn't started yet at dispatch time. */
+    public @Nullable Integer serverPort() {
+        return serverPort;
+    }
+
+    public void serverPort(@Nullable Integer serverPort) {
+        this.serverPort = serverPort;
     }
 
     public @Nullable CapturedPayload requestPayload() {
@@ -91,5 +126,64 @@ public final class OperationInfo {
 
     public void target(@Nullable String target) {
         this.target = target;
+    }
+
+    /**
+     * Builder for the fields known up front, at construction time -- {@link #target}, the captured
+     * payloads, and (usually) {@link #sessionId} are only resolved later in the dispatch lifecycle
+     * and stay direct setters on the built {@link OperationInfo}.
+     */
+    public static final class Builder {
+
+        private final OperationKind kind;
+        private final String method;
+        private final @Nullable RequestId requestId;
+
+        private @Nullable String sessionId;
+        private @Nullable String traceParent;
+        private @Nullable String protocolVersion;
+        private @Nullable String serverAddress;
+        private @Nullable Integer serverPort;
+
+        private Builder(OperationKind kind, String method, @Nullable RequestId requestId) {
+            this.kind = kind;
+            this.method = method;
+            this.requestId = requestId;
+        }
+
+        public Builder sessionId(@Nullable String sessionId) {
+            this.sessionId = sessionId;
+            return this;
+        }
+
+        public Builder traceparent(@Nullable String traceparent) {
+            this.traceParent = traceparent;
+            return this;
+        }
+
+        public Builder protocolVersion(@Nullable String protocolVersion) {
+            this.protocolVersion = protocolVersion;
+            return this;
+        }
+
+        public Builder serverAddress(@Nullable String serverAddress) {
+            this.serverAddress = serverAddress;
+            return this;
+        }
+
+        public Builder serverPort(@Nullable Integer serverPort) {
+            this.serverPort = serverPort;
+            return this;
+        }
+
+        public OperationInfo build() {
+            var info = new OperationInfo(kind, method, requestId);
+            info.sessionId = sessionId;
+            info.traceParent = traceParent;
+            info.protocolVersion = protocolVersion;
+            info.serverAddress = serverAddress;
+            info.serverPort = serverPort;
+            return info;
+        }
     }
 }

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/observability/OperationInfo.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/observability/OperationInfo.java
@@ -30,6 +30,7 @@ public final class OperationInfo {
     private @Nullable CapturedPayload requestPayload;
     private @Nullable CapturedPayload responsePayload;
     private @Nullable String target;
+    private @Nullable Throwable exceptionCause;
 
     public OperationInfo(OperationKind kind, String method, @Nullable RequestId requestId) {
         this.kind = kind;
@@ -126,6 +127,21 @@ public final class OperationInfo {
 
     public void target(@Nullable String target) {
         this.target = target;
+    }
+
+    /**
+     * The throwable a feature handler (tool/resource/prompt/completion) converted into a {@link
+     * dev.tachyonmcp.api.server.domain.ServerError} value rather than letting propagate, captured
+     * only when the server's opt-in exception-detail capture policy is enabled -- that conversion
+     * is otherwise the one place the original throwable is lost before an {@code HandlerFailed}
+     * outcome is built.
+     */
+    public @Nullable Throwable exceptionCause() {
+        return exceptionCause;
+    }
+
+    public void exceptionCause(@Nullable Throwable exceptionCause) {
+        this.exceptionCause = exceptionCause;
     }
 
     /**

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/observability/OperationOutcome.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/observability/OperationOutcome.java
@@ -37,13 +37,19 @@ public sealed interface OperationOutcome {
      */
     record PayloadFailure() implements OperationOutcome {}
 
-    /** The handler produced a result but encoding it failed; the client received a fallback error. */
-    record SerializationFailed(Throwable cause) implements OperationOutcome {}
+    /**
+     * The handler produced a result but encoding it failed; the client received a fallback error.
+     * {@code causeType} (the throwable's class name) is always available for classification;
+     * {@code cause} is the throwable itself, present only when the server's opt-in exception-detail
+     * capture policy is enabled.
+     */
+    record SerializationFailed(String causeType, @Nullable Throwable cause) implements OperationOutcome {}
 
     /**
      * The operation ended in a JSON-RPC error after a handler ran. {@code cause} is the throwable
      * that produced it, or {@code null} when the handler returned a {@link ServerError} value
-     * directly rather than throwing/failing.
+     * directly rather than throwing/failing, or when a real throwable exists but the server's
+     * opt-in exception-detail capture policy is disabled.
      */
     record HandlerFailed(
             ServerError error, int wireCode, @Nullable Throwable cause) implements OperationOutcome {}

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/session/DispatchContext.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/session/DispatchContext.java
@@ -57,4 +57,18 @@ public interface DispatchContext extends ChannelContext {
 
     /** Returns the observation accumulator for the operation being dispatched ({@link Observation#NONE} when disabled). */
     Observation observation();
+
+    /**
+     * Captures {@code cause} onto the current operation, gated by the server's opt-in
+     * exception-detail capture policy -- for a feature handler (tool/resource/prompt/completion)
+     * converting a thrown exception into a {@code ServerError} value rather than letting it
+     * propagate, this is the only way that exception reaches a {@code HandlerFailed} outcome.
+     */
+    default void captureExceptionCause(Throwable cause) {
+        var observation = observation();
+        if (observation.active()
+                && engine().config().observability().payloadCapture().exceptionDetail()) {
+            observation.info().exceptionCause(cause);
+        }
+    }
 }

--- a/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/config/ObservabilityScope.kt
+++ b/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/config/ObservabilityScope.kt
@@ -3,7 +3,6 @@ package dev.tachyonmcp.kotlin.server.config
 
 import dev.tachyonmcp.api.annotations.ExperimentalApi
 import dev.tachyonmcp.core.server.config.ObservabilityConfig
-import dev.tachyonmcp.core.server.config.PayloadCapturePolicy
 import dev.tachyonmcp.core.server.observability.ObservationListener
 import dev.tachyonmcp.kotlin.server.TachyonDsl
 import java.time.Duration
@@ -21,7 +20,7 @@ public class ObservabilityScope
         private var slowRequestLogging: Boolean? = null
         private var slowRequestThreshold: Duration? = null
         private val listeners = mutableListOf<ObservationListener>()
-        private var payloadCapture: PayloadCapturePolicy? = null
+        private var payloadCapture: PayloadCaptureScope? = null
 
         /** Enables or disables slow-request diagnostics. */
         public fun slowRequestLogging(enabled: Boolean = true) {
@@ -45,11 +44,11 @@ public class ObservabilityScope
             listeners += listener
         }
 
-        /** Configures opt-in request and response payload capture. */
+        /** Configures opt-in request/response payload and exception-detail capture. */
         @OptIn(ExperimentalContracts::class)
-        public fun payloadCapture(configure: PayloadCapturePolicy.Builder.() -> Unit) {
+        public fun payloadCapture(configure: PayloadCaptureScope.() -> Unit) {
             contract { callsInPlace(configure, InvocationKind.EXACTLY_ONCE) }
-            payloadCapture = PayloadCapturePolicy.builder().apply(configure).build()
+            payloadCapture = PayloadCaptureScope().apply(configure)
         }
 
         @PublishedApi
@@ -57,14 +56,6 @@ public class ObservabilityScope
             slowRequestLogging?.let(builder::slowRequestLogging)
             slowRequestThreshold?.let(builder::slowRequestThreshold)
             listeners.forEach(builder::listener)
-            payloadCapture?.let { policy ->
-                builder.payloadCapture { payloadCapture ->
-                    payloadCapture.requestArgs(policy.requestArgs())
-                    payloadCapture.responseContent(policy.responseContent())
-                    payloadCapture.rawMessage(policy.rawMessage())
-                    payloadCapture.exceptionDetail(policy.exceptionDetail())
-                    payloadCapture.maxBytes(policy.maxBytes())
-                }
-            }
+            payloadCapture?.let { scope -> builder.payloadCapture(scope::applyTo) }
         }
     }

--- a/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/config/PayloadCaptureScope.kt
+++ b/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/config/PayloadCaptureScope.kt
@@ -1,0 +1,35 @@
+// Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors.
+package dev.tachyonmcp.kotlin.server.config
+
+import dev.tachyonmcp.core.server.config.PayloadCapturePolicy
+import dev.tachyonmcp.kotlin.server.TachyonDsl
+
+/** Kotlin DSL scope for the opt-in payload and exception-detail capture policy. */
+@TachyonDsl
+public class PayloadCaptureScope
+    @PublishedApi
+    internal constructor() {
+        /** Capture the request's params/arguments. */
+        public var requestArgs: Boolean? = null
+
+        /** Capture the encoded response content. */
+        public var responseContent: Boolean? = null
+
+        /** Capture the raw JSON-RPC envelope. */
+        public var rawMessage: Boolean? = null
+
+        /** Capture a redacted exception message on handler/serialization failure. */
+        public var exceptionDetail: Boolean? = null
+
+        /** Truncation limit, in UTF-8 bytes, applied to every captured value. */
+        public var maxBytes: Int? = null
+
+        @PublishedApi
+        internal fun applyTo(builder: PayloadCapturePolicy.Builder) {
+            requestArgs?.let(builder::requestArgs)
+            responseContent?.let(builder::responseContent)
+            rawMessage?.let(builder::rawMessage)
+            exceptionDetail?.let(builder::exceptionDetail)
+            maxBytes?.let(builder::maxBytes)
+        }
+    }


### PR DESCRIPTION
### Core (tachyon-core)

- OperationInfo gains a Builder plus protocolVersion/serverAddress/serverPort fields, populated once per operation in McpDispatcher instead of ad-hoc setters.
- exceptionDetail (PayloadCapturePolicy) was declared but never enforced: HandlerFailed/ SerializationFailed carried the raw Throwable unconditionally. Both now gate the cause on the policy, and SerializationFailed splits into a causeType (always present, for error.type) and a gated cause (drives the span exception event).

### tachyon-opentelemetry

- Publish mcp.protocol.version, jsonrpc.protocol.version, network.protocol.name, and server.address/server.port as span/metric attributes.
- SerializationFailed handling respects the new causeType/cause split, falling back to a generic ERROR status when exception detail isn't opted in.

### Docs

- New docs/observability.md: observation listeners, payload capture policy, the OpenTelemetry integration, trace context, and a full attribute reference.
- Linked from README.md, docs/README.md, docs/configuration.md, and examples/README.md; README highlights the built-in OpenTelemetry support.

### Examples (weather-mcp, weather-mcp-kotlin)

- Wire tachyon-opentelemetry with a verbose payload capture policy (all four toggles on) and slow-request logging.
- Export via both a logging exporter (zero-infra console output) and the standard OTLP/HTTP exporter, with a named service.name resource instead of unknown_service:java.
- Fixed an accidental runtime-scope on opentelemetry-sdk/opentelemetry-exporter-logging that broke compilation.

Closes #149