### PR TITLE
fix(core): ObservationListeners nest in registration order

### DIFF
--- a/docs/features/tools.md
+++ b/docs/features/tools.md
@@ -209,9 +209,8 @@ Values must be ASCII; see [Configuration](../running/configuration.md) for the c
 > Do not annotate secrets. Mirrored values are visible to every intermediary on the path, and Base64
 > is an encoding, not encryption.
 
-## Jackson note
-
-Tachyon uses **Jackson 3** (`tools.jackson.*`), not Jackson 2. Import `tools.jackson.databind.JsonNode`, not `com.fasterxml.jackson.databind.JsonNode`.
+> [!NOTE] 
+> Tachyon uses **Jackson 3** (`tools.jackson.*`), not Jackson 2. Import `tools.jackson.databind.JsonNode`, not `com.fasterxml.jackson.databind.JsonNode`.
 
 ## Kotlin DSL
 
@@ -259,5 +258,5 @@ tool(
 - `scope.success(value)` / `scope.success(value, text)` — symmetric typed result via configured serializer
 
 `typedTool<In, Out>` derives both schemas from the types, so the literals above disappear
-entirely. See [typed tools](../kotlin/#typed-tools) and the
-[Kotlin DSL](../kotlin/) for the full Kotlin API.
+entirely. See [typed tools](/docs/kotlin/#typed-tools) and the
+[Kotlin DSL](/docs/kotlin/) for the full Kotlin API.

--- a/docs/running/observability.md
+++ b/docs/running/observability.md
@@ -21,6 +21,8 @@ OpenTelemetry using the [MCP semantic conventions](https://github.com/open-telem
 
 Listeners cannot short-circuit, reject, or substitute results. Exceptions in listeners are fault-isolated and never affect handler execution, responses, or other listeners.
 
+Listeners nest in registration order: the scope a listener returns from `start` is opened inside the scope of every listener registered before it, so a later-registered listener's context is the active one while dispatch work runs. Scopes close innermost-first, which means each `close()` runs while its own context is current and restores whatever it displaced.
+
 ```java
 var server = TachyonServer.builder()
     .observability(o -> o.listener(myListener))
@@ -127,6 +129,8 @@ TachyonServer(port = 8080) {
 ### Trace Context
 
 Spans parent from `Context.current()` on the dispatch thread. The listener only attaches scope around synchronous dispatch work (decode, kicking off async handler, and — after reattach — completion callback), so handler-started spans join as children without blocking `CompletionStage`s.
+
+Registering two listeners produces two spans per operation, the second nested under the first, and a handler-started span parents from the innermost one.
 
 ### Attributes
 

--- a/integrations/tachyon-opentelemetry/src/test/java/dev/tachyonmcp/opentelemetry/McpOpenTelemetryListenerTest.java
+++ b/integrations/tachyon-opentelemetry/src/test/java/dev/tachyonmcp/opentelemetry/McpOpenTelemetryListenerTest.java
@@ -30,6 +30,7 @@ import dev.tachyonmcp.core.server.config.ObservabilityConfig;
 import dev.tachyonmcp.testkit.Mcp20251125Client;
 import dev.tachyonmcp.testkit.Mcp20260728Client;
 import dev.tachyonmcp.testkit.McpTestServers;
+import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
@@ -41,6 +42,8 @@ import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
 import java.io.IOException;
 import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -61,6 +64,9 @@ class McpOpenTelemetryListenerTest {
     private InMemorySpanExporter spans;
     private InMemoryMetricReader metrics;
     private OpenTelemetrySdk otel;
+
+    /** Span id {@code Span.current()} reported inside the {@code nesting} tool handler. */
+    private final AtomicReference<String> handlerSpanId = new AtomicReference<>();
 
     @BeforeEach
     void setUp() {
@@ -365,6 +371,43 @@ class McpOpenTelemetryListenerTest {
     }
 
     @Test
+    @DisplayName(
+            "two listeners nest: the second's span is a child of the first's, and the handler runs inside the innermost")
+    void nestedListenersProduceNestedSpansWithHandlerInsideInnermost() throws Exception {
+        // ObservationScope contract: a listener registered later opens its scope inside one
+        // registered earlier, so dispatch work runs under the innermost listener's context.
+        try (var server = startServer(o -> o.listener(McpOpenTelemetryListener.create(otel)));
+                var client = new Mcp20251125Client(server.port())) {
+            final var sessionId = client.initialize();
+            final var response = client.post(sessionId, callNesting());
+            assertThat(response).isSuccess().hasTextContent("nested");
+
+            final var serverSpans = spansFor("tools/call nesting");
+            assertThat(serverSpans).as("one span per registered listener").hasSize(2);
+
+            final var roots = serverSpans.stream()
+                    .filter(span -> !span.getParentSpanContext().isValid())
+                    .toList();
+            assertThat(roots)
+                    .as("only the first-registered listener's span is parentless")
+                    .hasSize(1);
+            final var outerSpanId = roots.getFirst().getSpanId();
+
+            final var nested = serverSpans.stream()
+                    .filter(span ->
+                            outerSpanId.equals(span.getParentSpanContext().getSpanId()))
+                    .toList();
+            assertThat(nested)
+                    .as("the second-registered listener's span is a child of the first's")
+                    .hasSize(1);
+
+            assertThat(handlerSpanId.get())
+                    .as("the handler runs under the innermost listener's span")
+                    .isEqualTo(nested.getFirst().getSpanId());
+        }
+    }
+
+    @Test
     @DisplayName("notifications are traced, without a jsonrpc.request.id")
     void notificationSpan() throws Exception {
         try (var server = startServer();
@@ -532,6 +575,20 @@ class McpOpenTelemetryListenerTest {
         return spanFor(name);
     }
 
+    private static String callNesting() {
+        // language=json
+        return """
+                {"jsonrpc":"2.0","id":11,"method":"tools/call",\
+                "params":{"name":"nesting","arguments":{}}}""";
+    }
+
+    /** Every finished span with this name -- two listeners each record one per operation. */
+    private List<SpanData> spansFor(String name) {
+        return spans.getFinishedSpanItems().stream()
+                .filter(span -> name.equals(span.getName()))
+                .toList();
+    }
+
     private SpanData spanFor(String name) {
         var matching = spans.getFinishedSpanItems().stream()
                 .filter(span -> name.equals(span.getName()))
@@ -562,6 +619,10 @@ class McpOpenTelemetryListenerTest {
                     server.tools().register(tool -> tool.name("failing"), (ctx, request) -> ToolResult.error("nope"));
                     server.tools().register(tool -> tool.name("throwing"), (ctx, request) -> {
                         throw new IOException("🔥 boom");
+                    });
+                    server.tools().register(tool -> tool.name("nesting"), (ctx, request) -> {
+                        handlerSpanId.set(Span.current().getSpanContext().getSpanId());
+                        return ToolResult.text("nested");
                     });
                     server.tools().register(tool -> tool.name("logging"), (ctx, request) -> {
                         ctx.notifications().info("otel.probe", "streamed log");

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/observability/Observation.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/observability/Observation.java
@@ -96,7 +96,8 @@ public final class Observation {
     }
 
     /**
-     * Closes the scopes {@link #start} opened, on the thread {@link #start} ran on. Idempotent —
+     * Closes the scopes {@link #start} opened, on the thread {@link #start} ran on, in reverse
+     * registration order so each scope closes while its own context is current. Idempotent —
      * dispatch has multiple exit paths (a handler hand-off, several early-rejection branches) and
      * only one of them runs per operation, but guarding here means a future call site calling this
      * defensively can never double-close the underlying scope.
@@ -109,7 +110,8 @@ public final class Observation {
 
     /**
      * Re-attaches every scope onto the current thread for one bounded phase of synchronous dispatch
-     * work; close the returned list with {@link #closeReattached} before the phase ends. May be
+     * work, in registration order so the phase rebuilds the same nesting {@link #start} built; close
+     * the returned list with {@link #closeReattached} before the phase ends. May be
      * called more than once per operation — once per phase that runs after an executor hop (e.g.
      * once for a handler's async kickoff, again for its later completion callback) — never
      * concurrently for the same operation, since the dispatch chain sequences those phases.
@@ -131,7 +133,7 @@ public final class Observation {
         return reattached;
     }
 
-    /** Closes scopes previously returned by {@link #reattach}. */
+    /** Closes scopes previously returned by {@link #reattach}, in reverse registration order. */
     public void closeReattached(List<ObservationScope> reattached) {
         closeAll(reattached);
     }
@@ -158,10 +160,14 @@ public final class Observation {
         }
     }
 
+    /**
+     * Closes scopes innermost-first. Attaching a context nests it inside whatever was attached
+     * before, so unwinding forward would restore a finished listener's context onto the thread.
+     */
     private void closeAll(List<ObservationScope> toClose) {
-        for (var scope : toClose) {
+        for (var i = toClose.size() - 1; i >= 0; i--) {
             try {
-                scope.close();
+                toClose.get(i).close();
             } catch (Exception e) {
                 fault("scope.close", info.method(), e);
             }

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/observability/ObservationListener.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/observability/ObservationListener.java
@@ -21,7 +21,11 @@ import jdk.jfr.Experimental;
 @Experimental
 public interface ObservationListener {
 
-    /** Fires once, as early as {@code method} (and {@code id}, if any) is known, before any handler or rejection. */
+    /**
+     * Fires once, as early as {@code method} (and {@code id}, if any) is known, before any handler or
+     * rejection. Listeners are called in registration order, so the {@link ObservationScope} a
+     * listener returns here nests inside the scope of every listener registered before it.
+     */
     ObservationScope start(OperationInfo info);
 
     /** Fires exactly once, at the operation's terminal boundary — see the observability design notes for what that boundary is per operation kind. */

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/observability/ObservationScope.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/observability/ObservationScope.java
@@ -10,6 +10,11 @@ import dev.tachyonmcp.api.annotations.InternalApi;
  * <p>The dispatcher closes a scope on the same thread it opened or reattached it on, and never
  * keeps one open across an incomplete {@code CompletionStage} — only across the synchronous
  * dispatch work that runs while attached.
+ *
+ * <p>Scopes from multiple registered listeners nest: a listener registered later is opened inside
+ * one registered earlier, and the dispatcher closes them innermost-first. An implementation may
+ * therefore assume {@link #close()} runs while its own context is the current one, and restore
+ * whatever context it displaced.
  */
 @InternalApi
 public interface ObservationScope {

--- a/tachyon-core/src/test/java/dev/tachyonmcp/core/server/ObservationDispatchTest.java
+++ b/tachyon-core/src/test/java/dev/tachyonmcp/core/server/ObservationDispatchTest.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
@@ -57,6 +58,51 @@ class ObservationDispatchTest {
         public void complete(OperationInfo info, OperationOutcome outcome) {
             completions.add(new CompleteCall(info, outcome));
             if (throwOnComplete != null) throw throwOnComplete;
+        }
+    }
+
+    /**
+     * Stands in for a real context-setting listener such as {@code McpOpenTelemetryListener}: {@code
+     * start} and {@code reattach} displace the thread's current context id with this listener's own,
+     * and the returned scope restores whatever it displaced. Every close appends one {@code
+     * id:seen->restored} row, so a test sees both the order scopes unwound in and what each close left
+     * attached to the thread.
+     */
+    private static final class StackingListener implements ObservationListener {
+
+        private final String id;
+        private final ThreadLocal<String> current;
+        private final List<String> trace;
+
+        StackingListener(String id, ThreadLocal<String> current, List<String> trace) {
+            this.id = id;
+            this.current = current;
+            this.trace = trace;
+        }
+
+        @Override
+        public ObservationScope start(OperationInfo info) {
+            return attach();
+        }
+
+        @Override
+        public void complete(OperationInfo info, OperationOutcome outcome) {}
+
+        private ObservationScope attach() {
+            final var previous = current.get();
+            current.set(id);
+            return new ObservationScope() {
+                @Override
+                public void close() {
+                    trace.add(id + ":" + current.get() + "->" + previous);
+                    current.set(previous);
+                }
+
+                @Override
+                public ObservationScope reattach() {
+                    return attach();
+                }
+            };
         }
     }
 
@@ -256,6 +302,56 @@ class ObservationDispatchTest {
             assertThat(healthy.starts).hasSize(1);
             assertThat(healthy.completions).hasSize(1);
             assertThat(healthy.completions.getFirst().outcome()).isInstanceOf(OperationOutcome.Completed.class);
+        }
+    }
+
+    @Test
+    void nestedListenerScopesCloseInnermostFirstAcrossHops() throws Exception {
+        // ObservationScope contract: scopes from multiple listeners nest in registration order and
+        // the dispatcher closes them innermost-first, so each close runs under its own context.
+        final var current = new ThreadLocal<String>();
+        final var trace = new CopyOnWriteArrayList<String>();
+        final var handlerSaw = new CopyOnWriteArrayList<String>();
+        final var outer = new StackingListener("A", current, trace);
+        final var inner = new StackingListener("B", current, trace);
+
+        // Completes the handler's future off the dispatch thread, so the encode phase is a genuine
+        // post-hop reattach rather than an inline continuation.
+        final var completer = Executors.newSingleThreadExecutor(r -> new Thread(r, "obs-completer"));
+        final AsyncToolFn fn = (ctx, request) -> {
+            handlerSaw.add(String.valueOf(current.get()));
+            return CompletableFuture.supplyAsync(() -> ToolResult.text("ok"), completer);
+        };
+        final var descriptor =
+                ToolDescriptor.builder().name("nested").description("nested").build();
+
+        try (ServerEngine server = newEngine(
+                b -> b.observability(o -> o.listener(outer).listener(inner)),
+                s -> s.tools().registerAsync(descriptor, fn))) {
+            server.createSession("sess-nested").activate();
+            final var dispatcher = new McpDispatcher(server, server.executor());
+            final var params = Map.of("name", "nested", "arguments", Map.of());
+
+            final var result = asResponse(dispatcher
+                    .dispatchRequestAsync(RequestId.of(1), "tools/call", params, "sess-nested")
+                    .join());
+            assertThat(result.responseBodyString()).contains("ok");
+
+            // Nesting still follows registration order: the later-registered listener is innermost.
+            assertThat(handlerSaw).containsExactly("B");
+
+            // More than one phase ran -- the start phase plus at least one post-hop reattach.
+            assertThat(trace.size()).isGreaterThanOrEqualTo(4).isEven();
+
+            // Each phase unwinds innermost-first and hands the thread back clean. Under forward
+            // closure a phase instead reads ["A:B->null", "B:null->A"], leaving "A" attached.
+            for (var i = 0; i < trace.size(); i += 2) {
+                assertThat(trace.subList(i, i + 2))
+                        .as("phase starting at %d", i)
+                        .containsExactly("B:B->A", "A:A->null");
+            }
+        } finally {
+            completer.shutdownNow();
         }
     }
 


### PR DESCRIPTION
### Bug Fixes

- Fixed observability scope handling so nested listeners close in the correct order and preserve the active context during asynchronous operations.
- Ensured handler-created spans correctly nest under the innermost active listener span.

### Documentation

- Clarified listener registration order, scope nesting, context restoration, and span parentage.
- Reformatted the Jackson note and corrected Kotlin documentation links.

### Tests

- Added coverage for nested listeners, asynchronous context propagation, span relationships, and complete context restoration.