### PR TITLE
fix(core)!: Refactor session store around snapshots

### DIFF
--- a/.agents/skills/tachyon-mcp/SKILL.md
+++ b/.agents/skills/tachyon-mcp/SKILL.md
@@ -62,7 +62,7 @@ server.start();
 |---|---|
 | `.info(cfg)` | name, version, description, title, websiteUrl, instructions |
 | `.capabilities(cfg)` | tools/resources/prompts/tasks/completions/logging |
-| `.session(cfg)` | enabled (off by default = stateless), sessionTtl, SessionEventStore, SessionStore, SessionIdGenerator |
+| `.session(cfg)` | enabled (off by default = stateless), sessionTtl, SessionIdGenerator, experimental persistence stores |
 | `.network(cfg)` | host, port, endpointPath, timeouts, CORS, maxContentLength, ioEngine |
 | `.runtime(cfg)` | shutdownGracePeriod, requestTimeout, clock |
 | `.monitoring(cfg)` | slow-request diagnostics (off by default) |
@@ -247,7 +247,7 @@ handler's `InteractionContext` and needs no token.
 | `.sessionTtl(d)` | 30s |
 | `.janitorInterval(d)` | 5s |
 | `.sessionIdGenerator(g)` | `sess_<uuid8>` (derives id from initialize `HttpRequest`) |
-| `.sessionEventStore(r)` / `.sessionStore(s)` | null (in-memory) |
+| `.sessionEventStore(r)` / `.sessionStore(s)` | in-memory (experimental persistence SPIs) |
 
 ### Runtime `runtime(cfg -> ...)`
 

--- a/.agents/skills/tachyon-mcp/resources/java/ConfigReference.java
+++ b/.agents/skills/tachyon-mcp/resources/java/ConfigReference.java
@@ -12,8 +12,6 @@ import dev.tachyonmcp.core.server.config.NetworkConfig;
 import dev.tachyonmcp.core.server.config.ResourcesConfig;
 import dev.tachyonmcp.core.server.config.SessionConfig;
 import dev.tachyonmcp.core.server.config.TasksConfig;
-import dev.tachyonmcp.core.server.session.InMemorySessionEventStore;
-import dev.tachyonmcp.core.server.session.InMemorySessionStore;
 import dev.tachyonmcp.core.transport.netty.NettyIoEngine;
 
 import java.time.Clock;
@@ -107,8 +105,6 @@ final class ConfigReference {
         return SessionConfig.builder()
             .enabled(true) // stateless by default; enable server-side sessions explicitly
             .sessionIdGenerator(SessionIdGenerator.DEFAULT)
-            .sessionEventStore(new InMemorySessionEventStore())
-            .sessionStore(new InMemorySessionStore())
             .sessionTtl(Duration.ofMinutes(10))
             .janitorInterval(Duration.ofSeconds(5))
             .build();

--- a/.agents/skills/tachyon-mcp/resources/kotlin/ServerBasic.kt
+++ b/.agents/skills/tachyon-mcp/resources/kotlin/ServerBasic.kt
@@ -63,8 +63,6 @@ fun assembleServer(port: Int = NetworkConfig.UNSET_PORT): TachyonServer =
             enabled = true
             sessionTtl = 5.minutes
             janitorInterval = 5.seconds
-            sessionStore = null // default: InMemorySessionStore
-            sessionEventStore = null // default: InMemorySessionEventStore
             // lambda DSL
             sessionIdGenerator { _, request -> request?.headers()?.get("X-Tenant-Id") ?: "anon" }
             // or direct assignment, request-independent:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -276,9 +276,19 @@ them on a stateless server fails at construction.
 | `enabled` | `false` | Server-side sessions are off by default (stateless). Set `true` to create sessions with TTL tracking |
 | `sessionTtl` | `30s` | Idle sessions are evicted after this duration |
 | `janitorInterval` | `5s` | Janitor sweep interval; controls how often expired sessions are checked |
-| `sessionEventStore` | in-memory | Custom session event store |
-| `sessionStore` | in-memory | Custom session store |
+| `sessionEventStore` | in-memory | Experimental custom session event store |
+| `sessionStore` | in-memory | Experimental immutable session snapshot store |
 | `sessionIdGenerator` | `sess_<uuid>` | Custom hook for deriving session ids from the initialize `HttpRequest` (headers/URI) |
+
+Live `Session` objects remain internal and process-local. `SessionStore` persists immutable,
+transport-free `SessionSnapshot` values. `SessionEventStore` persists replay events. These
+experimental stores enable restart recovery, but do not distribute live sessions or transport
+connections between nodes.
+
+A persistent implementation can use the session ID as its key and encode the complete snapshot
+as its value. `create` is an atomic put, `find` decodes the value, `compareAndSet` is a conditional
+replace, `touch` conditionally extends the matching generation's expiry, and `terminate` removes
+only the matching generation. Store implementations must make these operations thread-safe.
 
 ## Runtime
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -289,6 +289,8 @@ A persistent implementation can use the session ID as its key and encode the com
 as its value. `create` is an atomic put, `find` decodes the value, `compareAndSet` is a conditional
 replace, `touch` conditionally extends the matching generation's expiry, and `terminate` removes
 only the matching generation. Store implementations must make these operations thread-safe.
+Operations execute synchronously and may perform I/O. Tachyon invokes them outside transport
+event-loop threads. Implementations must be thread-safe.
 
 ## Runtime
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -94,9 +94,11 @@ most MCP clients.
 ## More than one instance
 
 Sessions are off by default, and a stateless server scales horizontally with no
-sticky routing. A server that sets `session.enabled(true)` keeps sessions and
-events in memory, so more than one instance needs sticky routing or shared
-`SessionStore` and `SessionEventStore` implementations. See
+sticky routing. A server that sets `session.enabled(true)` keeps live sessions
+in-process, so more than one instance needs sticky routing while a session is
+active. Experimental `SessionStore` and `SessionEventStore` implementations can
+persist session snapshots and replay events across restarts. They do not
+coordinate live session or transport ownership between nodes. See
 [session configuration](configuration.md#session).
 
 ## Containers

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -58,7 +58,7 @@ Yes, by default. Stateless mode avoids server-side session affinity and is the s
 
 ### When should I enable sessions?
 
-Enable sessions when you need resumable SSE streams, `Last-Event-ID` replay, or session-scoped state. The defaults store sessions and events in memory; clustered deployments need sticky routing or shared `SessionStore` and `SessionEventStore` implementations. See
+Enable sessions when you need resumable SSE streams, `Last-Event-ID` replay, or session-scoped state. Live sessions stay in-process, so clustered deployments need sticky routing while a session is active. Durable `SessionStore` and `SessionEventStore` implementations enable restart recovery, not distributed live-session ownership. See
 [session configuration](configuration.md#session).
 
 ### How should I deploy long-running tools?

--- a/tachyon-core/revapi.json
+++ b/tachyon-core/revapi.json
@@ -1116,6 +1116,60 @@
         {
           "ignore": true,
           "code": "java.method.removed",
+          "old": "method dev.tachyonmcp.core.runtime.Session dev.tachyonmcp.core.server.session.SessionStore::computeIfAbsent(java.lang.String, java.util.function.Function<java.lang.String, dev.tachyonmcp.core.runtime.Session>)",
+          "justification": "SessionStore accidentally exposed mutable process-local transport state; the pre-1.0 contract now persists immutable SessionSnapshot values so durable stores never own live Session objects",
+          "attachments": {
+            "since": "1.0.0-beta.26"
+          }
+        },
+        {
+          "ignore": true,
+          "code": "java.method.removed",
+          "old": "method java.util.Optional<dev.tachyonmcp.core.runtime.Session> dev.tachyonmcp.core.server.session.SessionStore::get(java.lang.String)",
+          "justification": "SessionStore accidentally exposed mutable process-local transport state; the pre-1.0 contract now persists immutable SessionSnapshot values so durable stores never own live Session objects",
+          "attachments": {
+            "since": "1.0.0-beta.26"
+          }
+        },
+        {
+          "ignore": true,
+          "code": "java.method.removed",
+          "old": "method dev.tachyonmcp.core.runtime.Session dev.tachyonmcp.core.server.session.SessionStore::put(java.lang.String, dev.tachyonmcp.core.runtime.Session)",
+          "justification": "SessionStore accidentally exposed mutable process-local transport state; the pre-1.0 contract now persists immutable SessionSnapshot values so durable stores never own live Session objects",
+          "attachments": {
+            "since": "1.0.0-beta.26"
+          }
+        },
+        {
+          "ignore": true,
+          "code": "java.method.removed",
+          "old": "method dev.tachyonmcp.core.runtime.Session dev.tachyonmcp.core.server.session.SessionStore::remove(java.lang.String)",
+          "justification": "SessionStore accidentally exposed mutable process-local transport state; the pre-1.0 contract now persists immutable SessionSnapshot values so durable stores never own live Session objects",
+          "attachments": {
+            "since": "1.0.0-beta.26"
+          }
+        },
+        {
+          "ignore": true,
+          "code": "java.method.removed",
+          "old": "method boolean dev.tachyonmcp.core.server.session.SessionStore::remove(java.lang.String, dev.tachyonmcp.core.runtime.Session)",
+          "justification": "SessionStore accidentally exposed mutable process-local transport state; the pre-1.0 contract now persists immutable SessionSnapshot values so durable stores never own live Session objects",
+          "attachments": {
+            "since": "1.0.0-beta.26"
+          }
+        },
+        {
+          "ignore": true,
+          "code": "java.method.removed",
+          "old": "method java.util.Collection<dev.tachyonmcp.core.runtime.Session> dev.tachyonmcp.core.server.session.SessionStore::values()",
+          "justification": "SessionStore accidentally exposed mutable process-local transport state; the pre-1.0 contract now persists immutable SessionSnapshot values so durable stores never own live Session objects",
+          "attachments": {
+            "since": "1.0.0-beta.26"
+          }
+        },
+        {
+          "ignore": true,
+          "code": "java.method.removed",
           "old": "method dev.tachyonmcp.core.server.ServerBuilder dev.tachyonmcp.core.server.ServerBuilder::monitoring(java.util.function.Consumer<dev.tachyonmcp.api.server.config.MonitoringConfig.Builder>)",
           "justification": "ADD YOUR EXPLANATION FOR THE NECESSITY OF THIS CHANGE",
           "attachments": {

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/runtime/Session.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/runtime/Session.java
@@ -1,12 +1,19 @@
 /* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
 package dev.tachyonmcp.core.runtime;
 
+import dev.tachyonmcp.api.annotations.InternalApi;
+import dev.tachyonmcp.api.server.domain.LoggingLevel;
 import dev.tachyonmcp.core.protocol.Protocol;
+import dev.tachyonmcp.core.protocol.Protocols;
+import dev.tachyonmcp.core.server.session.SessionKey;
+import dev.tachyonmcp.core.server.session.SessionSnapshot;
+import java.time.Instant;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -14,9 +21,13 @@ import org.jspecify.annotations.Nullable;
  * the SSE channel (connection, backpressure, replay cursor) for a single client identified by
  * a unique string ID1
  */
+@InternalApi(since = "1.0.0-beta.26")
 public class Session {
 
     private final String id;
+    private final SessionKey key;
+    private final Consumer<Session> onChange;
+    private final Consumer<Session> onTouch;
     protected final AtomicReference<SessionState> state;
     protected volatile long lastActivityNanos;
 
@@ -25,20 +36,58 @@ public class Session {
     private final AtomicLong cursor;
     private final Set<String> enabledExtensions = ConcurrentHashMap.newKeySet();
     private final AtomicReference<@Nullable Protocol> protocol = new AtomicReference<>();
+    private final AtomicReference<@Nullable LoggingLevel> loggingLevel = new AtomicReference<>();
+    private final AtomicReference<Instant> snapshotExpiresAt;
     private volatile @Nullable String resumingStreamKey;
 
     public Session(String id, SseConnection connection) {
-        this.id = Objects.requireNonNull(id, "id");
-        this.state = new AtomicReference<>(SessionState.INITIALIZING);
+        this(
+                new SessionSnapshot(
+                        new SessionKey(id, "local"), SessionState.INITIALIZING, null, Set.of(), null, Instant.MAX, 0),
+                connection,
+                ignored -> {},
+                ignored -> {});
+    }
+
+    private Session(
+            SessionSnapshot snapshot, SseConnection connection, Consumer<Session> onChange, Consumer<Session> onTouch) {
+        this.id = snapshot.key().sessionId();
+        this.key = snapshot.key();
+        this.onChange = Objects.requireNonNull(onChange, "onChange");
+        this.onTouch = Objects.requireNonNull(onTouch, "onTouch");
+        this.state = new AtomicReference<>(snapshot.state());
         this.lastActivityNanos = System.nanoTime();
         this.connection = new AtomicReference<>(Objects.requireNonNull(connection, "connection"));
         this.backpressure = new AtomicReference<>(Backpressure.HOT);
         this.cursor = new AtomicLong(-1);
+        this.enabledExtensions.addAll(snapshot.enabledExtensionIds());
+        this.loggingLevel.set(snapshot.loggingLevel());
+        this.snapshotExpiresAt = new AtomicReference<>(snapshot.expiresAt());
+        final var protocolVersion = snapshot.protocolVersion();
+        if (protocolVersion != null) {
+            final var restoredProtocol = Protocols.list().stream()
+                    .filter(candidate -> candidate.versionString().equals(snapshot.protocolVersion()))
+                    .findFirst()
+                    .orElseThrow(() ->
+                            new IllegalArgumentException("Unsupported session protocol version: " + protocolVersion));
+            protocol.set(restoredProtocol);
+        }
+    }
+
+    /** Reconstructs process-local runtime state from a transport-free snapshot. */
+    public static Session fromSnapshot(
+            SessionSnapshot snapshot, SseConnection connection, Consumer<Session> onChange, Consumer<Session> onTouch) {
+        return new Session(snapshot, connection, onChange, onTouch);
     }
 
     /** Returns the unique session identifier. */
     public String id() {
         return id;
+    }
+
+    /** Returns the persisted generation key. */
+    public SessionKey key() {
+        return key;
     }
 
     /** Returns the current session state. */
@@ -54,12 +103,14 @@ public class Session {
     /** Updates the last-activity timestamp to now. */
     public void touch() {
         this.lastActivityNanos = System.nanoTime();
+        onTouch.accept(this);
     }
 
     /** Transitions from {@link SessionState#INITIALIZING} to {@link SessionState#ACTIVE}. */
     public boolean activate() {
         if (state.compareAndSet(SessionState.INITIALIZING, SessionState.ACTIVE)) {
             this.lastActivityNanos = System.nanoTime();
+            onChange.accept(this);
             return true;
         }
         return false;
@@ -140,17 +191,62 @@ public class Session {
 
     /** Records the protocol negotiated when this session was initialized. */
     public void protocol(Protocol protocol) {
-        this.protocol.compareAndSet(null, Objects.requireNonNull(protocol, "protocol"));
+        if (this.protocol.compareAndSet(null, Objects.requireNonNull(protocol, "protocol"))) {
+            onChange.accept(this);
+        }
     }
 
     /** Enables an extension for this session. */
     public void enableExtension(String extensionId) {
-        enabledExtensions.add(extensionId);
+        if (enabledExtensions.add(extensionId)) {
+            onChange.accept(this);
+        }
+    }
+
+    /** Returns the enabled extension identifiers. */
+    public Set<String> enabledExtensionIds() {
+        return Set.copyOf(enabledExtensions);
     }
 
     /** Returns whether the given extension is enabled for this session. */
     public boolean isExtensionEnabled(String extensionId) {
         return enabledExtensions.contains(extensionId);
+    }
+
+    /** Returns the client-selected logging threshold, if configured. */
+    public @Nullable LoggingLevel loggingLevel() {
+        return loggingLevel.get();
+    }
+
+    /** Records the client-selected logging threshold. */
+    public void loggingLevel(LoggingLevel level) {
+        var next = Objects.requireNonNull(level, "level");
+        if (loggingLevel.getAndSet(next) != next) {
+            onChange.accept(this);
+        }
+    }
+
+    /** Captures transport-free state for durable storage. */
+    public SessionSnapshot snapshot(Instant expiresAt, long revision) {
+        var negotiatedProtocol = protocol.get();
+        return new SessionSnapshot(
+                key,
+                state(),
+                negotiatedProtocol != null ? negotiatedProtocol.versionString() : null,
+                enabledExtensionIds(),
+                loggingLevel(),
+                expiresAt,
+                revision);
+    }
+
+    /** Returns the expiry represented by the last snapshot persisted by this runtime. */
+    public Instant snapshotExpiresAt() {
+        return snapshotExpiresAt.get();
+    }
+
+    /** Records the expiry represented by the last snapshot persisted by this runtime. */
+    public void snapshotExpiresAt(Instant expiresAt) {
+        snapshotExpiresAt.set(Objects.requireNonNull(expiresAt, "expiresAt"));
     }
 
     /** Recomputes and returns the backpressure state based on stream writability. */
@@ -194,6 +290,7 @@ public class Session {
         if (closed) {
             var conn = connection.getAndSet(SseConnection.noop());
             conn.close();
+            onChange.accept(this);
         }
         return closed;
     }

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/runtime/Session.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/runtime/Session.java
@@ -37,7 +37,7 @@ public class Session {
     private final Set<String> enabledExtensions = ConcurrentHashMap.newKeySet();
     private final AtomicReference<@Nullable Protocol> protocol = new AtomicReference<>();
     private final AtomicReference<@Nullable LoggingLevel> loggingLevel = new AtomicReference<>();
-    private final AtomicReference<Instant> snapshotExpiresAt;
+    private final AtomicReference<SessionSnapshot> persistedSnapshot;
     private volatile @Nullable String resumingStreamKey;
 
     public Session(String id, SseConnection connection) {
@@ -62,7 +62,7 @@ public class Session {
         this.cursor = new AtomicLong(-1);
         this.enabledExtensions.addAll(snapshot.enabledExtensionIds());
         this.loggingLevel.set(snapshot.loggingLevel());
-        this.snapshotExpiresAt = new AtomicReference<>(snapshot.expiresAt());
+        this.persistedSnapshot = new AtomicReference<>(snapshot);
         final var protocolVersion = snapshot.protocolVersion();
         if (protocolVersion != null) {
             final var restoredProtocol = Protocols.list().stream()
@@ -239,14 +239,14 @@ public class Session {
                 revision);
     }
 
-    /** Returns the expiry represented by the last snapshot persisted by this runtime. */
-    public Instant snapshotExpiresAt() {
-        return snapshotExpiresAt.get();
+    /** Returns the last snapshot persisted by this runtime. */
+    public SessionSnapshot persistedSnapshot() {
+        return persistedSnapshot.get();
     }
 
-    /** Records the expiry represented by the last snapshot persisted by this runtime. */
-    public void snapshotExpiresAt(Instant expiresAt) {
-        snapshotExpiresAt.set(Objects.requireNonNull(expiresAt, "expiresAt"));
+    /** Records the last snapshot persisted by this runtime. */
+    public void persistedSnapshot(SessionSnapshot snapshot) {
+        persistedSnapshot.set(Objects.requireNonNull(snapshot, "snapshot"));
     }
 
     /** Recomputes and returns the backpressure state based on stream writability. */

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/runtime/SessionState.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/runtime/SessionState.java
@@ -1,7 +1,10 @@
 /* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
 package dev.tachyonmcp.core.runtime;
 
+import dev.tachyonmcp.api.annotations.ExperimentalApi;
+
 /** Lifecycle states for a session. */
+@ExperimentalApi(since = "1.0.0-beta.26")
 public enum SessionState {
     /** Session created, not yet initialized. */
     INITIALIZING,

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/DefaultTachyonServer.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/DefaultTachyonServer.java
@@ -295,7 +295,8 @@ final class DefaultTachyonServer implements ServerEngine, ExtensionContext {
         this.sessionManager = new SessionManager(
                 sessionStore,
                 config.runtime().clock(),
-                configuredSessionTtl != null ? configuredSessionTtl : SessionConfig.DEFAULT_SESSION_TTL);
+                configuredSessionTtl != null ? configuredSessionTtl : SessionConfig.DEFAULT_SESSION_TTL,
+                executor);
         final JsonSchemaValidator inputValidator1 =
                 inputValidator != null ? inputValidator : new NetworkntJsonSchemaValidator();
         final JsonSchemaValidator outputValidator1 = outputValidator != null ? outputValidator : inputValidator1;
@@ -683,6 +684,11 @@ final class DefaultTachyonServer implements ServerEngine, ExtensionContext {
     @Override
     public Optional<Session> getSession(String sessionId) {
         return sessionManager.getSession(sessionId);
+    }
+
+    @Override
+    public Optional<Session> getLocalSession(String sessionId) {
+        return sessionManager.getLocalSession(sessionId);
     }
 
     @Override

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/DefaultTachyonServer.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/DefaultTachyonServer.java
@@ -32,6 +32,7 @@ import dev.tachyonmcp.core.runtime.Session;
 import dev.tachyonmcp.core.runtime.SessionState;
 import dev.tachyonmcp.core.runtime.SseEvent;
 import dev.tachyonmcp.core.server.config.ServerConfig;
+import dev.tachyonmcp.core.server.config.SessionConfig;
 import dev.tachyonmcp.core.server.features.completions.CompletionMethodHandlers;
 import dev.tachyonmcp.core.server.features.completions.DefaultCompletionRegistry;
 import dev.tachyonmcp.core.server.features.prompts.DefaultPromptRegistry;
@@ -109,7 +110,6 @@ final class DefaultTachyonServer implements ServerEngine, ExtensionContext {
     private final PayloadSerializer payloadSerializer;
     private final PayloadDeserializer payloadDeserializer;
     private final Map<String, RpcMethodHandler<?, ?>> methodHandlers = new ConcurrentHashMap<>();
-    final Map<String, LoggingLevel> loggingLevels = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<RequestId, PendingRequestEntry> pendingRequests = new ConcurrentHashMap<>();
     private final ExecutorService executor;
     private final List<ServerExtension> extensions;
@@ -171,13 +171,13 @@ final class DefaultTachyonServer implements ServerEngine, ExtensionContext {
 
     @Override
     public void setLoggingLevel(String sessionId, LoggingLevel level) {
-        loggingLevels.put(sessionId, level);
+        sessionManager.getSession(sessionId).ifPresent(session -> session.loggingLevel(level));
     }
 
     @Override
     @Nullable
     public LoggingLevel getLoggingLevel(String sessionId) {
-        return loggingLevels.get(sessionId);
+        return sessionManager.getSession(sessionId).map(Session::loggingLevel).orElse(null);
     }
 
     /**
@@ -291,7 +291,11 @@ final class DefaultTachyonServer implements ServerEngine, ExtensionContext {
         this.port = config.network().port();
         this.extensions = extensions != null ? extensions : List.of();
         this.pipelineCustomizer = pipelineCustomizer;
-        this.sessionManager = new SessionManager(sessionStore);
+        var configuredSessionTtl = config.session().sessionTtl();
+        this.sessionManager = new SessionManager(
+                sessionStore,
+                config.runtime().clock(),
+                configuredSessionTtl != null ? configuredSessionTtl : SessionConfig.DEFAULT_SESSION_TTL);
         final JsonSchemaValidator inputValidator1 =
                 inputValidator != null ? inputValidator : new NetworkntJsonSchemaValidator();
         final JsonSchemaValidator outputValidator1 = outputValidator != null ? outputValidator : inputValidator1;
@@ -662,7 +666,8 @@ final class DefaultTachyonServer implements ServerEngine, ExtensionContext {
             if (session.state() != SessionState.ACTIVE) {
                 continue;
             }
-            var threshold = loggingLevels.getOrDefault(session.id(), LoggingLevel.INFO);
+            var configuredLevel = session.loggingLevel();
+            var threshold = configuredLevel != null ? configuredLevel : LoggingLevel.INFO;
             if (level.ordinal() < threshold.ordinal()) {
                 continue;
             }

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/config/SessionConfig.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/config/SessionConfig.java
@@ -1,6 +1,7 @@
 /* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
 package dev.tachyonmcp.core.server.config;
 
+import dev.tachyonmcp.api.annotations.ExperimentalApi;
 import dev.tachyonmcp.api.server.session.SessionIdGenerator;
 import dev.tachyonmcp.core.server.session.InMemorySessionEventStore;
 import dev.tachyonmcp.core.server.session.InMemorySessionStore;
@@ -25,8 +26,8 @@ import org.jspecify.annotations.Nullable;
 public record SessionConfig(
         boolean enabled,
         @Nullable Duration sessionTtl,
-        @Nullable SessionEventStore sessionEventStore,
-        @Nullable SessionStore sessionStore,
+        @ExperimentalApi(since = "1.0.0-beta.26") @Nullable SessionEventStore sessionEventStore,
+        @ExperimentalApi(since = "1.0.0-beta.26") @Nullable SessionStore sessionStore,
         @Nullable SessionIdGenerator<? super HttpRequest> sessionIdGenerator,
         @Nullable Duration janitorInterval) {
 
@@ -96,14 +97,16 @@ public record SessionConfig(
         /**
          * Sets a custom session event store.
          */
+        @ExperimentalApi(since = "1.0.0-beta.26")
         public Builder sessionEventStore(@Nullable SessionEventStore store) {
             this.sessionEventStore = store;
             return this;
         }
 
         /**
-         * Sets a custom session store implementation.
+         * Sets a custom immutable session snapshot store.
          */
+        @ExperimentalApi(since = "1.0.0-beta.26")
         public Builder sessionStore(@Nullable SessionStore store) {
             this.sessionStore = store;
             return this;

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/internal/ServerEngine.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/internal/ServerEngine.java
@@ -83,6 +83,9 @@ public interface ServerEngine extends TachyonServer {
     /** Returns the session with the given ID, if present. */
     Optional<Session> getSession(String sessionId);
 
+    /** Returns only a process-local session, without consulting persistent storage. */
+    Optional<Session> getLocalSession(String sessionId);
+
     /** Removes and closes the session with the given ID. */
     void removeSession(String sessionId);
 

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/session/InMemorySessionStore.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/session/InMemorySessionStore.java
@@ -2,51 +2,63 @@
 package dev.tachyonmcp.core.server.session;
 
 import dev.tachyonmcp.api.annotations.InternalApi;
-import dev.tachyonmcp.core.runtime.Session;
-import java.util.Collection;
+import dev.tachyonmcp.core.runtime.SessionState;
+import java.time.Instant;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.function.Function;
-import org.jspecify.annotations.Nullable;
 
+/** Default process-local session snapshot store. */
 @InternalApi
-public class InMemorySessionStore implements SessionStore {
+public final class InMemorySessionStore implements SessionStore {
 
-    private final ConcurrentHashMap<String, Session> sessions = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, SessionSnapshot> snapshots = new ConcurrentHashMap<>();
 
     @Override
-    public @Nullable Session put(String sessionId, Session session) {
-        return sessions.put(sessionId, session);
+    public SessionSnapshot create(SessionKey key, Instant expiresAt) {
+        final var snapshot = new SessionSnapshot(key, SessionState.INITIALIZING, null, Set.of(), null, expiresAt, 0);
+        snapshots.put(key.sessionId(), snapshot);
+        return snapshot;
     }
 
     @Override
-    public Optional<Session> get(String sessionId) {
-        return Optional.ofNullable(sessions.get(sessionId));
+    public Optional<SessionSnapshot> find(String sessionId) {
+        return Optional.ofNullable(snapshots.get(sessionId));
     }
 
     @Override
-    public Session computeIfAbsent(String sessionId, Function<String, Session> factory) {
-        return sessions.computeIfAbsent(sessionId, factory);
+    public boolean compareAndSet(SessionSnapshot expected, SessionSnapshot updated) {
+        if (!expected.key().equals(updated.key()) || updated.revision() <= expected.revision()) {
+            return false;
+        }
+        return snapshots.replace(expected.key().sessionId(), expected, updated);
     }
 
     @Override
-    public Collection<Session> values() {
-        return sessions.values();
+    public boolean touch(SessionKey key, Instant expiresAt) {
+        final var touched = new boolean[1];
+        snapshots.computeIfPresent(key.sessionId(), (sessionId, current) -> {
+            if (!current.key().equals(key)) {
+                return current;
+            }
+            touched[0] = true;
+            return new SessionSnapshot(
+                    current.key(),
+                    current.state(),
+                    current.protocolVersion(),
+                    current.enabledExtensionIds(),
+                    current.loggingLevel(),
+                    expiresAt,
+                    current.revision() + 1);
+        });
+        return touched[0];
     }
 
     @Override
-    public @Nullable Session remove(String sessionId) {
-        return sessions.remove(sessionId);
-    }
-
-    @Override
-    public boolean remove(String sessionId, Session expected) {
-        // Not sessions.remove(key, value): that compares by equals, and Session.equals is
-        // id-based — it would match (and evict) a replacement instance under the same id.
-        // computeIfPresent gives an atomic identity-conditional remove.
-        var removed = new boolean[1];
-        sessions.computeIfPresent(sessionId, (id, current) -> {
-            if (current == expected) {
+    public boolean terminate(SessionKey key) {
+        final var removed = new boolean[1];
+        snapshots.computeIfPresent(key.sessionId(), (sessionId, current) -> {
+            if (current.key().equals(key)) {
                 removed[0] = true;
                 return null;
             }
@@ -57,6 +69,6 @@ public class InMemorySessionStore implements SessionStore {
 
     @Override
     public void close() {
-        sessions.clear();
+        snapshots.clear();
     }
 }

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/session/SessionEvent.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/session/SessionEvent.java
@@ -1,12 +1,12 @@
 /* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
 package dev.tachyonmcp.core.server.session;
 
-import dev.tachyonmcp.api.annotations.InternalApi;
+import dev.tachyonmcp.api.annotations.ExperimentalApi;
 import dev.tachyonmcp.api.server.domain.RequestId;
 import org.jspecify.annotations.Nullable;
 
 /** A recorded session event — request, response, notification, or cancellation. */
-@InternalApi
+@ExperimentalApi(since = "1.0.0-beta.26")
 public sealed interface SessionEvent {
 
     /** The session this event belongs to. */

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/session/SessionEventStore.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/session/SessionEventStore.java
@@ -1,12 +1,14 @@
 /* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
 package dev.tachyonmcp.core.server.session;
 
+import dev.tachyonmcp.api.annotations.ExperimentalApi;
 import java.io.Closeable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Predicate;
 
 /** Persists and replays session events (request/responses, notifications). */
+@ExperimentalApi(since = "1.0.0-beta.26")
 public interface SessionEventStore extends Closeable {
     /** Appends an event to the log. */
     void append(SessionEvent event);

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/session/SessionKey.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/session/SessionKey.java
@@ -1,0 +1,25 @@
+/* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
+package dev.tachyonmcp.core.server.session;
+
+import dev.tachyonmcp.api.annotations.ExperimentalApi;
+import java.util.Objects;
+
+/**
+ * Identifies one generation of an MCP session.
+ *
+ * @param sessionId stable client-visible session identifier
+ * @param generationId opaque identifier that fences stale lifecycle work
+ */
+@ExperimentalApi(since = "1.0.0-beta.26")
+public record SessionKey(String sessionId, String generationId) {
+
+    /** Validates the session and generation identifiers. */
+    public SessionKey {
+        if (Objects.requireNonNull(sessionId, "sessionId").isBlank()) {
+            throw new IllegalArgumentException("sessionId cannot be blank");
+        }
+        if (Objects.requireNonNull(generationId, "generationId").isBlank()) {
+            throw new IllegalArgumentException("generationId cannot be blank");
+        }
+    }
+}

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/session/SessionManager.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/session/SessionManager.java
@@ -14,7 +14,9 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.Executor;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.locks.ReentrantLock;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -25,24 +27,32 @@ public final class SessionManager implements AutoCloseable {
 
     private static final Logger logger = LoggerFactory.getLogger(SessionManager.class);
     private final ConcurrentHashMap<String, Session> sessions = new ConcurrentHashMap<>();
-    private final ConcurrentHashMap<String, CreationLock> creationLocks = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, LifecycleLock> lifecycleLocks = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<SessionKey, Boolean> pendingExpiryRefreshes = new ConcurrentHashMap<>();
     private final SessionStore store;
     private final Clock clock;
+    private final Executor persistenceExecutor;
     private volatile Duration ttl;
     private volatile Duration expiryRefreshMargin;
     private @Nullable AbstractJanitor janitor;
 
     /** Creates a manager using the system clock and a five-minute snapshot TTL. */
     public SessionManager(SessionStore store) {
-        this(store, Clock.systemUTC(), Duration.ofMinutes(5));
+        this(store, Clock.systemUTC(), Duration.ofMinutes(5), Runnable::run);
     }
 
     /** Creates a manager with explicit time sources for deterministic lifecycle handling. */
     public SessionManager(SessionStore store, Clock clock, Duration ttl) {
+        this(store, clock, ttl, Runnable::run);
+    }
+
+    /** Creates a manager that delegates expiry refreshes to the supplied executor. */
+    public SessionManager(SessionStore store, Clock clock, Duration ttl, Executor persistenceExecutor) {
         this.store = store;
         this.clock = clock;
         this.ttl = ttl;
         this.expiryRefreshMargin = ttl.dividedBy(2);
+        this.persistenceExecutor = persistenceExecutor;
     }
 
     /** Creates a session with no initial connection. */
@@ -67,15 +77,39 @@ public final class SessionManager implements AutoCloseable {
         if (sessionId == null) {
             return Optional.empty();
         }
-        var local = sessions.get(sessionId);
+        final var local = sessions.get(sessionId);
         if (local != null) {
             return Optional.of(local);
         }
-        var persisted = store.find(sessionId);
+        return hydrate(sessionId);
+    }
+
+    /** Returns the process-local runtime without consulting the snapshot store. */
+    public Optional<Session> getLocalSession(@Nullable String sessionId) {
+        return Optional.ofNullable(sessionId == null ? null : sessions.get(sessionId));
+    }
+
+    private Optional<Session> hydrate(String sessionId) {
+        final var lifecycleLock = acquireLifecycleLock(sessionId);
+        lifecycleLock.lock();
+        try {
+            final var local = sessions.get(sessionId);
+            if (local != null) {
+                return Optional.of(local);
+            }
+            return hydrateAbsent(sessionId);
+        } finally {
+            lifecycleLock.unlock();
+            releaseLifecycleLock(sessionId, lifecycleLock);
+        }
+    }
+
+    private Optional<Session> hydrateAbsent(String sessionId) {
+        final var persisted = store.find(sessionId);
         if (persisted.isEmpty()) {
             return Optional.empty();
         }
-        var snapshot = persisted.orElseThrow();
+        final var snapshot = persisted.orElseThrow();
         if (snapshot.state() == SessionState.CLOSED || !snapshot.expiresAt().isAfter(clock.instant())) {
             store.terminate(snapshot.key());
             return Optional.empty();
@@ -90,11 +124,7 @@ public final class SessionManager implements AutoCloseable {
                     snapshot.protocolVersion());
             return Optional.empty();
         }
-        var winner = sessions.putIfAbsent(sessionId, hydrated);
-        if (winner != null) {
-            hydrated.close();
-            return Optional.of(winner);
-        }
+        sessions.put(sessionId, hydrated);
         return Optional.of(hydrated);
     }
 
@@ -105,12 +135,7 @@ public final class SessionManager implements AutoCloseable {
 
     /** Removes and closes the current generation for the session ID. */
     public void removeSession(String sessionId) {
-        var removed = new AtomicReference<Session>();
-        sessions.computeIfPresent(sessionId, (id, current) -> {
-            removed.set(current);
-            return null;
-        });
-        var local = removed.get();
+        final var local = sessions.remove(sessionId);
         if (local != null) {
             store.terminate(local.key());
             local.close();
@@ -151,15 +176,7 @@ public final class SessionManager implements AutoCloseable {
     }
 
     private void removeIfCurrent(Session expected) {
-        var removed = new boolean[1];
-        sessions.computeIfPresent(expected.id(), (id, current) -> {
-            if (current == expected) {
-                removed[0] = true;
-                return null;
-            }
-            return current;
-        });
-        if (removed[0]) {
+        if (sessions.remove(expected.id(), expected)) {
             store.terminate(expected.key());
             expected.close();
         }
@@ -170,33 +187,33 @@ public final class SessionManager implements AutoCloseable {
     }
 
     private Creation createAndInstall(String sessionId, SseConnection connection) {
-        final var creationLock = acquireCreationLock(sessionId);
+        final var lifecycleLock = acquireLifecycleLock(sessionId);
+        lifecycleLock.lock();
         try {
-            synchronized (creationLock) {
-                final var key = new SessionKey(sessionId, UUID.randomUUID().toString());
-                final var snapshot = store.create(key, expiresAt());
-                final var created = runtime(snapshot, connection);
-                return new Creation(created, sessions.put(sessionId, created));
-            }
+            final var key = new SessionKey(sessionId, UUID.randomUUID().toString());
+            final var snapshot = store.create(key, expiresAt());
+            final var created = runtime(snapshot, connection);
+            return new Creation(created, sessions.put(sessionId, created));
         } finally {
-            releaseCreationLock(sessionId, creationLock);
+            lifecycleLock.unlock();
+            releaseLifecycleLock(sessionId, lifecycleLock);
         }
     }
 
-    private CreationLock acquireCreationLock(String sessionId) {
-        return creationLocks.compute(sessionId, (id, current) -> {
-            final var lock = current == null ? new CreationLock() : current;
+    private LifecycleLock acquireLifecycleLock(String sessionId) {
+        return lifecycleLocks.compute(sessionId, (id, current) -> {
+            final var lock = current == null ? new LifecycleLock() : current;
             lock.retain();
             return lock;
         });
     }
 
-    private void releaseCreationLock(String sessionId, CreationLock creationLock) {
-        creationLocks.computeIfPresent(sessionId, (id, current) -> {
-            if (current != creationLock) {
+    private void releaseLifecycleLock(String sessionId, LifecycleLock lifecycleLock) {
+        lifecycleLocks.computeIfPresent(sessionId, (id, current) -> {
+            if (current != lifecycleLock) {
                 return current;
             }
-            return creationLock.release() ? null : creationLock;
+            return lifecycleLock.release() ? null : lifecycleLock;
         });
     }
 
@@ -209,17 +226,14 @@ public final class SessionManager implements AutoCloseable {
                 return;
             }
             try {
-                final var current = store.find(session.id());
-                if (current.isEmpty() || !current.orElseThrow().key().equals(session.key())) {
-                    return;
-                }
-                final var expected = current.orElseThrow();
+                final var expected = session.persistedSnapshot();
                 final var updated = session.snapshot(expiresAt(), expected.revision() + 1);
                 if (store.compareAndSet(expected, updated)) {
-                    session.snapshotExpiresAt(updated.expiresAt());
+                    session.persistedSnapshot(updated);
                     return;
                 }
                 logger.warn("Session snapshot update lost ownership: {}", session.id());
+                evictLocal(session);
             } catch (RuntimeException e) {
                 logger.warn("Failed to persist session snapshot: {}", session.id(), e);
             }
@@ -227,31 +241,73 @@ public final class SessionManager implements AutoCloseable {
     }
 
     private void touch(Session session) {
-        if (sessions.get(session.id()) != session) {
+        if (sessions.get(session.id()) != session || !refreshDue(session, clock.millis())) {
             return;
         }
+        if (pendingExpiryRefreshes.putIfAbsent(session.key(), Boolean.TRUE) != null) {
+            return;
+        }
+        try {
+            persistenceExecutor.execute(() -> refreshExpiry(session));
+        } catch (RejectedExecutionException e) {
+            pendingExpiryRefreshes.remove(session.key());
+            logger.debug("Session expiry refresh rejected during shutdown: {}", session.id());
+        }
+    }
+
+    private void refreshExpiry(Session session) {
+        try {
+            refreshExpiryIfDue(session);
+        } finally {
+            pendingExpiryRefreshes.remove(session.key());
+        }
+    }
+
+    private void refreshExpiryIfDue(Session session) {
         synchronized (session) {
             if (sessions.get(session.id()) != session) {
                 return;
             }
             final var now = clock.instant();
-            final var refreshAt = session.snapshotExpiresAt().minus(expiryRefreshMargin);
+            final var expected = session.persistedSnapshot();
+            final var refreshAt = expected.expiresAt().minus(expiryRefreshMargin);
             if (now.isBefore(refreshAt)) {
                 return;
             }
             final var updatedExpiry = now.plus(ttl);
             try {
                 if (store.touch(session.key(), updatedExpiry)) {
-                    session.snapshotExpiresAt(updatedExpiry);
+                    session.persistedSnapshot(refreshed(expected, updatedExpiry));
                 } else {
                     logger.warn("Session expiry refresh lost ownership: {}", session.id());
-                    if (sessions.remove(session.id(), session)) {
-                        session.close();
-                    }
+                    evictLocal(session);
                 }
             } catch (RuntimeException e) {
                 logger.warn("Failed to refresh session snapshot expiry: {}", session.id(), e);
             }
+        }
+    }
+
+    private boolean refreshDue(Session session, long nowMillis) {
+        final var refreshAtMillis =
+                session.persistedSnapshot().expiresAt().toEpochMilli() - expiryRefreshMargin.toMillis();
+        return nowMillis >= refreshAtMillis;
+    }
+
+    private static SessionSnapshot refreshed(SessionSnapshot expected, Instant expiresAt) {
+        return new SessionSnapshot(
+                expected.key(),
+                expected.state(),
+                expected.protocolVersion(),
+                expected.enabledExtensionIds(),
+                expected.loggingLevel(),
+                expiresAt,
+                expected.revision() + 1);
+    }
+
+    private void evictLocal(Session session) {
+        if (sessions.remove(session.id(), session)) {
+            session.close();
         }
     }
 
@@ -261,24 +317,41 @@ public final class SessionManager implements AutoCloseable {
 
     @Override
     public void close() {
+        if (janitor != null) {
+            janitor.close();
+        }
+        final var local = List.copyOf(sessions.values());
+        sessions.clear();
+        local.forEach(this::closeLocal);
         try {
-            if (janitor != null) {
-                janitor.close();
-            }
-            var local = List.copyOf(sessions.values());
-            sessions.clear();
-            local.forEach(Session::close);
             store.close();
             logger.debug("SessionManager closed");
         } catch (Exception e) {
-            logger.warn("Error while closing SessionManager", e);
+            logger.warn("Failed to close session store", e);
+        }
+    }
+
+    private void closeLocal(Session session) {
+        try {
+            session.close();
+        } catch (RuntimeException e) {
+            logger.warn("Failed to close session: {}", session.id(), e);
         }
     }
 
     private record Creation(Session created, @Nullable Session replaced) {}
 
-    private static final class CreationLock {
+    private static final class LifecycleLock {
+        private final ReentrantLock delegate = new ReentrantLock();
         private int users;
+
+        void lock() {
+            delegate.lock();
+        }
+
+        void unlock() {
+            delegate.unlock();
+        }
 
         void retain() {
             users++;

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/session/SessionManager.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/session/SessionManager.java
@@ -6,25 +6,43 @@ import dev.tachyonmcp.core.runtime.Session;
 import dev.tachyonmcp.core.runtime.SessionState;
 import dev.tachyonmcp.core.runtime.SseConnection;
 import dev.tachyonmcp.core.server.internal.AbstractJanitor;
+import java.time.Clock;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicReference;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** Manages the lifecycle of MCP sessions. */
+/** Coordinates process-local session runtimes with immutable persisted snapshots. */
 @InternalApi
-public class SessionManager implements AutoCloseable {
+public final class SessionManager implements AutoCloseable {
 
     private static final Logger logger = LoggerFactory.getLogger(SessionManager.class);
-
+    private final ConcurrentHashMap<String, Session> sessions = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, CreationLock> creationLocks = new ConcurrentHashMap<>();
     private final SessionStore store;
+    private final Clock clock;
+    private volatile Duration ttl;
+    private volatile Duration expiryRefreshMargin;
     private @Nullable AbstractJanitor janitor;
 
-    /** Creates a session manager backed by the given store. */
+    /** Creates a manager using the system clock and a five-minute snapshot TTL. */
     public SessionManager(SessionStore store) {
+        this(store, Clock.systemUTC(), Duration.ofMinutes(5));
+    }
+
+    /** Creates a manager with explicit time sources for deterministic lifecycle handling. */
+    public SessionManager(SessionStore store, Clock clock, Duration ttl) {
         this.store = store;
+        this.clock = clock;
+        this.ttl = ttl;
+        this.expiryRefreshMargin = ttl.dividedBy(2);
     }
 
     /** Creates a session with no initial connection. */
@@ -32,42 +50,80 @@ public class SessionManager implements AutoCloseable {
         return createSession(sessionId, SseConnection.noop());
     }
 
-    /** Creates a session with the given SSE connection. */
+    /** Creates a new persisted generation with the given process-local SSE connection. */
     public Session createSession(String sessionId, SseConnection connection) {
-        var session = new Session(sessionId, connection);
-        var previous = store.put(sessionId, session);
+        final var creation = createAndInstall(sessionId, connection);
+        final var previous = creation.replaced();
         if (previous != null) {
-            logger.debug("Replaced existing session: {}", sessionId);
             previous.close();
+            logger.debug("Replaced existing session: {}", sessionId);
         }
         logger.info("Session created: {}", sessionId);
-        return session;
+        return creation.created();
     }
 
-    /** Returns the session for the given ID, if present. */
+    /** Returns the local runtime, reconstructing it from a non-expired snapshot when absent. */
     public Optional<Session> getSession(@Nullable String sessionId) {
         if (sessionId == null) {
             return Optional.empty();
         }
-        return store.get(sessionId);
-    }
-
-    /** Returns all active sessions. */
-    public Collection<Session> allSessions() {
-        return store.values();
-    }
-
-    /** Removes and closes the session with the given ID. */
-    public void removeSession(String sessionId) {
-        var session = store.remove(sessionId);
-        if (session != null) {
-            session.close();
-            logger.info("Session removed: {}", sessionId);
+        var local = sessions.get(sessionId);
+        if (local != null) {
+            return Optional.of(local);
         }
+        var persisted = store.find(sessionId);
+        if (persisted.isEmpty()) {
+            return Optional.empty();
+        }
+        var snapshot = persisted.orElseThrow();
+        if (snapshot.state() == SessionState.CLOSED || !snapshot.expiresAt().isAfter(clock.instant())) {
+            store.terminate(snapshot.key());
+            return Optional.empty();
+        }
+        final Session hydrated;
+        try {
+            hydrated = runtime(snapshot, SseConnection.noop());
+        } catch (IllegalArgumentException e) {
+            logger.warn(
+                    "Cannot restore incompatible session snapshot: sessionId={}, protocolVersion={}",
+                    sessionId,
+                    snapshot.protocolVersion());
+            return Optional.empty();
+        }
+        var winner = sessions.putIfAbsent(sessionId, hydrated);
+        if (winner != null) {
+            hydrated.close();
+            return Optional.of(winner);
+        }
+        return Optional.of(hydrated);
+    }
+
+    /** Returns all process-local runtime sessions. */
+    public Collection<Session> allSessions() {
+        return sessions.values();
+    }
+
+    /** Removes and closes the current generation for the session ID. */
+    public void removeSession(String sessionId) {
+        var removed = new AtomicReference<Session>();
+        sessions.computeIfPresent(sessionId, (id, current) -> {
+            removed.set(current);
+            return null;
+        });
+        var local = removed.get();
+        if (local != null) {
+            store.terminate(local.key());
+            local.close();
+            logger.info("Session removed: {}", sessionId);
+            return;
+        }
+        store.find(sessionId).ifPresent(snapshot -> store.terminate(snapshot.key()));
     }
 
     /** Starts the background janitor that closes expired sessions. */
     public void startJanitor(Duration ttl, Duration interval) {
+        this.ttl = ttl;
+        this.expiryRefreshMargin = ttl.dividedBy(2);
         final var ttlNanos = ttl.toNanos();
         janitor = new AbstractJanitor("session-janitor") {
             @Override
@@ -79,38 +135,157 @@ public class SessionManager implements AutoCloseable {
         logger.debug("Session janitor started (interval={}ms, ttl={}ms)", interval.toMillis(), ttlNanos / 1_000_000);
     }
 
-    /** One janitor pass: closes and evicts sessions that are CLOSED or idle beyond the TTL. */
+    /** One janitor pass: closes and evicts local sessions that are closed or idle past the TTL. */
     void sweep(long ttlNanos) {
-        long now = System.nanoTime();
-        for (var session : store.values()) {
+        var now = System.nanoTime();
+        for (var session : sessions.values()) {
             try {
-                // Elapsed-based comparison, not `lastActivity < now - ttl`: the latter breaks
-                // across nanoTime's sign wraparound.
                 var expired = now - session.lastActivityNanos() > ttlNanos;
                 if (session.state() == SessionState.CLOSED || expired) {
-                    session.close();
-                    // Atomic conditional remove: a replacement session created under the
-                    // same id (custom SessionIdGenerator) must never be evicted.
-                    if (store.remove(session.id(), session)) {
-                        logger.debug("Janitor removed session: {}", session.id());
-                    }
+                    removeIfCurrent(session);
                 }
-            } catch (Exception e) {
+            } catch (RuntimeException e) {
                 logger.warn("Error while sweeping session: {}", session.id(), e);
             }
         }
     }
 
+    private void removeIfCurrent(Session expected) {
+        var removed = new boolean[1];
+        sessions.computeIfPresent(expected.id(), (id, current) -> {
+            if (current == expected) {
+                removed[0] = true;
+                return null;
+            }
+            return current;
+        });
+        if (removed[0]) {
+            store.terminate(expected.key());
+            expected.close();
+        }
+    }
+
+    private Session runtime(SessionSnapshot snapshot, SseConnection connection) {
+        return Session.fromSnapshot(snapshot, connection, this::persist, this::touch);
+    }
+
+    private Creation createAndInstall(String sessionId, SseConnection connection) {
+        final var creationLock = acquireCreationLock(sessionId);
+        try {
+            synchronized (creationLock) {
+                final var key = new SessionKey(sessionId, UUID.randomUUID().toString());
+                final var snapshot = store.create(key, expiresAt());
+                final var created = runtime(snapshot, connection);
+                return new Creation(created, sessions.put(sessionId, created));
+            }
+        } finally {
+            releaseCreationLock(sessionId, creationLock);
+        }
+    }
+
+    private CreationLock acquireCreationLock(String sessionId) {
+        return creationLocks.compute(sessionId, (id, current) -> {
+            final var lock = current == null ? new CreationLock() : current;
+            lock.retain();
+            return lock;
+        });
+    }
+
+    private void releaseCreationLock(String sessionId, CreationLock creationLock) {
+        creationLocks.computeIfPresent(sessionId, (id, current) -> {
+            if (current != creationLock) {
+                return current;
+            }
+            return creationLock.release() ? null : creationLock;
+        });
+    }
+
+    private void persist(Session session) {
+        if (sessions.get(session.id()) != session) {
+            return;
+        }
+        synchronized (session) {
+            if (sessions.get(session.id()) != session) {
+                return;
+            }
+            try {
+                final var current = store.find(session.id());
+                if (current.isEmpty() || !current.orElseThrow().key().equals(session.key())) {
+                    return;
+                }
+                final var expected = current.orElseThrow();
+                final var updated = session.snapshot(expiresAt(), expected.revision() + 1);
+                if (store.compareAndSet(expected, updated)) {
+                    session.snapshotExpiresAt(updated.expiresAt());
+                    return;
+                }
+                logger.warn("Session snapshot update lost ownership: {}", session.id());
+            } catch (RuntimeException e) {
+                logger.warn("Failed to persist session snapshot: {}", session.id(), e);
+            }
+        }
+    }
+
+    private void touch(Session session) {
+        if (sessions.get(session.id()) != session) {
+            return;
+        }
+        synchronized (session) {
+            if (sessions.get(session.id()) != session) {
+                return;
+            }
+            final var now = clock.instant();
+            final var refreshAt = session.snapshotExpiresAt().minus(expiryRefreshMargin);
+            if (now.isBefore(refreshAt)) {
+                return;
+            }
+            final var updatedExpiry = now.plus(ttl);
+            try {
+                if (store.touch(session.key(), updatedExpiry)) {
+                    session.snapshotExpiresAt(updatedExpiry);
+                } else {
+                    logger.warn("Session expiry refresh lost ownership: {}", session.id());
+                    if (sessions.remove(session.id(), session)) {
+                        session.close();
+                    }
+                }
+            } catch (RuntimeException e) {
+                logger.warn("Failed to refresh session snapshot expiry: {}", session.id(), e);
+            }
+        }
+    }
+
+    private Instant expiresAt() {
+        return clock.instant().plus(ttl);
+    }
+
+    @Override
     public void close() {
         try {
             if (janitor != null) {
                 janitor.close();
             }
-            store.values().forEach(Session::close);
+            var local = List.copyOf(sessions.values());
+            sessions.clear();
+            local.forEach(Session::close);
             store.close();
             logger.debug("SessionManager closed");
         } catch (Exception e) {
             logger.warn("Error while closing SessionManager", e);
+        }
+    }
+
+    private record Creation(Session created, @Nullable Session replaced) {}
+
+    private static final class CreationLock {
+        private int users;
+
+        void retain() {
+            users++;
+        }
+
+        boolean release() {
+            return --users == 0;
         }
     }
 }

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/session/SessionSnapshot.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/session/SessionSnapshot.java
@@ -1,0 +1,43 @@
+/* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
+package dev.tachyonmcp.core.server.session;
+
+import dev.tachyonmcp.api.annotations.ExperimentalApi;
+import dev.tachyonmcp.api.server.domain.LoggingLevel;
+import dev.tachyonmcp.core.runtime.SessionState;
+import java.time.Instant;
+import java.util.Objects;
+import java.util.Set;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Immutable, transport-free state that can reconstruct one MCP session generation.
+ *
+ * @param key session generation key
+ * @param state lifecycle state
+ * @param protocolVersion negotiated MCP protocol version, or {@code null} before negotiation
+ * @param enabledExtensionIds negotiated extension identifiers
+ * @param loggingLevel client-selected logging threshold, or {@code null} when unset
+ * @param expiresAt wall-clock expiry instant
+ * @param revision monotonically increasing snapshot revision within the generation
+ */
+@ExperimentalApi(since = "1.0.0-beta.26")
+public record SessionSnapshot(
+        SessionKey key,
+        SessionState state,
+        @Nullable String protocolVersion,
+        Set<String> enabledExtensionIds,
+        @Nullable LoggingLevel loggingLevel,
+        Instant expiresAt,
+        long revision) {
+
+    /** Validates and defensively copies snapshot state. */
+    public SessionSnapshot {
+        key = Objects.requireNonNull(key, "key");
+        state = Objects.requireNonNull(state, "state");
+        enabledExtensionIds = Set.copyOf(enabledExtensionIds);
+        expiresAt = Objects.requireNonNull(expiresAt, "expiresAt");
+        if (revision < 0) {
+            throw new IllegalArgumentException("revision cannot be negative");
+        }
+    }
+}

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/session/SessionStore.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/session/SessionStore.java
@@ -1,44 +1,29 @@
 /* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
 package dev.tachyonmcp.core.server.session;
 
-import dev.tachyonmcp.core.runtime.Session;
-import java.util.Collection;
+import dev.tachyonmcp.api.annotations.ExperimentalApi;
+import java.time.Instant;
 import java.util.Optional;
-import java.util.function.Function;
-import org.jspecify.annotations.Nullable;
 
-/** Storage abstraction for MCP sessions. */
+/** Persistence boundary for immutable, transport-free MCP session snapshots. */
+@ExperimentalApi(since = "1.0.0-beta.26")
 public interface SessionStore extends AutoCloseable {
 
-    /** Stores a session, returning any previous session with the same ID. */
-    @Nullable
-    Session put(String sessionId, Session session);
+    /** Creates a new generation, atomically replacing the current generation for its session ID. */
+    SessionSnapshot create(SessionKey key, Instant expiresAt);
 
-    /** Returns the session for the given ID, if present. */
-    Optional<Session> get(String sessionId);
+    /** Finds the current snapshot for a session ID. */
+    Optional<SessionSnapshot> find(String sessionId);
 
-    /** Returns the existing session or creates and stores a new one via the factory. */
-    Session computeIfAbsent(String sessionId, Function<String, Session> factory);
-
-    /** Returns all stored sessions. */
-    Collection<Session> values();
-
-    /** Removes and returns the session for the given ID. */
-    @Nullable
-    Session remove(String sessionId);
+    /** Replaces the current snapshot when it exactly equals {@code expected}. */
+    boolean compareAndSet(SessionSnapshot expected, SessionSnapshot updated);
 
     /**
-     * Removes the session for the given ID only if the stored instance is {@code expected},
-     * returning whether it was removed. Used by expiry sweeps so a replacement session created
-     * under the same ID between the expiry check and the removal is never evicted. This default
-     * is check-then-act; implementations backed by an atomic store should override it (see
-     * {@code InMemorySessionStore}).
+     * Extends expiry and advances the revision when the current snapshot still belongs to
+     * {@code key}.
      */
-    default boolean remove(String sessionId, Session expected) {
-        if (get(sessionId).orElse(null) == expected) {
-            remove(sessionId);
-            return true;
-        }
-        return false;
-    }
+    boolean touch(SessionKey key, Instant expiresAt);
+
+    /** Removes the current snapshot when its generation still equals {@code key}. */
+    boolean terminate(SessionKey key);
 }

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/session/SessionStore.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/session/SessionStore.java
@@ -5,7 +5,12 @@ import dev.tachyonmcp.api.annotations.ExperimentalApi;
 import java.time.Instant;
 import java.util.Optional;
 
-/** Persistence boundary for immutable, transport-free MCP session snapshots. */
+/**
+ * Persistence boundary for immutable, transport-free MCP session snapshots.
+ *
+ * <p>Methods execute synchronously and may perform I/O. Tachyon invokes them outside transport
+ * event-loop threads. Implementations must be thread-safe.
+ */
 @ExperimentalApi(since = "1.0.0-beta.26")
 public interface SessionStore extends AutoCloseable {
 
@@ -19,7 +24,7 @@ public interface SessionStore extends AutoCloseable {
     boolean compareAndSet(SessionSnapshot expected, SessionSnapshot updated);
 
     /**
-     * Extends expiry and advances the revision when the current snapshot still belongs to
+     * Extends expiry and increments the revision once when the current snapshot still belongs to
      * {@code key}.
      */
     boolean touch(SessionKey key, Instant expiresAt);

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/session/package-info.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/session/package-info.java
@@ -3,7 +3,7 @@
  */
 
 /**
- * Session management — dispatch contexts, session lifecycle events, and session storage.
+ * Internal live-session coordination and experimental immutable persistence contracts.
  */
 @NullMarked
 package dev.tachyonmcp.core.server.session;

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/transport/netty/ChannelHandlerUtils.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/transport/netty/ChannelHandlerUtils.java
@@ -96,7 +96,12 @@ public final class ChannelHandlerUtils {
      */
     public static void setSession(ChannelHandlerContext ctx, Session session) {
         SessionTouchHandler.install(ctx);
-        ctx.channel().attr(SESSION_KEY).set(session);
+        bindSession(ctx.channel(), session);
+    }
+
+    /** Binds a session after the pipeline's session touch handler has been installed. */
+    public static void bindSession(Channel channel, Session session) {
+        channel.attr(SESSION_KEY).set(session);
     }
 
     /**

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/transport/netty/McpHandlerManager.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/transport/netty/McpHandlerManager.java
@@ -5,10 +5,14 @@ import dev.tachyonmcp.core.server.McpDispatcher;
 import dev.tachyonmcp.core.server.internal.ServerEngine;
 import io.netty.channel.ChannelHandler;
 import java.util.concurrent.Executor;
+import java.util.concurrent.RejectedExecutionException;
 import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class McpHandlerManager implements ProtocolHandlerManager {
 
+    private static final Logger logger = LoggerFactory.getLogger(McpHandlerManager.class);
     static final String HANDLER_INIT = "mcp-phase-init";
     static final String HANDLER_OPS = "mcp-phase-operations";
 
@@ -44,7 +48,11 @@ public class McpHandlerManager implements ProtocolHandlerManager {
     @Override
     public void onShutdownStarted(@Nullable String sessionId) {
         if (sessionId != null) {
-            server.removeSession(sessionId);
+            try {
+                executor.execute(() -> server.removeSession(sessionId));
+            } catch (RejectedExecutionException e) {
+                logger.debug("Session cleanup rejected during server shutdown: {}", sessionId);
+            }
         }
     }
 }

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/transport/netty/McpInitializationHandler.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/transport/netty/McpInitializationHandler.java
@@ -251,7 +251,7 @@ public class McpInitializationHandler extends ChannelInboundHandlerAdapter {
                         // InteractionContext, and LifecyclePipelineCoordinator replaces this handler
                         // with McpOperationHandler.
                         var mcpSession = resultSessionId != null
-                                ? server.getSession(resultSessionId).orElse(null)
+                                ? server.getLocalSession(resultSessionId).orElse(null)
                                 : null;
                         ctx.pipeline().fireUserEventTriggered(new InteractionEvent.OperationStarted(mcpSession));
                         logger.debug("Pipeline transitioned to OPERATION phase for session: {}", resultSessionId);

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/transport/netty/McpOperationHandler.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/transport/netty/McpOperationHandler.java
@@ -1,11 +1,11 @@
 /* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
 package dev.tachyonmcp.core.transport.netty;
 
+import static dev.tachyonmcp.core.transport.netty.ChannelHandlerUtils.bindSession;
 import static dev.tachyonmcp.core.transport.netty.ChannelHandlerUtils.captureInitRequest;
 import static dev.tachyonmcp.core.transport.netty.ChannelHandlerUtils.sendAccepted;
 import static dev.tachyonmcp.core.transport.netty.ChannelHandlerUtils.sendPlainTextAndClose;
 import static dev.tachyonmcp.core.transport.netty.ChannelHandlerUtils.sendResponseAndClose;
-import static dev.tachyonmcp.core.transport.netty.ChannelHandlerUtils.setSession;
 import static dev.tachyonmcp.core.transport.netty.McpResponseWriter.sendInternalError;
 import static dev.tachyonmcp.core.transport.netty.McpResponseWriter.sendJsonResponse;
 import static dev.tachyonmcp.core.transport.netty.McpResponseWriter.sendOptions;
@@ -13,7 +13,7 @@ import static dev.tachyonmcp.core.transport.netty.McpResponseWriter.sendOptions;
 import dev.tachyonmcp.api.server.domain.RequestId;
 import dev.tachyonmcp.core.protocol.mcp.McpHeaderNames;
 import dev.tachyonmcp.core.runtime.ChannelContext;
-import dev.tachyonmcp.core.runtime.InteractionEvent;
+import dev.tachyonmcp.core.runtime.Session;
 import dev.tachyonmcp.core.runtime.SseEvent;
 import dev.tachyonmcp.core.server.McpDispatcher;
 import dev.tachyonmcp.core.server.internal.ServerEngine;
@@ -31,10 +31,12 @@ import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.timeout.IdleStateEvent;
 import java.nio.charset.StandardCharsets;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.RejectedExecutionException;
+import java.util.function.Consumer;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -62,6 +64,11 @@ public class McpOperationHandler extends ChannelInboundHandlerAdapter {
         this.dispatcher = dispatcher;
         this.executor = executor;
         this.sseManager = new SseManager(server);
+    }
+
+    @Override
+    public void handlerAdded(ChannelHandlerContext ctx) {
+        SessionTouchHandler.install(ctx);
     }
 
     @Override
@@ -104,14 +111,7 @@ public class McpOperationHandler extends ChannelInboundHandlerAdapter {
 
     private void handlePost(ChannelHandlerContext ctx, FullHttpRequest req, @Nullable String origin) {
         var sessionId = req.headers().get(McpHeaderNames.MCP_SESSION_ID);
-        if (sessionId != null) {
-            var session = server.getSession(sessionId);
-            if (session.isEmpty()) {
-                sendPlainTextAndClose(ctx, HttpResponseStatus.NOT_FOUND, "Unknown session", origin);
-                return;
-            }
-            setSession(ctx, session.get());
-        } else {
+        if (sessionId == null) {
             // A session-less POST may be an initialize (e.g. on a keep-alive channel already in
             // the operation phase); preserve the request for a custom SessionIdGenerator.
             captureInitRequest(ctx, req, server);
@@ -129,6 +129,19 @@ public class McpOperationHandler extends ChannelInboundHandlerAdapter {
                             () -> {
                                 final JsonRpcMessage message;
                                 try {
+                                    if (sessionId != null) {
+                                        final var session = server.getSession(sessionId);
+                                        if (session.isEmpty()) {
+                                            ctx.executor()
+                                                    .execute(() -> sendPlainTextAndClose(
+                                                            ctx,
+                                                            HttpResponseStatus.NOT_FOUND,
+                                                            "Unknown session",
+                                                            origin));
+                                            return;
+                                        }
+                                        bindSession(ctx.channel(), session.orElseThrow());
+                                    }
                                     message = dispatcher.parseMessage(body);
                                 } finally {
                                     body.release();
@@ -393,7 +406,7 @@ public class McpOperationHandler extends ChannelInboundHandlerAdapter {
             return null;
         }
         var wireId = ServerEngine.wireEventId(sseEventId, streamKey);
-        return () -> server.getSession(sessionId).ifPresent(session -> {
+        return () -> server.getLocalSession(sessionId).ifPresent(session -> {
             // ponytail: the resumed reconnect may also replay this event from the log, so a rare
             // race can deliver it twice with the same SSE id — harmless (the client dedupes the
             // JSON-RPC response by request id). Per-connection id de-dup if that ever bites.
@@ -413,12 +426,24 @@ public class McpOperationHandler extends ChannelInboundHandlerAdapter {
             sendPlainTextAndClose(ctx, HttpResponseStatus.BAD_REQUEST, "Missing MCP-Session-Id header", origin);
             return;
         }
-        var sessionOpt = server.getSession(sessionId);
-        if (sessionOpt.isEmpty()) {
-            sendPlainTextAndClose(ctx, HttpResponseStatus.NOT_FOUND, "Unknown session", origin);
+        final var lastEventId = req.headers().get(McpHeaderNames.LAST_EVENT_ID);
+        final var local = server.getLocalSession(sessionId);
+        if (local.isPresent()) {
+            sseManager.openStream(ctx, local.orElseThrow(), lastEventId, origin);
             return;
         }
-        sseManager.openStream(ctx, sessionOpt.get(), req.headers().get(McpHeaderNames.LAST_EVENT_ID), origin);
+        try {
+            CompletableFuture.supplyAsync(() -> server.getSession(sessionId), executor)
+                    .whenComplete((session, failure) -> marshalSessionLookup(
+                            ctx,
+                            sessionId,
+                            origin,
+                            session,
+                            failure,
+                            found -> sseManager.openStream(ctx, found, lastEventId, origin)));
+        } catch (RejectedExecutionException e) {
+            sendPlainTextAndClose(ctx, HttpResponseStatus.SERVICE_UNAVAILABLE, "Server shutting down", origin);
+        }
     }
 
     private void handleDelete(ChannelHandlerContext ctx, FullHttpRequest req, @Nullable String origin) {
@@ -427,15 +452,58 @@ public class McpOperationHandler extends ChannelInboundHandlerAdapter {
             sendPlainTextAndClose(ctx, HttpResponseStatus.BAD_REQUEST, "Missing MCP-Session-Id header", origin);
             return;
         }
-        if (server.getSession(sessionId).isEmpty()) {
-            sendPlainTextAndClose(ctx, HttpResponseStatus.NOT_FOUND, "Unknown session", origin);
-            return;
+        try {
+            CompletableFuture.supplyAsync(
+                            () -> {
+                                if (server.getSession(sessionId).isEmpty()) {
+                                    return false;
+                                }
+                                server.removeSession(sessionId);
+                                return true;
+                            },
+                            executor)
+                    .whenComplete((removed, failure) -> ctx.executor().execute(() -> {
+                        if (failure != null) {
+                            logger.error("Failed to terminate session: {}", sessionId, failure);
+                            sendPlainTextAndClose(
+                                    ctx,
+                                    HttpResponseStatus.INTERNAL_SERVER_ERROR,
+                                    "Session termination failed",
+                                    origin);
+                        } else if (!removed) {
+                            sendPlainTextAndClose(ctx, HttpResponseStatus.NOT_FOUND, "Unknown session", origin);
+                        } else {
+                            sendPlainTextAndClose(ctx, HttpResponseStatus.OK, "", origin);
+                            logger.info("Session terminated via DELETE: {}", sessionId);
+                        }
+                    }));
+        } catch (RejectedExecutionException e) {
+            sendPlainTextAndClose(ctx, HttpResponseStatus.SERVICE_UNAVAILABLE, "Server shutting down", origin);
         }
-        // Fire ShutdownStarted before sending the response so the session is removed
-        // before the client receives the OK (eliminates race on server.session()).
-        ctx.pipeline().fireUserEventTriggered(new InteractionEvent.ShutdownStarted(sessionId));
-        sendPlainTextAndClose(ctx, HttpResponseStatus.OK, "", origin);
-        logger.info("Session terminated via DELETE: {}", sessionId);
+    }
+
+    private static void marshalSessionLookup(
+            ChannelHandlerContext ctx,
+            String sessionId,
+            @Nullable String origin,
+            @Nullable Optional<Session> session,
+            @Nullable Throwable failure,
+            Consumer<Session> onFound) {
+        try {
+            ctx.executor().execute(() -> {
+                if (failure != null) {
+                    logger.error("Failed to resolve session: {}", sessionId, failure);
+                    sendPlainTextAndClose(
+                            ctx, HttpResponseStatus.INTERNAL_SERVER_ERROR, "Session lookup failed", origin);
+                } else if (session == null || session.isEmpty()) {
+                    sendPlainTextAndClose(ctx, HttpResponseStatus.NOT_FOUND, "Unknown session", origin);
+                } else {
+                    onFound.accept(session.orElseThrow());
+                }
+            });
+        } catch (RejectedExecutionException e) {
+            logger.debug("Event loop rejected session lookup result during shutdown: {}", sessionId);
+        }
     }
 
     @Override

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/transport/netty/SessionTouchHandler.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/transport/netty/SessionTouchHandler.java
@@ -26,7 +26,7 @@ public final class SessionTouchHandler extends ChannelOutboundHandlerAdapter {
      * Installs the shared {@link SessionTouchHandler} into the channel pipeline, if not already
      * present. Safe to call multiple times per channel. In production the pipeline always has an
      * {@code "http"} (HttpServerCodec) handler, so the handler is added after it. In test pipelines
-     * without one, the handler is appended at the end.
+     * without one, the handler is added immediately before the binding handler.
      */
     public static void install(ChannelHandlerContext ctx) {
         var pipeline = ctx.pipeline();
@@ -34,7 +34,7 @@ public final class SessionTouchHandler extends ChannelOutboundHandlerAdapter {
             if (pipeline.get("http") != null) {
                 pipeline.addAfter("http", HANDLER_NAME, INSTANCE);
             } else {
-                pipeline.addLast(HANDLER_NAME, INSTANCE);
+                pipeline.addBefore(ctx.name(), HANDLER_NAME, INSTANCE);
             }
         }
     }

--- a/tachyon-core/src/test/java/dev/tachyonmcp/core/server/ServerTest.java
+++ b/tachyon-core/src/test/java/dev/tachyonmcp/core/server/ServerTest.java
@@ -53,7 +53,7 @@ class ServerTest {
     }
 
     @Test
-    void appendResponsePersistsToChronicle() {
+    void appendResponsePersistsToDurableStore() {
         try (DefaultTachyonServer server =
                 (DefaultTachyonServer) TachyonServer.builder().build()) {
             var session = server.createSession("sess_1");

--- a/tachyon-core/src/test/java/dev/tachyonmcp/core/server/session/InMemorySessionStoreTest.java
+++ b/tachyon-core/src/test/java/dev/tachyonmcp/core/server/session/InMemorySessionStoreTest.java
@@ -3,32 +3,44 @@ package dev.tachyonmcp.core.server.session;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import dev.tachyonmcp.core.runtime.Session;
-import dev.tachyonmcp.core.runtime.SseConnection;
+import dev.tachyonmcp.core.runtime.SessionState;
+import java.time.Instant;
 import org.junit.jupiter.api.Test;
 
 class InMemorySessionStoreTest {
 
-    private static Session session(String id) {
-        return new Session(id, SseConnection.noop());
-    }
-
     @Test
-    void conditionalRemoveEvictsOnlyTheExpectedInstance() {
+    void replacementGenerationRejectsStaleWritesAndTermination() {
         try (var store = new InMemorySessionStore()) {
-            var expired = session("s1");
-            store.put("s1", expired);
+            var firstKey = new SessionKey("s1", "g1");
+            var first = store.create(firstKey, Instant.parse("2026-09-09T12:00:00Z"));
+            var active = new SessionSnapshot(
+                    first.key(),
+                    SessionState.ACTIVE,
+                    "2025-11-25",
+                    first.enabledExtensionIds(),
+                    null,
+                    first.expiresAt(),
+                    first.revision() + 1);
 
-            // A replacement session appears under the same id (custom SessionIdGenerator scenario)
-            // between the janitor's expiry check and its removal.
-            var replacement = session("s1");
-            store.put("s1", replacement);
+            assertThat(store.compareAndSet(first, active)).isTrue();
+            assertThat(store.find("s1")).contains(active);
 
-            assertThat(store.remove("s1", expired)).isFalse();
-            assertThat(store.get("s1")).contains(replacement);
+            var replacement = store.create(new SessionKey("s1", "g2"), Instant.parse("2026-09-09T13:00:00Z"));
 
-            assertThat(store.remove("s1", replacement)).isTrue();
-            assertThat(store.get("s1")).isEmpty();
+            assertThat(store.compareAndSet(active, active)).isFalse();
+            assertThat(store.touch(firstKey, Instant.parse("2026-09-09T14:00:00Z")))
+                    .isFalse();
+            assertThat(store.terminate(firstKey)).isFalse();
+            assertThat(store.find("s1")).contains(replacement);
+            assertThat(store.touch(replacement.key(), Instant.parse("2026-09-09T14:00:00Z")))
+                    .isTrue();
+            assertThat(store.find("s1")).hasValueSatisfying(touched -> {
+                assertThat(touched.expiresAt()).isEqualTo(Instant.parse("2026-09-09T14:00:00Z"));
+                assertThat(touched.revision()).isEqualTo(replacement.revision() + 1);
+            });
+            assertThat(store.terminate(replacement.key())).isTrue();
+            assertThat(store.find("s1")).isEmpty();
         }
     }
 }

--- a/tachyon-core/src/test/java/dev/tachyonmcp/core/server/session/SessionManagerTest.java
+++ b/tachyon-core/src/test/java/dev/tachyonmcp/core/server/session/SessionManagerTest.java
@@ -6,16 +6,21 @@ import static org.assertj.core.api.Assertions.assertThat;
 import dev.tachyonmcp.api.server.domain.LoggingLevel;
 import dev.tachyonmcp.core.protocol.Protocols;
 import dev.tachyonmcp.core.runtime.SessionState;
+import dev.tachyonmcp.core.runtime.SseConnection;
+import dev.tachyonmcp.core.runtime.SseEvent;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.util.Optional;
+import java.util.Queue;
 import java.util.Set;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.Test;
@@ -107,12 +112,14 @@ class SessionManagerTest {
         final var clock = new MutableClock(NOW);
         final var manager = new SessionManager(store, clock, Duration.ofSeconds(30));
         final var session = manager.createSession("s1");
+        clock.resetInstantCount();
 
         session.touch();
         clock.advance(Duration.ofSeconds(14));
         session.touch();
 
         assertThat(store.touchCount()).isZero();
+        assertThat(clock.instantCount()).isZero();
 
         clock.advance(Duration.ofSeconds(1));
         session.touch();
@@ -121,6 +128,26 @@ class SessionManagerTest {
         assertThat(store.touchCount()).isOne();
         assertThat(store.find("s1"))
                 .hasValueSatisfying(snapshot -> assertThat(snapshot.expiresAt()).isEqualTo(NOW.plusSeconds(45)));
+    }
+
+    @Test
+    void touchDelegatesDueSnapshotRefreshToExecutor() {
+        final var store = new TrackingSessionStore();
+        final var clock = new MutableClock(NOW);
+        final Queue<Runnable> tasks = new ConcurrentLinkedQueue<>();
+        final var manager = new SessionManager(store, clock, Duration.ofSeconds(30), tasks::add);
+        final var session = manager.createSession("s1");
+        clock.advance(Duration.ofSeconds(15));
+
+        session.touch();
+        session.touch();
+
+        assertThat(store.touchCount()).isZero();
+        assertThat(tasks).hasSize(1);
+
+        tasks.remove().run();
+
+        assertThat(store.touchCount()).isOne();
     }
 
     @Test
@@ -142,13 +169,60 @@ class SessionManagerTest {
     }
 
     @Test
+    void stateChangeUsesCachedSnapshotWithoutReadingStore() {
+        final var store = new TrackingSessionStore();
+        final var manager = manager(store);
+        final var session = manager.createSession("s1");
+        store.resetOperationCounts();
+
+        session.activate();
+
+        assertThat(store.findCount()).isZero();
+        assertThat(store.compareAndSetCount()).isOne();
+    }
+
+    @Test
+    void stateChangeUsesRevisionAdvancedByTouch() {
+        final var store = new TrackingSessionStore();
+        final var clock = new MutableClock(NOW);
+        final var manager = new SessionManager(store, clock, Duration.ofSeconds(30));
+        final var session = manager.createSession("s1");
+        clock.advance(Duration.ofSeconds(15));
+        session.touch();
+        store.resetOperationCounts();
+
+        session.loggingLevel(LoggingLevel.ERROR);
+
+        assertThat(store.findCount()).isZero();
+        assertThat(store.compareAndSetCount()).isOne();
+        assertThat(store.find("s1"))
+                .hasValueSatisfying(
+                        snapshot -> assertThat(snapshot.loggingLevel()).isEqualTo(LoggingLevel.ERROR));
+    }
+
+    @Test
+    void stateChangeEvictsLocalRuntimeAfterGenerationReplacement() {
+        final var store = new TrackingSessionStore();
+        final var manager = manager(store);
+        final var session = manager.createSession("s1");
+        final var replacement = store.create(new SessionKey("s1", "replacement"), NOW.plusSeconds(60));
+
+        session.activate();
+
+        assertThat(session.state()).isEqualTo(SessionState.CLOSED);
+        assertThat(manager.allSessions()).isEmpty();
+        assertThat(store.find("s1")).contains(replacement);
+        assertThat(store.terminateCount()).isZero();
+    }
+
+    @Test
     void sameIdCreationsDoNotOverlapStoreAndKeepOneGeneration() throws Exception {
         final var store = new TrackingSessionStore();
         final var manager = manager(store);
         manager.createSession("s1");
         store.armCreateTracking();
 
-        try (final var executor = Executors.newVirtualThreadPerTaskExecutor()) {
+        try (final var executor = Executors.newFixedThreadPool(2)) {
             final var first = executor.submit(() -> manager.createSession("s1"));
             assertThat(store.awaitFirstCreate()).isTrue();
             final var second = executor.submit(() -> {
@@ -156,8 +230,8 @@ class SessionManagerTest {
                 return manager.createSession("s1");
             });
 
-            first.get(2, TimeUnit.SECONDS);
-            second.get(2, TimeUnit.SECONDS);
+            first.get(10, TimeUnit.SECONDS);
+            second.get(10, TimeUnit.SECONDS);
         }
 
         final var local = manager.getSession("s1").orElseThrow();
@@ -195,6 +269,48 @@ class SessionManagerTest {
     }
 
     @Test
+    void concurrentHydrationReadsStoreOnce() throws Exception {
+        final var store = new TrackingSessionStore();
+        store.create(new SessionKey("s1", "generation"), NOW.plusSeconds(30));
+        store.armFindTracking();
+        final var manager = manager(store);
+
+        try (final var executor = Executors.newVirtualThreadPerTaskExecutor()) {
+            final var first = executor.submit(() -> manager.getSession("s1"));
+            assertThat(store.awaitFirstFind()).isTrue();
+            final var second = executor.submit(() -> {
+                store.secondFindAttempted();
+                return manager.getSession("s1");
+            });
+
+            assertThat(first.get(2, TimeUnit.SECONDS)).isPresent();
+            assertThat(second.get(2, TimeUnit.SECONDS)).isPresent();
+        }
+
+        assertThat(store.findCount()).isOne();
+        assertThat(store.maxConcurrentFinds()).isOne();
+    }
+
+    @Test
+    void closeContinuesAfterConnectionFailureAndClosesStore() {
+        final var store = new TrackingSessionStore();
+        final var manager = manager(store);
+        final var failedCloseAttempted = new AtomicBoolean();
+        final var healthyCloseAttempted = new AtomicBoolean();
+        manager.createSession("broken", new TestConnection(() -> {
+            failedCloseAttempted.set(true);
+            throw new IllegalStateException("boom");
+        }));
+        manager.createSession("healthy", new TestConnection(() -> healthyCloseAttempted.set(true)));
+
+        manager.close();
+
+        assertThat(failedCloseAttempted).isTrue();
+        assertThat(healthyCloseAttempted).isTrue();
+        assertThat(store.closeCount()).isOne();
+    }
+
+    @Test
     void sweepEvictsExpiredLocalSessionAndSnapshot() {
         var store = new InMemorySessionStore();
         var manager = manager(store);
@@ -228,12 +344,21 @@ class SessionManagerTest {
         private final InMemorySessionStore delegate = new InMemorySessionStore();
         private final AtomicInteger touchCount = new AtomicInteger();
         private final AtomicInteger terminateCount = new AtomicInteger();
+        private final AtomicInteger findCount = new AtomicInteger();
+        private final AtomicInteger compareAndSetCount = new AtomicInteger();
+        private final AtomicInteger closeCount = new AtomicInteger();
         private final AtomicInteger concurrentCreates = new AtomicInteger();
         private final AtomicInteger maxConcurrentCreates = new AtomicInteger();
+        private final AtomicInteger concurrentFinds = new AtomicInteger();
+        private final AtomicInteger maxConcurrentFinds = new AtomicInteger();
         private final CountDownLatch firstCreateEntered = new CountDownLatch(1);
         private final CountDownLatch secondCreateAttempted = new CountDownLatch(1);
         private final CountDownLatch overlappingCreateEntered = new CountDownLatch(1);
+        private final CountDownLatch firstFindEntered = new CountDownLatch(1);
+        private final CountDownLatch secondFindAttempted = new CountDownLatch(1);
+        private final CountDownLatch overlappingFindEntered = new CountDownLatch(1);
         private volatile boolean trackCreates;
+        private volatile boolean trackFinds;
 
         @Override
         public SessionSnapshot create(SessionKey key, Instant expiresAt) {
@@ -258,11 +383,29 @@ class SessionManagerTest {
 
         @Override
         public Optional<SessionSnapshot> find(String sessionId) {
-            return delegate.find(sessionId);
+            findCount.incrementAndGet();
+            if (!trackFinds) {
+                return delegate.find(sessionId);
+            }
+            final var concurrent = concurrentFinds.incrementAndGet();
+            maxConcurrentFinds.accumulateAndGet(concurrent, Math::max);
+            try {
+                if (concurrent == 1) {
+                    firstFindEntered.countDown();
+                    await(secondFindAttempted);
+                    await(overlappingFindEntered, 250, TimeUnit.MILLISECONDS);
+                } else {
+                    overlappingFindEntered.countDown();
+                }
+                return delegate.find(sessionId);
+            } finally {
+                concurrentFinds.decrementAndGet();
+            }
         }
 
         @Override
         public boolean compareAndSet(SessionSnapshot expected, SessionSnapshot updated) {
+            compareAndSetCount.incrementAndGet();
             return delegate.compareAndSet(expected, updated);
         }
 
@@ -280,6 +423,7 @@ class SessionManagerTest {
 
         @Override
         public void close() {
+            closeCount.incrementAndGet();
             delegate.close();
         }
 
@@ -287,12 +431,30 @@ class SessionManagerTest {
             trackCreates = true;
         }
 
+        void armFindTracking() {
+            resetOperationCounts();
+            trackFinds = true;
+        }
+
         boolean awaitFirstCreate() throws InterruptedException {
             return firstCreateEntered.await(2, TimeUnit.SECONDS);
         }
 
+        boolean awaitFirstFind() throws InterruptedException {
+            return firstFindEntered.await(2, TimeUnit.SECONDS);
+        }
+
         void secondCreateAttempted() {
             secondCreateAttempted.countDown();
+        }
+
+        void secondFindAttempted() {
+            secondFindAttempted.countDown();
+        }
+
+        void resetOperationCounts() {
+            findCount.set(0);
+            compareAndSetCount.set(0);
         }
 
         int touchCount() {
@@ -303,8 +465,24 @@ class SessionManagerTest {
             return terminateCount.get();
         }
 
+        int findCount() {
+            return findCount.get();
+        }
+
+        int compareAndSetCount() {
+            return compareAndSetCount.get();
+        }
+
+        int closeCount() {
+            return closeCount.get();
+        }
+
         int maxConcurrentCreates() {
             return maxConcurrentCreates.get();
+        }
+
+        int maxConcurrentFinds() {
+            return maxConcurrentFinds.get();
         }
 
         private static void await(CountDownLatch latch) {
@@ -326,8 +504,25 @@ class SessionManagerTest {
         }
     }
 
+    private record TestConnection(Runnable onClose) implements SseConnection {
+
+        @Override
+        public boolean isWritable() {
+            return true;
+        }
+
+        @Override
+        public void send(SseEvent event) {}
+
+        @Override
+        public void close() {
+            onClose.run();
+        }
+    }
+
     private static final class MutableClock extends Clock {
         private final AtomicReference<Instant> now;
+        private final AtomicInteger instantCount = new AtomicInteger();
 
         private MutableClock(Instant now) {
             this.now = new AtomicReference<>(now);
@@ -335,6 +530,14 @@ class SessionManagerTest {
 
         void advance(Duration duration) {
             now.updateAndGet(current -> current.plus(duration));
+        }
+
+        void resetInstantCount() {
+            instantCount.set(0);
+        }
+
+        int instantCount() {
+            return instantCount.get();
         }
 
         @Override
@@ -348,7 +551,13 @@ class SessionManagerTest {
         }
 
         @Override
+        public long millis() {
+            return now.get().toEpochMilli();
+        }
+
+        @Override
         public Instant instant() {
+            instantCount.incrementAndGet();
             return now.get();
         }
     }

--- a/tachyon-core/src/test/java/dev/tachyonmcp/core/server/session/SessionManagerTest.java
+++ b/tachyon-core/src/test/java/dev/tachyonmcp/core/server/session/SessionManagerTest.java
@@ -3,99 +3,353 @@ package dev.tachyonmcp.core.server.session;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import dev.tachyonmcp.core.runtime.Session;
+import dev.tachyonmcp.api.server.domain.LoggingLevel;
+import dev.tachyonmcp.core.protocol.Protocols;
 import dev.tachyonmcp.core.runtime.SessionState;
-import dev.tachyonmcp.core.runtime.SseConnection;
-import java.util.Collection;
-import java.util.List;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.util.Optional;
-import java.util.function.Function;
-import org.jspecify.annotations.Nullable;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.Test;
 
 class SessionManagerTest {
 
+    private static final Instant NOW = Instant.parse("2026-09-09T12:00:00Z");
+
     @Test
-    void sweepEvictsExpiredSessions() {
+    void persistsRuntimeStateAsImmutableSnapshot() {
         var store = new InMemorySessionStore();
-        var manager = new SessionManager(store);
+        var manager = manager(store);
         var session = manager.createSession("s1");
+        var protocol = Protocols.list().getFirst();
 
-        manager.sweep(-1); // any idle time exceeds a negative TTL
+        session.protocol(protocol);
+        session.enableExtension("io.tachyon/test");
+        session.loggingLevel(LoggingLevel.WARNING);
+        session.activate();
+        session.touch();
 
-        assertThat(session.state()).isEqualTo(SessionState.CLOSED);
-        assertThat(store.get("s1")).isEmpty();
+        assertThat(store.find("s1")).hasValueSatisfying(snapshot -> {
+            assertThat(snapshot.key().sessionId()).isEqualTo("s1");
+            assertThat(snapshot.state()).isEqualTo(SessionState.ACTIVE);
+            assertThat(snapshot.protocolVersion()).isEqualTo(protocol.versionString());
+            assertThat(snapshot.enabledExtensionIds()).containsExactly("io.tachyon/test");
+            assertThat(snapshot.loggingLevel()).isEqualTo(LoggingLevel.WARNING);
+            assertThat(snapshot.expiresAt()).isEqualTo(NOW.plusSeconds(30));
+            assertThat(snapshot.revision()).isPositive();
+        });
     }
 
     @Test
-    void sweepKeepsFreshSessions() {
+    void hydratesLocalRuntimeFromSnapshot() {
         var store = new InMemorySessionStore();
-        var manager = new SessionManager(store);
+        var protocol = Protocols.list().getFirst();
+        var key = new SessionKey("s1", "generation");
+        var created = store.create(key, NOW.plusSeconds(30));
+        var persisted = new SessionSnapshot(
+                key,
+                SessionState.ACTIVE,
+                protocol.versionString(),
+                Set.of("io.tachyon/test"),
+                LoggingLevel.ERROR,
+                created.expiresAt(),
+                created.revision() + 1);
+        assertThat(store.compareAndSet(created, persisted)).isTrue();
+
+        var session = manager(store).getSession("s1").orElseThrow();
+
+        assertThat(session.state()).isEqualTo(SessionState.ACTIVE);
+        assertThat(session.protocol()).isSameAs(protocol);
+        assertThat(session.isExtensionEnabled("io.tachyon/test")).isTrue();
+        assertThat(session.loggingLevel()).isEqualTo(LoggingLevel.ERROR);
+    }
+
+    @Test
+    void expiredSnapshotDoesNotHydrate() {
+        var store = new InMemorySessionStore();
+        var key = new SessionKey("s1", "generation");
+        store.create(key, NOW.minusSeconds(1));
+
+        assertThat(manager(store).getSession("s1")).isEmpty();
+        assertThat(store.find("s1")).isEmpty();
+    }
+
+    @Test
+    void snapshotWithUnsupportedProtocolDoesNotHydrate() {
+        final var store = new InMemorySessionStore();
+        final var key = new SessionKey("s1", "generation");
+        final var created = store.create(key, NOW.plusSeconds(30));
+        final var incompatible = new SessionSnapshot(
+                key,
+                SessionState.ACTIVE,
+                "unsupported-version",
+                Set.of(),
+                null,
+                created.expiresAt(),
+                created.revision() + 1);
+        assertThat(store.compareAndSet(created, incompatible)).isTrue();
+
+        assertThat(manager(store).getSession("s1")).isEmpty();
+        assertThat(store.find("s1")).contains(incompatible);
+    }
+
+    @Test
+    void touchRefreshesPersistedExpiryOnlyWhenHalfTheTtlHasElapsed() {
+        final var store = new TrackingSessionStore();
+        final var clock = new MutableClock(NOW);
+        final var manager = new SessionManager(store, clock, Duration.ofSeconds(30));
+        final var session = manager.createSession("s1");
+
+        session.touch();
+        clock.advance(Duration.ofSeconds(14));
+        session.touch();
+
+        assertThat(store.touchCount()).isZero();
+
+        clock.advance(Duration.ofSeconds(1));
+        session.touch();
+        session.touch();
+
+        assertThat(store.touchCount()).isOne();
+        assertThat(store.find("s1"))
+                .hasValueSatisfying(snapshot -> assertThat(snapshot.expiresAt()).isEqualTo(NOW.plusSeconds(45)));
+    }
+
+    @Test
+    void touchEvictsOnlyLocalRuntimeAfterGenerationReplacement() {
+        final var store = new TrackingSessionStore();
+        final var clock = new MutableClock(NOW);
+        final var manager = new SessionManager(store, clock, Duration.ofSeconds(30));
+        final var session = manager.createSession("s1");
+        final var replacementKey = new SessionKey("s1", "replacement");
+        final var replacement = store.create(replacementKey, NOW.plusSeconds(60));
+        clock.advance(Duration.ofSeconds(15));
+
+        session.touch();
+
+        assertThat(session.state()).isEqualTo(SessionState.CLOSED);
+        assertThat(manager.allSessions()).isEmpty();
+        assertThat(store.find("s1")).contains(replacement);
+        assertThat(store.terminateCount()).isZero();
+    }
+
+    @Test
+    void sameIdCreationsDoNotOverlapStoreAndKeepOneGeneration() throws Exception {
+        final var store = new TrackingSessionStore();
+        final var manager = manager(store);
+        manager.createSession("s1");
+        store.armCreateTracking();
+
+        try (final var executor = Executors.newVirtualThreadPerTaskExecutor()) {
+            final var first = executor.submit(() -> manager.createSession("s1"));
+            assertThat(store.awaitFirstCreate()).isTrue();
+            final var second = executor.submit(() -> {
+                store.secondCreateAttempted();
+                return manager.createSession("s1");
+            });
+
+            first.get(2, TimeUnit.SECONDS);
+            second.get(2, TimeUnit.SECONDS);
+        }
+
+        final var local = manager.getSession("s1").orElseThrow();
+        final var persisted = store.find("s1").orElseThrow();
+        assertThat(store.maxConcurrentCreates()).isOne();
+        assertThat(local.key()).isEqualTo(persisted.key());
+    }
+
+    @Test
+    void hashCollidingIdsDoNotSerializeStoreCreation() throws Exception {
+        final var firstId = "Aa";
+        final var secondId = "BB";
+        assertThat(firstId.hashCode()).isEqualTo(secondId.hashCode());
+        final var store = new TrackingSessionStore();
+        final var manager = manager(store);
+        store.armCreateTracking();
+
+        try (final var executor = Executors.newVirtualThreadPerTaskExecutor()) {
+            final var first = executor.submit(() -> manager.createSession(firstId));
+            assertThat(store.awaitFirstCreate()).isTrue();
+            final var second = executor.submit(() -> {
+                store.secondCreateAttempted();
+                return manager.createSession(secondId);
+            });
+
+            first.get(2, TimeUnit.SECONDS);
+            second.get(2, TimeUnit.SECONDS);
+        }
+
+        assertThat(store.maxConcurrentCreates()).isEqualTo(2);
+        assertThat(manager.getSession(firstId).orElseThrow().key())
+                .isEqualTo(store.find(firstId).orElseThrow().key());
+        assertThat(manager.getSession(secondId).orElseThrow().key())
+                .isEqualTo(store.find(secondId).orElseThrow().key());
+    }
+
+    @Test
+    void sweepEvictsExpiredLocalSessionAndSnapshot() {
+        var store = new InMemorySessionStore();
+        var manager = manager(store);
+        var session = manager.createSession("s1");
+
+        manager.sweep(-1);
+
+        assertThat(session.state()).isEqualTo(SessionState.CLOSED);
+        assertThat(store.find("s1")).isEmpty();
+    }
+
+    @Test
+    void sweepKeepsFreshSession() {
+        var store = new InMemorySessionStore();
+        var manager = manager(store);
         var session = manager.createSession("s1");
         session.activate();
 
         manager.sweep(Long.MAX_VALUE);
 
         assertThat(session.state()).isEqualTo(SessionState.ACTIVE);
-        assertThat(store.get("s1")).contains(session);
+        assertThat(manager.getSession("s1")).containsSame(session);
+        assertThat(store.find("s1")).isPresent();
     }
 
-    /**
-     * The race the conditional remove exists for: the sweep iterates a snapshot containing a
-     * stale session while the store already holds a replacement created under the same id
-     * (custom SessionIdGenerator scenario). The stale session must be closed, but the
-     * replacement must survive the eviction.
-     */
-    @Test
-    void sweepNeverEvictsReplacementCreatedUnderSameId() {
-        var stale = new Session("s1", SseConnection.noop());
-        stale.close(); // CLOSED → sweep will try to evict it
+    private static SessionManager manager(SessionStore store) {
+        return new SessionManager(store, Clock.fixed(NOW, ZoneOffset.UTC), Duration.ofSeconds(30));
+    }
 
-        var backing = new InMemorySessionStore();
-        var replacement = new Session("s1", SseConnection.noop());
-        backing.put("s1", replacement);
+    private static final class TrackingSessionStore implements SessionStore {
+        private final InMemorySessionStore delegate = new InMemorySessionStore();
+        private final AtomicInteger touchCount = new AtomicInteger();
+        private final AtomicInteger terminateCount = new AtomicInteger();
+        private final AtomicInteger concurrentCreates = new AtomicInteger();
+        private final AtomicInteger maxConcurrentCreates = new AtomicInteger();
+        private final CountDownLatch firstCreateEntered = new CountDownLatch(1);
+        private final CountDownLatch secondCreateAttempted = new CountDownLatch(1);
+        private final CountDownLatch overlappingCreateEntered = new CountDownLatch(1);
+        private volatile boolean trackCreates;
 
-        // Store whose iteration still yields the stale session — the janitor mid-race.
-        var manager = new SessionManager(new SessionStore() {
-            @Override
-            public @Nullable Session put(String sessionId, Session session) {
-                return backing.put(sessionId, session);
+        @Override
+        public SessionSnapshot create(SessionKey key, Instant expiresAt) {
+            if (!trackCreates) {
+                return delegate.create(key, expiresAt);
             }
-
-            @Override
-            public Optional<Session> get(String sessionId) {
-                return backing.get(sessionId);
+            final var concurrent = concurrentCreates.incrementAndGet();
+            maxConcurrentCreates.accumulateAndGet(concurrent, Math::max);
+            try {
+                if (concurrent == 1) {
+                    firstCreateEntered.countDown();
+                    await(secondCreateAttempted);
+                    await(overlappingCreateEntered, 2, TimeUnit.SECONDS);
+                } else {
+                    overlappingCreateEntered.countDown();
+                }
+                return delegate.create(key, expiresAt);
+            } finally {
+                concurrentCreates.decrementAndGet();
             }
+        }
 
-            @Override
-            public Session computeIfAbsent(String sessionId, Function<String, Session> factory) {
-                return backing.computeIfAbsent(sessionId, factory);
+        @Override
+        public Optional<SessionSnapshot> find(String sessionId) {
+            return delegate.find(sessionId);
+        }
+
+        @Override
+        public boolean compareAndSet(SessionSnapshot expected, SessionSnapshot updated) {
+            return delegate.compareAndSet(expected, updated);
+        }
+
+        @Override
+        public boolean touch(SessionKey key, Instant expiresAt) {
+            touchCount.incrementAndGet();
+            return delegate.touch(key, expiresAt);
+        }
+
+        @Override
+        public boolean terminate(SessionKey key) {
+            terminateCount.incrementAndGet();
+            return delegate.terminate(key);
+        }
+
+        @Override
+        public void close() {
+            delegate.close();
+        }
+
+        void armCreateTracking() {
+            trackCreates = true;
+        }
+
+        boolean awaitFirstCreate() throws InterruptedException {
+            return firstCreateEntered.await(2, TimeUnit.SECONDS);
+        }
+
+        void secondCreateAttempted() {
+            secondCreateAttempted.countDown();
+        }
+
+        int touchCount() {
+            return touchCount.get();
+        }
+
+        int terminateCount() {
+            return terminateCount.get();
+        }
+
+        int maxConcurrentCreates() {
+            return maxConcurrentCreates.get();
+        }
+
+        private static void await(CountDownLatch latch) {
+            try {
+                latch.await();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new IllegalStateException(e);
             }
+        }
 
-            @Override
-            public Collection<Session> values() {
-                return List.of(stale);
+        private static void await(CountDownLatch latch, long timeout, TimeUnit unit) {
+            try {
+                latch.await(timeout, unit);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new IllegalStateException(e);
             }
+        }
+    }
 
-            @Override
-            public @Nullable Session remove(String sessionId) {
-                return backing.remove(sessionId);
-            }
+    private static final class MutableClock extends Clock {
+        private final AtomicReference<Instant> now;
 
-            @Override
-            public boolean remove(String sessionId, Session expected) {
-                return backing.remove(sessionId, expected);
-            }
+        private MutableClock(Instant now) {
+            this.now = new AtomicReference<>(now);
+        }
 
-            @Override
-            public void close() {
-                backing.close();
-            }
-        });
+        void advance(Duration duration) {
+            now.updateAndGet(current -> current.plus(duration));
+        }
 
-        manager.sweep(Long.MAX_VALUE);
+        @Override
+        public ZoneId getZone() {
+            return ZoneOffset.UTC;
+        }
 
-        assertThat(backing.get("s1")).contains(replacement);
-        assertThat(replacement.state()).isNotEqualTo(SessionState.CLOSED);
+        @Override
+        public Clock withZone(ZoneId zone) {
+            return this;
+        }
+
+        @Override
+        public Instant instant() {
+            return now.get();
+        }
     }
 }

--- a/tachyon-core/src/test/java/dev/tachyonmcp/core/transport/netty/McpOperationHandlerTest.java
+++ b/tachyon-core/src/test/java/dev/tachyonmcp/core/transport/netty/McpOperationHandlerTest.java
@@ -7,7 +7,11 @@ import dev.tachyonmcp.api.server.domain.RequestId;
 import dev.tachyonmcp.core.server.McpDispatcher;
 import dev.tachyonmcp.core.server.TachyonServer;
 import dev.tachyonmcp.core.server.internal.ServerEngine;
+import dev.tachyonmcp.core.server.session.InMemorySessionStore;
 import dev.tachyonmcp.core.server.session.SessionEvent;
+import dev.tachyonmcp.core.server.session.SessionKey;
+import dev.tachyonmcp.core.server.session.SessionSnapshot;
+import dev.tachyonmcp.core.server.session.SessionStore;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.http.DefaultFullHttpRequest;
@@ -21,7 +25,13 @@ import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.timeout.IdleStateEvent;
 import io.netty.util.ReferenceCountUtil;
 import java.nio.charset.StandardCharsets;
+import java.time.Instant;
 import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -165,6 +175,85 @@ class McpOperationHandlerTest {
         var response = (HttpResponse) msg;
         assertThat(response.status()).isEqualTo(HttpResponseStatus.OK);
         assertThat(response.headers().get(HttpHeaderNames.CONTENT_TYPE)).isEqualTo("text/event-stream");
+    }
+
+    @Test
+    void sessionLookupRunsOutsideEventLoop() throws Exception {
+        final var lookupThread = new AtomicReference<Thread>();
+        final var lookupFinished = new CountDownLatch(1);
+        final var store = new ThreadRecordingSessionStore(lookupThread, lookupFinished);
+        final var testServer = (ServerEngine) TachyonServer.builder()
+                .session(config -> config.enabled(true).sessionStore(store))
+                .build();
+
+        try {
+            try (final var lookupExecutor = Executors.newSingleThreadExecutor()) {
+                final var testChannel = new EmbeddedChannel(new McpOperationHandler(
+                        testServer, new McpDispatcher(testServer, Runnable::run), lookupExecutor));
+                try {
+                    final var eventLoopThread = Thread.currentThread();
+                    final var request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/mcp");
+                    request.headers().set("MCP-Session-Id", "missing");
+
+                    testChannel.writeInbound(request);
+
+                    assertThat(lookupFinished.await(2, TimeUnit.SECONDS)).isTrue();
+                    assertThat(lookupThread)
+                            .hasValueSatisfying(thread -> assertThat(thread).isNotSameAs(eventLoopThread));
+                    testChannel.runPendingTasks();
+                    final var response = (FullHttpResponse) testChannel.readOutbound();
+                    assertThat(response.status()).isEqualTo(HttpResponseStatus.NOT_FOUND);
+                    response.release();
+                } finally {
+                    testChannel.finishAndReleaseAll();
+                }
+            }
+        } finally {
+            testServer.close();
+        }
+    }
+
+    private static final class ThreadRecordingSessionStore implements SessionStore {
+        private final InMemorySessionStore delegate = new InMemorySessionStore();
+        private final AtomicReference<Thread> lookupThread;
+        private final CountDownLatch lookupFinished;
+
+        private ThreadRecordingSessionStore(AtomicReference<Thread> lookupThread, CountDownLatch lookupFinished) {
+            this.lookupThread = lookupThread;
+            this.lookupFinished = lookupFinished;
+        }
+
+        @Override
+        public SessionSnapshot create(SessionKey key, Instant expiresAt) {
+            return delegate.create(key, expiresAt);
+        }
+
+        @Override
+        public Optional<SessionSnapshot> find(String sessionId) {
+            lookupThread.set(Thread.currentThread());
+            lookupFinished.countDown();
+            return delegate.find(sessionId);
+        }
+
+        @Override
+        public boolean compareAndSet(SessionSnapshot expected, SessionSnapshot updated) {
+            return delegate.compareAndSet(expected, updated);
+        }
+
+        @Override
+        public boolean touch(SessionKey key, Instant expiresAt) {
+            return delegate.touch(key, expiresAt);
+        }
+
+        @Override
+        public boolean terminate(SessionKey key) {
+            return delegate.terminate(key);
+        }
+
+        @Override
+        public void close() {
+            delegate.close();
+        }
     }
 
     @Test

--- a/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/config/SessionScope.kt
+++ b/tachyon-kotlin/src/main/kotlin/dev/tachyonmcp/kotlin/server/config/SessionScope.kt
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors.
 package dev.tachyonmcp.kotlin.server.config
 
+import dev.tachyonmcp.api.annotations.ExperimentalApi
 import dev.tachyonmcp.api.runtime.InteractionContext
 import dev.tachyonmcp.api.server.session.SessionIdGenerator
 import dev.tachyonmcp.core.server.config.SessionConfig
@@ -24,10 +25,12 @@ public class SessionScope
         /** Janitor sweep interval. */
         public var janitorInterval: Duration? = null
 
-        /** Custom session store implementation. */
+        /** Custom immutable session snapshot store. */
+        @ExperimentalApi(since = "1.0.0-beta.26")
         public var sessionStore: SessionStore? = null
 
         /** Custom session event store. */
+        @ExperimentalApi(since = "1.0.0-beta.26")
         public var sessionEventStore: SessionEventStore? = null
 
         /** Session ID generator;


### PR DESCRIPTION
### New Features

- Sessions can be persisted as immutable snapshots and restored after server restarts.
- Session state, protocol details, extensions, logging level, expiration, and lifecycle status are preserved during recovery.
- Logging levels can be configured per session.

### Bug Fixes

- Prevented stale session generations from overwriting or terminating newer sessions.
- Session expiration and cleanup now respect configured time-to-live values.


### Documentation

- Clarified clustering behavior, sticky routing requirements, restart recovery, and experimental persistence options.