### PR TITLE
feat(core): drain in-flight requests through transport writes on close()

### DIFF
--- a/docs/running/configuration.md
+++ b/docs/running/configuration.md
@@ -321,9 +321,13 @@ Configured via `runtime { }` / `RuntimeConfig.Builder`.
 
 | Option | Default | Description |
 |---|---|---|
-| `shutdownGracePeriod` | `5s` | Time in-flight handlers get to drain on `close()`; `ZERO` interrupts immediately |
+| `shutdownGracePeriod` | `5s` | Shared time budget to drain admitted requests through handler completion and transport finalization, then terminate the executor on `close()`; `ZERO` interrupts immediately |
 | `requestTimeout` | `60s` | Timeout for pending requests sent to the client |
 | `clock` | `Clock.systemUTC()` | Clock for task timestamps and TTL/expiry checks; set a fixed or controllable clock in tests |
+
+Shutdown rejects new dispatches while draining, answering them with `503 Service Unavailable`. The executor remains available for asynchronous continuations during the grace period. Subscriptions, extensions, sessions, and event storage are torn down after draining completes or the grace period expires. Unfinished asynchronous stages can outlive that deadline.
+
+`close()` blocks its calling thread until draining finishes, and draining needs the I/O event loops to flush in-flight responses — so calling it from an event loop throws `IllegalStateException` rather than stalling for the whole grace period.
 
 ## Observability
 

--- a/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/ShutdownDrainTest.java
+++ b/e2e/src/test/java/dev/tachyonmcp/e2e/mcp/ShutdownDrainTest.java
@@ -1,0 +1,137 @@
+/* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
+package dev.tachyonmcp.e2e.mcp;
+
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import dev.tachyonmcp.api.server.domain.RequestId;
+import dev.tachyonmcp.api.server.features.tools.ToolResult;
+import dev.tachyonmcp.core.server.McpDispatcher;
+import dev.tachyonmcp.core.server.TachyonServer;
+import dev.tachyonmcp.core.server.internal.ServerEngine;
+import dev.tachyonmcp.testkit.Mcp20251125Client;
+import io.netty.channel.Channel;
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+
+class ShutdownDrainTest {
+    /** Draining rejects new work with 503, not the 500 a genuine dispatch failure earns. */
+    @Test
+    void refusesNewRequestsWithServiceUnavailableWhileDraining() throws Exception {
+        final var result = new CompletableFuture<ToolResult>();
+        final var server = (ServerEngine) TachyonServer.builder()
+                .network(n -> n.port(0))
+                .session(s -> s.enabled(true))
+                .runtime(r -> r.shutdownGracePeriod(Duration.ofSeconds(5)))
+                .build();
+        server.tools().registerAsync(b -> b.name("drain"), (context, request) -> {
+            context.notifications().comment("started");
+            return result;
+        });
+        server.start();
+        try (final var slow = new Mcp20251125Client(server.port());
+                final var other = new Mcp20251125Client(server.port())) {
+            final var slowSession = slow.initialize();
+            final var otherSession = other.initialize();
+            // language=json
+            try (final var stream = slow.openPostStream(slowSession, """
+                    {"jsonrpc":"2.0","id":42,"method":"tools/call","params":{"name":"drain","arguments":{}}}
+                    """)) {
+                final var closing = CompletableFuture.runAsync(server::close, Thread::startVirtualThread);
+                try {
+                    await().atMost(Duration.ofSeconds(2)).untilAsserted(() -> {
+                        final var refused = other.ping(otherSession, 7);
+                        assertThat(refused.statusCode()).isEqualTo(503);
+                        assertThat(refused.body()).isEqualTo("Server shutting down");
+                    });
+                    // The already-admitted request still gets its real answer.
+                    result.complete(ToolResult.empty());
+                    final var frame = stream.await(
+                            f -> !f.data().isBlank() && f.json().path("id").asInt() == 42, Duration.ofSeconds(3));
+                    // language=json
+                    assertThatJson(frame.data()).isEqualTo("""
+                            {"id":42,"jsonrpc":"2.0","result":{"content":[]}}
+                            """);
+                } finally {
+                    result.complete(ToolResult.empty());
+                    closing.get(10, TimeUnit.SECONDS);
+                }
+            }
+        }
+    }
+
+    @Test
+    void drainsPostSseFinalizationAcrossEventLoopHop() throws Exception {
+        final var channel = new AtomicReference<Channel>();
+        final var result = new CompletableFuture<ToolResult>();
+        final var releaseEventLoop = new CountDownLatch(1);
+        final var eventLoopBlocked = new CountDownLatch(1);
+        final var server = (ServerEngine) TachyonServer.builder()
+                .network(n -> n.port(0))
+                .session(s -> s.enabled(true))
+                .runtime(r -> r.shutdownGracePeriod(Duration.ofSeconds(5)))
+                .pipelineCustomizer(p -> channel.set(p.channel()))
+                .build();
+        server.tools().registerAsync(b -> b.name("drain"), (context, request) -> {
+            context.notifications().comment("started");
+            return result;
+        });
+        server.start();
+        var closeStarted = false;
+        try (final var client = new Mcp20251125Client(server.port())) {
+            final var session = client.initialize();
+            // language=json
+            try (final var stream = client.openPostStream(session, """
+                    {"jsonrpc":"2.0","id":42,"method":"tools/call","params":{"name":"drain","arguments":{}}}
+                    """)) {
+                channel.get().eventLoop().execute(() -> {
+                    eventLoopBlocked.countDown();
+                    try {
+                        releaseEventLoop.await(10, TimeUnit.SECONDS);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    }
+                });
+                assertThat(eventLoopBlocked.await(5, TimeUnit.SECONDS)).isTrue();
+                final var closing = CompletableFuture.runAsync(server::close, Thread::startVirtualThread);
+                closeStarted = true;
+                try {
+                    final var dispatcher = new McpDispatcher(server, server.executor());
+                    await().atMost(Duration.ofSeconds(2))
+                            .until(() -> dispatcher
+                                    .dispatchRequestAsync(RequestId.of(99), "ping", Map.of(), session)
+                                    .isCompletedExceptionally());
+                    result.complete(ToolResult.empty());
+                    // The handler is done, but its response still needs the blocked event loop —
+                    // close() stays parked until that hop can run.
+                    await().during(Duration.ofMillis(200))
+                            .atMost(Duration.ofSeconds(1))
+                            .untilAsserted(() -> assertThat(closing).isNotDone());
+                    releaseEventLoop.countDown();
+                    final var frame = stream.await(
+                            f -> !f.data().isBlank() && f.json().path("id").asInt() == 42, Duration.ofSeconds(3));
+                    // language=json
+                    assertThatJson(frame.data()).isEqualTo("""
+                            {"id":42,"jsonrpc":"2.0","result":{"content":[]}}
+                            """);
+                    closing.get(5, TimeUnit.SECONDS);
+                } finally {
+                    releaseEventLoop.countDown();
+                    result.complete(ToolResult.empty());
+                    closing.get(10, TimeUnit.SECONDS);
+                }
+            }
+        } finally {
+            releaseEventLoop.countDown();
+            result.complete(ToolResult.empty());
+            // close() is not re-entrant — only close here if the body never got that far.
+            if (!closeStarted) server.close();
+        }
+    }
+}

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/DefaultTachyonServer.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/DefaultTachyonServer.java
@@ -595,12 +595,39 @@ final class DefaultTachyonServer implements ServerEngine, ExtensionContext {
         }
     }
 
-    private void shutdownExtensions() {
+    /**
+     * Runs each extension's {@link ServerExtension#shutdown()} bounded by the shared shutdown
+     * deadline, so a slow extension cannot make {@link #close()} run past the configured grace
+     * period on top of whatever {@link OperationTracker#drain} already spent waiting on in-flight
+     * requests. A slow extension is logged and left running in the background rather than blocked
+     * on indefinitely.
+     */
+    private void shutdownExtensions(long deadlineNanos) {
         for (var ext : extensions) {
+            final var worker = Thread.ofVirtual()
+                    .name("ext-shutdown-" + ext.extensionId())
+                    .start(() -> {
+                        try {
+                            ext.shutdown();
+                        } catch (Exception e) {
+                            logger.warn("Extension shutdown error: {}", ext.extensionId(), e);
+                        }
+                    });
+            var remainingMs = (deadlineNanos - System.nanoTime()) / 1_000_000;
+            if (remainingMs <= 0) {
+                logger.warn("Shutdown grace period already elapsed, not waiting on extension: {}", ext.extensionId());
+                continue;
+            }
             try {
-                ext.shutdown();
-            } catch (Exception e) {
-                logger.warn("Extension shutdown error: {}", ext.extensionId(), e);
+                worker.join(remainingMs);
+                if (worker.isAlive()) {
+                    logger.warn(
+                            "Extension shutdown exceeded remaining grace period, continuing without waiting further: {}",
+                            ext.extensionId());
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return;
             }
         }
     }
@@ -944,7 +971,7 @@ final class DefaultTachyonServer implements ServerEngine, ExtensionContext {
                 Thread.currentThread().interrupt();
             }
             subscriptionRegistry.closeAll();
-            shutdownExtensions();
+            shutdownExtensions(deadline);
             taskRegistry.stopTtlJanitor();
             sessionManager.close();
             sessionEventStore.close();

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/DefaultTachyonServer.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/DefaultTachyonServer.java
@@ -51,6 +51,7 @@ import dev.tachyonmcp.core.server.handlers.LoggingHandlers;
 import dev.tachyonmcp.core.server.handlers.PingHandler;
 import dev.tachyonmcp.core.server.handlers.SubscriptionsListenHandler;
 import dev.tachyonmcp.core.server.internal.NotificationLogSupport;
+import dev.tachyonmcp.core.server.internal.OperationTracker;
 import dev.tachyonmcp.core.server.internal.ServerEngine;
 import dev.tachyonmcp.core.server.json.JacksonPayloadSerde;
 import dev.tachyonmcp.core.server.json.JsonUtils;
@@ -112,6 +113,7 @@ final class DefaultTachyonServer implements ServerEngine, ExtensionContext {
     private final Map<String, RpcMethodHandler<?, ?>> methodHandlers = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<RequestId, PendingRequestEntry> pendingRequests = new ConcurrentHashMap<>();
     private final ExecutorService executor;
+    private final OperationTracker operations = new OperationTracker();
     private final List<ServerExtension> extensions;
     private final @Nullable Consumer<ChannelPipeline> pipelineCustomizer;
     private final Map<String, String> extensionMethodOwners = new ConcurrentHashMap<>();
@@ -162,6 +164,11 @@ final class DefaultTachyonServer implements ServerEngine, ExtensionContext {
     @Override
     public ExecutorService executor() {
         return executor;
+    }
+
+    @Override
+    public OperationTracker operations() {
+        return operations;
     }
 
     @Override
@@ -915,22 +922,29 @@ final class DefaultTachyonServer implements ServerEngine, ExtensionContext {
     @Override
     public void close() {
         if (transport instanceof NettyServer netty) {
+            if (netty.inEventLoop()) {
+                throw new IllegalStateException("close() must not be called from a Netty event loop thread — "
+                        + "draining in-flight requests needs that thread to flush their responses. "
+                        + "Call close() from another thread.");
+            }
             netty.stopAccepting();
         }
         try {
             logger.info("Shutting down TachyonMCP Server");
-            subscriptionRegistry.closeAll();
-            shutdownExtensions();
-            executor.shutdown();
+            final var deadline =
+                    System.nanoTime() + config.runtime().shutdownGracePeriod().toNanos();
             try {
-                var grace = config.runtime().shutdownGracePeriod();
-                if (!executor.awaitTermination(grace.toMillis(), TimeUnit.MILLISECONDS)) {
+                operations.drain(deadline);
+                executor.shutdown();
+                if (!executor.awaitTermination(Math.max(0, deadline - System.nanoTime()), TimeUnit.NANOSECONDS)) {
                     executor.shutdownNow();
                 }
             } catch (InterruptedException e) {
                 executor.shutdownNow();
                 Thread.currentThread().interrupt();
             }
+            subscriptionRegistry.closeAll();
+            shutdownExtensions();
             taskRegistry.stopTtlJanitor();
             sessionManager.close();
             sessionEventStore.close();

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/McpDispatcher.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/McpDispatcher.java
@@ -216,6 +216,39 @@ public class McpDispatcher {
             @Nullable String sessionId,
             @Nullable OutboundSseStream outboundSseStream,
             @Nullable ChannelContext channelContext) {
+        return dispatchRequestAsync(
+                id,
+                method,
+                params,
+                sessionId,
+                outboundSseStream,
+                channelContext,
+                CompletableFuture.completedFuture(null));
+    }
+
+    /** Dispatches a request and retains its shutdown admission until the transport finishes writing. */
+    public CompletableFuture<DispatchResult> dispatchRequestAsync(
+            RequestId id,
+            String method,
+            Object params,
+            @Nullable String sessionId,
+            @Nullable OutboundSseStream outboundSseStream,
+            @Nullable ChannelContext channelContext,
+            CompletableFuture<Void> transportCompletion) {
+        return server.operations()
+                .execute(
+                        () -> dispatchTrackedRequestAsync(
+                                id, method, params, sessionId, outboundSseStream, channelContext),
+                        transportCompletion);
+    }
+
+    private CompletableFuture<DispatchResult> dispatchTrackedRequestAsync(
+            RequestId id,
+            String method,
+            Object params,
+            @Nullable String sessionId,
+            @Nullable OutboundSseStream outboundSseStream,
+            @Nullable ChannelContext channelContext) {
         Objects.requireNonNull(id, "id");
         Objects.requireNonNull(method, "method");
 

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/internal/OperationTracker.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/internal/OperationTracker.java
@@ -1,0 +1,50 @@
+/* Copyright (c) 2026 Konstantin Pavlov/IT Staff and contributors. */
+package dev.tachyonmcp.core.server.internal;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+/** Tracks admitted requests until their complete dispatch pipeline terminates. */
+public final class OperationTracker {
+    private boolean closing;
+    private int active;
+
+    /**
+     * Admits an operation unless shutdown has started, then tracks dispatch and transport
+     * completion under that one admission decision.
+     */
+    public <T> CompletableFuture<T> execute(
+            Supplier<CompletableFuture<T>> operation, CompletableFuture<Void> transportCompletion) {
+        synchronized (this) {
+            if (closing) {
+                return CompletableFuture.failedFuture(new RejectedExecutionException("Server is shutting down"));
+            }
+            active++;
+        }
+        try {
+            final var result = operation.get();
+            CompletableFuture.allOf(result, transportCompletion).whenComplete((value, failure) -> finished());
+            return result;
+        } catch (Throwable failure) {
+            finished();
+            throw failure;
+        }
+    }
+
+    private synchronized void finished() {
+        active--;
+        if (closing) notifyAll();
+    }
+
+    /** Stops admission and waits for active operations using the shared shutdown deadline. */
+    public synchronized void drain(long deadline) throws InterruptedException {
+        closing = true;
+        while (active != 0) {
+            final var remaining = deadline - System.nanoTime();
+            if (remaining <= 0) return;
+            TimeUnit.NANOSECONDS.timedWait(this, remaining);
+        }
+    }
+}

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/server/internal/ServerEngine.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/server/internal/ServerEngine.java
@@ -98,6 +98,9 @@ public interface ServerEngine extends TachyonServer {
     /** Returns the executor used for handler dispatch. */
     ExecutorService executor();
 
+    /** Returns the server-wide request lifecycle tracker. */
+    OperationTracker operations();
+
     TaskRegistry tasksRegistry();
 
     /** Maps and sends a task status notification. */

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/transport/netty/ChannelHandlerUtils.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/transport/netty/ChannelHandlerUtils.java
@@ -25,6 +25,7 @@ import io.netty.handler.codec.http.HttpVersion;
 import io.netty.util.AttributeKey;
 import io.netty.util.ReferenceCountUtil;
 import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.RejectedExecutionException;
 import org.jspecify.annotations.Nullable;
@@ -167,8 +168,9 @@ public final class ChannelHandlerUtils {
      * broken and no operator action is needed.
      */
     public static boolean isRefused(Throwable ex) {
-        var cause = ex instanceof CompletionException && ex.getCause() != null ? ex.getCause() : ex;
-        return cause instanceof RejectedExecutionException;
+        return ex instanceof CompletionException ce && ce.getCause() != null
+                ? ce.getCause() instanceof RejectedExecutionException
+                : ex instanceof RejectedExecutionException;
     }
 
     /** Writes an accepted response and returns its write completion. */
@@ -179,6 +181,21 @@ public final class ChannelHandlerUtils {
             response.headers().set(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN, origin);
         }
         return ctx.writeAndFlush(response);
+    }
+
+    /**
+     * Completes {@code transportCompletion} once {@code future} finishes, mirroring its outcome —
+     * used to let {@link dev.tachyonmcp.core.server.internal.OperationTracker#drain} know a
+     * response write has finished, whether it succeeded or failed.
+     */
+    public static void completeOn(ChannelFuture future, CompletableFuture<Void> transportCompletion) {
+        future.addListener(f -> {
+            if (f.isSuccess()) {
+                transportCompletion.complete(null);
+            } else {
+                transportCompletion.completeExceptionally(f.cause());
+            }
+        });
     }
 
     /**

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/transport/netty/ChannelHandlerUtils.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/transport/netty/ChannelHandlerUtils.java
@@ -25,6 +25,8 @@ import io.netty.handler.codec.http.HttpVersion;
 import io.netty.util.AttributeKey;
 import io.netty.util.ReferenceCountUtil;
 import java.util.Objects;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.RejectedExecutionException;
 import org.jspecify.annotations.Nullable;
 
 public final class ChannelHandlerUtils {
@@ -155,12 +157,28 @@ public final class ChannelHandlerUtils {
     }
 
     public static void sendAccepted(ChannelHandlerContext ctx, @Nullable String origin) {
+        sendAcceptedAsync(ctx, origin);
+    }
+
+    /**
+     * Returns whether a failed dispatch was refused because the server has no capacity for it —
+     * shutdown has started, or the handler executor rejected the task. Callers answer these with
+     * {@code 503 Service Unavailable} and a DEBUG log, not a {@code 500} and an ERROR: nothing is
+     * broken and no operator action is needed.
+     */
+    public static boolean isRefused(Throwable ex) {
+        var cause = ex instanceof CompletionException && ex.getCause() != null ? ex.getCause() : ex;
+        return cause instanceof RejectedExecutionException;
+    }
+
+    /** Writes an accepted response and returns its write completion. */
+    public static ChannelFuture sendAcceptedAsync(ChannelHandlerContext ctx, @Nullable String origin) {
         var response = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.ACCEPTED);
         response.headers().set(HttpHeaderNames.CONTENT_LENGTH, 0);
         if (origin != null) {
             response.headers().set(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN, origin);
         }
-        ctx.writeAndFlush(response);
+        return ctx.writeAndFlush(response);
     }
 
     /**

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/transport/netty/McpInitializationHandler.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/transport/netty/McpInitializationHandler.java
@@ -2,6 +2,7 @@
 package dev.tachyonmcp.core.transport.netty;
 
 import static dev.tachyonmcp.core.transport.netty.ChannelHandlerUtils.captureInitRequest;
+import static dev.tachyonmcp.core.transport.netty.ChannelHandlerUtils.completeOn;
 import static dev.tachyonmcp.core.transport.netty.ChannelHandlerUtils.isRefused;
 import static dev.tachyonmcp.core.transport.netty.ChannelHandlerUtils.sendAccepted;
 import static dev.tachyonmcp.core.transport.netty.ChannelHandlerUtils.sendAcceptedAsync;
@@ -174,23 +175,27 @@ public class McpInitializationHandler extends ChannelInboundHandlerAdapter {
                         postStream.terminate();
                         if (isRefused(ex)) {
                             logger.debug("Pre-session request refused: method={}", method);
-                            sendPlainTextAndClose(
-                                            ctx, HttpResponseStatus.SERVICE_UNAVAILABLE, "Server shutting down", origin)
-                                    .addListener(f -> transportCompletion.complete(null));
+                            completeOn(
+                                    sendPlainTextAndClose(
+                                            ctx,
+                                            HttpResponseStatus.SERVICE_UNAVAILABLE,
+                                            "Server shutting down",
+                                            origin),
+                                    transportCompletion);
                             return;
                         }
                         logger.error("Dispatch failed for pre-session request: method={}", method, ex);
-                        sendResponseAndClose(
+                        completeOn(
+                                sendResponseAndClose(
                                         ctx,
                                         HttpResponseStatus.INTERNAL_SERVER_ERROR,
                                         "application/json",
                                         dispatcher.parseError(ChannelHandlerUtils.requireInteractionContext(ctx)),
-                                        origin)
-                                .addListener(f -> transportCompletion.complete(null));
+                                        origin),
+                                transportCompletion);
                         return;
                     }
-                    completeDispatch(ctx, postStream, result, origin, null)
-                            .addListener(f -> transportCompletion.complete(null));
+                    completeOn(completeDispatch(ctx, postStream, result, origin, null), transportCompletion);
                 }));
     }
 
@@ -266,23 +271,29 @@ public class McpInitializationHandler extends ChannelInboundHandlerAdapter {
                         postStream.terminate();
                         if (isRefused(ex)) {
                             logger.debug("Initialize refused: id={}, elapsed={}ms", id, elapsedMs);
-                            sendPlainTextAndClose(
-                                            ctx, HttpResponseStatus.SERVICE_UNAVAILABLE, "Server shutting down", origin)
-                                    .addListener(f -> transportCompletion.complete(null));
+                            completeOn(
+                                    sendPlainTextAndClose(
+                                            ctx,
+                                            HttpResponseStatus.SERVICE_UNAVAILABLE,
+                                            "Server shutting down",
+                                            origin),
+                                    transportCompletion);
                             return;
                         }
                         logger.error("Initialize dispatch failed: id={}, elapsed={}ms", id, elapsedMs, ex);
-                        sendResponseAndClose(
+                        completeOn(
+                                sendResponseAndClose(
                                         ctx,
                                         HttpResponseStatus.INTERNAL_SERVER_ERROR,
                                         "application/json",
                                         dispatcher.parseError(ChannelHandlerUtils.requireInteractionContext(ctx)),
-                                        origin)
-                                .addListener(f -> transportCompletion.complete(null));
+                                        origin),
+                                transportCompletion);
                         return;
                     }
                     logger.debug("Initialize response: id={}, elapsed={}ms", id, elapsedMs);
-                    completeDispatch(ctx, postStream, result, origin, response -> {
+                    completeOn(
+                            completeDispatch(ctx, postStream, result, origin, response -> {
                                 var resultSessionId = response.sessionId();
                                 // Fire event with the live Session — InteractionHandler binds it into
                                 // InteractionContext, and LifecyclePipelineCoordinator replaces this handler
@@ -295,8 +306,8 @@ public class McpInitializationHandler extends ChannelInboundHandlerAdapter {
                                         .fireUserEventTriggered(new InteractionEvent.OperationStarted(mcpSession));
                                 logger.debug(
                                         "Pipeline transitioned to OPERATION phase for session: {}", resultSessionId);
-                            })
-                            .addListener(f -> transportCompletion.complete(null));
+                            }),
+                            transportCompletion);
                 }));
     }
 

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/transport/netty/McpInitializationHandler.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/transport/netty/McpInitializationHandler.java
@@ -2,7 +2,9 @@
 package dev.tachyonmcp.core.transport.netty;
 
 import static dev.tachyonmcp.core.transport.netty.ChannelHandlerUtils.captureInitRequest;
+import static dev.tachyonmcp.core.transport.netty.ChannelHandlerUtils.isRefused;
 import static dev.tachyonmcp.core.transport.netty.ChannelHandlerUtils.sendAccepted;
+import static dev.tachyonmcp.core.transport.netty.ChannelHandlerUtils.sendAcceptedAsync;
 import static dev.tachyonmcp.core.transport.netty.ChannelHandlerUtils.sendPlainTextAndClose;
 import static dev.tachyonmcp.core.transport.netty.ChannelHandlerUtils.sendResponseAndClose;
 import static dev.tachyonmcp.core.transport.netty.McpResponseWriter.sendJsonResponse;
@@ -16,6 +18,7 @@ import dev.tachyonmcp.core.server.McpDispatcher;
 import dev.tachyonmcp.core.server.internal.ServerEngine;
 import dev.tachyonmcp.core.transport.jsonrpc.JsonRpcMessage;
 import dev.tachyonmcp.core.transport.netty.sse.PostSseStream;
+import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.handler.codec.http.FullHttpRequest;
@@ -156,22 +159,38 @@ public class McpInitializationHandler extends ChannelInboundHandlerAdapter {
         }
         var heartbeatInterval = server.config().network().heartbeatInterval();
         var postStream = new PostSseStream(ctx.channel(), origin, server::nextEventId, heartbeatInterval);
+        final var transportCompletion = new CompletableFuture<Void>();
         dispatcher
                 .dispatchRequestAsync(
-                        id, method, params, null, postStream, ChannelHandlerUtils.requireInteractionContext(ctx))
-                .whenComplete((result, ex) -> ctx.executor().execute(() -> {
+                        id,
+                        method,
+                        params,
+                        null,
+                        postStream,
+                        ChannelHandlerUtils.requireInteractionContext(ctx),
+                        transportCompletion)
+                .whenComplete((result, ex) -> marshalResponse(ctx, transportCompletion, () -> {
                     if (ex != null) {
                         postStream.terminate();
+                        if (isRefused(ex)) {
+                            logger.debug("Pre-session request refused: method={}", method);
+                            sendPlainTextAndClose(
+                                            ctx, HttpResponseStatus.SERVICE_UNAVAILABLE, "Server shutting down", origin)
+                                    .addListener(f -> transportCompletion.complete(null));
+                            return;
+                        }
                         logger.error("Dispatch failed for pre-session request: method={}", method, ex);
                         sendResponseAndClose(
-                                ctx,
-                                HttpResponseStatus.INTERNAL_SERVER_ERROR,
-                                "application/json",
-                                dispatcher.parseError(ChannelHandlerUtils.requireInteractionContext(ctx)),
-                                origin);
+                                        ctx,
+                                        HttpResponseStatus.INTERNAL_SERVER_ERROR,
+                                        "application/json",
+                                        dispatcher.parseError(ChannelHandlerUtils.requireInteractionContext(ctx)),
+                                        origin)
+                                .addListener(f -> transportCompletion.complete(null));
                         return;
                     }
-                    completeDispatch(ctx, postStream, result, origin, null);
+                    completeDispatch(ctx, postStream, result, origin, null)
+                            .addListener(f -> transportCompletion.complete(null));
                 }));
     }
 
@@ -183,7 +202,7 @@ public class McpInitializationHandler extends ChannelInboundHandlerAdapter {
      * transition once the {@link McpDispatcher.DispatchResult.Response} is known, before the response
      * is written; {@code onResponseReady} carries that (a no-op for every other pre-session request).
      */
-    private void completeDispatch(
+    private ChannelFuture completeDispatch(
             ChannelHandlerContext ctx,
             PostSseStream postStream,
             McpDispatcher.DispatchResult result,
@@ -191,13 +210,11 @@ public class McpInitializationHandler extends ChannelInboundHandlerAdapter {
             @Nullable Consumer<McpDispatcher.DispatchResult.Response> onResponseReady) {
         if (result instanceof McpDispatcher.DispatchResult.Accepted) {
             postStream.terminate();
-            sendAccepted(ctx, origin);
-            return;
+            return sendAcceptedAsync(ctx, origin);
         }
         if (result instanceof McpDispatcher.DispatchResult.Status(int code, String statusMessage)) {
             postStream.terminate();
-            sendPlainTextAndClose(ctx, HttpResponseStatus.valueOf(code), statusMessage, origin);
-            return;
+            return sendPlainTextAndClose(ctx, HttpResponseStatus.valueOf(code), statusMessage, origin);
         }
         var response = (McpDispatcher.DispatchResult.Response) result;
         if (onResponseReady != null) {
@@ -205,16 +222,26 @@ public class McpInitializationHandler extends ChannelInboundHandlerAdapter {
         }
         if (postStream.started()) {
             postStream.writeEvent(server.nextEventId(), response.responseBody(), null);
-            postStream.terminate();
-            return;
+            return postStream.terminateAsync();
         }
         postStream.terminate();
-        sendJsonResponse(
+        return sendJsonResponse(
                 ctx,
                 response.responseBody(),
                 HttpResponseStatus.valueOf(response.httpStatus()),
                 response.sessionId(),
                 origin);
+    }
+
+    private static void marshalResponse(
+            ChannelHandlerContext ctx, CompletableFuture<Void> completion, Runnable response) {
+        try {
+            CompletableFuture.runAsync(response, ctx.executor()).whenComplete((unused, failure) -> {
+                if (failure != null) completion.completeExceptionally(failure);
+            });
+        } catch (RuntimeException e) {
+            completion.completeExceptionally(e);
+        }
     }
 
     private void handleInitialize(ChannelHandlerContext ctx, RequestId id, Object params, @Nullable String origin) {
@@ -223,6 +250,7 @@ public class McpInitializationHandler extends ChannelInboundHandlerAdapter {
         final var startNs = System.nanoTime();
         logger.debug("Initialize request: id={}", id);
 
+        final var transportCompletion = new CompletableFuture<Void>();
         dispatcher
                 .dispatchRequestAsync(
                         id,
@@ -230,32 +258,45 @@ public class McpInitializationHandler extends ChannelInboundHandlerAdapter {
                         params,
                         null,
                         postStream,
-                        ChannelHandlerUtils.requireInteractionContext(ctx))
-                .whenComplete((result, ex) -> ctx.executor().execute(() -> {
+                        ChannelHandlerUtils.requireInteractionContext(ctx),
+                        transportCompletion)
+                .whenComplete((result, ex) -> marshalResponse(ctx, transportCompletion, () -> {
                     var elapsedMs = (System.nanoTime() - startNs) / 1_000_000;
                     if (ex != null) {
                         postStream.terminate();
+                        if (isRefused(ex)) {
+                            logger.debug("Initialize refused: id={}, elapsed={}ms", id, elapsedMs);
+                            sendPlainTextAndClose(
+                                            ctx, HttpResponseStatus.SERVICE_UNAVAILABLE, "Server shutting down", origin)
+                                    .addListener(f -> transportCompletion.complete(null));
+                            return;
+                        }
                         logger.error("Initialize dispatch failed: id={}, elapsed={}ms", id, elapsedMs, ex);
                         sendResponseAndClose(
-                                ctx,
-                                HttpResponseStatus.INTERNAL_SERVER_ERROR,
-                                "application/json",
-                                dispatcher.parseError(ChannelHandlerUtils.requireInteractionContext(ctx)),
-                                origin);
+                                        ctx,
+                                        HttpResponseStatus.INTERNAL_SERVER_ERROR,
+                                        "application/json",
+                                        dispatcher.parseError(ChannelHandlerUtils.requireInteractionContext(ctx)),
+                                        origin)
+                                .addListener(f -> transportCompletion.complete(null));
                         return;
                     }
                     logger.debug("Initialize response: id={}, elapsed={}ms", id, elapsedMs);
                     completeDispatch(ctx, postStream, result, origin, response -> {
-                        var resultSessionId = response.sessionId();
-                        // Fire event with the live Session — InteractionHandler binds it into
-                        // InteractionContext, and LifecyclePipelineCoordinator replaces this handler
-                        // with McpOperationHandler.
-                        var mcpSession = resultSessionId != null
-                                ? server.getLocalSession(resultSessionId).orElse(null)
-                                : null;
-                        ctx.pipeline().fireUserEventTriggered(new InteractionEvent.OperationStarted(mcpSession));
-                        logger.debug("Pipeline transitioned to OPERATION phase for session: {}", resultSessionId);
-                    });
+                                var resultSessionId = response.sessionId();
+                                // Fire event with the live Session — InteractionHandler binds it into
+                                // InteractionContext, and LifecyclePipelineCoordinator replaces this handler
+                                // with McpOperationHandler.
+                                var mcpSession = resultSessionId != null
+                                        ? server.getLocalSession(resultSessionId)
+                                                .orElse(null)
+                                        : null;
+                                ctx.pipeline()
+                                        .fireUserEventTriggered(new InteractionEvent.OperationStarted(mcpSession));
+                                logger.debug(
+                                        "Pipeline transitioned to OPERATION phase for session: {}", resultSessionId);
+                            })
+                            .addListener(f -> transportCompletion.complete(null));
                 }));
     }
 

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/transport/netty/McpOperationHandler.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/transport/netty/McpOperationHandler.java
@@ -3,6 +3,7 @@ package dev.tachyonmcp.core.transport.netty;
 
 import static dev.tachyonmcp.core.transport.netty.ChannelHandlerUtils.bindSession;
 import static dev.tachyonmcp.core.transport.netty.ChannelHandlerUtils.captureInitRequest;
+import static dev.tachyonmcp.core.transport.netty.ChannelHandlerUtils.completeOn;
 import static dev.tachyonmcp.core.transport.netty.ChannelHandlerUtils.isRefused;
 import static dev.tachyonmcp.core.transport.netty.ChannelHandlerUtils.sendAccepted;
 import static dev.tachyonmcp.core.transport.netty.ChannelHandlerUtils.sendAcceptedAsync;
@@ -332,20 +333,21 @@ public class McpOperationHandler extends ChannelInboundHandlerAdapter {
                     logger.error("Dispatch failed: id={}, method={}, elapsed={}ms", requestId, method, elapsedMs, ex);
                 }
                 if (postStream.started()) {
-                    postStream.terminateAsync().addListener(f -> transportCompletion.complete(null));
+                    completeOn(postStream.terminateAsync(), transportCompletion);
                 } else {
                     // Neutralize the stream so a late server→client message cannot start a
                     // second HTTP response on this channel, then send the error.
                     postStream.terminate();
-                    (refused
+                    completeOn(
+                            refused
                                     ? sendPlainTextAndClose(
                                             ctx, HttpResponseStatus.SERVICE_UNAVAILABLE, "Server shutting down", origin)
                                     : sendInternalError(
                                             ctx,
                                             requestId,
                                             origin,
-                                            ic.protocol().responseMapper()))
-                            .addListener(f -> transportCompletion.complete(null));
+                                            ic.protocol().responseMapper()),
+                            transportCompletion);
                 }
                 return;
             }
@@ -353,8 +355,9 @@ public class McpOperationHandler extends ChannelInboundHandlerAdapter {
                 // Transport-level signal from the dispatcher — spec ties this condition to a raw HTTP
                 // status, not a JSON-RPC error envelope.
                 postStream.terminate();
-                sendPlainTextAndClose(ctx, HttpResponseStatus.valueOf(code), message, origin)
-                        .addListener(f -> transportCompletion.complete(null));
+                completeOn(
+                        sendPlainTextAndClose(ctx, HttpResponseStatus.valueOf(code), message, origin),
+                        transportCompletion);
                 return;
             }
             if (postStream.started()) {
@@ -370,7 +373,7 @@ public class McpOperationHandler extends ChannelInboundHandlerAdapter {
                     executor.execute(() ->
                             finalizePostSseResponse(requestId, sessionId, postStream, result, transportCompletion));
                 } catch (RejectedExecutionException e) {
-                    postStream.terminateAsync().addListener(f -> transportCompletion.complete(null));
+                    completeOn(postStream.terminateAsync(), transportCompletion);
                 }
                 return;
             }
@@ -380,7 +383,7 @@ public class McpOperationHandler extends ChannelInboundHandlerAdapter {
             // and corrupt the next request's reuse of it.
             postStream.terminate();
             if (result instanceof McpDispatcher.DispatchResult.Accepted) {
-                sendAcceptedAsync(ctx, origin).addListener(f -> transportCompletion.complete(null));
+                completeOn(sendAcceptedAsync(ctx, origin), transportCompletion);
                 return;
             }
             if (m.slowRequestLogging() && elapsedMs > m.slowRequestThreshold().toMillis()) {
@@ -389,13 +392,14 @@ public class McpOperationHandler extends ChannelInboundHandlerAdapter {
                 logger.debug("POST response: id={}, method={}, elapsed={}ms", requestId, method, elapsedMs);
             }
             var response = (McpDispatcher.DispatchResult.Response) result;
-            sendJsonResponse(
+            completeOn(
+                    sendJsonResponse(
                             ctx,
                             response.responseBody(),
                             HttpResponseStatus.valueOf(response.httpStatus()),
                             response.sessionId(),
-                            origin)
-                    .addListener(f -> transportCompletion.complete(null));
+                            origin),
+                    transportCompletion);
         } catch (RuntimeException e) {
             transportCompletion.completeExceptionally(e);
             throw e;
@@ -409,7 +413,7 @@ public class McpOperationHandler extends ChannelInboundHandlerAdapter {
             McpDispatcher.@Nullable DispatchResult result,
             CompletableFuture<Void> transportCompletion) {
         if (!(result instanceof McpDispatcher.DispatchResult.Response response)) {
-            postStream.terminateAsync().addListener(f -> transportCompletion.complete(null));
+            completeOn(postStream.terminateAsync(), transportCompletion);
             return;
         }
         var responseBody = response.responseBody();
@@ -431,7 +435,7 @@ public class McpOperationHandler extends ChannelInboundHandlerAdapter {
         } catch (RuntimeException e) {
             logger.error("Failed to write final response on POST-SSE stream", e);
         } finally {
-            postStream.terminateAsync().addListener(f -> transportCompletion.complete(null));
+            completeOn(postStream.terminateAsync(), transportCompletion);
         }
     }
 

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/transport/netty/McpOperationHandler.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/transport/netty/McpOperationHandler.java
@@ -3,7 +3,9 @@ package dev.tachyonmcp.core.transport.netty;
 
 import static dev.tachyonmcp.core.transport.netty.ChannelHandlerUtils.bindSession;
 import static dev.tachyonmcp.core.transport.netty.ChannelHandlerUtils.captureInitRequest;
+import static dev.tachyonmcp.core.transport.netty.ChannelHandlerUtils.isRefused;
 import static dev.tachyonmcp.core.transport.netty.ChannelHandlerUtils.sendAccepted;
+import static dev.tachyonmcp.core.transport.netty.ChannelHandlerUtils.sendAcceptedAsync;
 import static dev.tachyonmcp.core.transport.netty.ChannelHandlerUtils.sendPlainTextAndClose;
 import static dev.tachyonmcp.core.transport.netty.ChannelHandlerUtils.sendResponseAndClose;
 import static dev.tachyonmcp.core.transport.netty.McpResponseWriter.sendInternalError;
@@ -279,8 +281,9 @@ public class McpOperationHandler extends ChannelInboundHandlerAdapter {
         final var requestId = req.id();
         final var method = req.method();
         final var startNs = System.nanoTime();
+        final var transportCompletion = new CompletableFuture<Void>();
         dispatcher
-                .dispatchRequestAsync(requestId, method, req.params(), sessionId, postStream, ic)
+                .dispatchRequestAsync(requestId, method, req.params(), sessionId, postStream, ic, transportCompletion)
                 .whenComplete((result, ex) -> {
                     try {
                         ctx.executor()
@@ -294,8 +297,10 @@ public class McpOperationHandler extends ChannelInboundHandlerAdapter {
                                         startNs,
                                         result,
                                         ex,
-                                        ic));
+                                        ic,
+                                        transportCompletion));
                     } catch (RejectedExecutionException e) {
+                        transportCompletion.completeExceptionally(e);
                         logger.debug(
                                 "Event loop rejected response marshal during shutdown: id={}, method={}",
                                 requestId,
@@ -314,73 +319,97 @@ public class McpOperationHandler extends ChannelInboundHandlerAdapter {
             long startNs,
             McpDispatcher.@Nullable DispatchResult result,
             @Nullable Throwable ex,
-            ChannelContext ic) {
-        var elapsedMs = (System.nanoTime() - startNs) / 1_000_000;
-        var m = server.config().observability();
-        if (ex != null) {
-            logger.error("Dispatch failed: id={}, method={}, elapsed={}ms", requestId, method, elapsedMs, ex);
+            ChannelContext ic,
+            CompletableFuture<Void> transportCompletion) {
+        try {
+            var elapsedMs = (System.nanoTime() - startNs) / 1_000_000;
+            var m = server.config().observability();
+            if (ex != null) {
+                final var refused = isRefused(ex);
+                if (refused) {
+                    logger.debug("Dispatch refused: id={}, method={}, elapsed={}ms", requestId, method, elapsedMs);
+                } else {
+                    logger.error("Dispatch failed: id={}, method={}, elapsed={}ms", requestId, method, elapsedMs, ex);
+                }
+                if (postStream.started()) {
+                    postStream.terminateAsync().addListener(f -> transportCompletion.complete(null));
+                } else {
+                    // Neutralize the stream so a late server→client message cannot start a
+                    // second HTTP response on this channel, then send the error.
+                    postStream.terminate();
+                    (refused
+                                    ? sendPlainTextAndClose(
+                                            ctx, HttpResponseStatus.SERVICE_UNAVAILABLE, "Server shutting down", origin)
+                                    : sendInternalError(
+                                            ctx,
+                                            requestId,
+                                            origin,
+                                            ic.protocol().responseMapper()))
+                            .addListener(f -> transportCompletion.complete(null));
+                }
+                return;
+            }
+            if (result instanceof McpDispatcher.DispatchResult.Status(int code, String message)) {
+                // Transport-level signal from the dispatcher — spec ties this condition to a raw HTTP
+                // status, not a JSON-RPC error envelope.
+                postStream.terminate();
+                sendPlainTextAndClose(ctx, HttpResponseStatus.valueOf(code), message, origin)
+                        .addListener(f -> transportCompletion.complete(null));
+                return;
+            }
             if (postStream.started()) {
-                postStream.terminate();
-            } else {
-                // Neutralize the stream so a late server→client message cannot start a
-                // second HTTP response on this channel, then send the JSON error.
-                postStream.terminate();
-                sendInternalError(ctx, requestId, origin, ic.protocol().responseMapper());
+                if (m.slowRequestLogging()
+                        && elapsedMs > m.slowRequestThreshold().toMillis()) {
+                    logger.warn("Slow POST-SSE response: id={}, method={}, elapsed={}ms", requestId, method, elapsedMs);
+                } else {
+                    logger.debug("POST-SSE response: id={}, method={}, elapsed={}ms", requestId, method, elapsedMs);
+                }
+                // Finalization decodes the response body and appends to the event log —
+                // too heavy for the event loop. PostSseStream writes marshal themselves.
+                try {
+                    executor.execute(() ->
+                            finalizePostSseResponse(requestId, sessionId, postStream, result, transportCompletion));
+                } catch (RejectedExecutionException e) {
+                    postStream.terminateAsync().addListener(f -> transportCompletion.complete(null));
+                }
+                return;
             }
-            return;
-        }
-        if (result instanceof McpDispatcher.DispatchResult.Status(int code, String message)) {
-            // Transport-level signal from the dispatcher — spec ties this condition to a raw HTTP
-            // status, not a JSON-RPC error envelope.
+            // A keep-alive JSON/202 response is about to be written; neutralize the unused
+            // stream so a server→client message that arrives after this check (e.g. an async
+            // tool's status notification) cannot open a second response on the pooled socket
+            // and corrupt the next request's reuse of it.
             postStream.terminate();
-            sendPlainTextAndClose(ctx, HttpResponseStatus.valueOf(code), message, origin);
-            return;
-        }
-        if (postStream.started()) {
+            if (result instanceof McpDispatcher.DispatchResult.Accepted) {
+                sendAcceptedAsync(ctx, origin).addListener(f -> transportCompletion.complete(null));
+                return;
+            }
             if (m.slowRequestLogging() && elapsedMs > m.slowRequestThreshold().toMillis()) {
-                logger.warn("Slow POST-SSE response: id={}, method={}, elapsed={}ms", requestId, method, elapsedMs);
+                logger.warn("Slow POST response: id={}, method={}, elapsed={}ms", requestId, method, elapsedMs);
             } else {
-                logger.debug("POST-SSE response: id={}, method={}, elapsed={}ms", requestId, method, elapsedMs);
+                logger.debug("POST response: id={}, method={}, elapsed={}ms", requestId, method, elapsedMs);
             }
-            // Finalization decodes the response body and appends to the event log —
-            // too heavy for the event loop. PostSseStream writes marshal themselves.
-            try {
-                executor.execute(() -> finalizePostSseResponse(requestId, sessionId, postStream, result));
-            } catch (RejectedExecutionException e) {
-                postStream.terminate();
-            }
-            return;
+            var response = (McpDispatcher.DispatchResult.Response) result;
+            sendJsonResponse(
+                            ctx,
+                            response.responseBody(),
+                            HttpResponseStatus.valueOf(response.httpStatus()),
+                            response.sessionId(),
+                            origin)
+                    .addListener(f -> transportCompletion.complete(null));
+        } catch (RuntimeException e) {
+            transportCompletion.completeExceptionally(e);
+            throw e;
         }
-        // A keep-alive JSON/202 response is about to be written; neutralize the unused
-        // stream so a server→client message that arrives after this check (e.g. an async
-        // tool's status notification) cannot open a second response on the pooled socket
-        // and corrupt the next request's reuse of it.
-        postStream.terminate();
-        if (result instanceof McpDispatcher.DispatchResult.Accepted) {
-            sendAccepted(ctx, origin);
-            return;
-        }
-        if (m.slowRequestLogging() && elapsedMs > m.slowRequestThreshold().toMillis()) {
-            logger.warn("Slow POST response: id={}, method={}, elapsed={}ms", requestId, method, elapsedMs);
-        } else {
-            logger.debug("POST response: id={}, method={}, elapsed={}ms", requestId, method, elapsedMs);
-        }
-        var response = (McpDispatcher.DispatchResult.Response) result;
-        sendJsonResponse(
-                ctx,
-                response.responseBody(),
-                HttpResponseStatus.valueOf(response.httpStatus()),
-                response.sessionId(),
-                origin);
     }
 
     private void finalizePostSseResponse(
             RequestId requestId,
             @Nullable String sessionId,
             PostSseStream postStream,
-            McpDispatcher.@Nullable DispatchResult result) {
+            McpDispatcher.@Nullable DispatchResult result,
+            CompletableFuture<Void> transportCompletion) {
         if (!(result instanceof McpDispatcher.DispatchResult.Response response)) {
-            postStream.terminate();
+            postStream.terminateAsync().addListener(f -> transportCompletion.complete(null));
             return;
         }
         var responseBody = response.responseBody();
@@ -402,7 +431,7 @@ public class McpOperationHandler extends ChannelInboundHandlerAdapter {
         } catch (RuntimeException e) {
             logger.error("Failed to write final response on POST-SSE stream", e);
         } finally {
-            postStream.terminate();
+            postStream.terminateAsync().addListener(f -> transportCompletion.complete(null));
         }
     }
 

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/transport/netty/NettyServer.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/transport/netty/NettyServer.java
@@ -99,6 +99,18 @@ public final class NettyServer implements Closeable {
     }
 
     /**
+     * Returns whether the calling thread is one of this server's I/O event loops. Shutdown drains
+     * in-flight requests by waiting for their responses to flush, which only these threads can do —
+     * so a shutdown started from one of them could never make progress.
+     */
+    public boolean inEventLoop() {
+        for (var eventLoop : eventLoopGroup) {
+            if (eventLoop.inEventLoop()) return true;
+        }
+        return false;
+    }
+
+    /**
      * Stops accepting new connections by closing the server channel. Existing child channels and
      * event loops stay alive so in-flight requests can complete and flush. Idempotent;
      * {@link #close()} finishes the teardown.

--- a/tachyon-core/src/main/java/dev/tachyonmcp/core/transport/netty/sse/PostSseStream.java
+++ b/tachyon-core/src/main/java/dev/tachyonmcp/core/transport/netty/sse/PostSseStream.java
@@ -9,6 +9,7 @@ import dev.tachyonmcp.core.server.internal.ServerEngine;
 import dev.tachyonmcp.core.transport.netty.http.HttpHelpers;
 import io.netty.buffer.ByteBufUtil;
 import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.handler.codec.http.DefaultHttpContent;
 import io.netty.handler.codec.http.DefaultHttpResponse;
@@ -58,6 +59,7 @@ public final class PostSseStream implements OutboundSseStream {
     private final Duration heartbeatInterval;
     private final List<SseEvent> queued = new ArrayList<>();
     private volatile State state = State.NEW;
+    private @Nullable ChannelFuture closeWrite;
 
     public PostSseStream(
             Channel channel, @Nullable String origin, LongSupplier eventIdSupplier, Duration heartbeatInterval) {
@@ -132,6 +134,29 @@ public final class PostSseStream implements OutboundSseStream {
 
     public void terminate() {
         runOnEventLoop(() -> doClose(false));
+    }
+
+    /** Terminates the stream and completes after its final write succeeds or fails. */
+    public ChannelFuture terminateAsync() {
+        final var completion = channel.newPromise();
+        // Fallback: a shutting-down event loop can accept the task below and never run it, which
+        // would leave this promise — and the shutdown drain waiting on it — pending forever.
+        channel.closeFuture().addListener(f -> completion.trySuccess());
+        try {
+            runOnEventLoop(() -> {
+                try {
+                    doClose(false).addListener(f -> {
+                        if (f.isSuccess()) completion.trySuccess();
+                        else completion.tryFailure(f.cause());
+                    });
+                } catch (RuntimeException e) {
+                    completion.tryFailure(e);
+                }
+            });
+        } catch (RuntimeException e) {
+            completion.tryFailure(e);
+        }
+        return completion;
     }
 
     @Override
@@ -234,16 +259,17 @@ public final class PostSseStream implements OutboundSseStream {
         });
     }
 
-    private void doClose(boolean reconnect) {
-        if (state.closed) return;
+    private ChannelFuture doClose(boolean reconnect) {
+        if (state.closed) return closeWrite != null ? closeWrite : channel.newSucceededFuture();
         var wasOpen = state.opened;
         state = wasOpen ? State.CLOSED_OPENED : State.CLOSED_UNOPENED;
-        if (!channel.isActive() || !wasOpen) return;
+        if (!channel.isActive() || !wasOpen) return channel.newSucceededFuture();
         if (reconnect) {
             channel.write(new DefaultHttpContent(
                     ByteBufUtil.writeUtf8(channel.alloc(), "retry: " + SSE_RETRY_DELAY_MS + "\n")));
         }
-        channel.writeAndFlush(LastHttpContent.EMPTY_LAST_CONTENT).addListener(ChannelFutureListener.CLOSE);
+        closeWrite = channel.writeAndFlush(LastHttpContent.EMPTY_LAST_CONTENT).addListener(ChannelFutureListener.CLOSE);
+        return closeWrite;
     }
 
     private static String abbreviate(String s) {

--- a/tachyon-core/src/test/java/dev/tachyonmcp/core/server/ServerShutdownGraceTest.java
+++ b/tachyon-core/src/test/java/dev/tachyonmcp/core/server/ServerShutdownGraceTest.java
@@ -3,13 +3,17 @@ package dev.tachyonmcp.core.server;
 
 import static dev.tachyonmcp.core.test.TestUtils.newEngine;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 
 import dev.tachyonmcp.api.server.config.RuntimeConfig;
 import dev.tachyonmcp.api.server.domain.RequestId;
+import dev.tachyonmcp.api.server.extensions.AdvertiseMode;
+import dev.tachyonmcp.api.server.extensions.ServerExtension;
 import dev.tachyonmcp.api.server.features.tools.ToolResult;
 import dev.tachyonmcp.core.server.internal.ServerEngine;
 import java.time.Duration;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
@@ -41,6 +45,85 @@ class ServerShutdownGraceTest {
         assertThat(elapsedMs)
                 .as("idle close must not wait for the grace period")
                 .isLessThan(1_000L);
+    }
+
+    @Test
+    void closeDrainsAsyncHandlerAndItsExecutorContinuation() throws Exception {
+        final var started = new CountDownLatch(1);
+        final var result = new CompletableFuture<ToolResult>();
+        final var extensionClosed = new CountDownLatch(1);
+        final var extension = new ServerExtension() {
+            @Override
+            public String extensionId() {
+                return "test/shutdown";
+            }
+
+            @Override
+            public AdvertiseMode advertiseMode() {
+                return AdvertiseMode.ALWAYS;
+            }
+
+            @Override
+            public void shutdown() {
+                extensionClosed.countDown();
+            }
+        };
+        final var server = newEngine(
+                b -> b.withExtensions(extension).runtime(r -> r.shutdownGracePeriod(Duration.ofSeconds(2))),
+                s -> s.tools().registerAsync(builder -> builder.name("async_probe"), (context, request) -> {
+                    started.countDown();
+                    return result;
+                }));
+        server.createSession("sess-async").activate();
+        final var dispatcher = new McpDispatcher(server, server.executor());
+        final var response = dispatcher.dispatchRequestAsync(
+                RequestId.of(1), "tools/call", Map.of("name", "async_probe", "arguments", Map.of()), "sess-async");
+        assertThat(started.await(5, TimeUnit.SECONDS)).isTrue();
+        final var closing = CompletableFuture.runAsync(server::close, Thread::startVirtualThread);
+        try {
+            await().atMost(Duration.ofSeconds(1))
+                    .until(() -> dispatcher
+                            .dispatchRequestAsync(RequestId.of(2), "ping", Map.of(), "sess-async")
+                            .isCompletedExceptionally());
+            assertThat(closing).isNotDone();
+            assertThat(extensionClosed.getCount()).isEqualTo(1);
+            result.complete(ToolResult.empty());
+            assertThat(response.get(5, TimeUnit.SECONDS))
+                    .isInstanceOfSatisfying(
+                            McpDispatcher.DispatchResult.Response.class,
+                            value -> assertThat(value.responseBodyString()).doesNotContain("error"));
+            closing.get(5, TimeUnit.SECONDS);
+            assertThat(extensionClosed.getCount()).isZero();
+        } finally {
+            result.complete(ToolResult.empty());
+            closing.get(5, TimeUnit.SECONDS);
+        }
+    }
+
+    @Test
+    void closeBoundsUnfinishedAsyncHandlerAndRejectsNewRequests() throws Exception {
+        final var started = new CountDownLatch(1);
+        final var result = new CompletableFuture<ToolResult>();
+        final var server = newEngine(
+                b -> b.runtime(r -> r.shutdownGracePeriod(Duration.ofMillis(200))),
+                s -> s.tools().registerAsync(builder -> builder.name("async_probe"), (context, request) -> {
+                    started.countDown();
+                    return result;
+                }));
+        server.createSession("sess-async").activate();
+        final var dispatcher = new McpDispatcher(server, server.executor());
+        dispatcher.dispatchRequestAsync(
+                RequestId.of(1), "tools/call", Map.of("name", "async_probe", "arguments", Map.of()), "sess-async");
+        assertThat(started.await(5, TimeUnit.SECONDS)).isTrue();
+        final var start = System.nanoTime();
+        try {
+            server.close();
+            assertThat(Duration.ofNanos(System.nanoTime() - start).toMillis()).isBetween(200L, 2000L);
+            assertThat(dispatcher.dispatchRequestAsync(RequestId.of(2), "ping", Map.of(), "sess-async"))
+                    .isCompletedExceptionally();
+        } finally {
+            result.complete(ToolResult.empty());
+        }
     }
 
     @Test


### PR DESCRIPTION
Shutdown previously only waited for the handler executor to terminate, so a response that had completed its handler but not yet flushed could be cut off.

OperationTracker admits each dispatch and holds that admission until both the handler future and the transport write complete; close() drains it before shutting the executor down, sharing one deadline across drain and awaitTermination. Subscriptions, extensions, sessions and event storage tear down after the drain.

Requests arriving while draining are refused with 503 Service Unavailable and a DEBUG log, not a 500 (initialize previously answered them with a bogus -32700 Parse error) and not an ERROR — a graceful shutdown should not page.

close() blocks on flushes that only the I/O event loops can perform, so calling it from one now throws IllegalStateException instead of stalling for the whole grace period.