### PR TITLE
fix(core): handle session lookup failures and stabilize async test

### DIFF
--- a/docs/running/deployment.md
+++ b/docs/running/deployment.md
@@ -103,10 +103,11 @@ most MCP clients.
 Sessions are off by default, and a stateless server scales horizontally with no
 sticky routing. A server that sets `session.enabled(true)` keeps live sessions
 in-process, so more than one instance needs sticky routing while a session is
-active. Experimental `SessionStore` and `SessionEventStore` implementations can
-persist session snapshots and replay events across restarts. They do not
-coordinate live session or transport ownership between nodes. See
-[session configuration](configuration.md#session).
+active.
+
+Experimental `SessionStore` and `SessionEventStore` implementations can persist session snapshots and replay events across restarts. They do not
+coordinate live session or transport ownership between nodes. See [session configuration](configuration.md#session).
+If session-store lookup fails during a POST, the server returns HTTP 500 with `Session lookup failed`. An unknown session returns HTTP 404.
 
 ## Containers
 

--- a/tachyon-core/pom.xml
+++ b/tachyon-core/pom.xml
@@ -48,6 +48,11 @@
 
         <!-- Test -->
         <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-params</artifactId>
             <scope>test</scope>

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/transport/netty/McpOperationHandler.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/transport/netty/McpOperationHandler.java
@@ -130,7 +130,19 @@ public class McpOperationHandler extends ChannelInboundHandlerAdapter {
                                 final JsonRpcMessage message;
                                 try {
                                     if (sessionId != null) {
-                                        final var session = server.getSession(sessionId);
+                                        final Optional<Session> session;
+                                        try {
+                                            session = server.getSession(sessionId);
+                                        } catch (RuntimeException e) {
+                                            logger.warn("Failed to resolve session: {}", sessionId, e);
+                                            ctx.executor()
+                                                    .execute(() -> sendPlainTextAndClose(
+                                                            ctx,
+                                                            HttpResponseStatus.INTERNAL_SERVER_ERROR,
+                                                            "Session lookup failed",
+                                                            origin));
+                                            return;
+                                        }
                                         if (session.isEmpty()) {
                                             ctx.executor()
                                                     .execute(() -> sendPlainTextAndClose(
@@ -150,7 +162,7 @@ public class McpOperationHandler extends ChannelInboundHandlerAdapter {
                             },
                             executor)
                     .exceptionally(ex -> {
-                        logger.error("Failed to parse POST body", ex);
+                        logger.debug("Failed to parse POST body", ex);
                         ctx.executor()
                                 .execute(() -> sendResponseAndClose(
                                         ctx,

--- a/tachyon-core/src/test/java/dev/tachyonmcp/core/transport/netty/McpOperationHandlerTest.java
+++ b/tachyon-core/src/test/java/dev/tachyonmcp/core/transport/netty/McpOperationHandlerTest.java
@@ -2,6 +2,10 @@
 package dev.tachyonmcp.core.transport.netty;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import dev.tachyonmcp.api.server.domain.RequestId;
 import dev.tachyonmcp.core.server.McpDispatcher;
@@ -16,7 +20,6 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.http.DefaultFullHttpRequest;
 import io.netty.handler.codec.http.FullHttpResponse;
-import io.netty.handler.codec.http.HttpContent;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpResponse;
@@ -179,14 +182,13 @@ class McpOperationHandlerTest {
 
     @Test
     void sessionLookupRunsOutsideEventLoop() throws Exception {
-        final var lookupThread = new AtomicReference<Thread>();
+        final var lookupThread = new AtomicReference<@Nullable Thread>();
         final var lookupFinished = new CountDownLatch(1);
-        final var store = new ThreadRecordingSessionStore(lookupThread, lookupFinished);
-        final var testServer = (ServerEngine) TachyonServer.builder()
-                .session(config -> config.enabled(true).sessionStore(store))
-                .build();
 
-        try {
+        try (final var store = new ThreadRecordingSessionStore(lookupThread, lookupFinished);
+                final var testServer = (ServerEngine) TachyonServer.builder()
+                        .session(config -> config.enabled(true).sessionStore(store))
+                        .build()) {
             try (final var lookupExecutor = Executors.newSingleThreadExecutor()) {
                 final var testChannel = new EmbeddedChannel(new McpOperationHandler(
                         testServer, new McpDispatcher(testServer, Runnable::run), lookupExecutor));
@@ -200,7 +202,10 @@ class McpOperationHandlerTest {
                     assertThat(lookupFinished.await(2, TimeUnit.SECONDS)).isTrue();
                     assertThat(lookupThread)
                             .hasValueSatisfying(thread -> assertThat(thread).isNotSameAs(eventLoopThread));
-                    testChannel.runPendingTasks();
+                    await().pollInSameThread().atMost(2, TimeUnit.SECONDS).untilAsserted(() -> {
+                        testChannel.runPendingTasks();
+                        assertThat(testChannel.outboundMessages()).isNotEmpty();
+                    });
                     final var response = (FullHttpResponse) testChannel.readOutbound();
                     assertThat(response.status()).isEqualTo(HttpResponseStatus.NOT_FOUND);
                     response.release();
@@ -208,7 +213,41 @@ class McpOperationHandlerTest {
                     testChannel.finishAndReleaseAll();
                 }
             }
+        }
+    }
+
+    @Test
+    void postSessionLookupFailureReturns500() {
+        final var store = mock(SessionStore.class);
+        when(store.find("unavailable")).thenThrow(new IllegalStateException("Store unavailable"));
+        final var testServer = (ServerEngine) TachyonServer.builder()
+                .session(config -> config.enabled(true).sessionStore(store))
+                .build();
+        final var testChannel = new EmbeddedChannel(
+                new InteractionHandler(),
+                new McpOperationHandler(testServer, new McpDispatcher(testServer, Runnable::run), Runnable::run));
+        try {
+            final var request = new DefaultFullHttpRequest(
+                    HttpVersion.HTTP_1_1, HttpMethod.POST, "/mcp", Unpooled.copiedBuffer("""
+                {"jsonrpc":"2.0","id":1,"method":"ping"}
+                """, StandardCharsets.UTF_8));
+            request.headers().set("MCP-Session-Id", "unavailable");
+            testChannel.writeInbound(request);
+            testChannel.runPendingTasks();
+            final var response = (FullHttpResponse) testChannel.readOutbound();
+            assertThat(response).isNotNull();
+            try {
+                assertThat(response.status()).isEqualTo(HttpResponseStatus.INTERNAL_SERVER_ERROR);
+                assertThat(response.content().toString(StandardCharsets.UTF_8)).isEqualTo("Session lookup failed");
+                assertThat(response.headers().get(HttpHeaderNames.CONTENT_TYPE)).startsWith("text/plain");
+                assertThat(response.headers().get(HttpHeaderNames.CONNECTION)).isEqualTo("close");
+                assertThat(request.refCnt()).isZero();
+                verify(store).find("unavailable");
+            } finally {
+                response.release();
+            }
         } finally {
+            testChannel.finishAndReleaseAll();
             testServer.close();
         }
     }
@@ -403,17 +442,6 @@ class McpOperationHandlerTest {
         Object msg;
         while ((msg = channel.readOutbound()) != null) {
             ReferenceCountUtil.release(msg);
-        }
-    }
-
-    private String readComment() {
-        var msg = channel.readOutbound();
-        assertThat(msg).isInstanceOf(HttpContent.class);
-        var content = (HttpContent) msg;
-        try {
-            return content.content().toString(StandardCharsets.UTF_8);
-        } finally {
-            content.release();
         }
     }
 }


### PR DESCRIPTION
- Fix flaky test waits for outbound response
- Fix POST misclassifies session-store failures as malformed JSON.