### PR TITLE
(feat): Extend Kotlin API for parity with Java

### DIFF
--- a/.agents/skills/tachyon-mcp/SKILL.md
+++ b/.agents/skills/tachyon-mcp/SKILL.md
@@ -40,8 +40,8 @@ Import `tachyon-bom` once, then add modules with no `<version>`:
 - `TachyonServer.builder()` → `ServerBuilder`. Start here.
 - `.build()` (only terminal method) → `TachyonServer` (`AutoCloseable`), no transport bound yet.
 - `TachyonServer.start()` (blocking) → binds the Netty transport.
-- `TachyonServer`: `.tools()`, `.resources()`, `.prompts()`, `.tasks()` first; then `.start()`, `.port()` (throws before `.start()`), `.close()`, `.config()`.
-- Dynamic registration: `.tools().register(...)`, `.resources().register(...)`, `.prompts().register(...)`.
+- `TachyonServer`: `.tools()`, `.resources()`, `.prompts()`, `.tasks()`, `.completions()` first; then `.start()`, `.port()` (throws before `.start()`), `.close()`, `.config()`.
+- Dynamic registration: `.tools().register(...)`, `.resources().register(...)`, `.prompts().register(...)`, `.completions().registerForPrompt(...)`/`.registerForResource(...)` — all work before or after `.start()`.
 - Every function gets `dev.tachyonmcp.api.runtime.InteractionContext` → protocol + optional session + notifications.
 - ⚡ **Virtual threads**: All synchronous functions (`ToolFn`, `ResourceFn`, `PromptFn`, `CompletionFn`) run on a virtual thread per request. Blocking for I/O is fine — never use `synchronized` (pins carrier thread). Use `ReentrantLock` instead.
 
@@ -365,7 +365,12 @@ tool(name = "greet", description = "Typed greet", inputSchema = ..., outputSchem
 - `scope.success(value)` — mirrors `decode`, defers serialization to the configured serializer
 - `scope.success(value, text)` — structured + human-readable text fallback
 
-Post-build registration with `registerTool`:
+Post-build registration — `TachyonServer` (Kotlin) mirrors every builder-time DSL function
+(`tool`/`resource`/`resourceTemplate`/`prompt`/`promptCompletion`/`resourceCompletion`) as a
+suspend `register*` method, callable before or after `.start()`, each with a flat-parameter
+overload and a prebuilt-descriptor overload — the Kotlin equivalent of Java's
+`server.tools().register(...)`/`.resources().register(...)`/`.prompts().register(...)`/
+`.completions().registerForPrompt(...)`/`.registerForResource(...)`:
 
 ```kotlin
 server.registerTool(
@@ -377,7 +382,39 @@ server.registerTool(
 ) {
     ToolResult.text(request.arguments().stringValue("message").reversed())
 }
+
+server.registerResource(name = "config", uri = "myapp://config") {
+    TextResourceContents { text = """{"mode":"demo"}""" }
+}
+
+server.registerResourceTemplate(name = "user-profile", uriTemplate = "myapp://users/{userId}/profile") {
+    TextResourceContents { text = """{"userId":"${param("userId")}"}""" }
+}
+
+server.registerPrompt(name = "rewrite-forecast") {
+    content { text("Rewrite this forecast.") }
+}
+
+server.registerPromptCompletion("rewrite-forecast") {
+    CompletionResult {
+        values = listOf("plain", "concise", "pirate").filter { it.startsWith(argumentValue) }
+    }
+}
+
+server.registerResourceCompletion("myapp://users/{userId}/profile") {
+    CompletionResult { values = listOf("alice", "bob") }
+}
 ```
+
+⚠️ Handler scopes (`CompletionScope`, `ResourceScope`, …) and most builder receivers carry
+`@TachyonDsl` — a `@DslMarker` — so inside a nested `TextResourceContents { }` you cannot reach the
+outer scope's `ctx`/`request` implicitly; capture them in a local `val` first. The accessors you
+actually need are re-exposed on the builder (`param`/`sequence`) or reachable because the builder is
+unmarked (`CompletionResultBuilder`), so both of these compile as written:
+`TextResourceContents { text = param("id") }` and
+`CompletionResult { values = candidates.filter { it.startsWith(argumentValue) } }`.
+
+Full: `resources/kotlin/PostBuildRegistrationExample.kt`
 
 ## Resource files
 
@@ -392,3 +429,4 @@ Load on demand (next to this skill):
 - [resources/kotlin/ToolHandlerExample.kt](resources/kotlin/ToolHandlerExample.kt) — suspend handler, `extends AbstractToolHandler` (`handle`/`handleAsync`), `registerTool`
 - [resources/kotlin/ResourceFnExample.kt](resources/kotlin/ResourceFnExample.kt) — static resources, URI templates (Kotlin DSL)
 - [resources/kotlin/PromptFnExample.kt](resources/kotlin/PromptFnExample.kt) — prompt descriptors and handlers (Kotlin DSL)
+- [resources/kotlin/PostBuildRegistrationExample.kt](resources/kotlin/PostBuildRegistrationExample.kt) — `registerResource`/`registerResourceTemplate`/`registerPrompt`/`registerPromptCompletion`/`registerResourceCompletion` on an already-built `TachyonServer`

--- a/.agents/skills/tachyon-mcp/resources/kotlin/PostBuildRegistrationExample.kt
+++ b/.agents/skills/tachyon-mcp/resources/kotlin/PostBuildRegistrationExample.kt
@@ -1,0 +1,40 @@
+// Copyright (c) 2026 Konstantin Pavlov and contributors.
+
+package dev.tachyonmcp.skill
+
+import dev.tachyonmcp.kotlin.server.TachyonServer
+import dev.tachyonmcp.kotlin.server.buildServer
+import dev.tachyonmcp.kotlin.server.features.completions.CompletionResult
+
+/**
+ * Post-build registration beyond tools (see `buildWithPostRegistration` in
+ * ToolHandlerExample.kt for `registerTool`): resources, resource templates, prompts, and
+ * completions all get the same suspend `register*` sugar on an already-built [TachyonServer] —
+ * the Kotlin equivalents of the Java runtime server's `server.resources().register(...)`,
+ * `server.prompts().register(...)`, and `server.completions().registerForPrompt/Resource(...)`.
+ */
+fun buildWithFullPostRegistration(): TachyonServer {
+    val server = buildServer { }
+
+    server.registerResource(name = "config", uri = "myapp://config") {
+        TextResourceContents { text = """{"mode":"demo"}""" }
+    }
+
+    server.registerResourceTemplate(name = "user-profile", uriTemplate = "myapp://users/{userId}/profile") {
+        TextResourceContents { text = """{"userId":"${param("userId")}"}""" }
+    }
+
+    server.registerPrompt(name = "rewrite-forecast", description = "Rewrites a forecast in a chosen style") {
+        content { text("Rewrite this forecast in a chosen style.") }
+    }
+
+    server.registerPromptCompletion("rewrite-forecast") {
+        CompletionResult { values = listOf("plain", "concise", "pirate").filter { it.startsWith(argumentValue) } }
+    }
+
+    server.registerResourceCompletion("myapp://users/{userId}/profile") {
+        CompletionResult { values = listOf("alice", "bob").filter { it.startsWith(argumentValue) } }
+    }
+
+    return server
+}

--- a/docs/kotlin.md
+++ b/docs/kotlin.md
@@ -353,14 +353,47 @@ Available via `ToolScope.arguments` (or `PromptScope.arguments`):
 | `ToolScope` | tool lambda | `ctx`, `request`, `arguments`; `success(v)`, `text(t)`, `fail(msg)`, `content { }` |
 | `ResourceScope` | resource lambda | `ctx`, `uri`, `params`, `uriTemplate` |
 | `TemplateScope` | resource-template lambda | `ctx`, `uri`, `params`, `uriTemplate`; contextual `TextResourceContents { }` |
-| `PromptScope` | prompt lambda | `ctx`, `request`, `arguments` |
+| `PromptScope` | prompt lambda | `ctx`, `request`, `arguments`; `content { }` |
+| `CompletionScope` | completion lambda | `ctx`, `request`, `argumentName`, `argumentValue`, `resolvedArguments` |
+
+`argumentName`, `argumentValue`, and `resolvedArguments` are raw client input — escape or
+allow-list before using them in a query, command, or path.
+
+## Completions
+
+`promptCompletion` answers `ref/prompt` refs by prompt name; `resourceCompletion` answers
+`ref/resource` refs by URI or `uriTemplate`, matched verbatim against what the client sends. A ref
+with no handler yields an empty result rather than an error. `CompletionResult { }` builds the
+response (`values`, `total`, `hasMore`, `meta`); the protocol caps a response at 100 values and the
+dispatcher truncates and forces `hasMore = true` beyond that.
+
+```kotlin
+TachyonServer(port = 8080) {
+    promptCompletion("rewrite-forecast") {
+        CompletionResult {
+            values = listOf("plain", "concise", "pirate").filter { it.startsWith(argumentValue) }
+        }
+    }
+    resourceCompletion("myapp://users/{userId}/profile") {
+        CompletionResult {
+            values = listOf("alice", "bob").filter { it.startsWith(argumentValue) }
+            hasMore = false
+        }
+    }
+}
+```
 
 ## Post-build registration
 
-The Kotlin `TachyonServer` supports suspend tool registration after construction:
+Every builder-time registration function has a suspend `register*` twin on the built
+`TachyonServer`, callable before or after `start()` — the Kotlin equivalent of Java's
+`server.tools().register(...)`, `server.resources().register(...)`,
+`server.prompts().register(...)`, and `server.completions().registerForPrompt/Resource(...)`.
+Each takes either flat named parameters or a prebuilt descriptor.
 
 ```kotlin
 val server = buildServer { /* base config */ }
+
 server.registerTool(
     ToolDescriptor {
         name = "echo"
@@ -369,7 +402,38 @@ server.registerTool(
 ) {
     text(arguments.stringValue("msg"))
 }
+
+server.registerResource(name = "config", uri = "myapp://config") {
+    TextResourceContents { text = """{"mode":"demo"}""" }
+}
+
+server.registerResourceTemplate(name = "user-profile", uriTemplate = "myapp://users/{userId}/profile") {
+    TextResourceContents { text = """{"userId":"${param("userId")}"}""" }
+}
+
+server.registerPrompt(name = "rewrite-forecast") {
+    content { text("Rewrite this forecast.") }
+}
+
+server.registerPromptCompletion("rewrite-forecast") {
+    CompletionResult { values = listOf("plain", "concise", "pirate") }
+}
+
+server.registerResourceCompletion("myapp://users/{userId}/profile") {
+    CompletionResult { values = listOf("alice", "bob") }
+}
 ```
+
+Duplicate handling differs per feature, and matters more here than at build time:
+
+| Call | Registering an existing key |
+|---|---|
+| `registerTool`, `registerPrompt`, `registerPromptCompletion`, `registerResourceCompletion` | replaces silently |
+| `registerResource` | replaces the same URI in place; throws `IllegalArgumentException` if that URI is held under a different name |
+| `registerResourceTemplate` | throws `IllegalArgumentException` — unregister first to swap a handler |
+
+When the matching capability is off, `register*` is a no-op that still returns the server, so a
+misconfigured capability shows up as a missing feature rather than an exception.
 
 ## Netty pipeline customization
 

--- a/e2e/src/test/kotlin/dev/tachyonmcp/e2e/PostBuildRegistrationE2eTest.kt
+++ b/e2e/src/test/kotlin/dev/tachyonmcp/e2e/PostBuildRegistrationE2eTest.kt
@@ -1,0 +1,152 @@
+// Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors.
+package dev.tachyonmcp.e2e
+
+import dev.tachyonmcp.e2e.mcp.AbstractStatelessMcpE2eTest
+import dev.tachyonmcp.kotlin.server.TachyonServer
+import dev.tachyonmcp.kotlin.server.features.completions.CompletionResult
+import dev.tachyonmcp.testkit.Mcp20251125Client
+import io.kotest.matchers.equals.shouldEqual
+import net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson
+import org.junit.jupiter.api.Test
+
+/**
+ * Exercises the Kotlin `TachyonServer`'s post-build suspend registration —
+ * `registerResource`/`registerResourceTemplate`/`registerPrompt`/`registerPromptCompletion`/
+ * `registerResourceCompletion` — the Kotlin equivalents of the Java runtime server's
+ * `server.resources().register(...)`, `server.prompts().register(...)`, and
+ * `server.completions().registerForPrompt/Resource(...)`. Only `registerTool` had a Kotlin
+ * post-build counterpart before; this proves the other four now round-trip over the wire too.
+ */
+internal class PostBuildRegistrationE2eTest : AbstractStatelessMcpE2eTest<Mcp20251125Client>() {
+    override fun createTestClient(): Mcp20251125Client = createTestClient(port)
+
+    override fun createTestClient(port: Int): Mcp20251125Client = Mcp20251125Client(port)
+
+    @Test
+    fun `registerResource adds a static resource to an already-built server`() {
+        TachyonServer(port = 0) { }.use { server ->
+            server.registerResource(name = "post-config", uri = "test://post-config") {
+                TextResourceContents { text = "post-build" }
+            }
+
+            val client = createTestClient(server.port())
+            client.initialize()
+            val response =
+                client.post("""{"jsonrpc":"2.0","id":2,"method":"resources/list","params":{}}""")
+
+            response.statusCode() shouldEqual 200
+            assertThatJson(response.body())
+                .inPath("$.result.resources[0].uri")
+                .isEqualTo("test://post-config")
+
+            val readResponse =
+                client.post(
+                    """{"jsonrpc":"2.0","id":3,"method":"resources/read","params":{
+                        "uri":"test://post-config"
+                    }}""",
+                )
+
+            readResponse.statusCode() shouldEqual 200
+            assertThatJson(readResponse.body())
+                .inPath("$.result.contents[0].text")
+                .isEqualTo("post-build")
+        }
+    }
+
+    @Test
+    fun `registerResourceTemplate adds a resource template to an already-built server`() {
+        TachyonServer(port = 0) { }.use { server ->
+            server.registerResourceTemplate(
+                name = "post-item",
+                uriTemplate = "test://post-items/{id}",
+            ) {
+                TextResourceContents { text = "item-${param("id")}" }
+            }
+
+            val client = createTestClient(server.port())
+            client.initialize()
+            val listResponse =
+                client.post(
+                    """{"jsonrpc":"2.0","id":2,"method":"resources/templates/list","params":{}}""",
+                )
+            assertThatJson(listResponse.body())
+                .inPath("$.result.resourceTemplates[0].uriTemplate")
+                .isEqualTo("test://post-items/{id}")
+
+            val readResponse =
+                client.post(
+                    """{"jsonrpc":"2.0","id":3,"method":"resources/read","params":{
+                        "uri":"test://post-items/42"
+                    }}""",
+                )
+            assertThatJson(readResponse.body())
+                .inPath("$.result.contents[0].text")
+                .isEqualTo("item-42")
+        }
+    }
+
+    @Test
+    fun `registerPrompt adds a prompt to an already-built server`() {
+        TachyonServer(port = 0) { }.use { server ->
+            server.registerPrompt(name = "post-greet") {
+                content { text("post-build greeting") }
+            }
+
+            val client = createTestClient(server.port())
+            client.initialize()
+            val getResponse =
+                client.post(
+                    """{"jsonrpc":"2.0","id":2,"method":"prompts/get","params":{
+                        "name":"post-greet"
+                    }}""",
+                )
+
+            getResponse.statusCode() shouldEqual 200
+            assertThatJson(getResponse.body())
+                .inPath("$.result.messages[0].content.text")
+                .isEqualTo("post-build greeting")
+        }
+    }
+
+    @Test
+    fun `registerPromptCompletion and registerResourceCompletion both work post-build`() {
+        TachyonServer(port = 0) { }.use { server ->
+            server.registerPrompt(name = "post-review", arguments = emptyList()) {
+                content { text("review") }
+            }
+            server.registerPromptCompletion("post-review") {
+                CompletionResult { values = listOf("kotlin", "java") }
+            }
+            server.registerResourceCompletion("test://post-items/{id}") {
+                CompletionResult { values = listOf("$argumentValue-suggested") }
+            }
+
+            val client = createTestClient(server.port())
+            client.initialize()
+
+            val promptCompletion =
+                client.post(
+                    """{"jsonrpc":"2.0","id":2,"method":"completion/complete","params":{
+                        "ref":{"type":"ref/prompt","name":"post-review"},
+                        "argument":{"name":"language","value":"k"}
+                    }}""",
+                )
+            assertThatJson(promptCompletion.body())
+                .inPath("$.result.completion.values")
+                .isArray
+                .containsExactly("kotlin", "java")
+
+            val resourceCompletion =
+                client.post(
+                    """{"jsonrpc":"2.0","id":3,"method":"completion/complete","params":{
+                        "ref":{"type":"ref/resource","uri":"test://post-items/{id}"},
+                        "argument":{"name":"id","value":"7"}
+                    }}""",
+                )
+            assertThatJson(resourceCompletion.body())
+                .inPath("$.result.completion.values")
+                .isArray
+                .containsExactly("7-suggested")
+        }
+    }
+}

--- a/e2e/src/test/kotlin/dev/tachyonmcp/e2e/PromptResourceCompletionE2eTest.kt
+++ b/e2e/src/test/kotlin/dev/tachyonmcp/e2e/PromptResourceCompletionE2eTest.kt
@@ -1,0 +1,79 @@
+// Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors.
+package dev.tachyonmcp.e2e
+
+import dev.tachyonmcp.e2e.mcp.AbstractStatelessMcpE2eTest
+import dev.tachyonmcp.kotlin.server.TachyonServer
+import dev.tachyonmcp.kotlin.server.features.completions.CompletionResult
+import dev.tachyonmcp.testkit.Mcp20251125Client
+import io.kotest.matchers.equals.shouldEqual
+import net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson
+import org.junit.jupiter.api.Test
+
+/**
+ * Exercises the Kotlin DSL's `promptCompletion`/`resourceCompletion` registration, the
+ * `CompletionResult { }` builder, and `CompletionScope`'s `argumentName`/`argumentValue`
+ * properties end-to-end over `completion/complete` — the Kotlin equivalent of the Java-side
+ * coverage in `CompletionTest`, since no prior test called these two DSL entry points at all.
+ */
+internal class PromptResourceCompletionE2eTest : AbstractStatelessMcpE2eTest<Mcp20251125Client>() {
+    override fun createTestClient(): Mcp20251125Client = createTestClient(port)
+
+    override fun createTestClient(port: Int): Mcp20251125Client = Mcp20251125Client(port)
+
+    @Test
+    fun `promptCompletion registers a completion handler built with CompletionResult builder`() {
+        TachyonServer(port = 0) {
+            promptCompletion("code_review") {
+                CompletionResult {
+                    values = listOf("python", "pytorch", "pyside")
+                    total = 10
+                    hasMore = true
+                }
+            }
+        }.use { server ->
+            val client = createTestClient(server.port())
+            client.initialize()
+            val response =
+                client.post(
+                    """{"jsonrpc":"2.0","id":2,"method":"completion/complete","params":{
+                        "ref":{"type":"ref/prompt","name":"code_review"},
+                        "argument":{"name":"language","value":"py"}
+                    }}""",
+                )
+
+            response.statusCode() shouldEqual 200
+            assertThatJson(response.body())
+                .inPath("$.result.completion.values")
+                .isArray
+                .containsExactly("python", "pytorch", "pyside")
+            assertThatJson(response.body()).inPath("$.result.completion.total").isEqualTo(10)
+            assertThatJson(response.body()).inPath("$.result.completion.hasMore").isEqualTo(true)
+        }
+    }
+
+    @Test
+    fun `resourceCompletion reads argumentName and argumentValue from CompletionScope`() {
+        TachyonServer(port = 0) {
+            resourceCompletion("file:///{path}") {
+                val candidate = "$argumentName:$argumentValue.txt"
+                CompletionResult { values = listOf(candidate) }
+            }
+        }.use { server ->
+            val client = createTestClient(server.port())
+            client.initialize()
+            val response =
+                client.post(
+                    """{"jsonrpc":"2.0","id":2,"method":"completion/complete","params":{
+                        "ref":{"type":"ref/resource","uri":"file:///{path}"},
+                        "argument":{"name":"path","value":"note"}
+                    }}""",
+                )
+
+            response.statusCode() shouldEqual 200
+            assertThatJson(response.body())
+                .inPath("$.result.completion.values")
+                .isArray
+                .containsExactly("path:note.txt")
+        }
+    }
+}

--- a/e2e/src/test/kotlin/dev/tachyonmcp/e2e/PromptResourceCompletionE2eTest.kt
+++ b/e2e/src/test/kotlin/dev/tachyonmcp/e2e/PromptResourceCompletionE2eTest.kt
@@ -55,8 +55,7 @@ internal class PromptResourceCompletionE2eTest : AbstractStatelessMcpE2eTest<Mcp
     fun `resourceCompletion reads argumentName and argumentValue from CompletionScope`() {
         TachyonServer(port = 0) {
             resourceCompletion("file:///{path}") {
-                val candidate = "$argumentName:$argumentValue.txt"
-                CompletionResult { values = listOf(candidate) }
+                CompletionResult { values = listOf("$argumentName:$argumentValue.txt") }
             }
         }.use { server ->
             val client = createTestClient(server.port())

--- a/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/TachyonServer.kt
+++ b/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/TachyonServer.kt
@@ -3,13 +3,31 @@ package dev.tachyonmcp.kotlin.server
 
 import dev.tachyonmcp.api.annotations.ExperimentalApi
 import dev.tachyonmcp.api.json.JsonSchema
+import dev.tachyonmcp.api.server.domain.Annotations
 import dev.tachyonmcp.api.server.domain.Icon
+import dev.tachyonmcp.api.server.domain.PromptArgument
+import dev.tachyonmcp.api.server.domain.PromptMessage
+import dev.tachyonmcp.api.server.domain.ResourceContents
 import dev.tachyonmcp.api.server.domain.ToolAnnotations
+import dev.tachyonmcp.api.server.features.completions.CompletionResult
+import dev.tachyonmcp.api.server.features.prompts.PromptDescriptor
+import dev.tachyonmcp.api.server.features.resources.ResourceDescriptor
+import dev.tachyonmcp.api.server.features.resources.ResourceTemplateDescriptor
 import dev.tachyonmcp.api.server.features.tasks.TaskSupport
 import dev.tachyonmcp.api.server.features.tools.ToolDescriptor
 import dev.tachyonmcp.api.server.features.tools.ToolResult
+import dev.tachyonmcp.core.server.features.resources.MimeTypes
+import dev.tachyonmcp.kotlin.server.config.CompletionScope
+import dev.tachyonmcp.kotlin.server.config.PromptScope
+import dev.tachyonmcp.kotlin.server.config.ResourceScope
+import dev.tachyonmcp.kotlin.server.config.TemplateScope
 import dev.tachyonmcp.kotlin.server.config.ToolScope
 import dev.tachyonmcp.kotlin.server.features.CoroutineRuntime
+import dev.tachyonmcp.kotlin.server.features.completions.promptCompletionFn
+import dev.tachyonmcp.kotlin.server.features.completions.resourceCompletionFn
+import dev.tachyonmcp.kotlin.server.features.prompts.promptFn
+import dev.tachyonmcp.kotlin.server.features.resources.resourceFn
+import dev.tachyonmcp.kotlin.server.features.resources.templateFn
 import dev.tachyonmcp.kotlin.server.features.tools.toolDescriptorOf
 import dev.tachyonmcp.kotlin.server.features.tools.toolFn
 import dev.tachyonmcp.kotlin.server.json.toJsonSchema
@@ -23,6 +41,7 @@ import dev.tachyonmcp.core.server.TachyonServer as CoreTachyonServer
  * Extends the core [CoreTachyonServer] API with suspend post-build registration.
  * Instances are created by [TachyonServer] and [buildServer].
  */
+@Suppress("TooManyFunctions")
 public sealed interface TachyonServer : CoreTachyonServer {
     /**
      * Registers a suspend tool handler.
@@ -145,6 +164,234 @@ public sealed interface TachyonServer : CoreTachyonServer {
             meta = meta,
             block = block,
         )
+
+    /**
+     * Registers a static resource with a suspend handler, accepting every optional attribute of
+     * [ResourceDescriptor.Builder]; pass a prebuilt [ResourceDescriptor] instead when a descriptor
+     * is already at hand.
+     *
+     * @param name resource name; need not be unique — [uri] is the resource's identity
+     * @param uri resource URI
+     * @param description optional resource description
+     * @param mimeType resource MIME type, guessed from [uri]'s extension by default
+     * @param title optional human-readable title
+     * @param annotations optional resource annotations
+     * @param size optional raw content size in bytes
+     * @param icons associated icons, or an empty list
+     * @param meta optional protocol extension metadata
+     * @param block handles reads of the registered resource
+     * @return this server
+     * @throws IllegalArgumentException if [uri] is already registered under a different name
+     */
+    @JvmSynthetic
+    @Suppress("LongParameterList")
+    public fun registerResource(
+        name: String,
+        uri: String,
+        description: String? = null,
+        mimeType: String? = MimeTypes.guess(uri),
+        title: String? = null,
+        annotations: Annotations? = null,
+        size: Long? = null,
+        icons: List<Icon> = emptyList(),
+        meta: Map<String, Any>? = null,
+        block: suspend ResourceScope.() -> ResourceContents,
+    ): TachyonServer =
+        registerResource(
+            descriptor =
+                ResourceDescriptor
+                    .builder()
+                    .name(name)
+                    .uri(uri)
+                    .description(description)
+                    .mimeType(mimeType)
+                    .title(title)
+                    .annotations(annotations)
+                    .size(size)
+                    .icons(icons)
+                    .meta(meta)
+                    .build(),
+            block = block,
+        )
+
+    /**
+     * Registers a prebuilt static-resource descriptor with a suspend handler.
+     *
+     * Callable before or after [start]. Re-registering the same URI under the same name replaces
+     * the resource in place; registering it under a different name is rejected. Does nothing when
+     * the resources capability is off — the call still returns this server.
+     *
+     * @param descriptor static-resource descriptor
+     * @param block handler invoked for resource reads
+     * @return this server
+     * @throws IllegalArgumentException if the descriptor's URI is already registered under a
+     * different name
+     */
+    @JvmSynthetic
+    public fun registerResource(
+        descriptor: ResourceDescriptor,
+        block: suspend ResourceScope.() -> ResourceContents,
+    ): TachyonServer
+
+    /**
+     * Registers a resource template with a suspend handler, accepting every optional attribute of
+     * [ResourceTemplateDescriptor.Builder]; pass a prebuilt [ResourceTemplateDescriptor] instead
+     * when a descriptor is already at hand.
+     *
+     * @param name template name; must be unique among registered templates
+     * @param uriTemplate URI template used to match resource requests
+     * @param description optional template description
+     * @param mimeType optional MIME type of the matched resources
+     * @param title optional human-readable title
+     * @param annotations optional template annotations
+     * @param icons associated icons, or an empty list
+     * @param meta optional protocol extension metadata
+     * @param block handles requests for resources matching the template
+     * @return this server
+     * @throws IllegalArgumentException if a template is already registered under [name]
+     */
+    @JvmSynthetic
+    @Suppress("LongParameterList")
+    public fun registerResourceTemplate(
+        name: String,
+        uriTemplate: String,
+        description: String? = null,
+        mimeType: String? = null,
+        title: String? = null,
+        annotations: Annotations? = null,
+        icons: List<Icon> = emptyList(),
+        meta: Map<String, Any>? = null,
+        block: suspend TemplateScope.() -> ResourceContents,
+    ): TachyonServer =
+        registerResourceTemplate(
+            descriptor =
+                ResourceTemplateDescriptor
+                    .builder()
+                    .name(name)
+                    .uriTemplate(uriTemplate)
+                    .description(description)
+                    .mimeType(mimeType)
+                    .title(title)
+                    .annotations(annotations)
+                    .icons(icons)
+                    .meta(meta)
+                    .build(),
+            block = block,
+        )
+
+    /**
+     * Registers a prebuilt resource-template descriptor with a suspend handler.
+     *
+     * Callable before or after [start]. Unlike the other `register*` functions this one rejects
+     * duplicates outright rather than replacing — unregister the template first to swap its
+     * handler. Does nothing when the resources capability is off — the call still returns this
+     * server.
+     *
+     * @param descriptor resource-template descriptor
+     * @param block handler invoked for matching resource requests
+     * @return this server
+     * @throws IllegalArgumentException if a template is already registered under the descriptor's
+     * name
+     */
+    @JvmSynthetic
+    public fun registerResourceTemplate(
+        descriptor: ResourceTemplateDescriptor,
+        block: suspend TemplateScope.() -> ResourceContents,
+    ): TachyonServer
+
+    /**
+     * Registers a prompt with a suspend handler, accepting every optional attribute of
+     * [PromptDescriptor.Builder]; pass a prebuilt [PromptDescriptor] instead when a descriptor is
+     * already at hand.
+     *
+     * @param name prompt name; registering an existing name replaces that prompt
+     * @param description optional prompt description
+     * @param title optional human-readable title
+     * @param arguments arguments accepted by this prompt, or an empty list
+     * @param inputSchema optional JSON schema describing the prompt's arguments
+     * @param icons associated icons, or an empty list
+     * @param meta optional protocol extension metadata
+     * @param block handler that generates the prompt messages
+     * @return this server
+     */
+    @JvmSynthetic
+    @Suppress("LongParameterList")
+    public fun registerPrompt(
+        name: String,
+        description: String? = null,
+        title: String? = null,
+        arguments: List<PromptArgument> = emptyList(),
+        inputSchema: JsonSchema? = null,
+        icons: List<Icon> = emptyList(),
+        meta: Map<String, Any>? = null,
+        block: suspend PromptScope.() -> List<PromptMessage>,
+    ): TachyonServer =
+        registerPrompt(
+            descriptor =
+                PromptDescriptor
+                    .builder()
+                    .name(name)
+                    .description(description)
+                    .title(title)
+                    .arguments(arguments)
+                    .inputSchema(inputSchema)
+                    .icons(icons)
+                    .meta(meta)
+                    .build(),
+            block = block,
+        )
+
+    /**
+     * Registers a prebuilt prompt descriptor with a suspend handler.
+     *
+     * Callable before or after [start]. Registering a name that already exists silently replaces
+     * that prompt. Does nothing when the prompts capability is off — the call still returns this
+     * server.
+     *
+     * @param descriptor prompt descriptor
+     * @param block handler invoked for prompt requests
+     * @return this server
+     */
+    @JvmSynthetic
+    public fun registerPrompt(
+        descriptor: PromptDescriptor,
+        block: suspend PromptScope.() -> List<PromptMessage>,
+    ): TachyonServer
+
+    /**
+     * Registers a completion handler for a prompt's arguments.
+     *
+     * Callable before or after [start]. Registering a prompt name that already has a handler
+     * silently replaces it. Does nothing when the completions capability is off — the call still
+     * returns this server.
+     *
+     * @param promptName the prompt name
+     * @param block the suspend function that returns completion candidates
+     * @return this server
+     */
+    @JvmSynthetic
+    public fun registerPromptCompletion(
+        promptName: String,
+        block: suspend CompletionScope.() -> CompletionResult,
+    ): TachyonServer
+
+    /**
+     * Registers a completion handler for a resource template's variables.
+     *
+     * Callable before or after [start]. [uriOrTemplate] is matched verbatim against the URI the
+     * client sends, so it need not name a registered resource. Registering a URI or template that
+     * already has a handler silently replaces it. Does nothing when the completions capability is
+     * off — the call still returns this server.
+     *
+     * @param uriOrTemplate the resource URI or template
+     * @param block the suspend function that returns completion candidates
+     * @return this server
+     */
+    @JvmSynthetic
+    public fun registerResourceCompletion(
+        uriOrTemplate: String,
+        block: suspend CompletionScope.() -> CompletionResult,
+    ): TachyonServer
 }
 
 internal class DefaultKotlinTachyonServer(
@@ -157,6 +404,56 @@ internal class DefaultKotlinTachyonServer(
         block: suspend ToolScope.() -> ToolResult,
     ): TachyonServer {
         tools().registerAsync(descriptor, toolFn(descriptor.name(), coroutineRuntime, block))
+        return this
+    }
+
+    override fun registerResource(
+        descriptor: ResourceDescriptor,
+        block: suspend ResourceScope.() -> ResourceContents,
+    ): TachyonServer {
+        resources().registerAsync(descriptor, resourceFn(descriptor, coroutineRuntime, block))
+        return this
+    }
+
+    override fun registerResourceTemplate(
+        descriptor: ResourceTemplateDescriptor,
+        block: suspend TemplateScope.() -> ResourceContents,
+    ): TachyonServer {
+        resources().registerTemplateAsync(
+            descriptor,
+            templateFn(descriptor, coroutineRuntime, block),
+        )
+        return this
+    }
+
+    override fun registerPrompt(
+        descriptor: PromptDescriptor,
+        block: suspend PromptScope.() -> List<PromptMessage>,
+    ): TachyonServer {
+        prompts().registerAsync(descriptor, promptFn(descriptor, coroutineRuntime, block))
+        return this
+    }
+
+    override fun registerPromptCompletion(
+        promptName: String,
+        block: suspend CompletionScope.() -> CompletionResult,
+    ): TachyonServer {
+        completions().registerForPromptAsync(
+            promptName,
+            promptCompletionFn(promptName, coroutineRuntime, block),
+        )
+        return this
+    }
+
+    override fun registerResourceCompletion(
+        uriOrTemplate: String,
+        block: suspend CompletionScope.() -> CompletionResult,
+    ): TachyonServer {
+        completions()
+            .registerForResourceAsync(
+                uriOrTemplate,
+                resourceCompletionFn(uriOrTemplate, coroutineRuntime, block),
+            )
         return this
     }
 }

--- a/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/config/CompletionScope.kt
+++ b/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/config/CompletionScope.kt
@@ -13,15 +13,28 @@ public class CompletionScope
         public val ctx: InteractionContext,
         public val request: CompletionRequest,
     ) {
-        /** Name of the argument being completed. */
+        /**
+         * Name of the argument being completed.
+         *
+         * Unvalidated client input beyond being non-blank — treat it as untrusted.
+         */
         public val argumentName: String
             get() = request.argumentName()
 
-        /** Current (partial) value typed for the argument. */
+        /**
+         * Current (partial) value typed for the argument.
+         *
+         * Unvalidated client input of unbounded length — never splice it into a SQL predicate,
+         * shell command, or filesystem path without escaping or allow-listing first.
+         */
         public val argumentValue: String
             get() = request.argumentValue()
 
-        /** Previously-resolved argument name/value pairs, or empty if none. */
+        /**
+         * Previously-resolved argument name/value pairs, or empty if none.
+         *
+         * Unvalidated client input, same caveat as [argumentValue].
+         */
         public val resolvedArguments: Map<String, String>
             get() = request.resolvedArguments()
     }

--- a/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/config/CompletionScope.kt
+++ b/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/config/CompletionScope.kt
@@ -1,4 +1,6 @@
 // Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors.
+@file:JvmSynthetic
+
 package dev.tachyonmcp.kotlin.server.config
 
 import dev.tachyonmcp.api.runtime.InteractionContext
@@ -10,4 +12,16 @@ public class CompletionScope
     internal constructor(
         public val ctx: InteractionContext,
         public val request: CompletionRequest,
-    )
+    ) {
+        /** Name of the argument being completed. */
+        public val argumentName: String
+            get() = request.argumentName()
+
+        /** Current (partial) value typed for the argument. */
+        public val argumentValue: String
+            get() = request.argumentValue()
+
+        /** Previously-resolved argument name/value pairs, or empty if none. */
+        public val resolvedArguments: Map<String, String>
+            get() = request.resolvedArguments()
+    }

--- a/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/features/completions/CompletionResultBuilder.kt
+++ b/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/features/completions/CompletionResultBuilder.kt
@@ -1,0 +1,45 @@
+// Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors.
+@file:Suppress("FunctionName")
+
+package dev.tachyonmcp.kotlin.server.features.completions
+
+import dev.tachyonmcp.api.server.features.completions.CompletionResult
+import dev.tachyonmcp.kotlin.server.TachyonDsl
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
+
+/** Builds a [dev.tachyonmcp.api.server.features.completions.CompletionResult]. */
+@TachyonDsl
+public class CompletionResultBuilder
+    @PublishedApi
+    internal constructor() {
+        /** Candidate values ranked by relevance. */
+        public var values: List<String> = emptyList()
+
+        /** Total number of matches, or `null` if unknown. */
+        public var total: Long? = null
+
+        /** Whether additional results exist beyond [values], or `null` if unknown. */
+        public var hasMore: Boolean? = null
+
+        /** Optional protocol extension metadata. */
+        public var meta: Map<String, Any>? = null
+
+        @PublishedApi
+        internal fun build(): CompletionResult =
+            CompletionResult
+                .builder()
+                .values(values)
+                .total(total)
+                .hasMore(hasMore)
+                .meta(meta)
+                .build()
+    }
+
+/** Builds a [CompletionResult] with a receiver DSL. */
+@OptIn(ExperimentalContracts::class)
+public inline fun CompletionResult(block: CompletionResultBuilder.() -> Unit): CompletionResult {
+    contract { callsInPlace(block, InvocationKind.EXACTLY_ONCE) }
+    return CompletionResultBuilder().apply(block).build()
+}

--- a/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/features/completions/CompletionResultBuilder.kt
+++ b/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/features/completions/CompletionResultBuilder.kt
@@ -4,13 +4,17 @@
 package dev.tachyonmcp.kotlin.server.features.completions
 
 import dev.tachyonmcp.api.server.features.completions.CompletionResult
-import dev.tachyonmcp.kotlin.server.TachyonDsl
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
-/** Builds a [dev.tachyonmcp.api.server.features.completions.CompletionResult]. */
-@TachyonDsl
+/**
+ * Builds a [dev.tachyonmcp.api.server.features.completions.CompletionResult].
+ *
+ * Deliberately not a `@TachyonDsl` receiver: nothing nests inside this leaf builder, so the marker
+ * would only hide the enclosing [dev.tachyonmcp.kotlin.server.config.CompletionScope] and block
+ * `CompletionResult { values = candidates.filter { it.startsWith(argumentValue) } }`.
+ */
 public class CompletionResultBuilder
     @PublishedApi
     internal constructor() {


### PR DESCRIPTION
### New Features

- Added Kotlin support for registering resources, resource templates, prompts, and completion handlers after server creation.
- Added prompt and resource completion APIs, including completion result builders and access to completion request arguments.
- Post-build registrations support both descriptor-based and convenience registration patterns.

### Documentation

- Expanded Kotlin documentation with completion concepts, registration behavior, duplicate handling, and capability details.
- Added a complete post-build registration example.

### Tests

- Added end-to-end coverage for post-build registration and prompt/resource completion responses.